### PR TITLE
[RWKV7, but applicable to all models] Update modeling_rwkv7.py: Fixing `base_model_prefix`

### DIFF
--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -163,6 +163,7 @@ class RWKV7PreTrainedModel(PreTrainedModel):
     config_class = RWKV7Config
     supports_gradient_checkpointing = True
     _no_split_modules = ['RWKV7Block']
+    base_model_prefix = 'model'
 
     def __init__(self, *inputs, **kwargs):
         super().__init__(*inputs, **kwargs)


### PR DESCRIPTION
Adding `base_model_prefix` at line 166: `base_model_prefix = 'model'`.

This ensures that new models built on the base of `RWKV7PreTrainedModel` recognizes proper keys in `model.safetensors`.

Content of `model.safetensors`:
```
1. lm_head.weight | shape: torch.Size([50304, 768]) | dtype: torch.float32
2. model.embeddings.weight | shape: torch.Size([50304, 768]) | dtype: torch.float32
3. model.layers.0.attn.a_lora.lora.0.weight | shape: torch.Size([64, 768]) | dtype: torch.float32
4. model.layers.0.attn.a_lora.lora.2.bias | shape: torch.Size([768]) | dtype: torch.float32
5. ...
```

However, if `base_model_prefix` is not set, the new model expects these keys, yielding this warning:
```
Some weights of RewardModel were not initialized from the model checkpoint at fla-hub/rwkv7-168M-pile and are newly initialized: ['.embeddings.weight', '.layers.0.attn.a_lora.lora.0.weight', '.layers.0.attn.a_lora.lora.2.bias', '.layers.0.attn.a_lora.lora.2.weight', ...]
```

This line should be applicable to all models in this repo.