### PR TITLE
[LinAttn] Fix handling of None scale in chunk_linear_attn for output normalization

### DIFF
--- a/fla/ops/linear_attn/chunk.py
+++ b/fla/ops/linear_attn/chunk.py
@@ -43,6 +43,10 @@ def chunk_linear_attn(
         final_state (torch.Tensor):
             Final state of shape `[B, H, K, V]` if `output_final_state=True` else `None`
     """
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
     o, final_state = chunk_simple_gla(
         q=q,
         k=k,


### PR DESCRIPTION
This is handled in `chunk_simple_gla`, but scale is still `None` for post output normalization