### PR TITLE
[Utils] use fla.utils.device instead of cuda

### DIFF
--- a/benchmarks/modules/benchmark_cross_entropy.py
+++ b/benchmarks/modules/benchmark_cross_entropy.py
@@ -30,7 +30,7 @@ from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, V = 4, 4096, 120000

--- a/benchmarks/modules/benchmark_layernorm.py
+++ b/benchmarks/modules/benchmark_layernorm.py
@@ -31,7 +31,7 @@ from fla.modules import GroupNorm, LayerNorm
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, D = 16, 1024

--- a/benchmarks/ops/benchmark_abc.py
+++ b/benchmarks/ops/benchmark_abc.py
@@ -37,7 +37,7 @@ except BaseException:
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, D, M = 16, 4, 128, 64

--- a/benchmarks/ops/benchmark_based.py
+++ b/benchmarks/ops/benchmark_based.py
@@ -38,7 +38,7 @@ except Exception:
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, D = 8, 16, 128

--- a/benchmarks/ops/benchmark_delta_rule.py
+++ b/benchmarks/ops/benchmark_delta_rule.py
@@ -2,12 +2,12 @@
 # pip install "git+https://github.com/openai/triton.git#egg=triton&subdirectory=python"
 
 import torch
-from benchmark import benchmark_combined, benchmark_forward, benchmark_backward
+from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
 
-from fla.ops.delta_rule import (chunk_delta_rule,
-                                fused_recurrent_delta_rule, fused_chunk_delta_rule)
+from fla.ops.delta_rule import chunk_delta_rule, fused_chunk_delta_rule, fused_recurrent_delta_rule
 from fla.ops.retention import fused_chunk_retention
 # from flash_attn import flash_attn_func
+from fla.utils import device
 
 
 def time_fwd(func, *args, **kwargs):
@@ -26,7 +26,6 @@ def time_bwd(func, *args, **kwargs):
 
 
 repeats = 256
-device = 'cuda'
 dtype = torch.bfloat16
 
 

--- a/benchmarks/ops/benchmark_delta_rule.py
+++ b/benchmarks/ops/benchmark_delta_rule.py
@@ -5,9 +5,7 @@ import torch
 from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
 from torch.nn import functional as F
 
-from fla.ops.delta_rule import chunk_delta_rule, fused_chunk_delta_rule, fused_recurrent_delta_rule
-from fla.ops.retention import fused_chunk_retention
-# from flash_attn import flash_attn_func
+from fla.ops.delta_rule import chunk_delta_rule, fused_chunk_delta_rule
 from fla.utils import device
 
 

--- a/benchmarks/ops/benchmark_delta_rule.py
+++ b/benchmarks/ops/benchmark_delta_rule.py
@@ -19,6 +19,7 @@ def time_fwd_bwd(func, *args, **kwargs):
     time_fb = benchmark_combined(func, *args, **kwargs)
     return time_fb[1].mean
 
+
 def time_bwd(func, *args, **kwargs):
     time_fb = benchmark_backward(func, *args, **kwargs)
     return time_fb[1].mean
@@ -49,7 +50,8 @@ for causal in causal_vals:
             config = (causal, headdim, B, seqlen)
             H = dim // headdim
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
+                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             beta = torch.rand(B, H, seqlen, device=device, dtype=dtype).sigmoid().requires_grad_(True)
             o1, _ = chunk_delta_rule(q, k, v, beta)
@@ -66,7 +68,6 @@ for causal in causal_vals:
                 fused_chunk_delta_rule, q, k, v, beta, verbose=False
             )
             time_f_b[config, "fused_chunk_delta_rule"] = f_b
-
 
             print(f"### causal={causal}, headdim={headdim}, B={B}, seqlen={seqlen} ###")
             for method in methods:

--- a/benchmarks/ops/benchmark_delta_rule.py
+++ b/benchmarks/ops/benchmark_delta_rule.py
@@ -3,6 +3,7 @@
 
 import torch
 from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
+from torch.nn import functional as F
 
 from fla.ops.delta_rule import chunk_delta_rule, fused_chunk_delta_rule, fused_recurrent_delta_rule
 from fla.ops.retention import fused_chunk_retention
@@ -49,8 +50,7 @@ for causal in causal_vals:
             config = (causal, headdim, B, seqlen)
             H = dim // headdim
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
-                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = F.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             beta = torch.rand(B, H, seqlen, device=device, dtype=dtype).sigmoid().requires_grad_(True)
             o1, _ = chunk_delta_rule(q, k, v, beta)

--- a/benchmarks/ops/benchmark_fla.py
+++ b/benchmarks/ops/benchmark_fla.py
@@ -38,7 +38,7 @@ except ImportError:
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, D = 16, 8, 128

--- a/benchmarks/ops/benchmark_gla.py
+++ b/benchmarks/ops/benchmark_gla.py
@@ -33,7 +33,7 @@ from fla.ops.retention.naive import naive_retention
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, D = 16, 8, 128

--- a/benchmarks/ops/benchmark_gsa.py
+++ b/benchmarks/ops/benchmark_gsa.py
@@ -39,7 +39,7 @@ except BaseException:
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, D, M = 16, 4, 128, 64

--- a/benchmarks/ops/benchmark_hgrn.py
+++ b/benchmarks/ops/benchmark_hgrn.py
@@ -27,11 +27,12 @@ from fla.ops.hgrn import chunk_hgrn, fused_recurrent_hgrn
     )
 )
 def benchmark(T, provider):
+    from fla.utils import device
     dtype = torch.bfloat16
     B, D = 16, 512
 
-    x = torch.randn((B, T, D), dtype=dtype, device='cuda')
-    g = torch.randn((B, T, D), dtype=dtype, device='cuda').sigmoid()
+    x = torch.randn((B, T, D), dtype=dtype, device=device)
+    g = torch.randn((B, T, D), dtype=dtype, device=device).sigmoid()
     x = (1 - g) * x
     x, g = (i.detach().clone().to(dtype).requires_grad_() for i in (x, g))
     do = torch.randn_like(x, dtype=dtype)

--- a/benchmarks/ops/benchmark_nsa.py
+++ b/benchmarks/ops/benchmark_nsa.py
@@ -29,7 +29,7 @@ from fla.ops.nsa import parallel_nsa
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, HQ, D, S = 4, 4, 64, 128, 16
@@ -40,7 +40,7 @@ def benchmark(T, provider):
     v = torch.randn(B, T, H, D, device=device, requires_grad=requires_grad, dtype=dtype)
     do = torch.ones_like(q, dtype=dtype)
 
-    indices = torch.full((B, T, H, S), T, dtype=torch.long, device='cuda')
+    indices = torch.full((B, T, H, S), T, dtype=torch.long, device=device)
     for b in range(B):
         for t in range(T):
             for h in range(H):

--- a/benchmarks/ops/benchmark_retention.py
+++ b/benchmarks/ops/benchmark_retention.py
@@ -5,8 +5,7 @@ import os
 import torch
 import triton
 
-from fla.ops.retention import (chunk_retention, fused_recurrent_retention,
-                               parallel_retention)
+from fla.ops.retention import chunk_retention, fused_recurrent_retention, parallel_retention
 from fla.ops.retention.naive import naive_retention
 
 try:
@@ -40,7 +39,7 @@ except BaseException:
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, D = 4, 8, 256

--- a/benchmarks/ops/benchmark_rwkv6.py
+++ b/benchmarks/ops/benchmark_rwkv6.py
@@ -37,7 +37,7 @@ except BaseException:
     )
 )
 def benchmark(T, provider):
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     requires_grad = True
     B, H, D = 16, 8, 128

--- a/benchmarks/ops/benchmark_simple_gla_vs_mamba2.py
+++ b/benchmarks/ops/benchmark_simple_gla_vs_mamba2.py
@@ -8,10 +8,9 @@ https://github.com/sustcsonglin/flash-linear-attention/pull/49
 
 import torch
 import triton
+from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
 
 from fla.ops.simple_gla import chunk_simple_gla
-
-from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
 
 
 @triton.testing.perf_report(
@@ -36,7 +35,7 @@ from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
 )
 def benchmark(T, provider):
     # TODO: also add bwd pass benchmark
-    device = 'cuda'
+    from fla.utils import device
     dtype = torch.bfloat16
     B, H, D = 16, 8, 128
     # TODO: test more shapes

--- a/benchmarks/ops/benchmark_simple_gla_vs_mamba2.py
+++ b/benchmarks/ops/benchmark_simple_gla_vs_mamba2.py
@@ -82,5 +82,6 @@ def benchmark(T, provider):
         )
     return results
 
+
 if __name__ == '__main__':
     benchmark.run(print_data=True, save_path='.')

--- a/benchmarks/ops/benchmark_titans.py
+++ b/benchmarks/ops/benchmark_titans.py
@@ -2,8 +2,8 @@
 # pip install "git+https://github.com/openai/triton.git#egg=triton&subdirectory=python"
 
 import torch
-from torch.nn import functional as F
 from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
+from torch.nn import functional as F
 
 from fla.ops.titans.naive import chunk_titans_linear_ref
 

--- a/benchmarks/ops/benchmark_titans.py
+++ b/benchmarks/ops/benchmark_titans.py
@@ -2,6 +2,7 @@
 # pip install "git+https://github.com/openai/triton.git#egg=triton&subdirectory=python"
 
 import torch
+from torch.nn import functional as F
 from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
 
 from fla.ops.titans.naive import chunk_titans_linear_ref
@@ -50,7 +51,7 @@ for causal in causal_vals:
             q = torch.randn(
                 B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype
             )
-            k = torch.nn.functional.normalize(
+            k = F.normalize(
                 torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype),
                 p=2,
                 dim=-1,

--- a/benchmarks/ops/benchmark_ttt.py
+++ b/benchmarks/ops/benchmark_ttt.py
@@ -2,12 +2,14 @@
 # pip install "git+https://github.com/openai/triton.git#egg=triton&subdirectory=python"
 
 import torch
+from torch.nn import functional as F
 from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
 
 from fla.ops.delta_rule import chunk_delta_rule
 from fla.ops.gla import chunk_gla
 from fla.ops.ttt import chunk_ttt_linear, fused_chunk_ttt_linear
 from fla.ops.ttt.naive import chunk_ttt_linear_ref
+from fla.utils import device
 
 # from flash_attn import flash_attn_func
 
@@ -28,7 +30,7 @@ def time_bwd(func, *args, **kwargs):
 
 
 repeats = 256
-from fla.utils import device
+
 
 dtype = torch.bfloat16
 
@@ -65,8 +67,7 @@ for causal in causal_vals:
             time_f_b[config, "chunk_gla"] = f_b
 
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
-                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = F.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             beta = torch.rand(B, H, seqlen, device=device, dtype=dtype).sigmoid().requires_grad_(True)
             o2, _ = chunk_delta_rule(q, k, v, beta)
@@ -77,8 +78,7 @@ for causal in causal_vals:
             time_f_b[config, "chunk_delta_rule"] = f_b
 
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
-                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = F.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             w = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)
             b = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)
@@ -91,8 +91,7 @@ for causal in causal_vals:
             time_f_b[config, "chunk_ttt_linear"] = f_b
 
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
-                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = F.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             w = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)
             b = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)

--- a/benchmarks/ops/benchmark_ttt.py
+++ b/benchmarks/ops/benchmark_ttt.py
@@ -8,7 +8,6 @@ from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
 from fla.ops.delta_rule import chunk_delta_rule
 from fla.ops.gla import chunk_gla
 from fla.ops.ttt import chunk_ttt_linear, fused_chunk_ttt_linear
-from fla.ops.ttt.naive import chunk_ttt_linear_ref
 from fla.utils import device
 
 # from flash_attn import flash_attn_func

--- a/benchmarks/ops/benchmark_ttt.py
+++ b/benchmarks/ops/benchmark_ttt.py
@@ -2,12 +2,13 @@
 # pip install "git+https://github.com/openai/triton.git#egg=triton&subdirectory=python"
 
 import torch
-from benchmark import benchmark_combined, benchmark_forward, benchmark_backward
+from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
 
-from fla.ops.gla import chunk_gla
 from fla.ops.delta_rule import chunk_delta_rule
+from fla.ops.gla import chunk_gla
 from fla.ops.ttt import chunk_ttt_linear, fused_chunk_ttt_linear
 from fla.ops.ttt.naive import chunk_ttt_linear_ref
+
 # from flash_attn import flash_attn_func
 
 
@@ -27,7 +28,8 @@ def time_bwd(func, *args, **kwargs):
 
 
 repeats = 256
-device = 'cuda'
+from fla.utils import device
+
 dtype = torch.bfloat16
 
 

--- a/benchmarks/ops/benchmark_ttt.py
+++ b/benchmarks/ops/benchmark_ttt.py
@@ -20,6 +20,7 @@ def time_fwd_bwd(func, *args, **kwargs):
     time_fb = benchmark_combined(func, *args, **kwargs)
     return time_fb[1].mean
 
+
 def time_bwd(func, *args, **kwargs):
     time_fb = benchmark_backward(func, *args, **kwargs)
     return time_fb[1].mean
@@ -62,7 +63,8 @@ for causal in causal_vals:
             time_f_b[config, "chunk_gla"] = f_b
 
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
+                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             beta = torch.rand(B, H, seqlen, device=device, dtype=dtype).sigmoid().requires_grad_(True)
             o2, _ = chunk_delta_rule(q, k, v, beta)
@@ -73,7 +75,8 @@ for causal in causal_vals:
             time_f_b[config, "chunk_delta_rule"] = f_b
 
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
+                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             w = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)
             b = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)
@@ -86,7 +89,8 @@ for causal in causal_vals:
             time_f_b[config, "chunk_ttt_linear"] = f_b
 
             q = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
-            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device, dtype=dtype), p=2, dim=-1).requires_grad_(True)
+            k = torch.nn.functional.normalize(torch.randn(B, H, seqlen, headdim, device=device,
+                                              dtype=dtype), p=2, dim=-1).requires_grad_(True)
             v = torch.randn(B, H, seqlen, headdim, device=device, requires_grad=True, dtype=dtype)
             w = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)
             b = torch.randn(H, headdim, device=device, requires_grad=True, dtype=dtype)

--- a/benchmarks/ops/benchmark_ttt.py
+++ b/benchmarks/ops/benchmark_ttt.py
@@ -2,8 +2,8 @@
 # pip install "git+https://github.com/openai/triton.git#egg=triton&subdirectory=python"
 
 import torch
-from torch.nn import functional as F
 from benchmark import benchmark_backward, benchmark_combined, benchmark_forward
+from torch.nn import functional as F
 
 from fla.ops.delta_rule import chunk_delta_rule
 from fla.ops.gla import chunk_gla

--- a/evals/ppl.py
+++ b/evals/ppl.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, Iterator, List
 import torch
 from datasets import Dataset, load_dataset
 from tqdm import tqdm
-from transformers import (AutoModelForCausalLM, AutoTokenizer, PreTrainedModel,
-                          PreTrainedTokenizer)
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizer
 
 from fla.modules.fused_cross_entropy import FusedCrossEntropyLoss
 

--- a/evals/ppl.py
+++ b/evals/ppl.py
@@ -174,10 +174,14 @@ def main():
     parser.add_argument('--block_size', type=int, default=28672)
     parser.add_argument('--bucket_size', type=int, default=2048)
     parser.add_argument('--batch_size', type=int, default=1)
+    parser.add_argument('--device', type=str, default=None)
     args = parser.parse_args()
 
     # Set device and random seed
-    device = "cuda"
+    if args.device is None:
+        from fla.utils import device
+    else:
+        device = args.device
     torch.manual_seed(0)
 
     # Load model and tokenizer

--- a/fla/ops/delta_rule/naive.py
+++ b/fla/ops/delta_rule/naive.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import torch
+from torch.nn import functional as F
 from einops import rearrange
 
 
@@ -129,7 +130,7 @@ if __name__ == '__main__':
     from fla.utils import device
     q = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
     k = (torch.randn(B, H, L, DK)).to(device)
-    k = torch.nn.functional.normalize(k, dim=-1, p=2).requires_grad_(True)
+    k = F.normalize(k, dim=-1, p=2).requires_grad_(True)
     v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
     beta = torch.randn(B, H, L).to(device).sigmoid().requires_grad_(True)
 

--- a/fla/ops/delta_rule/naive.py
+++ b/fla/ops/delta_rule/naive.py
@@ -126,14 +126,15 @@ if __name__ == '__main__':
     L = 512
     DK = 128
     DV = 128
-    q = (torch.randn(B, H, L, DK)).cuda().requires_grad_(True)
-    k = (torch.randn(B, H, L, DK)).cuda()
+    from fla.utils import device
+    q = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
+    k = (torch.randn(B, H, L, DK)).to(device)
     k = torch.nn.functional.normalize(k, dim=-1, p=2).requires_grad_(True)
-    v = (torch.randn(B, H, L, DV)).cuda().requires_grad_(True)
-    beta = torch.randn(B, H, L).cuda().sigmoid().requires_grad_(True)
+    v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
+    beta = torch.randn(B, H, L).to(device).sigmoid().requires_grad_(True)
 
     o, _ = delta_rule_recurrence(q, k, v, beta)
-    do = torch.randn(B, H, L, DV).cuda()
+    do = torch.randn(B, H, L, DV).to(device)
     o.backward(do, retain_graph=True)
     q_grad, q.grad = q.grad, None
     k_grad, k.grad = k.grad, None

--- a/fla/ops/delta_rule/naive.py
+++ b/fla/ops/delta_rule/naive.py
@@ -2,7 +2,6 @@
 
 import torch
 from einops import rearrange
-from torch.nn import functional as F
 
 
 def delta_rule_recurrence(q, k, v, beta, initial_state=None, output_final_state=True):
@@ -119,48 +118,3 @@ def delta_rule_parallel(q, k, v, beta, BM=128, BN=32):
         A[:, :, i*BN:i*BN+BN, i*BN:i*BN+BN] = A_local[:, :, i]
 
     return o, A
-
-
-if __name__ == '__main__':
-    B = 2
-    H = 4
-    L = 512
-    DK = 128
-    DV = 128
-    from fla.utils import device
-    q = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
-    k = (torch.randn(B, H, L, DK)).to(device)
-    k = F.normalize(k, dim=-1, p=2).requires_grad_(True)
-    v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
-    beta = torch.randn(B, H, L).to(device).sigmoid().requires_grad_(True)
-
-    o, _ = delta_rule_recurrence(q, k, v, beta)
-    do = torch.randn(B, H, L, DV).to(device)
-    o.backward(do, retain_graph=True)
-    q_grad, q.grad = q.grad, None
-    k_grad, k.grad = k.grad, None
-    v_grad, v.grad = v.grad, None
-    beta_grad, beta.grad = beta.grad, None
-
-    o2, _ = delta_rule_chunkwise(q, k, v, beta)
-    o2.backward(do)
-    assert torch.allclose(o, o2, atol=1e-4), breakpoint()
-    assert torch.allclose(q.grad, q_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(k.grad, k_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(v.grad, v_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(beta.grad, beta_grad, atol=1e-4), breakpoint()
-
-    q_grad, q.grad = q.grad, None
-    k_grad, k.grad = k.grad, None
-    v_grad, v.grad = v.grad, None
-    beta_grad, beta.grad = beta.grad, None
-
-    o3, _ = delta_rule_parallel(q, k, v, beta)
-    o3.backward(do)
-    assert torch.allclose(o, o3, atol=1e-4), breakpoint()
-    assert torch.allclose(q.grad, q_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(k.grad, k_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(v.grad, v_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(beta.grad, beta_grad, atol=1e-4), breakpoint()
-
-    print("All passed!")

--- a/fla/ops/delta_rule/naive.py
+++ b/fla/ops/delta_rule/naive.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import torch
-from torch.nn import functional as F
 from einops import rearrange
+from torch.nn import functional as F
 
 
 def delta_rule_recurrence(q, k, v, beta, initial_state=None, output_final_state=True):

--- a/fla/ops/delta_rule/parallel.py
+++ b/fla/ops/delta_rule/parallel.py
@@ -385,12 +385,13 @@ def naive_delta_rule_parallel(q, k, v, beta, BM=128, BN=32):
 
 if __name__ == "__main__":
     B, H, T, K, V = 2, 4, 512, 64, 64
+    from fla.utils import device
     torch.set_default_dtype(torch.bfloat16)
 
-    q = torch.randn[B, H, T, K].cuda()
-    k = torch.nn.functional.normalize(torch.randn[B, H, T, K].cuda(), p=2, dim=-1)
-    v = torch.randn[B, H, T, V].cuda()
-    beta = torch.ones(B, H, T).cuda()
+    q = torch.randn[B, H, T, K].to(device)
+    k = torch.nn.functional.normalize(torch.randn[B, H, T, K].to(device), p=2, dim=-1)
+    v = torch.randn[B, H, T, V].to(device)
+    beta = torch.ones(B, H, T).to(device)
 
     output_attentions = True
     ref_o, ref_attn = naive_delta_rule_parallel(q.clone(), k.clone(), v.clone(), beta.clone())

--- a/fla/ops/delta_rule/parallel.py
+++ b/fla/ops/delta_rule/parallel.py
@@ -386,10 +386,11 @@ def naive_delta_rule_parallel(q, k, v, beta, BM=128, BN=32):
 if __name__ == "__main__":
     B, H, T, K, V = 2, 4, 512, 64, 64
     from fla.utils import device
+    from torch.nn import functional as F
     torch.set_default_dtype(torch.bfloat16)
 
     q = torch.randn[B, H, T, K].to(device)
-    k = torch.nn.functional.normalize(torch.randn[B, H, T, K].to(device), p=2, dim=-1)
+    k = F.normalize(torch.randn[B, H, T, K].to(device), p=2, dim=-1)
     v = torch.randn[B, H, T, V].to(device)
     beta = torch.ones(B, H, T).to(device)
 

--- a/fla/ops/delta_rule/parallel.py
+++ b/fla/ops/delta_rule/parallel.py
@@ -385,8 +385,9 @@ def naive_delta_rule_parallel(q, k, v, beta, BM=128, BN=32):
 
 if __name__ == "__main__":
     B, H, T, K, V = 2, 4, 512, 64, 64
-    from fla.utils import device
     from torch.nn import functional as F
+
+    from fla.utils import device
     torch.set_default_dtype(torch.bfloat16)
 
     q = torch.randn[B, H, T, K].to(device)

--- a/fla/ops/generalized_delta_rule/dplr/naive.py
+++ b/fla/ops/generalized_delta_rule/dplr/naive.py
@@ -114,6 +114,7 @@ def dplr_chunkwise(q, k, v, alpha, beta, gk, initial_state=None, output_final_st
 
 if __name__ == '__main__':
     from fla.utils import device
+    from torch.nn import functional as F
 
     # disallow tf32
     torch.set_float32_matmul_precision('high')
@@ -127,7 +128,7 @@ if __name__ == '__main__':
     k = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
     v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
 
-    alpha = -torch.nn.functional.normalize(torch.randn(B, H, L, DK).to(device), dim=-1, p=2)
+    alpha = -F.normalize(torch.randn(B, H, L, DK).to(device), dim=-1, p=2)
     beta = -alpha
     alpha = alpha.clone().detach().requires_grad_(True)
     beta = beta.clone().detach().requires_grad_(True)

--- a/fla/ops/generalized_delta_rule/dplr/naive.py
+++ b/fla/ops/generalized_delta_rule/dplr/naive.py
@@ -113,8 +113,9 @@ def dplr_chunkwise(q, k, v, alpha, beta, gk, initial_state=None, output_final_st
 
 
 if __name__ == '__main__':
-    from fla.utils import device
     from torch.nn import functional as F
+
+    from fla.utils import device
 
     # disallow tf32
     torch.set_float32_matmul_precision('high')

--- a/fla/ops/generalized_delta_rule/iplr/naive.py
+++ b/fla/ops/generalized_delta_rule/iplr/naive.py
@@ -75,14 +75,15 @@ if __name__ == '__main__':
     L = 128
     DK = 128
     DV = 128
-    q = (torch.randn(B, H, L, DK)).cuda().requires_grad_(True)
-    k = (torch.randn(B, H, L, DK)).cuda().requires_grad_(True)
-    v = (torch.randn(B, H, L, DV)).cuda().requires_grad_(True)
-    alpha = torch.randn(B, H, L, DK).cuda().softmax(-1).requires_grad_(True)
-    beta = torch.randn(B, H, L, DK).cuda().softmax(-1).requires_grad_(True)
+    from fla.utils import device
+    q = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
+    k = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
+    v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
+    alpha = torch.randn(B, H, L, DK).to(device).softmax(-1).requires_grad_(True)
+    beta = torch.randn(B, H, L, DK).to(device).softmax(-1).requires_grad_(True)
 
     o, s = iplr_recurrence(q, k, v, -alpha, beta)
-    do = torch.randn_like(o).cuda()
+    do = torch.randn_like(o).to(device)
     o.backward(do, retain_graph=True)
     q_grad, q.grad = q.grad, None
     k_grad, k.grad = k.grad, None

--- a/fla/ops/generalized_delta_rule/iplr/naive.py
+++ b/fla/ops/generalized_delta_rule/iplr/naive.py
@@ -67,35 +67,3 @@ def iplr_chunkwise(q, k, v, alpha, beta, initial_state=None, output_final_state=
         S = S + k_i.transpose(-1, -2) @ v_i + beta_i.transpose(-1, -2) @ v2_i
     S = None if output_final_state is False else S
     return rearrange(o, 'b h n c d -> b h (n c) d'), S
-
-
-if __name__ == '__main__':
-    B = 2
-    H = 4
-    L = 128
-    DK = 128
-    DV = 128
-    from fla.utils import device
-    q = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
-    k = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
-    v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
-    alpha = torch.randn(B, H, L, DK).to(device).softmax(-1).requires_grad_(True)
-    beta = torch.randn(B, H, L, DK).to(device).softmax(-1).requires_grad_(True)
-
-    o, s = iplr_recurrence(q, k, v, -alpha, beta)
-    do = torch.randn_like(o).to(device)
-    o.backward(do, retain_graph=True)
-    q_grad, q.grad = q.grad, None
-    k_grad, k.grad = k.grad, None
-    v_grad, v.grad = v.grad, None
-    beta_grad, beta.grad = beta.grad, None
-
-    o2, s2 = iplr_chunkwise(q, k, v, -alpha, beta)
-    o2.backward(do)
-    assert torch.allclose(o, o2, atol=1e-4), breakpoint()
-    assert torch.allclose(s, s2, atol=1e-4), breakpoint()
-    assert torch.allclose(q.grad, q_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(k.grad, k_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(v.grad, v_grad, atol=1e-4), breakpoint()
-    assert torch.allclose(beta.grad, beta_grad, atol=1e-4), breakpoint()
-    print("All passed!")

--- a/fla/ops/rebased/naive.py
+++ b/fla/ops/rebased/naive.py
@@ -26,11 +26,12 @@ if __name__ == "__main__":
     L = 128
     # D = 15
     dtype = torch.float32
-    q = (torch.randn(B, H, L, 16).cuda().to(dtype)).requires_grad_(True)
-    k = (torch.randn(B, H, L, 16).cuda().to(dtype)).requires_grad_(True)
-    v = torch.randn(B, H, L, 128).cuda().to(dtype).requires_grad_(True)
+    from fla.utils import device
+    q = (torch.randn(B, H, L, 16).to(device).to(dtype)).requires_grad_(True)
+    k = (torch.randn(B, H, L, 16).to(device).to(dtype)).requires_grad_(True)
+    v = torch.randn(B, H, L, 128).to(device).to(dtype).requires_grad_(True)
 
-    do = torch.randn_like(v).cuda()
+    do = torch.randn_like(v).to(device)
     ref = naive_parallel_rebased(q, k, v, True, True)
     ref.backward(do, retain_graph=True)
     ref_dq, q.grad = q.grad.clone(), None

--- a/fla/ops/rwkv4/fused_recurrent.py
+++ b/fla/ops/rwkv4/fused_recurrent.py
@@ -450,16 +450,6 @@ class FusedRecurrentRWKV4Function(Function):
     ) -> tuple[Tensor, Tensor]:
         ctx.input_dtype = k.dtype
 
-        if (
-            w.device.type != "cuda"
-            or u.device.type != "cuda"
-            or k.device.type != "cuda"
-            or v.device.type != "cuda"
-        ):
-            raise ValueError(
-                "Calling the CUDA kernel for wkv attention requires all tensors to be on CUDA devices."
-            )
-
         w = -torch.exp(w.float().contiguous())
         if k.dtype == torch.float16:
             u = u.float()

--- a/tests/layers/test_based.py
+++ b/tests/layers/test_based.py
@@ -16,9 +16,10 @@ def test_based(
     H: int,
     dtype: torch.dtype
 ):
-    x = torch.randn(B, T, H).to(dtype).cuda().requires_grad_(True)
-    dy = torch.randn(B, T, H).to(dtype).cuda()
-    model = BasedLinearAttention(H, mode='chunk').to(dtype).cuda()
+    from fla.utils import device
+    x = torch.randn(B, T, H).to(dtype).to(device).requires_grad_(True)
+    dy = torch.randn(B, T, H).to(dtype).to(device)
+    model = BasedLinearAttention(H, mode='chunk').to(dtype).to(device)
     y = model(x)
     y.backward(dy, retain_graph=True)
     x_grad, x.grad = x.grad, None

--- a/tests/layers/test_gla.py
+++ b/tests/layers/test_gla.py
@@ -18,8 +18,9 @@ def test_gla(
     dtype: torch.dtype,
     activation: str
 ):
-    naive = GatedLinearAttention(hidden_size=H, gate_fn=activation, fuse_norm=False).to(dtype).cuda()
-    fused = GatedLinearAttention(hidden_size=H, gate_fn=activation, fuse_norm=True).to(dtype).cuda()
+    from fla.utils import device
+    naive = GatedLinearAttention(hidden_size=H, gate_fn=activation, fuse_norm=False).to(dtype).to(device)
+    fused = GatedLinearAttention(hidden_size=H, gate_fn=activation, fuse_norm=True).to(dtype).to(device)
     fused.q_proj.weight.data.copy_(naive.q_proj.weight.data)
     fused.k_proj.weight.data.copy_(naive.k_proj.weight.data)
     fused.v_proj.weight.data.copy_(naive.v_proj.weight.data)
@@ -29,7 +30,7 @@ def test_gla(
     fused.gk_proj[1].weight.data.copy_(naive.gk_proj[1].weight.data)
     fused.gk_proj[1].bias.data.copy_(naive.gk_proj[1].bias.data)
 
-    x = torch.randn(B, T, H, dtype=dtype).cuda()
+    x = torch.randn(B, T, H, dtype=dtype).to(device)
     naive_x = x.clone().requires_grad_(True)
     fused_x = x.clone().requires_grad_(True)
     naive_o, *_ = naive(naive_x)

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -5,6 +5,7 @@ import torch
 
 from fla.modules.convolution import ShortConvolution
 from fla.ops.common.utils import prepare_position_ids, prepare_sequence_ids
+from fla.utils import device
 
 
 def get_abs_err(x, y):
@@ -29,13 +30,13 @@ def assert_close(prefix, ref, tri, ratio):
 @pytest.mark.parametrize("C", [4])
 def test_shortconv(B: int, T: int, H: int, C: int):
     torch.manual_seed(42)
-    conv_slow = ShortConvolution(H, C, activation='silu', use_fast_conv1d=False).cuda()
-    conv_fast = ShortConvolution(H, C, activation='silu', use_fast_conv1d=True).cuda()
+    conv_slow = ShortConvolution(H, C, activation='silu', use_fast_conv1d=False).to(device)
+    conv_fast = ShortConvolution(H, C, activation='silu', use_fast_conv1d=True).to(device)
     conv_fast.weight.data.copy_(conv_slow.weight.data)
     if conv_fast.bias is not None:
         conv_fast.bias.data.copy_(conv_slow.bias.data)
 
-    x = torch.randn(B, T, H).cuda()
+    x = torch.randn(B, T, H).to(device)
     y_slow, _ = conv_slow(x)
     y_fast, _ = conv_fast(x)
     assert y_slow.shape == x.shape
@@ -49,14 +50,14 @@ def test_shortconv(B: int, T: int, H: int, C: int):
 @pytest.mark.parametrize("C", [4])
 def test_shortconv_varlen(N: int, T: int, H: int, C: int):
     torch.manual_seed(42)
-    conv = ShortConvolution(H, C, activation='silu', use_fast_conv1d=True).cuda()
+    conv = ShortConvolution(H, C, activation='silu', use_fast_conv1d=True).to(device)
     offsets = torch.cat([
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
 
-    x = torch.randn(1, T, H).cuda()
+    x = torch.randn(1, T, H).to(device)
     seq_idx = prepare_sequence_ids(prepare_position_ids(offsets)).to(torch.int32).unsqueeze(0)
 
     ref = torch.cat([conv(x[:, bos:eos].contiguous())[0] for bos, eos in zip(offsets[:-1], offsets[1:])], 1)
@@ -70,14 +71,14 @@ def test_shortconv_varlen(N: int, T: int, H: int, C: int):
 @pytest.mark.parametrize("C", [4])
 def test_shortconv_cache(B: int, T: int, H: int, C: int):
     torch.manual_seed(42)
-    conv_slow = ShortConvolution(H, C, use_fast_conv1d=False).cuda()
-    conv_fast = ShortConvolution(H, C, use_fast_conv1d=True).cuda()
+    conv_slow = ShortConvolution(H, C, use_fast_conv1d=False).to(device)
+    conv_fast = ShortConvolution(H, C, use_fast_conv1d=True).to(device)
     conv_fast.weight.data.copy_(conv_slow.weight.data)
     if conv_fast.bias is not None:
         conv_fast.bias.data.copy_(conv_slow.bias.data)
 
-    x = torch.randn(B, T, H).cuda()
-    mask = torch.randint(T//3, T, (B,)).unsqueeze(-1).gt(torch.arange(T).flip(-1)).bool().cuda()
+    x = torch.randn(B, T, H).to(device)
+    mask = torch.randint(T//3, T, (B,)).unsqueeze(-1).gt(torch.arange(T).flip(-1)).bool().to(device)
     y, _ = conv_slow(x, mask=mask)
     cache_slow, cache_fast = None, None
     for i in range(T):

--- a/tests/ops/test_based.py
+++ b/tests/ops/test_based.py
@@ -5,6 +5,7 @@ import torch
 
 from fla.ops.based import fused_chunk_based, parallel_based
 from fla.ops.based.naive import naive_parallel_based
+from fla.utils import device
 
 
 @pytest.mark.parametrize("B", [4])
@@ -20,9 +21,9 @@ def test_based(
     dtype: torch.dtype
 ):
     torch.manual_seed(42)
-    q = torch.randn((B, H, T, 16), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((B, H, T, 16), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
+    q = torch.randn((B, H, T, 16), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((B, H, T, 16), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
     do = torch.randn_like(v)
     ref = naive_parallel_based(q, k, v, use_norm=True)
     ref.backward(do)

--- a/tests/ops/test_cumsum.py
+++ b/tests/ops/test_cumsum.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from fla.ops.utils.cumsum import chunk_global_cumsum, chunk_local_cumsum
+from fla.utils import device
 
 
 def get_abs_err(x, y):
@@ -56,9 +57,9 @@ def cumsum_global_reference(s, reverse=False, head_first=False):
 @pytest.mark.parametrize("reverse", [False, True])
 def test_cumsum_local_vector(B, T, H, D, dtype, head_first, reverse, chunk_size):
     if head_first:
-        s = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
     else:
-        s = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
     ref = cumsum_local_reference(s, reverse=reverse, head_first=head_first, chunk_size=chunk_size)
     tri = chunk_local_cumsum(s, reverse=reverse, head_first=head_first, chunk_size=chunk_size)
     assert_close("local cumsum vector", ref, tri, 0.001 if dtype == torch.float else 0.003)
@@ -73,9 +74,9 @@ def test_cumsum_local_vector(B, T, H, D, dtype, head_first, reverse, chunk_size)
 @pytest.mark.parametrize("chunk_size", [32, 64])
 def test_cumsum_local_scalar(B, T, H, dtype, head_first, reverse, chunk_size):
     if head_first:
-        s = torch.randn((B, H, T), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, H, T), dtype=dtype, device=device).requires_grad_()
     else:
-        s = torch.randn((B, T, H), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, T, H), dtype=dtype, device=device).requires_grad_()
     ref = cumsum_local_reference(s, reverse=reverse, head_first=head_first, chunk_size=chunk_size)
     tri = chunk_local_cumsum(s, reverse=reverse, head_first=head_first, chunk_size=chunk_size)
     assert_close("local cumsum scalar", ref, tri, 0.001 if dtype == torch.float else 0.003)
@@ -90,9 +91,9 @@ def test_cumsum_local_scalar(B, T, H, dtype, head_first, reverse, chunk_size):
 @pytest.mark.parametrize("reverse", [True, False])
 def test_cumsum_global_vector(B, T, H, D, dtype, head_first, reverse):
     if head_first:
-        s = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
     else:
-        s = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
     ref = cumsum_global_reference(s, reverse=reverse, head_first=head_first)
     tri = chunk_global_cumsum(s, reverse=reverse, head_first=head_first)
     assert_close("global cumsum vector", ref, tri, 0.001 if dtype == torch.float else 0.003)
@@ -106,9 +107,9 @@ def test_cumsum_global_vector(B, T, H, D, dtype, head_first, reverse):
 @pytest.mark.parametrize("reverse", [True, False])
 def test_cumsum_global_scalar(B, T, H, dtype, head_first, reverse):
     if head_first:
-        s = torch.randn((B, H, T), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, H, T), dtype=dtype, device=device).requires_grad_()
     else:
-        s = torch.randn((B, T, H), dtype=dtype, device='cuda').requires_grad_()
+        s = torch.randn((B, T, H), dtype=dtype, device=device).requires_grad_()
     ref = cumsum_global_reference(s, reverse=reverse, head_first=head_first)
     tri = chunk_global_cumsum(s, reverse=reverse, head_first=head_first)
     assert_close("global cumsum scalar", ref, tri, 0.001 if dtype == torch.float else 0.003)

--- a/tests/ops/test_delta.py
+++ b/tests/ops/test_delta.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn.functional as F
 
 from fla.ops.delta_rule import chunk_delta_rule, fused_recurrent_delta_rule
+from fla.utils import device
 
 
 def get_abs_err(x, y):
@@ -53,7 +54,7 @@ def test_chunk(
         v = torch.randn(B, T, H, D, dtype=dtype)
         beta = torch.rand(B, T, H, dtype=dtype).sigmoid()
         h0 = torch.randn(B, H, D, D, dtype=torch.float32)
-    q, k, v, beta, h0 = map(lambda x: x.cuda().requires_grad_(True), (q, k, v, beta, h0))
+    q, k, v, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, beta, h0))
     do = torch.rand_like(v)
     dht = torch.rand_like(h0)
 
@@ -114,14 +115,14 @@ def test_chunk_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
     q = torch.randn((1, T, H, D), dtype=dtype)
     k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
     v = torch.randn((1, T, H, D), dtype=dtype)
     beta = torch.rand(1, T, H, dtype=dtype).sigmoid()
     h0 = torch.randn((N, H, D, D), dtype=dtype)
-    q, k, v, beta, h0 = map(lambda x: x.cuda().requires_grad_(), (q, k, v, beta, h0))
+    q, k, v, beta, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, beta, h0))
     do = torch.randn_like(v)
     dht = torch.rand_like(h0)
 
@@ -183,7 +184,7 @@ def test_l2_in_kernel(
     beta = torch.rand(B, H, T, dtype=dtype).sigmoid()
     h0 = torch.randn(B, H, D, D, dtype=torch.float32)
 
-    q, k, v, beta, h0 = map(lambda x: x.cuda().requires_grad_(True), (q, k, v, beta, h0))
+    q, k, v, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, beta, h0))
     do = torch.rand_like(v)
     dht = torch.rand_like(h0)
 

--- a/tests/ops/test_dplr_delta.py
+++ b/tests/ops/test_dplr_delta.py
@@ -176,7 +176,7 @@ def test_ref_equivalence(
         a = torch.rand(B, T, H, D, dtype=dtype)
         gk = torch.randn(B, T, H, D, dtype=torch.float)
 
-    a = torch.nn.functional.normalize(a, p=2, dim=-1)
+    a = F.normalize(a, p=2, dim=-1)
     b = -a
     gk = torch.nn.functional.logsigmoid(gk) / 16
 
@@ -241,7 +241,7 @@ def test_fused_recurrent_fwd(
         a = torch.rand(B, T, H, D, dtype=dtype)
         gk = torch.randn(B, T, H, D, dtype=torch.float)
 
-    a = torch.nn.functional.normalize(a, p=2, dim=-1)
+    a = F.normalize(a, p=2, dim=-1)
     b = -a
     gk = torch.nn.functional.logsigmoid(gk) / 4
 
@@ -311,7 +311,7 @@ def test_chunk(
         a = torch.rand(B, T, H, D, dtype=dtype)
         gk = torch.randn(B, T, H, D, dtype=torch.float)
 
-    a = torch.nn.functional.normalize(a, p=2, dim=-1)
+    a = F.normalize(a, p=2, dim=-1)
     b = -a
     gk = torch.nn.functional.logsigmoid(gk) / gate_logit_normalizer
 
@@ -393,7 +393,7 @@ def test_chunk_varlen(
     v = torch.randn(1, T, H, D, dtype=dtype)
     a = torch.rand(1, T, H, D, dtype=dtype)
     gk = torch.randn(1, T, H, D, dtype=torch.float)
-    a = torch.nn.functional.normalize(a, p=2, dim=-1)
+    a = F.normalize(a, p=2, dim=-1)
     b = -a
     gk = torch.nn.functional.logsigmoid(gk)
     h0 = torch.randn(N, H, D, D, dtype=torch.float32)

--- a/tests/ops/test_dplr_delta.py
+++ b/tests/ops/test_dplr_delta.py
@@ -7,8 +7,8 @@ import torch
 import torch.nn.functional as F
 from einops import rearrange
 
-from fla.ops.generalized_delta_rule.dplr import (
-    chunk_dplr_delta_rule, fused_recurrent_dplr_delta_rule)
+from fla.ops.generalized_delta_rule.dplr import chunk_dplr_delta_rule, fused_recurrent_dplr_delta_rule
+from fla.utils import device
 from utils import assert_close
 
 
@@ -181,7 +181,7 @@ def test_ref_equivalence(
     gk = torch.nn.functional.logsigmoid(gk) / 16
 
     h0 = torch.randn(B, H, D, D, dtype=torch.float32)
-    q, k, v, a, b, gk, h0 = map(lambda x: x.cuda().requires_grad_(False), (q, k, v, a, b, gk, h0))
+    q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(False), (q, k, v, a, b, gk, h0))
     ref, ref_ht = chunk_dplr_delta_rule_ref(
         q=q.clone(),
         k=k.clone(),
@@ -246,7 +246,7 @@ def test_fused_recurrent_fwd(
     gk = torch.nn.functional.logsigmoid(gk) / 4
 
     h0 = torch.randn(B, H, D, D, dtype=torch.float32)
-    q, k, v, a, b, gk, h0 = map(lambda x: x.cuda().requires_grad_(False), (q, k, v, a, b, gk, h0))
+    q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(False), (q, k, v, a, b, gk, h0))
     ref, ref_ht = recurrent_dplr_delta_rule_ref(
         q=q.clone(),
         k=k.clone(),
@@ -316,7 +316,7 @@ def test_chunk(
     gk = torch.nn.functional.logsigmoid(gk) / gate_logit_normalizer
 
     h0 = torch.randn(B, H, D, D, dtype=torch.float32)
-    q, k, v, a, b, gk, h0 = map(lambda x: x.cuda().requires_grad_(True), (q, k, v, a, b, gk, h0))
+    q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, a, b, gk, h0))
     ref, ref_ht = chunk_dplr_delta_rule_ref(
         q=q.clone(),
         k=k.clone(),
@@ -386,7 +386,7 @@ def test_chunk_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
     q = torch.randn(1, T, H, D, dtype=dtype)
     k = torch.randn(1, T, H, D, dtype=dtype)
@@ -397,7 +397,7 @@ def test_chunk_varlen(
     b = -a
     gk = torch.nn.functional.logsigmoid(gk)
     h0 = torch.randn(N, H, D, D, dtype=torch.float32)
-    q, k, v, a, b, gk, h0 = map(lambda x: x.cuda().requires_grad_(True), (q, k, v, a, b, gk, h0))
+    q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, a, b, gk, h0))
 
     tri, tri_ht = chunk_dplr_delta_rule(
         q=q.clone(),

--- a/tests/ops/test_gsa.py
+++ b/tests/ops/test_gsa.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 
 from fla.ops.gsa import chunk_gsa, fused_recurrent_gsa
 from fla.ops.gsa.naive import naive_recurrent_gsa
+from fla.utils import device
 
 
 def get_abs_err(x, y):
@@ -44,13 +45,13 @@ def test_fused_recurrent(
 ):
     torch.manual_seed(42)
 
-    q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    s = torch.randn((B, H, T, M), dtype=dtype, device='cuda').requires_grad_()
-    g = F.logsigmoid(torch.randn((B, H, T, M), dtype=dtype, device='cuda')).requires_grad_()
-    hk0 = torch.randn(B, H, D, M, device='cuda').requires_grad_()
-    hv0 = torch.randn(B, H, M, D, device='cuda').requires_grad_()
+    q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    s = torch.randn((B, H, T, M), dtype=dtype, device=device).requires_grad_()
+    g = F.logsigmoid(torch.randn((B, H, T, M), dtype=dtype, device=device)).requires_grad_()
+    hk0 = torch.randn(B, H, D, M, device=device).requires_grad_()
+    hv0 = torch.randn(B, H, M, D, device=device).requires_grad_()
 
     do = torch.randn_like(v)
     ref, (ref_hkt, ref_hvt) = naive_recurrent_gsa(q, k, v, s, g, initial_state=(hk0, hv0), output_final_state=True)
@@ -127,15 +128,15 @@ def test_fused_recurrent_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
 
-    q = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    s = torch.randn((1, T, H, M), dtype=dtype, device='cuda').requires_grad_()
-    g = F.logsigmoid(torch.randn((1, T, H, M), dtype=dtype, device='cuda')).requires_grad_()
-    hk0 = torch.randn(N, H, D, M, device='cuda').requires_grad_()
-    hv0 = torch.randn(N, H, M, D, device='cuda').requires_grad_()
+    q = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    s = torch.randn((1, T, H, M), dtype=dtype, device=device).requires_grad_()
+    g = F.logsigmoid(torch.randn((1, T, H, M), dtype=dtype, device=device)).requires_grad_()
+    hk0 = torch.randn(N, H, D, M, device=device).requires_grad_()
+    hv0 = torch.randn(N, H, M, D, device=device).requires_grad_()
 
     do = torch.randn_like(v)
     refs, ref_hkts, ref_hfts = [], [], []
@@ -229,19 +230,19 @@ def test_chunk(
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
     if head_first:
-        q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-        k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-        v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-        s = torch.randn((B, H, T, M), dtype=dtype, device='cuda').requires_grad_()
-        g = (F.logsigmoid(torch.randn((B, H, T, M), dtype=dtype, device='cuda')) / gate_logit_normalizer).requires_grad_()
+        q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+        k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+        v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+        s = torch.randn((B, H, T, M), dtype=dtype, device=device).requires_grad_()
+        g = (F.logsigmoid(torch.randn((B, H, T, M), dtype=dtype, device=device)) / gate_logit_normalizer).requires_grad_()
     else:
-        q = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-        k = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-        v = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-        s = torch.randn((B, T, H, M), dtype=dtype, device='cuda').requires_grad_()
-        g = (F.logsigmoid(torch.randn((B, T, H, M), dtype=dtype, device='cuda')) / gate_logit_normalizer).requires_grad_()
-    hk0 = torch.randn(B, H, D, M, device='cuda').requires_grad_()
-    hv0 = torch.randn(B, H, M, D, device='cuda').requires_grad_()
+        q = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+        k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+        v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+        s = torch.randn((B, T, H, M), dtype=dtype, device=device).requires_grad_()
+        g = (F.logsigmoid(torch.randn((B, T, H, M), dtype=dtype, device=device)) / gate_logit_normalizer).requires_grad_()
+    hk0 = torch.randn(B, H, D, M, device=device).requires_grad_()
+    hv0 = torch.randn(B, H, M, D, device=device).requires_grad_()
 
     do = torch.randn_like(v)
     ref, _ = fused_recurrent_gsa(q, k, v, s, g, initial_state=(hk0, hv0), head_first=head_first)
@@ -289,15 +290,15 @@ def test_chunk_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
-    q = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    s = torch.randn((1, T, H, M), dtype=dtype, device='cuda').requires_grad_()
-    g = F.logsigmoid(torch.randn((1, T, H, M), dtype=dtype, device='cuda')).requires_grad_()
-    hk0 = torch.randn(N, H, D, M, device='cuda').requires_grad_()
-    hv0 = torch.randn(N, H, M, D, device='cuda').requires_grad_()
+    q = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    s = torch.randn((1, T, H, M), dtype=dtype, device=device).requires_grad_()
+    g = F.logsigmoid(torch.randn((1, T, H, M), dtype=dtype, device=device)).requires_grad_()
+    hk0 = torch.randn(N, H, D, M, device=device).requires_grad_()
+    hv0 = torch.randn(N, H, M, D, device=device).requires_grad_()
     do = torch.randn_like(v)
 
     ref, (ref_hkt, ref_hvt) = fused_recurrent_gsa(
@@ -369,13 +370,13 @@ def test_inference(
 ):
     torch.manual_seed(42)
 
-    q = torch.randn((B, HQ, T, D), dtype=dtype, device='cuda')
-    k = torch.randn((B, H, T, D), dtype=dtype, device='cuda')
-    v = torch.randn((B, H, T, D), dtype=dtype, device='cuda')
-    s = torch.randn((B, H, T, M), dtype=dtype, device='cuda')
-    g = F.logsigmoid(torch.randn((B, H, T, M), dtype=dtype, device='cuda'))
-    h0 = (torch.zeros(B, H, D, M, dtype=dtype, device='cuda'),
-          torch.zeros(B, H, M, D, dtype=dtype, device='cuda'))
+    q = torch.randn((B, HQ, T, D), dtype=dtype, device=device)
+    k = torch.randn((B, H, T, D), dtype=dtype, device=device)
+    v = torch.randn((B, H, T, D), dtype=dtype, device=device)
+    s = torch.randn((B, H, T, M), dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn((B, H, T, M), dtype=dtype, device=device))
+    h0 = (torch.zeros(B, H, D, M, dtype=dtype, device=device),
+          torch.zeros(B, H, M, D, dtype=dtype, device=device))
 
     ref, _ = naive_recurrent_gsa(q, k, v, s, g, initial_state=h0)
     tri = torch.empty_like(ref)

--- a/tests/ops/test_hgrn.py
+++ b/tests/ops/test_hgrn.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 
 from fla.ops.hgrn import chunk_hgrn, fused_recurrent_hgrn
 from fla.ops.hgrn.naive import naive_recurrent_hgrn
+from fla.utils import device
 
 
 def get_abs_err(x, y):
@@ -39,8 +40,8 @@ def test_fused_recurrent(
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
-    x = torch.randn((B, T, D), dtype=dtype, device='cuda')
-    g = torch.randn((B, T, D), dtype=dtype, device='cuda')
+    x = torch.randn((B, T, D), dtype=dtype, device=device)
+    g = torch.randn((B, T, D), dtype=dtype, device=device)
     h0 = torch.randn_like(x[:, 0])
     x, g = (1 - g.sigmoid()) * x, F.logsigmoid(g)
     x, g, h0 = (i.detach().clone().to(dtype).requires_grad_() for i in (x, g, h0))
@@ -83,11 +84,11 @@ def test_fused_recurrent_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
 
-    x = torch.randn((1, T, D), dtype=dtype, device='cuda')
-    g = torch.randn((1, T, D), dtype=dtype, device='cuda')
-    h0 = torch.randn(N, D, dtype=dtype, device='cuda')
+    x = torch.randn((1, T, D), dtype=dtype, device=device)
+    g = torch.randn((1, T, D), dtype=dtype, device=device)
+    h0 = torch.randn(N, D, dtype=dtype, device=device)
     x, g = (1 - g.sigmoid()) * x, F.logsigmoid(g)
     x, g, h0 = (i.detach().clone().to(dtype).requires_grad_() for i in (x, g, h0))
 
@@ -136,8 +137,8 @@ def test_chunk(
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
-    x = torch.randn((B, T, D), dtype=dtype, device='cuda')
-    g = torch.randn((B, T, D), dtype=dtype, device='cuda')
+    x = torch.randn((B, T, D), dtype=dtype, device=device)
+    g = torch.randn((B, T, D), dtype=dtype, device=device)
     x, g = (1 - g.sigmoid()) * x, F.logsigmoid(g)
     x, g = (i.detach().clone().to(dtype).requires_grad_() for i in (x, g))
 

--- a/tests/ops/test_iplr_delta.py
+++ b/tests/ops/test_iplr_delta.py
@@ -8,8 +8,8 @@ import torch.nn.functional as F
 from einops import rearrange
 
 from fla.ops.generalized_delta_rule.iplr.chunk import chunk_iplr_delta_rule
-from fla.ops.generalized_delta_rule.iplr.fused_recurrent import \
-    fused_recurrent_iplr_delta_rule
+from fla.ops.generalized_delta_rule.iplr.fused_recurrent import fused_recurrent_iplr_delta_rule
+from fla.utils import device
 from utils import assert_close
 
 
@@ -161,7 +161,7 @@ def test_chunk(
     a = torch.nn.functional.normalize(a, p=2, dim=-1)
     b = -a
     h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
-    q, k, v, a, b, h0 = map(lambda x: x.cuda().requires_grad_(), (q, k, v, a, b, h0))
+    q, k, v, a, b, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, a, b, h0))
     ref, ref_ht = recurrence_iplr_delta_rule_ref(
         q=q.clone(),
         k=k.clone(),
@@ -218,7 +218,7 @@ def test_recurrent(
     a = torch.nn.functional.normalize(a, p=2, dim=-1)
     b = -a
     h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
-    q, k, v, a, b, h0 = map(lambda x: x.cuda().requires_grad_(True), (q, k, v, a, b, h0))
+    q, k, v, a, b, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, a, b, h0))
     ref, ref_ht = recurrence_iplr_delta_rule_ref(
         q=q.clone(),
         k=k.clone(),

--- a/tests/ops/test_iplr_delta.py
+++ b/tests/ops/test_iplr_delta.py
@@ -158,7 +158,7 @@ def test_chunk(
         v = torch.randn(B, T, H, D, dtype=dtype)
         a = torch.rand(B, T, H, D, dtype=dtype)
 
-    a = torch.nn.functional.normalize(a, p=2, dim=-1)
+    a = F.normalize(a, p=2, dim=-1)
     b = -a
     h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
     q, k, v, a, b, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, a, b, h0))
@@ -215,7 +215,7 @@ def test_recurrent(
         v = torch.randn(B, T, H, D, dtype=dtype)
         a = torch.rand(B, T, H, D, dtype=dtype)
 
-    a = torch.nn.functional.normalize(a, p=2, dim=-1)
+    a = F.normalize(a, p=2, dim=-1)
     b = -a
     h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
     q, k, v, a, b, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, a, b, h0))

--- a/tests/ops/test_linear_attn.py
+++ b/tests/ops/test_linear_attn.py
@@ -3,9 +3,9 @@
 import pytest
 import torch
 
-from fla.ops.linear_attn import (chunk_linear_attn, fused_chunk_linear_attn,
-                                 fused_recurrent_linear_attn)
+from fla.ops.linear_attn import chunk_linear_attn, fused_chunk_linear_attn, fused_recurrent_linear_attn
 from fla.ops.linear_attn.naive import naive_chunk_linear_attn
+from fla.utils import device
 
 
 @pytest.mark.parametrize("B", [4])
@@ -22,9 +22,9 @@ def test_fused_recurrent(
 ):
     torch.manual_seed(42)
     atol = 1e-3
-    q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
+    q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
 
     do = torch.randn_like(v)
     ref = naive_chunk_linear_attn(q, k, v, normalize=False)
@@ -59,10 +59,10 @@ def test_chunk(
 ):
     torch.manual_seed(42)
     atol = 1e-3
-    q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    h0 = torch.randn((B, H, D, D), dtype=dtype, device='cuda').requires_grad_()
+    q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    h0 = torch.randn((B, H, D, D), dtype=dtype, device=device).requires_grad_()
     do = torch.randn_like(v)
     ref, ref_ht = fused_recurrent_linear_attn(q, k, v, initial_state=h0, output_final_state=True, normalize=False)
     ref.backward(do)
@@ -97,10 +97,10 @@ def test_fused_chunk(
 ):
     torch.manual_seed(42)
     atol = 1e-3
-    q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-    h0 = torch.zeros((B, H, D, D), dtype=dtype, device='cuda').requires_grad_()
+    q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+    h0 = torch.zeros((B, H, D, D), dtype=dtype, device=device).requires_grad_()
     do = torch.randn_like(v)
     ref, ref_ht = fused_recurrent_linear_attn(q, k, v, initial_state=h0, output_final_state=True, normalize=False)
     ref.backward(do)

--- a/tests/ops/test_nsa.py
+++ b/tests/ops/test_nsa.py
@@ -9,6 +9,7 @@ import triton
 from fla.ops.common.utils import prepare_token_indices
 from fla.ops.nsa.naive import naive_nsa
 from fla.ops.nsa.parallel import parallel_nsa
+from fla.utils import device
 from utils import assert_close
 
 
@@ -35,12 +36,12 @@ def test_parallel(
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
-    q = torch.randn((B, T, HQ, D), dtype=dtype, device='cuda').requires_grad_(True)
-    k = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-    v = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-    do = torch.randn((B, T, HQ, D), dtype=dtype, device='cuda')
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device).requires_grad_(True)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
-    indices = torch.full((B, T, H, S), T, dtype=torch.long, device='cuda')
+    indices = torch.full((B, T, H, S), T, dtype=torch.long, device=device)
     for b in range(B):
         for t in range(T):
             for h in range(H):
@@ -92,14 +93,14 @@ def test_parallel_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
-    q = torch.randn((1, T, HQ, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    do = torch.randn((1, T, HQ, D), dtype=dtype, device='cuda')
+    q = torch.randn((1, T, HQ, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    do = torch.randn((1, T, HQ, D), dtype=dtype, device=device)
 
-    indices = torch.full((1, T, H, S), T, dtype=torch.long, device='cuda')
+    indices = torch.full((1, T, H, S), T, dtype=torch.long, device=device)
     seq_indices = prepare_token_indices(offsets).tolist()
 
     for i in range(T):

--- a/tests/ops/test_retention.py
+++ b/tests/ops/test_retention.py
@@ -5,9 +5,9 @@ import os
 import pytest
 import torch
 
-from fla.ops.retention import (chunk_retention, fused_recurrent_retention,
-                               parallel_retention)
+from fla.ops.retention import chunk_retention, fused_recurrent_retention, parallel_retention
 from fla.ops.retention.naive import naive_retention
+from fla.utils import device
 
 
 def get_abs_err(x, y):
@@ -47,14 +47,14 @@ def test_chunk(
     V = K * expand_ratio
 
     if head_first:
-        q = torch.randn((B, H, T, K), dtype=dtype, device='cuda').requires_grad_()
-        k = torch.randn((B, H, T, K), dtype=dtype, device='cuda').requires_grad_()
-        v = torch.randn((B, H, T, V), dtype=dtype, device='cuda').requires_grad_()
+        q = torch.randn((B, H, T, K), dtype=dtype, device=device).requires_grad_()
+        k = torch.randn((B, H, T, K), dtype=dtype, device=device).requires_grad_()
+        v = torch.randn((B, H, T, V), dtype=dtype, device=device).requires_grad_()
     else:
-        q = torch.randn((B, T, H, K), dtype=dtype, device='cuda').requires_grad_()
-        k = torch.randn((B, T, H, K), dtype=dtype, device='cuda').requires_grad_()
-        v = torch.randn((B, T, H, V), dtype=dtype, device='cuda').requires_grad_()
-    h0 = torch.randn((B, H, K, V), dtype=dtype, device='cuda').requires_grad_()
+        q = torch.randn((B, T, H, K), dtype=dtype, device=device).requires_grad_()
+        k = torch.randn((B, T, H, K), dtype=dtype, device=device).requires_grad_()
+        v = torch.randn((B, T, H, V), dtype=dtype, device=device).requires_grad_()
+    h0 = torch.randn((B, H, K, V), dtype=dtype, device=device).requires_grad_()
 
     do = torch.randn_like(v)
     dht = torch.randn_like(h0)
@@ -100,12 +100,12 @@ def test_chunk_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
-    q = torch.randn((1, T, H, K), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((1, T, H, K), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((1, T, H, V), dtype=dtype, device='cuda').requires_grad_()
-    h0 = torch.randn((N, H, K, V), dtype=dtype, device='cuda').requires_grad_()
+    q = torch.randn((1, T, H, K), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, K), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, V), dtype=dtype, device=device).requires_grad_()
+    h0 = torch.randn((N, H, K, V), dtype=dtype, device=device).requires_grad_()
     do = torch.randn_like(v)
     dht = torch.randn_like(h0)
 
@@ -164,9 +164,9 @@ def test_parallel(
     torch.manual_seed(42)
     V = K * expand_ratio
 
-    q = torch.randn((B, H, T, K), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((B, H, T, K), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((B, H, T, V), dtype=dtype, device='cuda').requires_grad_()
+    q = torch.randn((B, H, T, K), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((B, H, T, K), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((B, H, T, V), dtype=dtype, device=device).requires_grad_()
     do = torch.randn_like(v)
 
     ref = naive_retention(q, k, v)

--- a/tests/ops/test_rwkv6.py
+++ b/tests/ops/test_rwkv6.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 
 from fla.ops.rwkv6 import chunk_rwkv6
 from fla.ops.rwkv6.fused_recurrent import fused_recurrent_rwkv6
+from fla.utils import device
 
 
 def get_abs_err(x, y):
@@ -46,18 +47,18 @@ def test_chunk(
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
     if head_first:
-        q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-        k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-        v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_()
-        w = F.logsigmoid(torch.randn((B, H, T, D), dtype=dtype, device='cuda')) / gate_logit_normalizer
+        q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+        k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+        v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
+        w = F.logsigmoid(torch.randn((B, H, T, D), dtype=dtype, device=device)) / gate_logit_normalizer
     else:
-        q = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-        k = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-        v = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-        w = F.logsigmoid(torch.randn((B, T, H, D), dtype=dtype, device='cuda')) / gate_logit_normalizer
+        q = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+        k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+        v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+        w = F.logsigmoid(torch.randn((B, T, H, D), dtype=dtype, device=device)) / gate_logit_normalizer
 
-    u = torch.randn(H, D, dtype=dtype, device='cuda').requires_grad_(True)
-    h0 = torch.randn(B, H, D, D, dtype=dtype, device='cuda').requires_grad_()
+    u = torch.randn(H, D, dtype=dtype, device=device).requires_grad_(True)
+    h0 = torch.randn(B, H, D, D, dtype=dtype, device=device).requires_grad_()
     w = w.requires_grad_()
     do = torch.randn_like(v)
 
@@ -132,14 +133,14 @@ def test_chunk_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
-    q = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    w = F.logsigmoid(torch.randn((1, T, H, D), dtype=dtype, device='cuda')).requires_grad_(True)
-    u = torch.randn(H, D, dtype=dtype, device='cuda').requires_grad_(True)
-    h0 = torch.randn((N, H, D, D), dtype=dtype, device='cuda').requires_grad_()
+    q = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    w = F.logsigmoid(torch.randn((1, T, H, D), dtype=dtype, device=device)).requires_grad_(True)
+    u = torch.randn(H, D, dtype=dtype, device=device).requires_grad_(True)
+    h0 = torch.randn((N, H, D, D), dtype=dtype, device=device).requires_grad_()
     do = torch.randn_like(v)
 
     ref, ref_ht = fused_recurrent_rwkv6(

--- a/tests/ops/test_simple_gla.py
+++ b/tests/ops/test_simple_gla.py
@@ -11,6 +11,7 @@ from einops import rearrange
 from fla.ops.simple_gla import chunk_simple_gla
 from fla.ops.simple_gla.fused_recurrent import fused_recurrent_simple_gla
 from fla.ops.simple_gla.parallel import parallel_simple_gla
+from fla.utils import device
 from utils import assert_close
 
 
@@ -117,16 +118,16 @@ def test_chunk(
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     # [B, H, T, D]
     if head_first:
-        q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_(True)
-        k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_(True)
-        v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_(True)
-        g = torch.randn((B, H, T), dtype=torch.float32, device='cuda')
+        q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_(True)
+        k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_(True)
+        v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_(True)
+        g = torch.randn((B, H, T), dtype=torch.float32, device=device)
     else:
-        q = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-        k = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-        v = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-        g = torch.randn((B, T, H), dtype=torch.float32, device='cuda')
-    h0 = torch.rand((B, H, D, D), dtype=torch.float32, device='cuda').requires_grad_(True)
+        q = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+        k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+        v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+        g = torch.randn((B, T, H), dtype=torch.float32, device=device)
+    h0 = torch.rand((B, H, D, D), dtype=torch.float32, device=device).requires_grad_(True)
     dht = torch.randn_like(h0)
     g = (F.logsigmoid(g) / gate_logit_normalizer).requires_grad_(True)
     do = torch.randn_like(v)
@@ -184,13 +185,13 @@ def test_chunk_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
-    q = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    g = F.logsigmoid(torch.randn((1, T, H), dtype=dtype, device='cuda')).requires_grad_()
-    h0 = torch.randn((N, H, D, D), dtype=torch.float32, device='cuda').requires_grad_()
+    q = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    g = F.logsigmoid(torch.randn((1, T, H), dtype=dtype, device=device)).requires_grad_()
+    h0 = torch.randn((N, H, D, D), dtype=torch.float32, device=device).requires_grad_()
     do = torch.randn_like(v)
 
     ref, ref_ht = fused_recurrent_simple_gla(
@@ -256,12 +257,12 @@ def test_parallel_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 1)[:N-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
     # seq-first required for inputs with variable lengths
-    q = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    k = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    v = torch.randn((1, T, H, D), dtype=dtype, device='cuda').requires_grad_()
-    g = F.logsigmoid(torch.randn((1, T, H), dtype=dtype, device='cuda')).requires_grad_()
+    q = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
+    g = F.logsigmoid(torch.randn((1, T, H), dtype=dtype, device=device)).requires_grad_()
     do = torch.randn_like(v)
 
     ref, _ = fused_recurrent_simple_gla(
@@ -322,15 +323,15 @@ def test_parallel(
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     USE_G = gate_logit_normalizer > 0
     if head_first:
-        q = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_(True)
-        k = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_(True)
-        v = torch.randn((B, H, T, D), dtype=dtype, device='cuda').requires_grad_(True)
-        g = F.logsigmoid(torch.randn((B, H, T), dtype=dtype, device='cuda')) if USE_G else None
+        q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_(True)
+        k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_(True)
+        v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_(True)
+        g = F.logsigmoid(torch.randn((B, H, T), dtype=dtype, device=device)) if USE_G else None
     else:
-        q = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-        k = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-        v = torch.randn((B, T, H, D), dtype=dtype, device='cuda').requires_grad_(True)
-        g = F.logsigmoid(torch.randn((B, T, H), dtype=dtype, device='cuda')) if USE_G else None
+        q = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+        k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+        v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+        g = F.logsigmoid(torch.randn((B, T, H), dtype=dtype, device=device)) if USE_G else None
     g = (g / gate_logit_normalizer).requires_grad_(True) if USE_G else None
     do = torch.randn_like(v)
 
@@ -379,7 +380,6 @@ def test_simple_gla_to_mamba2(vary_A, dtype):
     n_heads = dim // headdim  # (H) in the paper
     ngroups = n_heads  # (G) in the paper; NOTE: do not use group-query here
     dstate = 64  # (N) in the paper
-    device = "cuda"
     atol = 5e-4 if dtype == torch.float else 1e-2
 
     x = 0.1 * torch.randn(batch, seq_len, n_heads, headdim, dtype=dtype, device=device)

--- a/tests/ops/test_titans.py
+++ b/tests/ops/test_titans.py
@@ -6,6 +6,8 @@ import torch.nn.functional as F
 from ops.titans.fused_chunk import fused_chunk_titans_linear
 from ops.titans.naive import chunk_titans_linear_ref
 
+from fla.utils import device
+
 
 def get_abs_err(x, y):
     return (x - y).flatten().abs().max().item()
@@ -88,10 +90,10 @@ def test_naive_chunk_fwd(
         alpha = alpha.permute(0, 2, 1, 3)
         eta = eta.permute(0, 2, 1, 3)
     q, k, v, w, b, theta, alpha, eta = map(
-        lambda x: x.cuda().requires_grad_(False), (q, k, v, w, b, theta, alpha, eta)
+        lambda x: x.to(device).requires_grad_(False), (q, k, v, w, b, theta, alpha, eta)
     )
     # in titans paper, h0 is not learnable
-    h0 = h0.cuda()
+    h0 = h0.to(device)
 
     ref_naive, ref_ht_naive = chunk_titans_linear_ref(
         q.clone(),
@@ -177,10 +179,10 @@ def test_fused_chunk_fwd(
         alpha = alpha.permute(0, 2, 1, 3)
         eta = eta.permute(0, 2, 1, 3)
     q, k, v, w, b, theta, alpha, eta = map(
-        lambda x: x.cuda().requires_grad_(False), (q, k, v, w, b, theta, alpha, eta)
+        lambda x: x.to(device).requires_grad_(False), (q, k, v, w, b, theta, alpha, eta)
     )
     # in titans paper, h0 is not learnable
-    h0 = h0.cuda()
+    h0 = h0.to(device)
 
     ref_naive, ref_ht_naive = fused_chunk_titans_linear(
         q.clone(),

--- a/tests/ops/test_utils.py
+++ b/tests/ops/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from fla.ops.utils import chunk_global_cumsum, chunk_local_cumsum, mean_pooling
+from fla.utils import device
 
 
 def reversed_cumsum(x, dim=-1):
@@ -29,12 +30,12 @@ def test_global_cumsum(
     head_first: bool
 ):
     torch.manual_seed(42)
-    s = torch.randn(B, H, T, dtype=dtype).cuda() if head_first else torch.randn(B, T, H, dtype=dtype).cuda()
+    s = torch.randn(B, H, T, dtype=dtype).to(device) if head_first else torch.randn(B, T, H, dtype=dtype).to(device)
     ref = s.float().cumsum(2 if head_first else 1).to(dtype)
     tri = chunk_global_cumsum(s, dtype, head_first=head_first)
     torch.testing.assert_close(ref, tri)
 
-    s = torch.randn(B, H, T, D, dtype=dtype).cuda() if head_first else torch.randn(B, T, H, D, dtype=dtype).cuda()
+    s = torch.randn(B, H, T, D, dtype=dtype).to(device) if head_first else torch.randn(B, T, H, D, dtype=dtype).to(device)
     ref = s.float().cumsum(2 if head_first else 1).to(dtype)
     tri = chunk_global_cumsum(s, dtype, head_first=head_first)
     torch.testing.assert_close(ref, tri)
@@ -57,13 +58,13 @@ def test_global_cumsum_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(1, T)[torch.randperm(T - 1)[:B-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
-    s = torch.randn(1, T, H, dtype=dtype).cuda()
+    ], 0).to(device).sort()[0]
+    s = torch.randn(1, T, H, dtype=dtype).to(device)
     ref = torch.cat([s[:, start:end].float().cumsum(1) for start, end in zip(offsets[:-1], offsets[1:])], 1).to(dtype)
     tri = chunk_global_cumsum(s, dtype, offsets=offsets, head_first=False)
     torch.testing.assert_close(ref, tri)
 
-    s = torch.randn(1, T, H, D, dtype=dtype).cuda()
+    s = torch.randn(1, T, H, D, dtype=dtype).to(device)
     ref = torch.cat([s[:, start:end].float().cumsum(1) for start, end in zip(offsets[:-1], offsets[1:])], 1).to(dtype)
     tri = chunk_global_cumsum(s, dtype, offsets=offsets, head_first=False)
     torch.testing.assert_close(ref, tri)
@@ -84,12 +85,12 @@ def test_global_reversed_cumsum(
     head_first: bool
 ):
     torch.manual_seed(42)
-    s = torch.randn(B, H, T, dtype=dtype).cuda() if head_first else torch.randn(B, T, H, dtype=dtype).cuda()
+    s = torch.randn(B, H, T, dtype=dtype).to(device) if head_first else torch.randn(B, T, H, dtype=dtype).to(device)
     ref = reversed_cumsum(s, dim=(2 if head_first else 1)).to(dtype)
     tri = chunk_global_cumsum(s, dtype, reverse=True, head_first=head_first)
     torch.testing.assert_close(ref, tri)
 
-    s = torch.randn(B, H, T, D, dtype=dtype).cuda() if head_first else torch.randn(B, T, H, D, dtype=dtype).cuda()
+    s = torch.randn(B, H, T, D, dtype=dtype).to(device) if head_first else torch.randn(B, T, H, D, dtype=dtype).to(device)
     ref = reversed_cumsum(s, dim=(2 if head_first else 1)).to(dtype)
     tri = chunk_global_cumsum(s, dtype, reverse=True, head_first=head_first)
     torch.testing.assert_close(ref, tri)
@@ -112,13 +113,13 @@ def test_global_reversed_cumsum_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(1, T)[torch.randperm(T - 1)[:B-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
-    s = torch.randn(1, T, H, dtype=dtype).cuda()
+    ], 0).to(device).sort()[0]
+    s = torch.randn(1, T, H, dtype=dtype).to(device)
     ref = torch.cat([reversed_cumsum(s[:, start:end], 1) for start, end in zip(offsets[:-1], offsets[1:])], 1).to(dtype)
     tri = chunk_global_cumsum(s, dtype, reverse=True, offsets=offsets, head_first=False)
     torch.testing.assert_close(ref, tri)
 
-    s = torch.randn(1, T, H, D, dtype=dtype).cuda()
+    s = torch.randn(1, T, H, D, dtype=dtype).to(device)
     ref = torch.cat([reversed_cumsum(s[:, start:end], 1) for start, end in zip(offsets[:-1], offsets[1:])], 1).to(dtype)
     tri = chunk_global_cumsum(s, dtype, reverse=True, offsets=offsets, head_first=False)
     torch.testing.assert_close(ref, tri)
@@ -141,7 +142,7 @@ def test_local_cumsum(
     head_first: bool
 ):
     torch.manual_seed(42)
-    s = torch.randn(B, H, T, dtype=dtype).cuda() if head_first else torch.randn(B, T, H, dtype=dtype).cuda()
+    s = torch.randn(B, H, T, dtype=dtype).to(device) if head_first else torch.randn(B, T, H, dtype=dtype).to(device)
     if head_first:
         ref = torch.cat([s[:, :, i:i+C].float().cumsum(2) for i in range(0, T, C)], 2)
     else:
@@ -149,7 +150,7 @@ def test_local_cumsum(
     tri = chunk_local_cumsum(s, chunk_size=C, head_first=head_first)
     torch.testing.assert_close(ref, tri)
 
-    s = torch.randn(B, H, T, D, dtype=dtype).cuda() if head_first else torch.randn(B, T, H, D, dtype=dtype).cuda()
+    s = torch.randn(B, H, T, D, dtype=dtype).to(device) if head_first else torch.randn(B, T, H, D, dtype=dtype).to(device)
     if head_first:
         ref = torch.cat([s[:, :, i:i+C].float().cumsum(2) for i in range(0, T, C)], 2)
     else:
@@ -177,8 +178,8 @@ def test_local_cumsum_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(1, T)[torch.randperm(T - 1)[:B-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
-    s = torch.randn(1, T, H, dtype=dtype).cuda()
+    ], 0).to(device).sort()[0]
+    s = torch.randn(1, T, H, dtype=dtype).to(device)
     ref = torch.cat([
         torch.cat([s[:, i:min(end, i+C), :].float().cumsum(1) for i in range(start, end, C)], 1)
         for start, end in zip(offsets[:-1], offsets[1:])
@@ -186,7 +187,7 @@ def test_local_cumsum_varlen(
     tri = chunk_local_cumsum(s, chunk_size=C, offsets=offsets, head_first=False)
     torch.testing.assert_close(ref, tri)
 
-    s = torch.randn(1, T, H, D, dtype=dtype).cuda()
+    s = torch.randn(1, T, H, D, dtype=dtype).to(device)
     ref = torch.cat([
         torch.cat([s[:, i:min(end, i+C), :].float().cumsum(1) for i in range(start, end, C)], 1)
         for start, end in zip(offsets[:-1], offsets[1:])
@@ -212,7 +213,7 @@ def test_mean_pooling(
     head_first: bool
 ):
     torch.manual_seed(42)
-    x = torch.randn(B, H, T, D, dtype=dtype).cuda() if head_first else torch.randn(B, T, H, D, dtype=dtype).cuda()
+    x = torch.randn(B, H, T, D, dtype=dtype).to(device) if head_first else torch.randn(B, T, H, D, dtype=dtype).to(device)
     x.requires_grad = True
     if head_first:
         ref = torch.cat([x[:, :, i:i+C].float().mean(2, True) for i in range(0, T, C)], 2).to(dtype)
@@ -249,9 +250,9 @@ def test_mean_pooling_varlen(
         torch.tensor([0], dtype=torch.long),
         torch.arange(1, T)[torch.randperm(T - 1)[:B-1]],
         torch.tensor([T], dtype=torch.long)
-    ], 0).cuda().sort()[0]
+    ], 0).to(device).sort()[0]
 
-    x = torch.randn(1, T, H, D, dtype=dtype).cuda().requires_grad_(True)
+    x = torch.randn(1, T, H, D, dtype=dtype).to(device).requires_grad_(True)
     ref = torch.cat([
         torch.cat([x[:, i:min(end, i+C), :].float().mean(1, True) for i in range(start, end, C)], 1)
         for start, end in zip(offsets[:-1], offsets[1:])

--- a/tests/test_fused_chunk.py
+++ b/tests/test_fused_chunk.py
@@ -101,10 +101,12 @@ if __name__ == '__main__':
     B, H, T, D = 2, 8, 1024, 128
     dtype = torch.float
     torch.manual_seed(42)
+    from fla.utils import device
+
     # [batch_size, n_heads, seq_len, d_head]
-    q = torch.randn((B, H, T, D), dtype=dtype, device='cuda')
-    k = torch.randn((B, H, T, D), dtype=dtype, device='cuda')
-    v = torch.randn((B, H, T, D), dtype=dtype, device='cuda')
+    q = torch.randn((B, H, T, D), dtype=dtype, device=device)
+    k = torch.randn((B, H, T, D), dtype=dtype, device=device)
+    v = torch.randn((B, H, T, D), dtype=dtype, device=device)
 
     ref = AttentionFunction.apply(q, k, v)
     infos = torch.cuda.get_device_properties(q)

--- a/utils/convert_from_rwkv6.py
+++ b/utils/convert_from_rwkv6.py
@@ -28,7 +28,7 @@ import torch
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 import fla  # noqa
-
+from fla.utils import device
 
 def sizeof_fmt(num, suffix='B'):
     for unit in ('', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi'):
@@ -45,11 +45,11 @@ def convert(
 ):
     torch.manual_seed(1)
     AutoTokenizer.from_pretrained(rwkv6, trust_remote_code=True).save_pretrained(output)
-    rwkv6 = AutoModelForCausalLM.from_pretrained(rwkv6, trust_remote_code=True).cuda()
+    rwkv6 = AutoModelForCausalLM.from_pretrained(rwkv6, trust_remote_code=True).to(device)
     print(f"Loading rwkv6 ...\n{rwkv6}")
 
     config = AutoConfig.from_pretrained(config)
-    model = AutoModelForCausalLM.from_config(config).cuda()
+    model = AutoModelForCausalLM.from_config(config).to(device)
     num_parameters = model.num_parameters()
     print(f"Initializing the model from the config:\n{config}\n{model}")
     print(f"Number of parameters in total: {num_parameters} ({sizeof_fmt(num_parameters)})")

--- a/utils/convert_from_rwkv6.py
+++ b/utils/convert_from_rwkv6.py
@@ -30,6 +30,7 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 import fla  # noqa
 from fla.utils import device
 
+
 def sizeof_fmt(num, suffix='B'):
     for unit in ('', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi'):
         if abs(num) < 1024.0:


### PR DESCRIPTION

This pull request aims to enhance the project's compatibility by adding preliminary support for multiple backends. Triton, a powerful framework, is well - known for its extensive support across a wide range of hardware backends, including AMD, NVIDIA, and Intel. Additionally, it has shown great potential in supporting certain Chinese - made hardware, such as GPUs from companies like MetaX, Moore Threads, and iluvatar. This PR takes a step forward in leveraging Triton's capabilities to integrate these diverse backends into our project.

#### Changes Made
**Backend Detection**: Implemented a mechanism to detect the availability of different backends at runtime. This includes checking for the presence of hardware from AMD, NVIDIA, and Intel, as well as the newly supported Chinese - made hardware from MetaX, Moore Threads, and iluvatar.


#### Testing
- Conducted a series of tests on various hardware platforms, including AMD, NVIDIA, and Intel GPUs.
- All existing test cases were re - run to ensure that the changes did not break any existing functionality.


By adding support for these multiple backends, we believe that FLA project will become more accessible and versatile, catering to a broader range of users and hardware configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line option to specify the runtime device for model inference.
  - Added new benchmarking utilities to capture backward pass performance.

- **Refactor**
  - Updated device management across the codebase, replacing fixed GPU calls with a flexible device abstraction.
  - Standardized tensor allocation in tests and runtime, enabling seamless switching between hardware configurations.
  - Simplified function calls by using aliases for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->