### PR TITLE
[RWKV] fix logits handling

### DIFF
--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -353,7 +353,7 @@ class ABCForCausalLM(ABCPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -404,7 +404,7 @@ class BitNetForCausalLM(BitNetPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -373,7 +373,7 @@ class GatedDeltaNetForCausalLM(GatedDeltaNetPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -377,7 +377,7 @@ class GLAForCausalLM(GLAPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -379,7 +379,7 @@ class GSAForCausalLM(GSAPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -380,7 +380,7 @@ class HGRNForCausalLM(HGRNPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -381,7 +381,7 @@ class HGRN2ForCausalLM(HGRN2PreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -370,7 +370,7 @@ class LightNetForCausalLM(LightNetPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -377,7 +377,7 @@ class LinearAttentionForCausalLM(LinearAttentionPreTrainedModel, GenerationMixin
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/mamba/modeling_mamba.py
+++ b/fla/models/mamba/modeling_mamba.py
@@ -812,7 +812,7 @@ class MambaForCausalLM(MambaPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -1056,7 +1056,7 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -385,7 +385,7 @@ class RetNetForCausalLM(RetNetPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -446,7 +446,7 @@ class RWKV6ForCausalLM(RWKV6PreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -454,7 +454,7 @@ class RWKV7ForCausalLM(RWKV7PreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -380,7 +380,7 @@ class SambaForCausalLM(SambaPreTrainedModel, GenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:])
+            logits = self.lm_head(hidden_states if num_logits_to_keep is None else hidden_states[:, -num_logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:


### PR DESCRIPTION
This fix handles the case when `num_logits_to_keep` is `None` and thus cannot be sliced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the model’s prediction processing logic for improved adaptability. The update allows for more flexible handling of the `hidden_states` input based on the `num_logits_to_keep` parameter, enabling the use of the entire tensor when no specific number of logits is requested. This results in more robust and versatile performance when generating outputs for varied inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->