### PR TITLE
Device banckend enhance3

### DIFF
--- a/fla/modules/activations.py
+++ b/fla/modules/activations.py
@@ -3,360 +3,19 @@
 
 import torch
 import torch.nn.functional as F
-import triton
-import triton.language as tl
-
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
-
-sigmoid_fwd_codestring = """
-template <typename T> T sigmoid_fwd(T x) {
-    return 1.0f / (1.0f + ::exp(-float(x)));
-}
-"""
-sigmoid_bwd_codestring = """
-template <typename T> T sigmoid_bwd(T x, T g) {
-    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
-    return float(g) * x_sigmoid * (1.0f - x_sigmoid);
-}
-"""
-
-sigmoid_fwd_jit_fn = torch.cuda.jiterator._create_jit_fn(sigmoid_fwd_codestring)
-sigmoid_bwd_jit_fn = torch.cuda.jiterator._create_jit_fn(sigmoid_bwd_codestring)
-
-
-@torch.compiler.disable
-def sigmoid_fwd(x):
-    return sigmoid_fwd_jit_fn(x)
-
-
-@torch.compiler.disable
-def sigmoid_bwd(x, g):
-    return sigmoid_bwd_jit_fn(x, g)
-
-
-class SigmoidFunction(torch.autograd.Function):
-
-    @staticmethod
-    def forward(ctx, x):
-        ctx.save_for_backward(x)
-        return sigmoid_fwd(x)
-
-    @staticmethod
-    def backward(ctx, dout):
-        x, = ctx.saved_tensors
-        return sigmoid_bwd(x, dout)
-
-
-sigmoid = SigmoidFunction.apply
-
-
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4, 8, 16, 32]
-    ],
-    key=['D']
-)
-@triton.jit
-def logsigmoid_fwd_kernel(
-    x,
-    y,
-    temperature,
-    T: tl.constexpr,
-    D: tl.constexpr,
-    B: tl.constexpr
-):
-    i = tl.program_id(0)
-    o_i = i * B + tl.arange(0, B)
-    m_i = o_i < T
-
-    b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
-    b_m = tl.minimum(0., b_x)
-    b_z = 1. + tl.exp(-tl.abs(b_x))
-    b_y = (b_m - tl.log(b_z)) / temperature
-    tl.store(y + o_i, b_y.to(y.dtype.element_ty), mask=m_i)
-
-
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4, 8, 16, 32]
-    ],
-    key=['D']
-)
-@triton.jit
-def logsigmoid_bwd_kernel(
-    x,
-    dx,
-    dy,
-    temperature,
-    T: tl.constexpr,
-    D: tl.constexpr,
-    B: tl.constexpr
-):
-    i = tl.program_id(0)
-    o_i = i * B + tl.arange(0, B)
-    m_i = o_i < T
-
-    b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
-    b_dy = tl.load(dy + o_i, mask=m_i, other=0.).to(tl.float32)
-    b_dx = b_dy * (1. - tl.sigmoid(b_x)) / temperature
-    tl.store(dx + o_i, b_dx.to(dx.dtype.element_ty), mask=m_i)
-
-
-def logsigmoid_fwd(x: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
-    T, D = x.numel(), x.shape[-1]
-    B = triton.next_power_of_2(triton.cdiv(T, torch.cuda.get_device_properties(x.device).multi_processor_count))
-    y = torch.empty_like(x)
-    logsigmoid_fwd_kernel[(triton.cdiv(T, B),)](
-        x=x,
-        y=y,
-        temperature=temperature,
-        T=T,
-        D=D,
-        B=B
-    )
-    return y
-
-
-def logsigmoid_bwd(x: torch.Tensor, dy: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
-    T, D = x.numel(), x.shape[-1]
-    B = triton.next_power_of_2(triton.cdiv(T, torch.cuda.get_device_properties(x.device).multi_processor_count))
-    dx = torch.empty_like(x)
-    logsigmoid_bwd_kernel[(triton.cdiv(T, B),)](
-        x=x,
-        dx=dx,
-        dy=dy,
-        temperature=temperature,
-        T=T,
-        D=D,
-        B=B
-    )
-    return dx
-
-
-class LogSigmoidFunction(torch.autograd.Function):
-
-    @staticmethod
-    @contiguous
-    def forward(ctx, x, temperature):
-        ctx.save_for_backward(x,)
-        ctx.temperature = temperature
-        return logsigmoid_fwd(x, temperature)
-
-    @staticmethod
-    @contiguous
-    def backward(ctx, dy):
-        x, = ctx.saved_tensors
-        return logsigmoid_bwd(x, dy, ctx.temperature), None
-
-
-def logsigmoid(x: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
-    return LogSigmoidFunction.apply(x, temperature)
-
-
-swish_fwd_codestring = """
-template <typename T> T swish_fwd(T x) {
-    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
-    return float(x) * x_sigmoid;
-}
-"""
-swish_bwd_codestring = """
-template <typename T> T swish_bwd(T x, T g) {
-    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
-    return float(g) * x_sigmoid * (1.0f - float(x) * x_sigmoid + float(x));
-}
-"""
-
-swish_fwd_jit_fn = torch.cuda.jiterator._create_jit_fn(swish_fwd_codestring)
-swish_bwd_jit_fn = torch.cuda.jiterator._create_jit_fn(swish_bwd_codestring)
-
-
-@torch.compiler.disable
-def swish_fwd(x):
-    return swish_fwd_jit_fn(x)
-
-
-@torch.compiler.disable
-def swish_bwd(x, g):
-    return swish_bwd_jit_fn(x, g)
-
-
-class SwishFunction(torch.autograd.Function):
-
-    @staticmethod
-    def forward(ctx, x):
-        ctx.save_for_backward(x)
-        return swish_fwd(x)
-
-    @staticmethod
-    def backward(ctx, dout):
-        x, = ctx.saved_tensors
-        return swish_bwd(x, dout)
-
-
-swish = SwishFunction.apply
-
-# 1/sqrt(2*pi)-> 0.3989423
-# 1/sqrt(2)   -> 0.70710678
-# sqrt(2/pi)  -> 0.79788456
-
-
-# this function is tanh approximation of gelu
-# actual gelu is:
-# x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
-@torch.jit.script
-def bias_gelu(y, bias):
-    x = bias + y
-    return (x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))).to(dtype=y.dtype)
-
-
-# gradient of tanh approximation of gelu
-# gradient of actual gelu is:
-# 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
-@torch.jit.script
-def bias_gelu_bwd(g, y, bias):
-    """Assume that y has shape (B, D) and bias has shape (D)"""
-    x = bias + y
-    tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
-    # sqrt(2/pi) * 3 * 0.044715 -> 0.1070322243
-    ff = 0.5 * x * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)) + 0.5 * (
-        1 + tanh_out
-    )
-    grad_y = ff * g
-    return grad_y.to(dtype=y.dtype), grad_y.sum(dim=(0), dtype=bias.dtype)
-
-
-class GeLUFunction(torch.autograd.Function):
-
-    @staticmethod
-    # bias is an optional argument
-    def forward(ctx, input, bias):
-        ctx.save_for_backward(input, bias)
-        return bias_gelu(input, bias)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        input, bias = ctx.saved_tensors
-        tmp = bias_gelu_bwd(grad_output, input, bias)
-        return tmp, tmp
-
-
-bias_gelu_impl = GeLUFunction.apply
-
-
-# this function is tanh approximation of gelu
-# actual gelu is:
-# x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
-@torch.jit.script
-def gelu_fwd(x):
-    return (x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))).to(dtype=x.dtype)
-
-
-# gradient of tanh approximation of gelu
-# gradient of actual gelu is:
-# 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
-@torch.jit.script
-def gelu_bwd(g, x):
-    tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
-    # sqrt(2/pi) * 3 * 0.044715 -> 0.1070322243
-    ff = 0.5 * x * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)) + 0.5 * (
-        1 + tanh_out
-    )
-    return (ff * g).to(dtype=x.dtype)
-
-
-class FastGeLUFunction(torch.autograd.Function):
-    @staticmethod
-    # bias is an optional argument
-    def forward(ctx, input):
-        ctx.save_for_backward(input)
-        return gelu_fwd(input)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        (input,) = ctx.saved_tensors
-        tmp = gelu_bwd(grad_output, input)
-        return tmp
-
-
-fast_gelu_impl = FastGeLUFunction.apply
-
-
-@torch.jit.script
-def relu_bwd(g, x):
-    return torch.where(x >= 0, g, 0.0).to(dtype=x.dtype)
-
-
-@torch.jit.script
-def sqrelu_fwd(x):
-    r = F.relu(x.float())
-    return (r * r).to(dtype=x.dtype)
-
-
-@torch.jit.script
-def sqrelu_bwd(g, x):
-    return (2.0 * g * F.relu(x.float())).to(dtype=x.dtype)
-
-
-class SquaredReLUFunction(torch.autograd.Function):
-
-    @staticmethod
-    def forward(ctx, input):
-        ctx.save_for_backward(input)
-        return sqrelu_fwd(input)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        input, = ctx.saved_tensors
-        return sqrelu_bwd(grad_output, input)
-
-
-sqrelu = SquaredReLUFunction.apply
-
-
-swiglu_fwd_codestring = """
-template <typename T> T swiglu_fwd(T x, T y) {
-    return float(x) * float(y) / (1.0f + ::exp(-float(x)));
-}
-"""
-swiglu_bwd_codestring = """
-template <typename T> T swiglu_bwd(T x, T y, T g, T& dx, T& dy) {
-    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
-    dx = x_sigmoid * (1 + float(x) * (1.0f - x_sigmoid)) * float(g) * float(y);
-    dy = float(x) * x_sigmoid * float(g);
-}
-"""
-
-swiglu_fwdbwd_codestring = """
-template <typename T> T swiglu_fwdbwd(T x, T y, T g, T& dx, T& dy, T& z) {
-    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
-    float x_swish = float(x) * x_sigmoid;
-    dx = x_sigmoid * (1 + float(x) * (1.0f - x_sigmoid)) * float(g) * float(y);
-    dy = x_swish * float(g);
-    z = x_swish * float(y);
-}
-"""
-
-
-swiglu_fwd_jit_fn = torch.cuda.jiterator._create_jit_fn(swiglu_fwd_codestring)
-swiglu_bwd_jit_fn = torch.cuda.jiterator._create_multi_output_jit_fn(swiglu_bwd_codestring, num_outputs=2)
-swiglu_fwdbwd_jit_fn = torch.cuda.jiterator._create_multi_output_jit_fn(swiglu_fwdbwd_codestring, num_outputs=3)
-
-
-@torch.compiler.disable
-def swiglu_fwd(x, y):
-    return swiglu_fwd_jit_fn(x, y)
-
-
-@torch.compiler.disable
-def swiglu_bwd(x, y, g):
-    return swiglu_bwd_jit_fn(x, y, g)
-
-
-@torch.compiler.disable
-def swiglu_fwdbwd(x, y, g):
-    return swiglu_fwdbwd_jit_fn(x, y, g)
+from fla.utils import (autocast_custom_bwd, autocast_custom_fwd,
+                       contiguous, device)
+from fla.modules.activations_triton import (logsigmoid_fwd,
+                                            logsigmoid_bwd)
+
+if device == 'cuda':
+    from fla.modules.activations_cuda import (sigmoid, swish, swiglu_fwd,
+                                              swiglu_bwd, swiglu_fwdbwd)
+else:
+    sigmoid = F.sigmoid
+    swish = F.silu
+    from fla.modules.activations_triton import (swiglu_fwd, swiglu_bwd,
+                                                swiglu_fwdbwd)
 
 
 @torch.jit.script
@@ -452,10 +111,137 @@ class SwiGLULinearFunction(torch.autograd.Function):
         return dx, dy, dlinear_weight, dlinear_bias
 
 
+class LogSigmoidFunction(torch.autograd.Function):
+
+    @staticmethod
+    @contiguous
+    def forward(ctx, x, temperature):
+        ctx.save_for_backward(x,)
+        ctx.temperature = temperature
+        return logsigmoid_fwd(x, temperature)
+
+    @staticmethod
+    @contiguous
+    def backward(ctx, dy):
+        x, = ctx.saved_tensors
+        return logsigmoid_bwd(x, dy, ctx.temperature), None
+
+
+# 1/sqrt(2*pi)-> 0.3989423
+# 1/sqrt(2)   -> 0.70710678
+# sqrt(2/pi)  -> 0.79788456
+
+
+# this function is tanh approximation of gelu
+# actual gelu is:
+# x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+@torch.jit.script
+def bias_gelu(y, bias):
+    x = bias + y
+    return (x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))).to(dtype=y.dtype)
+
+
+# gradient of tanh approximation of gelu
+# gradient of actual gelu is:
+# 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+@torch.jit.script
+def bias_gelu_bwd(g, y, bias):
+    """Assume that y has shape (B, D) and bias has shape (D)"""
+    x = bias + y
+    tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+    # sqrt(2/pi) * 3 * 0.044715 -> 0.1070322243
+    ff = 0.5 * x * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)) + 0.5 * (
+        1 + tanh_out
+    )
+    grad_y = ff * g
+    return grad_y.to(dtype=y.dtype), grad_y.sum(dim=(0), dtype=bias.dtype)
+
+
+class GeLUFunction(torch.autograd.Function):
+
+    @staticmethod
+    # bias is an optional argument
+    def forward(ctx, input, bias):
+        ctx.save_for_backward(input, bias)
+        return bias_gelu(input, bias)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, bias = ctx.saved_tensors
+        tmp = bias_gelu_bwd(grad_output, input, bias)
+        return tmp, tmp
+
+
+# this function is tanh approximation of gelu
+# actual gelu is:
+# x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+@torch.jit.script
+def gelu_fwd(x):
+    return (x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))).to(dtype=x.dtype)
+
+
+# gradient of tanh approximation of gelu
+# gradient of actual gelu is:
+# 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+@torch.jit.script
+def gelu_bwd(g, x):
+    tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+    # sqrt(2/pi) * 3 * 0.044715 -> 0.1070322243
+    ff = 0.5 * x * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)) + 0.5 * (
+        1 + tanh_out
+    )
+    return (ff * g).to(dtype=x.dtype)
+
+
+class FastGeLUFunction(torch.autograd.Function):
+    @staticmethod
+    # bias is an optional argument
+    def forward(ctx, input):
+        ctx.save_for_backward(input)
+        return gelu_fwd(input)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (input,) = ctx.saved_tensors
+        tmp = gelu_bwd(grad_output, input)
+        return tmp
+
+
+@torch.jit.script
+def relu_bwd(g, x):
+    return torch.where(x >= 0, g, 0.0).to(dtype=x.dtype)
+
+
+@torch.jit.script
+def sqrelu_fwd(x):
+    r = F.relu(x)
+    return (r * r).to(dtype=x.dtype)
+
+
+@torch.jit.script
+def sqrelu_bwd(g, x):
+    return (2.0 * g * F.relu(x)).to(dtype=x.dtype)
+
+
+class SquaredReLUFunction(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, input):
+        ctx.save_for_backward(input)
+        return sqrelu_fwd(input)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, = ctx.saved_tensors
+        return sqrelu_bwd(grad_output, input)
+
+
 swiglu = SwiGLUFunction.apply
-
-
+logsigmoid = LogSigmoidFunction.apply
 swiglu_linear = SwiGLULinearFunction.apply
+bias_gelu_impl = GeLUFunction.apply
+fast_gelu_impl = FastGeLUFunction.apply
+sqrelu = SquaredReLUFunction.apply
 
 
 ACT2FN = {

--- a/fla/modules/activations_cuda.py
+++ b/fla/modules/activations_cuda.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023-2024, Tri Dao, Yu Zhang, Songlin Yang.
+
+import torch
+
+sigmoid_fwd_codestring = """
+template <typename T> T sigmoid_fwd(T x) {
+    return 1.0f / (1.0f + ::exp(-float(x)));
+}
+"""
+sigmoid_bwd_codestring = """
+template <typename T> T sigmoid_bwd(T x, T g) {
+    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
+    return float(g) * x_sigmoid * (1.0f - x_sigmoid);
+}
+"""
+
+sigmoid_fwd_jit_fn = torch.cuda.jiterator._create_jit_fn(sigmoid_fwd_codestring)
+sigmoid_bwd_jit_fn = torch.cuda.jiterator._create_jit_fn(sigmoid_bwd_codestring)
+
+
+@torch.compiler.disable
+def sigmoid_fwd(x):
+    return sigmoid_fwd_jit_fn(x)
+
+
+@torch.compiler.disable
+def sigmoid_bwd(x, g):
+    return sigmoid_bwd_jit_fn(x, g)
+
+
+class SigmoidFunction(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        return sigmoid_fwd(x)
+
+    @staticmethod
+    def backward(ctx, dout):
+        x, = ctx.saved_tensors
+        return sigmoid_bwd(x, dout)
+
+
+sigmoid = SigmoidFunction.apply
+
+
+swish_fwd_codestring = """
+template <typename T> T swish_fwd(T x) {
+    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
+    return float(x) * x_sigmoid;
+}
+"""
+swish_bwd_codestring = """
+template <typename T> T swish_bwd(T x, T g) {
+    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
+    return float(g) * x_sigmoid * (1.0f - float(x) * x_sigmoid + float(x));
+}
+"""
+
+swish_fwd_jit_fn = torch.cuda.jiterator._create_jit_fn(swish_fwd_codestring)
+swish_bwd_jit_fn = torch.cuda.jiterator._create_jit_fn(swish_bwd_codestring)
+
+
+@torch.compiler.disable
+def swish_fwd(x):
+    return swish_fwd_jit_fn(x)
+
+
+@torch.compiler.disable
+def swish_bwd(x, g):
+    return swish_bwd_jit_fn(x, g)
+
+
+class SwishFunction(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        return swish_fwd(x)
+
+    @staticmethod
+    def backward(ctx, dout):
+        x, = ctx.saved_tensors
+        return swish_bwd(x, dout)
+
+
+swish = SwishFunction.apply
+
+
+swiglu_fwd_codestring = """
+template <typename T> T swiglu_fwd(T x, T y) {
+    return float(x) * float(y) / (1.0f + ::exp(-float(x)));
+}
+"""
+swiglu_bwd_codestring = """
+template <typename T> T swiglu_bwd(T x, T y, T g, T& dx, T& dy) {
+    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
+    dx = x_sigmoid * (1 + float(x) * (1.0f - x_sigmoid)) * float(g) * float(y);
+    dy = float(x) * x_sigmoid * float(g);
+}
+"""
+
+swiglu_fwdbwd_codestring = """
+template <typename T> T swiglu_fwdbwd(T x, T y, T g, T& dx, T& dy, T& z) {(T x, T y, T g, T& dx, T& dy, T& z) {
+    float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
+    float x_swish = float(x) * x_sigmoid;
+    dx = x_sigmoid * (1 + float(x) * (1.0f - x_sigmoid)) * float(g) * float(y);
+    dy = x_swish * float(g);
+    z = x_swish * float(y);
+}
+"""
+
+swiglu_fwd_jit_fn = torch.cuda.jiterator._create_jit_fn(swiglu_fwd_codestring)
+swiglu_bwd_jit_fn = torch.cuda.jiterator._create_multi_output_jit_fn(swiglu_bwd_codestring, num_outputs=2)
+swiglu_fwdbwd_jit_fn = torch.cuda.jiterator._create_multi_output_jit_fn(swiglu_fwdbwd_codestring, num_outputs=3)
+
+
+@torch.compiler.disable
+def swiglu_fwd(x, y):
+    return swiglu_fwd_jit_fn(x, y)
+
+
+@torch.compiler.disable
+def swiglu_bwd(x, y, g):
+    return swiglu_bwd_jit_fn(x, y, g)
+
+
+@torch.compiler.disable
+def swiglu_fwdbwd(x, y, g):
+    return swiglu_fwdbwd_jit_fn(x, y, g)

--- a/fla/modules/activations_triton.py
+++ b/fla/modules/activations_triton.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+
+
+import torch
+import triton
+import triton.language as tl
+from fla.utils import contiguous
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4, 8, 16, 32]
+    ],
+    key=['D']
+)
+@triton.jit
+def swiglu_fwd_kernel(
+    x,
+    y,
+    o,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    B: tl.constexpr
+):
+    # float(x) * float(y) / (1.0f + ::exp(-float(x)))
+    i = tl.program_id(0)
+    o_i = i * B + tl.arange(0, B)
+    m_i = o_i < T
+
+    b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_y = tl.load(y + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_o = b_x * b_y / (1. + tl.exp(-b_x))
+    tl.store(o + o_i, b_o.to(o.dtype.element_ty), mask=m_i)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4, 8, 16, 32]
+    ],
+    key=['D']
+)
+@triton.jit
+def swiglu_bwd_kernel(
+    x,
+    y,
+    g,
+    dx,
+    dy,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    B: tl.constexpr
+):
+    # float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
+    # dx = x_sigmoid * (1 + float(x) * (1.0f - x_sigmoid)) * float(g) * float(y);
+    # dy = float(x) * x_sigmoid * float(g);
+    i = tl.program_id(0)
+    o_i = i * B + tl.arange(0, B)
+    m_i = o_i < T
+
+    b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_y = tl.load(y + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_g = tl.load(g + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_x_sigmoid = 1. / (1. + tl.exp(-b_x))
+    b_dx = b_x_sigmoid * (1. + b_x * (1. - b_x_sigmoid)) * b_g * b_y
+    b_dy = b_x * b_x_sigmoid * b_g
+    tl.store(dx + o_i, b_dx.to(dx.dtype.element_ty), mask=m_i)
+    tl.store(dy + o_i, b_dy.to(dy.dtype.element_ty), mask=m_i)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4, 8, 16, 32]
+    ],
+    key=['D']
+)
+@triton.jit
+def swiglu_fwdbwd_kernel(
+    x,
+    y,
+    g,
+    z,
+    dx,
+    dy,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    B: tl.constexpr
+):
+    # float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
+    # float x_swish = float(x) * x_sigmoid;
+    # dx = x_sigmoid * (1 + float(x) * (1.0f - x_sigmoid)) * float(g) * float(y);
+    # dy = x_swish * float(g);
+    # z = x_swish * float(y);
+    i = tl.program_id(0)
+    o_i = i * B + tl.arange(0, B)
+    m_i = o_i < T
+
+    b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_y = tl.load(y + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_g = tl.load(g + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_x_sigmoid = 1. / (1. + tl.exp(-b_x))
+    b_x_swish = b_x * b_x_sigmoid
+    b_dx = b_x_sigmoid * (1. + b_x * (1. - b_x_sigmoid)) * b_g * b_y
+    b_dy = b_x_swish * b_g
+    b_z = b_x_swish * b_y
+    tl.store(dx + o_i, b_dx.to(dx.dtype.element_ty), mask=m_i)
+    tl.store(dy + o_i, b_dy.to(dy.dtype.element_ty), mask=m_i)
+    tl.store(z + o_i, b_z.to(z.dtype.element_ty), mask=m_i)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4, 8, 16, 32]
+    ],
+    key=['D']
+)
+@triton.jit
+def logsigmoid_fwd_kernel(
+    x,
+    y,
+    temperature,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    B: tl.constexpr
+):
+    i = tl.program_id(0)
+    o_i = i * B + tl.arange(0, B)
+    m_i = o_i < T
+
+    b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_m = tl.minimum(0., b_x)
+    b_z = 1. + tl.exp(-tl.abs(b_x))
+    b_y = (b_m - tl.log(b_z)) / temperature
+    tl.store(y + o_i, b_y.to(y.dtype.element_ty), mask=m_i)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4, 8, 16, 32]
+    ],
+    key=['D']
+)
+@triton.jit
+def logsigmoid_bwd_kernel(
+    x,
+    dx,
+    dy,
+    temperature,
+    T: tl.constexpr,
+    D: tl.constexpr,
+    B: tl.constexpr
+):
+    i = tl.program_id(0)
+    o_i = i * B + tl.arange(0, B)
+    m_i = o_i < T
+
+    b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_dy = tl.load(dy + o_i, mask=m_i, other=0.).to(tl.float32)
+    b_dx = b_dy * (1. - tl.sigmoid(b_x)) / temperature
+    tl.store(dx + o_i, b_dx.to(dx.dtype.element_ty), mask=m_i)
+
+
+@contiguous
+def swiglu_fwd(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    T, D = x.numel(), x.shape[-1]
+    B = triton.next_power_of_2(triton.cdiv(
+        T, triton.runtime.driver.active.utils.get_device_properties(x.device.index)['multiprocessor_count']))
+    o = torch.empty_like(x)
+    swiglu_fwd_kernel[(triton.cdiv(T, B),)](
+        x=x,
+        y=y,
+        o=o,
+        T=T,
+        D=D,
+        B=B
+    )
+    return o
+
+
+@contiguous
+def swiglu_bwd(x: torch.Tensor, y: torch.Tensor, dout: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    T, D = x.numel(), x.shape[-1]
+    B = triton.next_power_of_2(triton.cdiv(
+        T, triton.runtime.driver.active.utils.get_device_properties(x.device.index)['multiprocessor_count']))
+    dx = torch.empty_like(x)
+    dy = torch.empty_like(y)
+    swiglu_bwd_kernel[(triton.cdiv(T, B),)](
+        x=x,
+        y=y,
+        g=dout,
+        dx=dx,
+        dy=dy,
+        T=T,
+        D=D,
+        B=B
+    )
+    return dx, dy
+
+
+@contiguous
+def swiglu_fwdbwd(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    dout: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    T, D = x.numel(), x.shape[-1]
+    B = triton.next_power_of_2(triton.cdiv(
+        T, triton.runtime.driver.active.utils.get_device_properties(x.device.index)['multiprocessor_count']))
+    dx = torch.empty_like(x)
+    dy = torch.empty_like(y)
+    z = torch.empty_like(x)
+    swiglu_fwdbwd_kernel[(triton.cdiv(T, B),)](
+        x=x,
+        y=y,
+        g=dout,
+        z=z,
+        dx=dx,
+        dy=dy,
+        T=T,
+        D=D,
+        B=B
+    )
+    return dx, dy, z
+
+
+def logsigmoid_fwd(x: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
+    T, D = x.numel(), x.shape[-1]
+    B = triton.next_power_of_2(triton.cdiv(
+        T, triton.runtime.driver.active.utils.get_device_properties(x.device.index)['multiprocessor_count']))
+    y = torch.empty_like(x)
+    logsigmoid_fwd_kernel[(triton.cdiv(T, B),)](
+        x=x,
+        y=y,
+        temperature=temperature,
+        T=T,
+        D=D,
+        B=B
+    )
+    return y
+
+
+def logsigmoid_bwd(x: torch.Tensor, dy: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
+    T, D = x.numel(), x.shape[-1]
+    B = triton.next_power_of_2(triton.cdiv(
+        T, triton.runtime.driver.active.utils.get_device_properties(x.device.index)['multiprocessor_count']))
+    dx = torch.empty_like(x)
+    logsigmoid_bwd_kernel[(triton.cdiv(T, B),)](
+        x=x,
+        dx=dx,
+        dy=dy,
+        temperature=temperature,
+        T=T,
+        D=D,
+        B=B
+    )
+    return dx

--- a/fla/modules/layernorm_gated.py
+++ b/fla/modules/layernorm_gated.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 from einops import rearrange
+from fla.utils import device_torch_lib
 
 
 def rms_norm_ref(x, weight, bias, z=None, eps=1e-6, group_size=None, norm_before_gate=True, upcast=True):
@@ -145,7 +146,7 @@ def layer_norm_fwd(
     # heuristics for number of warps
     num_warps = min(max(BLOCK_N // 256, 1), 8)
     grid = (M, ngroups)
-    with torch.cuda.device(x.device.index):
+    with device_torch_lib.device(x.device.index):
         layer_norm_fwd_kernel[grid](
             x,
             out,
@@ -342,7 +343,7 @@ def layer_norm_bwd(
         raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
     # heuristics for number of warps
     num_warps = min(max(BLOCK_N // 256, 1), 8)
-    sm_count = torch.cuda.get_device_properties(x.device).multi_processor_count
+    sm_count = device_torch_lib.get_device_properties(x.device).multi_processor_count
     # If group size is small (e.g., 64), we're only using 1 warp. So having just 108 programs
     # would limit the occupancy.
     nrow_groups = math.ceil(sm_count * math.ceil(4 / num_warps) / ngroups)
@@ -350,7 +351,7 @@ def layer_norm_bwd(
     _db = torch.empty((nrow_groups, N), dtype=torch.float32, device=bias.device) if bias is not None else None
     rows_per_program = math.ceil(M / nrow_groups)
     grid = (nrow_groups, ngroups)
-    with torch.cuda.device(x.device.index):
+    with device_torch_lib.device(x.device.index):
         layer_norm_bwd_kernel[grid](
             x,
             weight,

--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -12,6 +12,7 @@ import triton.language as tl
 from einops import rearrange, repeat
 
 from fla.utils import contiguous
+from fla.utils import device_torch_lib
 
 
 def rotate_half(x, interleaved=False):
@@ -189,7 +190,7 @@ def rotary_embedding_fwdbwd(
     def grid(META): return (triton.cdiv(T, META['BT']), N, H)  # noqa
     # Need this, otherwise Triton tries to launch from cuda:0 and we get
     # ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)
-    with torch.cuda.device(x.device.index):
+    with device_torch_lib.device(x.device.index):
         rotary_embedding_kernel[grid](
             x,
             cos,

--- a/fla/ops/based/fused_chunk.py
+++ b/fla/ops/based/fused_chunk.py
@@ -6,7 +6,6 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
-
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 

--- a/fla/ops/based/parallel.py
+++ b/fla/ops/based/parallel.py
@@ -7,7 +7,6 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
-
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 # Based: An Educational and Effective Sequence Mixer

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -6,8 +6,12 @@ from typing import Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+from fla.utils import device_capacity
 
 from fla.ops.common.utils import prepare_chunk_offsets
+
+BV_LIST = [16, 32, 64] if device_capacity else [16, 32]
+BK_LIST = [16, 32, 64] if device_capacity else [16, 32]
 
 
 @triton.heuristics({
@@ -18,8 +22,8 @@ from fla.ops.common.utils import prepare_chunk_offsets
 @triton.autotune(
     configs=[
         triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64]
-        for BV in [32, 64]
+        for BK in BK_LIST
+        for BV in BV_LIST
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],

--- a/fla/ops/delta_rule/naive.py
+++ b/fla/ops/delta_rule/naive.py
@@ -121,19 +121,20 @@ def delta_rule_parallel(q, k, v, beta, BM=128, BN=32):
 
 
 if __name__ == '__main__':
+    from fla.utils import device
     B = 2
     H = 4
     L = 512
     DK = 128
     DV = 128
-    q = (torch.randn(B, H, L, DK)).cuda().requires_grad_(True)
-    k = (torch.randn(B, H, L, DK)).cuda()
+    q = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
+    k = (torch.randn(B, H, L, DK)).to(device)
     k = torch.nn.functional.normalize(k, dim=-1, p=2).requires_grad_(True)
-    v = (torch.randn(B, H, L, DV)).cuda().requires_grad_(True)
-    beta = torch.randn(B, H, L).cuda().sigmoid().requires_grad_(True)
+    v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
+    beta = torch.randn(B, H, L).to(device).sigmoid().requires_grad_(True)
 
     o, _ = delta_rule_recurrence(q, k, v, beta)
-    do = torch.randn(B, H, L, DV).cuda()
+    do = torch.randn(B, H, L, DV).to(device)
     o.backward(do, retain_graph=True)
     q_grad, q.grad = q.grad, None
     k_grad, k.grad = k.grad, None

--- a/fla/ops/delta_rule/parallel.py
+++ b/fla/ops/delta_rule/parallel.py
@@ -384,13 +384,14 @@ def naive_delta_rule_parallel(q, k, v, beta, BM=128, BN=32):
 
 
 if __name__ == "__main__":
+    from fla.utils import device
     B, H, T, K, V = 2, 4, 512, 64, 64
     torch.set_default_dtype(torch.bfloat16)
 
-    q = torch.randn[B, H, T, K].cuda()
-    k = torch.nn.functional.normalize(torch.randn[B, H, T, K].cuda(), p=2, dim=-1)
-    v = torch.randn[B, H, T, V].cuda()
-    beta = torch.ones(B, H, T).cuda()
+    q = torch.randn[B, H, T, K].to(device)
+    k = torch.nn.functional.normalize(torch.randn[B, H, T, K].to(device), p=2, dim=-1)
+    v = torch.randn[B, H, T, V].to(device)
+    beta = torch.ones(B, H, T).to(device)
 
     output_attentions = True
     ref_o, ref_attn = naive_delta_rule_parallel(q.clone(), k.clone(), v.clone(), beta.clone())

--- a/fla/ops/gated_delta_rule/chunk.py
+++ b/fla/ops/gated_delta_rule/chunk.py
@@ -15,7 +15,8 @@ from fla.ops.gated_delta_rule.wy_fast import (bwd_prepare_wy_repr,
                                               fwd_prepare_wy_repr,
                                               fwd_recompute_w_u)
 from fla.ops.utils import chunk_local_cumsum
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
+from fla.utils import (autocast_custom_bwd, autocast_custom_fwd,
+                       contiguous)
 
 
 def chunk_gated_delta_rule_fwd(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
@@ -8,6 +8,8 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.utils import device_capacity
+
 
 @triton.heuristics({
     'USE_OFFSETS': lambda args: args['offsets'] is not None
@@ -346,7 +348,7 @@ def chunk_dplr_bwd_dqk_intra(
         B, T, H, K = q.shape
     BT = min(chunk_size, max(16, triton.next_power_of_2(T)))
     BC = min(16, BT)
-    BK = min(64, triton.next_power_of_2(K))
+    BK = min(64, triton.next_power_of_2(K)) if device_capacity else min(32, triton.next_power_of_2(K))
     NT = triton.cdiv(T, BT) if offsets is None else len(indices)
     NC = triton.cdiv(BT, BC)
     NK = triton.cdiv(K, BK)

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
@@ -1,13 +1,30 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
+from fla.ops.common.utils import prepare_chunk_offsets
 from typing import Optional, Tuple
 
 import torch
 import triton
 import triton.language as tl
+from fla.utils import device_capacity, check_triton_shared_mem
 
-from fla.ops.common.utils import prepare_chunk_offsets
+
+triton_config = triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BT', 'BK', 'BV']
+) if device_capacity else \
+    triton.autotune(
+        configs=[
+            triton.Config({}, num_warps=num_warps)
+            for num_warps in [2, 4, 8]
+        ],
+        key=['BT', 'BK', 'BV'],
+)
 
 
 @triton.heuristics({
@@ -15,14 +32,7 @@ from fla.ops.common.utils import prepare_chunk_offsets
     'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
     'USE_OFFSETS': lambda args: args['offsets'] is not None,
 })
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [1, 2, 4]
-        for num_stages in [2, 3, 4]
-    ],
-    key=['BT', 'BK', 'BV']
-)
+@triton_config
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_fwd_kernel_h(
     kg,
@@ -144,12 +154,17 @@ def chunk_dplr_fwd_h(
     BK = triton.next_power_of_2(K)
     assert BK <= 256, "current kernel does not support head dimension larger than 256."
     # H100 can have larger block size
-    if torch.cuda.get_device_capability()[0] >= 9:
+
+    if check_triton_shared_mem(233472, kg.device.index):
         BV = 64
         BC = 64 if K <= 128 else 32
-    else:
+    elif check_triton_shared_mem(131072, kg.device.index):  # A100
         BV = 32
         BC = 32
+    else:
+        BV = 16
+        BC = 16
+
     BC = min(BT, BC)
     NK = triton.cdiv(K, BK)
     NV = triton.cdiv(V, BV)

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
@@ -7,6 +7,10 @@ from typing import Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+from fla.utils import device_capacity
+
+
+BK_LIST = [64, 128] if device_capacity else [16, 32]
 
 
 @triton.heuristics({
@@ -245,8 +249,8 @@ def chunk_dplr_bwd_o_kernel(
     configs=[
         triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps)
         for num_warps in [4, 8]
-        for BK in [64, 128]
-        for BV in [64, 128]
+        for BK in BK_LIST
+        for BV in BK_LIST
     ],
     key=['BT', 'BK', 'BV'],
 )
@@ -391,8 +395,8 @@ def chunk_dplr_bwd_o(
             indices = torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(offsets)
         NT = len(indices)
 
-    BK = min(triton.next_power_of_2(K), 64)
-    BV = min(triton.next_power_of_2(V), 64)
+    BK = min(triton.next_power_of_2(K), 64) if device_capacity else min(triton.next_power_of_2(K), 32)
+    BV = min(triton.next_power_of_2(V), 64) if device_capacity else min(triton.next_power_of_2(K), 32)
     NK = triton.cdiv(K, BK)
     dq = torch.empty_like(k)
     dk = torch.empty_like(k)
@@ -461,7 +465,7 @@ def chunk_dplr_bwd_dAu(
             indices = torch.cat([torch.arange(n) for n in triton.cdiv(offsets[1:] - offsets[:-1], BT).tolist()])
             indices = torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(offsets)
         NT = len(indices)
-    BV = min(triton.next_power_of_2(V), 128)
+    BV = min(triton.next_power_of_2(V), 128) if device_capacity else min(triton.next_power_of_2(V), 64)
     grid = (NT, B * H)
     dA_qk = torch.empty(B, H, T, BT, dtype=torch.float, device=v.device) if head_first \
         else torch.empty(B, T, H, BT, dtype=torch.float, device=v.device)

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
@@ -7,6 +7,9 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
+from fla.utils import device_capacity
+
+BK_LIST = [64, 128] if device_capacity else [16, 32]
 
 
 @triton.heuristics({
@@ -15,8 +18,8 @@ import triton.language as tl
 @triton.autotune(
     configs=[
         triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [64, 128]
-        for BV in [64, 128]
+        for BK in BK_LIST
+        for BV in BK_LIST
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3]
     ],

--- a/fla/ops/generalized_delta_rule/iplr/chunk.py
+++ b/fla/ops/generalized_delta_rule/iplr/chunk.py
@@ -8,7 +8,8 @@ import triton
 import triton.language as tl
 
 from fla.ops.generalized_delta_rule.iplr.wy_fast import fwd_prepare_wy_repr
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
+from fla.utils import (autocast_custom_bwd, autocast_custom_fwd,
+                       contiguous, check_triton_shared_mem)
 
 
 @triton.heuristics({
@@ -289,12 +290,17 @@ def chunk_generalized_iplr_delta_rule_fwd_h(
     BK = triton.next_power_of_2(K)
     assert BK <= 256, "current kernel does not support head dimension larger than 256."
     # H100 can have larger block size
-    if torch.cuda.get_device_capability()[0] >= 9:
+
+    if check_triton_shared_mem(233472, k.device.index):
         BV = 64
         BC = 64 if K <= 128 else 32
-    else:
+    elif check_triton_shared_mem(131072, k.device.index):  # A100
         BV = 32
         BC = 32
+    else:
+        BV = 16
+        BC = 16
+
     BC = min(BT, BC)
     NK = triton.cdiv(K, BK)
     NV = triton.cdiv(V, BV)

--- a/fla/ops/generalized_delta_rule/iplr/naive.py
+++ b/fla/ops/generalized_delta_rule/iplr/naive.py
@@ -70,19 +70,20 @@ def iplr_chunkwise(q, k, v, alpha, beta, initial_state=None, output_final_state=
 
 
 if __name__ == '__main__':
+    from fla.utils import device
     B = 2
     H = 4
     L = 128
     DK = 128
     DV = 128
-    q = (torch.randn(B, H, L, DK)).cuda().requires_grad_(True)
-    k = (torch.randn(B, H, L, DK)).cuda().requires_grad_(True)
-    v = (torch.randn(B, H, L, DV)).cuda().requires_grad_(True)
-    alpha = torch.randn(B, H, L, DK).cuda().softmax(-1).requires_grad_(True)
-    beta = torch.randn(B, H, L, DK).cuda().softmax(-1).requires_grad_(True)
+    q = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
+    k = (torch.randn(B, H, L, DK)).to(device).requires_grad_(True)
+    v = (torch.randn(B, H, L, DV)).to(device).requires_grad_(True)
+    alpha = torch.randn(B, H, L, DK).to(device).softmax(-1).requires_grad_(True)
+    beta = torch.randn(B, H, L, DK).to(device).softmax(-1).requires_grad_(True)
 
     o, s = iplr_recurrence(q, k, v, -alpha, beta)
-    do = torch.randn_like(o).cuda()
+    do = torch.randn_like(o).to(device)
     o.backward(do, retain_graph=True)
     q_grad, q.grad = q.grad, None
     k_grad, k.grad = k.grad, None

--- a/fla/ops/rebased/naive.py
+++ b/fla/ops/rebased/naive.py
@@ -21,16 +21,17 @@ def naive_parallel_rebased(q, k, v, use_scale=True, use_norm=True):
 
 
 if __name__ == "__main__":
+    from fla.utils import device
     B = 4
     H = 4
     L = 128
     # D = 15
     dtype = torch.float32
-    q = (torch.randn(B, H, L, 16).cuda().to(dtype)).requires_grad_(True)
-    k = (torch.randn(B, H, L, 16).cuda().to(dtype)).requires_grad_(True)
-    v = torch.randn(B, H, L, 128).cuda().to(dtype).requires_grad_(True)
+    q = (torch.randn(B, H, L, 16).to(device).to(dtype)).requires_grad_(True)
+    k = (torch.randn(B, H, L, 16).to(device).to(dtype)).requires_grad_(True)
+    v = torch.randn(B, H, L, 128).to(device).to(dtype).requires_grad_(True)
 
-    do = torch.randn_like(v).cuda()
+    do = torch.randn_like(v).to(device)
     ref = naive_parallel_rebased(q, k, v, True, True)
     ref.backward(do, retain_graph=True)
     ref_dq, q.grad = q.grad.clone(), None

--- a/fla/ops/rwkv6/fused_recurrent.py
+++ b/fla/ops/rwkv6/fused_recurrent.py
@@ -7,7 +7,9 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
+from fla.utils import (autocast_custom_bwd, autocast_custom_fwd,
+                       contiguous, set_torch_device,
+                       device_capacity)
 
 
 @triton.heuristics({
@@ -310,14 +312,18 @@ def fused_recurrent_rwkv6_bwd_kernel_dkv(
         tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=mask_h)
 
 
+BT_LIST = [16, 32, 64] if device_capacity else [16, 32]
+BK_LIST = [16, 32, 64] if device_capacity else [16, 32]
+
+
 @triton.heuristics({
     'USE_OFFSETS': lambda args: args['offsets'] is not None
 })
 @triton.autotune(
     configs=[
         triton.Config({'BT': BT, 'BK': BK}, num_warps=num_warps)
-        for BT in [16, 32, 64]
-        for BK in [32, 64]
+        for BT in BT_LIST
+        for BK in BK_LIST
         for num_warps in [1, 2, 4, 8]
     ],
     key=['K']
@@ -452,7 +458,8 @@ def fused_recurrent_rwkv6_bwd(
         B, T, H, K, V = *k.shape, v.shape[-1]
     N = B if offsets is None else len(offsets) - 1
 
-    BK, BV = min(triton.next_power_of_2(K), 16), min(triton.next_power_of_2(V), 64)
+    BK, BV = min(triton.next_power_of_2(K), 16),  \
+        min(triton.next_power_of_2(V), 64)
     NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
 
     dq = q.new_empty(NV, *q.shape, dtype=torch.float)
@@ -681,6 +688,7 @@ def fused_recurrent_rwkv6(
         >>> assert o.allclose(o_var.view(o.shape))
         >>> assert ht.allclose(ht_var)
     """
+    set_torch_device(r)
     if cu_seqlens is not None:
         if r.shape[0] != 1:
             raise ValueError(f"The batch size is expected to be 1 rather than {r.shape[0]} when using `cu_seqlens`."

--- a/fla/ops/simple_gla/parallel.py
+++ b/fla/ops/simple_gla/parallel.py
@@ -9,7 +9,8 @@ import triton.language as tl
 
 from fla.ops.utils import chunk_global_cumsum, chunk_local_cumsum
 from fla.ops.utils.exp import safe_exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
+from fla.utils import (autocast_custom_bwd, autocast_custom_fwd,
+                       contiguous, check_triton_shared_mem)
 
 
 @triton.heuristics({
@@ -487,12 +488,17 @@ def parallel_simple_gla_fwd(
     else:
         B, T, H, K, V = *k.shape, v.shape[-1]
     BT, BS = chunk_size, 32
-    if torch.cuda.get_device_capability()[0] >= 9:
+
+    if check_triton_shared_mem(233472, q.device.index):
         BK = min(256, triton.next_power_of_2(K))
         BV = min(256, triton.next_power_of_2(V))
-    else:
+    elif check_triton_shared_mem(131072, q.device.index):
         BK = min(128, triton.next_power_of_2(K))
         BV = min(128, triton.next_power_of_2(V))
+    else:
+        BK = min(64, triton.next_power_of_2(K))
+        BV = min(64, triton.next_power_of_2(V))
+
     NK = triton.cdiv(K, BK)
     NV = triton.cdiv(V, BV)
     assert BT % BS == 0

--- a/fla/ops/utils.py
+++ b/fla/ops/utils.py
@@ -1,0 +1,470 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2024, Yu Zhang, Songlin Yang
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.utils import contiguous
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BT': 16}, num_warps=2),
+        triton.Config({'BT': 16}, num_warps=4),
+        triton.Config({'BT': 16}, num_warps=8),
+        triton.Config({'BT': 32}, num_warps=2),
+        triton.Config({'BT': 32}, num_warps=4),
+        triton.Config({'BT': 32}, num_warps=8),
+        triton.Config({'BT': 64}, num_warps=2),
+        triton.Config({'BT': 64}, num_warps=4),
+        triton.Config({'BT': 64}, num_warps=8),
+    ],
+    key=['S']
+)
+@triton.jit
+def logcumsumexp_fwd_kernel(
+    s,
+    z,
+    s_s_h,
+    s_s_t,
+    s_s_d,
+    T: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr
+):
+    i_bh = tl.program_id(0)
+    o_i = tl.arange(0, BT)
+    m_s = tl.where(o_i[:, None] >= o_i[None, :], 1., 0.)
+
+    b_mp = tl.full([S,], float('-inf'), dtype=tl.float32)
+    b_zp = tl.zeros([S,], dtype=tl.float32)
+    for i_t in range(tl.cdiv(T, BT)):
+        p_s = tl.make_block_ptr(s + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, 0), (BT, S), (1, 0))
+        p_z = tl.make_block_ptr(z + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, 0), (BT, S), (1, 0))
+
+        # [BT, S]
+        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+        # [S,]
+        b_mc = tl.max(b_s, 0)
+        # workaround for compiler bugs
+        if i_t > 0:
+            b_mc = tl.maximum(b_mp, b_mc)
+        b_zp = b_zp * tl.exp(b_mp - b_mc)
+        # [BT, S]
+        b_s = tl.exp(b_s - b_mc)
+        b_z = tl.dot(m_s, b_s, allow_tf32=False) + b_zp
+        # [S,]
+        b_zc = tl.max(b_z, 0)
+        b_mp = b_mc
+        b_zp = b_zc
+        # [BT, BS]
+        # small eps to prevent underflows
+        b_z = tl.log(tl.where(b_z != 0, b_z, 1e-20)) + b_mc
+        tl.store(p_z, b_z.to(p_z.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+    ],
+    key=['S']
+)
+@triton.jit
+def softmax_fwd_kernel(
+    s,
+    p,
+    s_s_h,
+    s_s_t,
+    s_s_d,
+    T: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+
+    p_s = tl.make_block_ptr(s + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, 0), (BT, S), (1, 0))
+    p_p = tl.make_block_ptr(p + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, 0), (BT, S), (1, 0))
+
+    # [BT, S]
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    # [BT]
+    b_m = tl.max(b_s, 1)
+
+    # [BT, BS]
+    b_s = tl.exp(b_s - b_m[:, None])
+    b_z = tl.sum(b_s, 1)
+    b_p = tl.where(b_s != 0, b_s / b_z[:, None], 0.)
+    tl.store(p_p, b_p.to(p_p.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+    ],
+    key=['S']
+)
+@triton.jit
+def softmax_bwd_kernel(
+    p,
+    dp,
+    ds,
+    s_s_h,
+    s_s_t,
+    s_s_d,
+    T: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+
+    p_p = tl.make_block_ptr(p + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, 0), (BT, S), (1, 0))
+    p_dp = tl.make_block_ptr(dp + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, 0), (BT, S), (1, 0))
+    p_ds = tl.make_block_ptr(ds + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, 0), (BT, S), (1, 0))
+    # [BT, BS]
+    b_p = tl.load(p_p, boundary_check=(0, 1)).to(tl.float32)
+    b_dp = tl.load(p_dp, boundary_check=(0, 1)).to(tl.float32)
+    # [BT,]
+    b_pp = tl.sum(b_p * b_dp, 1)
+    # [BT, BS]
+    b_ds = b_p * b_dp - b_p * b_pp[:, None]
+    tl.store(p_ds, b_ds.to(p_ds.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BT': 16}, num_warps=2),
+        triton.Config({'BT': 16}, num_warps=4),
+        triton.Config({'BT': 16}, num_warps=8),
+        triton.Config({'BT': 32}, num_warps=2),
+        triton.Config({'BT': 32}, num_warps=4),
+        triton.Config({'BT': 32}, num_warps=8),
+        triton.Config({'BT': 64}, num_warps=2),
+        triton.Config({'BT': 64}, num_warps=4),
+        triton.Config({'BT': 64}, num_warps=8),
+    ],
+    key=['S']
+)
+@triton.jit
+def chunk_global_reversed_cumsum_vector_kernel(
+    s,
+    z,
+    s_s_h,
+    s_s_t,
+    s_s_d,
+    T: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr
+):
+    i_s, i_bh = tl.program_id(0), tl.program_id(1)
+    o_i = tl.arange(0, BT)
+    m_s = tl.where(o_i[:, None] <= o_i[None, :], 1., 0.)
+
+    b_z = tl.zeros([BS], dtype=tl.float32)
+    for i_t in range(tl.cdiv(T, BT) - 1, -1, -1):
+        p_s = tl.make_block_ptr(s + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        p_z = tl.make_block_ptr(z + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        # [BT, BS]
+        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+        b_c = b_z[None, :] + tl.dot(m_s, b_s, allow_tf32=False)
+        tl.store(p_z, b_c.to(p_z.dtype.element_ty), boundary_check=(0, 1))
+
+        if i_t >= 0:
+            b_z += tl.sum(b_s, 0)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BT': 16}, num_warps=2),
+        triton.Config({'BT': 16}, num_warps=4),
+        triton.Config({'BT': 16}, num_warps=8),
+        triton.Config({'BT': 32}, num_warps=2),
+        triton.Config({'BT': 32}, num_warps=4),
+        triton.Config({'BT': 32}, num_warps=8),
+        triton.Config({'BT': 64}, num_warps=2),
+        triton.Config({'BT': 64}, num_warps=4),
+        triton.Config({'BT': 64}, num_warps=8),
+    ],
+    key=['S']
+)
+@triton.jit
+def chunk_global_cumsum_vector_kernel(
+    s,
+    z,
+    s_s_h,
+    s_s_t,
+    s_s_d,
+    T: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr
+):
+    i_s, i_bh = tl.program_id(0), tl.program_id(1)
+    o_i = tl.arange(0, BT)
+    m_s = tl.where(o_i[:, None] >= o_i[None, :], 1., 0.)
+    b_z = tl.zeros([BS], dtype=tl.float32)
+    for i_t in range(tl.cdiv(T, BT)):
+        p_s = tl.make_block_ptr(s + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        p_z = tl.make_block_ptr(z + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        # [BT, BS]
+        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+        b_c = b_z[None, :] + tl.dot(m_s, b_s, allow_tf32=False)
+        tl.store(p_z, b_c.to(p_z.dtype.element_ty), boundary_check=(0, 1))
+        if i_t >= 0:
+            b_z += tl.sum(b_s, 0)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BT': 16}, num_warps=2),
+        triton.Config({'BT': 32}, num_warps=4),
+        triton.Config({'BT': 32}, num_warps=2),
+        triton.Config({'BT': 64}, num_warps=8),
+        triton.Config({'BT': 64}, num_warps=4),
+    ],
+    key=[]
+)
+@triton.jit
+def chunk_global_reversed_cumsum_scalar_kernel(
+    s,
+    o,
+    T: tl.constexpr,
+    BT: tl.constexpr,
+):
+    i_bh = tl.program_id(0)
+    b_z = tl.zeros([], dtype=tl.float32)
+    for i_t in range(tl.cdiv(T, BT) - 1, -1, -1):
+        p_s = tl.make_block_ptr(s + i_bh * T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        p_o = tl.make_block_ptr(o + i_bh * T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+        b_zz = tl.sum(b_s, axis=0)
+        b_z += b_zz
+        b_o = b_s - tl.cumsum(b_s, axis=0) + b_z[None]
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BT': 16}, num_warps=2),
+        triton.Config({'BT': 32}, num_warps=4),
+        triton.Config({'BT': 32}, num_warps=2),
+        triton.Config({'BT': 64}, num_warps=8),
+        triton.Config({'BT': 64}, num_warps=4),
+    ],
+    key=[]
+)
+@triton.jit
+def chunk_global_cumsum_scalar_kernel(
+    s,
+    o,
+    T: tl.constexpr,
+    BT: tl.constexpr,
+):
+    i_bh = tl.program_id(0)
+    b_z = tl.zeros([], dtype=tl.float32)
+    for i_t in range(tl.cdiv(T, BT)):
+        p_s = tl.make_block_ptr(s + i_bh * T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        p_o = tl.make_block_ptr(o + i_bh * T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+        b_o = tl.cumsum(b_s, axis=0) + b_z[None]
+        b_zz = tl.sum(b_s, axis=0)
+        b_z += b_zz
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BS': 16}, num_warps=2),
+        triton.Config({'BS': 16}, num_warps=4),
+        triton.Config({'BS': 16}, num_warps=8),
+        triton.Config({'BS': 32}, num_warps=2),
+        triton.Config({'BS': 32}, num_warps=4),
+        triton.Config({'BS': 32}, num_warps=8),
+        triton.Config({'BS': 64}, num_warps=2),
+        triton.Config({'BS': 64}, num_warps=4),
+        triton.Config({'BS': 64}, num_warps=8),
+    ],
+    key=['S', 'BT']
+)
+@triton.jit
+def chunk_local_cumsum_vector_kernel(
+    s,
+    o,
+    s_s_h,
+    s_s_t,
+    s_s_d,
+    T: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr
+):
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    o_i = tl.arange(0, BT)
+    m_s = tl.where(o_i[:, None] >= o_i[None, :], 1., 0.)
+    p_s = tl.make_block_ptr(s + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+    p_o = tl.make_block_ptr(o + i_bh * s_s_h, (T, S), (s_s_t, s_s_d), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+    # [BT, BS]
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_o = tl.dot(m_s, b_s, allow_tf32=False)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8)
+    ],
+    key=['BT']
+)
+@triton.jit
+def chunk_local_cumsum_scalar_kernel(
+    s,
+    o,
+    T: tl.constexpr,
+    BT: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    p_s = tl.make_block_ptr(s + i_bh * T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+    p_o = tl.make_block_ptr(o + i_bh * T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+    # [BT, BS]
+    b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+    b_o = tl.cumsum(b_s, axis=0)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+def chunk_local_cumsum_vector(g, BT):
+    B, H, T, S = g.shape
+    NT = triton.cdiv(T, BT)
+    g_org, g = g, torch.empty_like(g, dtype=torch.float)
+    def grid(meta): return (triton.cdiv(meta['S'], meta['BS']), NT, B * H)
+    # keep cummulative normalizer in fp32
+    # this kernel is equivalent to
+    # g = g.view(B, H, NT, BT, -1).cumsum(-2).view(B, H, T, -1)
+    chunk_local_cumsum_vector_kernel[grid](
+        g_org, g,
+        g.stride(1), g.stride(2), g.stride(3),
+        T=T, S=S, BT=BT
+    )
+    return g
+
+
+def chunk_local_cumsum_scalar(g, BT):
+    B, H, T = g.shape
+    NT = triton.cdiv(T, BT)
+    g_org, g = g, torch.empty_like(g, dtype=torch.float)
+    grid = (NT, B * H)
+    chunk_local_cumsum_scalar_kernel[grid](
+        g_org, g,
+        T=T, BT=BT
+    )
+    return g
+
+
+@contiguous
+def chunk_local_cumsum(g, BT):
+    if len(g.shape) == 3:
+        return chunk_local_cumsum_scalar(g, BT)
+    elif len(g.shape) == 4:
+        return chunk_local_cumsum_vector(g, BT)
+    else:
+        raise ValueError(f"Unsupported shape {g.shape}. "
+                         f"Should be either (batch size, num_heads, seq_len, dim) or (batch_size, num_heads, seq_len)")
+
+
+@contiguous
+def chunk_global_reversed_cumsum_vector(
+    s: torch.Tensor,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    B, H, T, S = s.shape
+    BS = 32
+    dtype = dtype or s.dtype
+    grid = (triton.cdiv(S, BS), B * H)
+    z = torch.empty_like(s, dtype=dtype)
+    chunk_global_reversed_cumsum_vector_kernel[grid](
+        s, z,
+        s.stride(1), s.stride(2), s.stride(3),
+        T=T, S=S, BS=BS
+    )
+    return z
+
+
+@contiguous
+def chunk_global_reversed_cumsum_scalar(
+    s: torch.Tensor,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    B, H, T = s.shape
+    dtype = dtype or s.dtype
+    grid = (B * H,)
+    z = torch.empty_like(s, dtype=dtype)
+    chunk_global_reversed_cumsum_scalar_kernel[grid](
+        s, z,
+        T=T
+    )
+    return z
+
+
+@contiguous
+def chunk_global_cumsum_vector(
+    s: torch.Tensor,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    B, H, T, S = s.shape
+    BS = 32
+    dtype = dtype or s.dtype
+    grid = (triton.cdiv(S, BS), B * H)
+    z = torch.empty_like(s, dtype=dtype)
+    chunk_global_cumsum_vector_kernel[grid](
+        s, z,
+        s.stride(1), s.stride(2), s.stride(3),
+        T=T, S=S, BS=BS
+    )
+    return z
+
+
+@contiguous
+def chunk_global_cumsum_scalar(
+    s: torch.Tensor,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    B, H, T = s.shape
+    dtype = dtype or s.dtype
+    grid = (B * H,)
+    z = torch.empty_like(s, dtype=dtype)
+    chunk_global_cumsum_scalar_kernel[grid](
+        s, z,
+        T=T
+    )
+    return z
+
+
+@contiguous
+def chunk_global_cumsum(s, dtype=None):
+    if len(s.shape) == 3:
+        return chunk_global_cumsum_scalar(s, dtype)
+    elif len(s.shape) == 4:
+        return chunk_global_cumsum_vector(s, dtype)
+    else:
+        raise ValueError(f"Unsupported shape {s.shape}. "
+                         f"Should be either [batch size, num_heads, seq_len] or [batch_size, num_heads, seq_len, dim]")
+
+
+@contiguous
+def chunk_global_reversed_cumsum(s, dtype=None):
+    if len(s.shape) == 3:
+        return chunk_global_reversed_cumsum_scalar(s, dtype)
+    elif len(s.shape) == 4:
+        return chunk_global_reversed_cumsum_vector(s, dtype)
+    else:
+        raise ValueError(f"Unsupported shape {s.shape}. "
+                         f"Should be either [batch size, num_heads, seq_len] or [batch_size, num_heads, seq_len, dim]")

--- a/tests/modules/test_activations.py
+++ b/tests/modules/test_activations.py
@@ -1,0 +1,118 @@
+import pytest
+import torch
+import torch.nn.functional as F
+from fla.modules.activations import swiglu, swiglu_linear, logsigmoid
+from fla.utils import device
+
+
+@pytest.mark.parametrize("shape", [(16, 32), (32, 64)])
+def test_swiglu_forward(shape):
+    x = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    y = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    torch_output = x * y * torch.sigmoid(x)
+    triton_output = swiglu(x, y)
+
+    assert torch.allclose(torch_output, triton_output, atol=1e-5, rtol=1e-3)
+
+
+@pytest.mark.parametrize("shape", [(16, 32), (32, 64)])
+def test_swiglu_backward(shape):
+    x = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    y = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    x.retain_grad()
+    y.retain_grad()
+    torch_output = x * y * torch.sigmoid(x)
+    grad_output = torch.randn_like(torch_output)
+    torch_output.backward(grad_output, retain_graph=True)
+    torch_dx = x.grad.clone()
+    torch_dy = y.grad.clone()
+
+    x.grad = None
+    y.grad = None
+
+    triton_output = swiglu(x, y)
+    triton_output.backward(grad_output)
+    triton_dx = x.grad.clone()
+    triton_dy = y.grad.clone()
+
+    assert torch.allclose(torch_dx, triton_dx, atol=1e-5, rtol=1e-3)
+    assert torch.allclose(torch_dy, triton_dy, atol=1e-5, rtol=1e-3)
+
+
+@pytest.mark.parametrize("shape", [(16, 32), (32, 64)])
+@pytest.mark.parametrize("out_features", [16, 32])
+def test_swiglu_linear_forward(shape, out_features):
+    x = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    y = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    weight = torch.randn(out_features, shape[-1], dtype=torch.float32, requires_grad=True).to(device)
+    bias = torch.randn(out_features, dtype=torch.float32, requires_grad=True).to(device)
+    swiglu_output = x * y * torch.sigmoid(x)
+    torch_output = F.linear(swiglu_output, weight, bias)
+    triton_output = swiglu_linear(x, y, weight, bias)
+
+    assert torch.allclose(torch_output, triton_output, atol=1e-5, rtol=1e-3)
+
+
+@pytest.mark.parametrize("shape", [(16, 32), (32, 64)])
+@pytest.mark.parametrize("out_features", [16, 32])
+def test_swiglu_linear_backward(shape, out_features):
+    x = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    y = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    weight = torch.randn(out_features, shape[-1], dtype=torch.float32, requires_grad=True).to(device)
+    bias = torch.randn(out_features, dtype=torch.float32, requires_grad=True).to(device)
+    x.retain_grad()
+    y.retain_grad()
+    weight.retain_grad()
+    bias.retain_grad()
+
+    swiglu_output = x * y * torch.sigmoid(x)
+    torch_output = F.linear(swiglu_output, weight, bias)
+    grad_output = torch.randn_like(torch_output)
+
+    torch_output.backward(grad_output, retain_graph=True)
+    torch_dx = x.grad.clone()
+    torch_dy = y.grad.clone()
+    torch_dweight = weight.grad.clone()
+    torch_dbias = bias.grad.clone()
+
+    x.grad = None
+    y.grad = None
+    weight.grad = None
+    bias.grad = None
+
+    triton_output = swiglu_linear(x, y, weight, bias)
+    triton_output.backward(grad_output)
+    triton_dx = x.grad.clone()
+    triton_dy = y.grad.clone()
+    triton_dweight = weight.grad.clone()
+    triton_dbias = bias.grad.clone()
+
+    assert torch.allclose(torch_dx, triton_dx, atol=1e-5, rtol=1e-3)
+    assert torch.allclose(torch_dy, triton_dy, atol=1e-5, rtol=1e-3)
+    assert torch.allclose(torch_dweight, triton_dweight, atol=1e-5, rtol=1e-3)
+    assert torch.allclose(torch_dbias, triton_dbias, atol=1e-5, rtol=1e-3)
+
+
+@pytest.mark.parametrize("shape", [(16, 32), (32, 64)])
+@pytest.mark.parametrize("temperature", [0.5, 1.0, 2.0])
+def test_logsigmoid_forward(shape, temperature):
+    x = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    torch_output = F.logsigmoid(x) / temperature
+    triton_output = logsigmoid(x, temperature)
+    assert torch.allclose(torch_output, triton_output, atol=1e-5, rtol=1e-3)
+
+
+@pytest.mark.parametrize("shape", [(16, 32), (32, 64)])
+@pytest.mark.parametrize("temperature", [0.5, 1.0, 2.0])
+def test_logsigmoid_backward(shape, temperature):
+    x = torch.randn(shape, dtype=torch.float32, requires_grad=True).to(device)
+    x.retain_grad()
+    torch_output = F.logsigmoid(x) / temperature
+    torch_output.sum().backward()
+    torch_dx = x.grad.clone()
+    x.grad = None
+    triton_output = logsigmoid(x, temperature)
+    triton_output.sum().backward()
+    triton_dx = x.grad.clone()
+
+    assert torch.allclose(torch_dx, triton_dx, atol=1e-5, rtol=1e-3)


### PR DESCRIPTION
This pr is behind https://github.com/fla-org/flash-linear-attention/pull/163

This PR aims to address the issue that the previous activation functions couldn't be used on non-CUDA - like devices. So in this PR, if there is a native PyTorch implementation, we use the one provided by PyTorch. If not, we use the implementation with Triton. I've added relevant tests in the PR and ensured that all the tests have passed. If there is a need to implement naive PyTorch, comments are welcome. 