### PR TITLE
Fix incorrect kwarg name in `fused_recurrent`

### DIFF
--- a/fla/ops/common/fused_recurrent.py
+++ b/fla/ops/common/fused_recurrent.py
@@ -553,7 +553,7 @@ def fused_recurrent(
     initial_state: Optional[torch.Tensor] = None,
     output_final_state: bool = False,
     reverse: bool = False,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
     head_first: bool = True
 ):
     if scale is None:
@@ -569,6 +569,6 @@ def fused_recurrent(
         initial_state,
         output_final_state,
         reverse,
-        offsets,
+        cu_seqlens,
         head_first
     )

--- a/fla/ops/retention/fused_recurrent.py
+++ b/fla/ops/retention/fused_recurrent.py
@@ -35,6 +35,6 @@ def fused_recurrent_retention(
         initial_state=initial_state,
         output_final_state=output_final_state,
         reverse=reverse,
-        offsets=offsets,
+        cu_seqlens=offsets,
         head_first=head_first
     )


### PR DESCRIPTION
Models that depend on this layer have been updated to use `cu_seqlens` instead of `offsets` as the kwarg, but the operator was not updated. This resulted in GLA and RetNet models not working, possibly others if they use them. kwarg name changes allow HF GLA and RetNet models to be loaded and run without issue. Haven't tested anything else beyond that.