### PR TITLE
modify to enable tp for transformer model using the flame framework

### DIFF
--- a/fla/layers/attn.py
+++ b/fla/layers/attn.py
@@ -94,9 +94,9 @@ class Attention(nn.Module):
         if self.norm_first:
             hidden_states = self.norm(hidden_states)
 
-        q = rearrange(self.q_proj(hidden_states), '... (h d) -> ... h d', h=self.num_heads)
-        k = rearrange(self.k_proj(hidden_states), '... (h d) -> ... h d', h=self.num_kv_heads)
-        v = rearrange(self.v_proj(hidden_states), '... (h d) -> ... h d', h=self.num_kv_heads)
+        q = rearrange(self.q_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
+        k = rearrange(self.k_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
+        v = rearrange(self.v_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
 
         # equivalent to cu_seqlens in `flash_attn`
         cu_seqlens = kwargs.get('cu_seqlens', None)
@@ -122,8 +122,8 @@ class Attention(nn.Module):
                 offset=q_len,
                 cache_kwargs=dict(window_size=self.window_size)
             )['attn_state']
-            k = rearrange(k, '... (h d) -> ... h d', h=self.num_kv_heads)
-            v = rearrange(v, '... (h d) -> ... h d', h=self.num_kv_heads)
+            k = rearrange(k, '... (h d) -> ... h d', d=self.head_dim)
+            v = rearrange(v, '... (h d) -> ... h d', d=self.head_dim)
 
         if flash_attn_func is None:
             raise ImportError("Please install Flash Attention via `pip install flash-attn --no-build-isolation` first")
@@ -159,7 +159,7 @@ class Attention(nn.Module):
                 causal=True,
                 window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0)
             )
-        o = o.reshape(batch_size, q_len, self.hidden_size)
+        o = o.reshape(batch_size, q_len, -1)
         o = self.o_proj(o)
 
         if not output_attentions:

--- a/fla/models/transformer/configuration_transformer.py
+++ b/fla/models/transformer/configuration_transformer.py
@@ -35,6 +35,7 @@ class TransformerConfig(PretrainedConfig):
         attention_bias: bool = False,
         fuse_norm: bool = True,
         fuse_cross_entropy: bool = True,
+        fuse_swiglu: bool = True,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -58,7 +59,7 @@ class TransformerConfig(PretrainedConfig):
         self.attention_bias = attention_bias
         self.fuse_cross_entropy = fuse_cross_entropy
         self.fuse_norm = fuse_norm
-
+        self.fuse_swiglu = fuse_swiglu
         super().__init__(
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,


### PR DESCRIPTION
This PR updated the transformer model to support tp using `apply_tp` from the Flame framework. The key modifications include:
1. TP splits attention heads across tp group, so the attention module has to account for it.
2. Make all the fused kernels configurable, as they are not incompatible with dtensor, allowing them to be disabled when tp is enabled.