### PR TITLE
fix(GatedDeltaNet): Ensure integer dimensions when using `expand_v`

### DIFF
--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -13,8 +13,7 @@ from torch.nn import functional as F
 
 from fla.modules import FusedRMSNormSwishGate, RMSNorm, ShortConvolution
 from fla.ops.common.utils import prepare_position_ids, prepare_sequence_ids
-from fla.ops.gated_delta_rule import (chunk_gated_delta_rule,
-                                      fused_recurrent_gated_delta_rule)
+from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -22,14 +21,14 @@ if TYPE_CHECKING:
     from fla.models.utils import Cache
 
 
+@torch.compile
 def elu_p1(x):
     return (F.elu(x, 1., False) + 1.).to(x)
 
 
+@torch.compile
 def sum_norm(x):
     return (x / x.sum(-1, keepdim=True)).to(x)
-
-# https://github.com/IDSIA/recurrent-fwp/blob/master/algorithmic/layers.py#L86C1-L146C1
 
 
 class GatedDeltaNet(nn.Module):
@@ -110,13 +109,13 @@ class GatedDeltaNet(nn.Module):
         self.num_heads = num_heads
 
         self.key_dim = self.num_heads * self.head_dim
-        self.value_dim = int(self.key_dim * expand_v) 
+        self.value_dim = int(self.key_dim * self.expand_v)
         self.head_k_dim = head_dim
         self.head_v_dim = int(head_dim * self.expand_v)
         self.layer_idx = layer_idx
         self.silu = nn.SiLU()
         
-                # Consistency check: Ensure expand_v produces integer values
+        # Consistency check: Ensure expand_v produces integer values
         if not math.isclose(self.key_dim * expand_v, self.value_dim, rel_tol=1e-5):
             raise ValueError(
                 f"expand_v={expand_v} does not produce an integer value when multiplied by key_dim={self.key_dim}. "
@@ -138,8 +137,6 @@ class GatedDeltaNet(nn.Module):
         A_log = torch.log(A)
         self.A_log = nn.Parameter(A_log)
         self.A_log._no_weight_decay = True
-        self.D = nn.Parameter(torch.ones(self.num_heads))
-        self.D._no_weight_decay = True
         # hard coded for now
         dt_min = 0.001
         dt_max = 0.1
@@ -219,21 +216,27 @@ class GatedDeltaNet(nn.Module):
                 if position_ids is None:
                     position_ids = prepare_position_ids(cu_seqlens)
                 seq_idx = prepare_sequence_ids(position_ids).to(torch.int32).unsqueeze(0)
-            q, conv_state_q = self.q_conv1d(x=self.q_proj(hidden_states),
-                                            mask=conv_mask,
-                                            cache=conv_state_q,
-                                            output_final_state=use_cache,
-                                            seq_idx=seq_idx)
-            k, conv_state_k = self.k_conv1d(x=self.k_proj(hidden_states),
-                                            mask=conv_mask,
-                                            cache=conv_state_k,
-                                            output_final_state=use_cache,
-                                            seq_idx=seq_idx)
-            v, conv_state_v = self.v_conv1d(x=self.v_proj(hidden_states),
-                                            mask=conv_mask,
-                                            cache=conv_state_v,
-                                            output_final_state=use_cache,
-                                            seq_idx=seq_idx)
+            q, conv_state_q = self.q_conv1d(
+                x=self.q_proj(hidden_states),
+                mask=conv_mask,
+                cache=conv_state_q,
+                output_final_state=use_cache,
+                seq_idx=seq_idx
+            )
+            k, conv_state_k = self.k_conv1d(
+                x=self.k_proj(hidden_states),
+                mask=conv_mask,
+                cache=conv_state_k,
+                output_final_state=use_cache,
+                seq_idx=seq_idx
+            )
+            v, conv_state_v = self.v_conv1d(
+                x=self.v_proj(hidden_states),
+                mask=conv_mask,
+                cache=conv_state_v,
+                output_final_state=use_cache,
+                seq_idx=seq_idx
+            )
         else:
             q = self.silu(self.q_proj(hidden_states))
             k = self.silu(self.k_proj(hidden_states))

--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -13,7 +13,8 @@ from torch.nn import functional as F
 
 from fla.modules import FusedRMSNormSwishGate, RMSNorm, ShortConvolution
 from fla.ops.common.utils import prepare_position_ids, prepare_sequence_ids
-from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
+from fla.ops.gated_delta_rule import (chunk_gated_delta_rule,
+                                      fused_recurrent_gated_delta_rule)
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -21,14 +22,14 @@ if TYPE_CHECKING:
     from fla.models.utils import Cache
 
 
-@torch.compile
 def elu_p1(x):
     return (F.elu(x, 1., False) + 1.).to(x)
 
 
-@torch.compile
 def sum_norm(x):
     return (x / x.sum(-1, keepdim=True)).to(x)
+
+# https://github.com/IDSIA/recurrent-fwp/blob/master/algorithmic/layers.py#L86C1-L146C1
 
 
 class GatedDeltaNet(nn.Module):
@@ -109,12 +110,23 @@ class GatedDeltaNet(nn.Module):
         self.num_heads = num_heads
 
         self.key_dim = self.num_heads * self.head_dim
-        self.value_dim = self.key_dim * self.expand_v
+        self.value_dim = int(self.key_dim * expand_v) 
         self.head_k_dim = head_dim
-        self.head_v_dim = head_dim * self.expand_v
+        self.head_v_dim = int(head_dim * self.expand_v)
         self.layer_idx = layer_idx
         self.silu = nn.SiLU()
-
+        
+                # Consistency check: Ensure expand_v produces integer values
+        if not math.isclose(self.key_dim * expand_v, self.value_dim, rel_tol=1e-5):
+            raise ValueError(
+                f"expand_v={expand_v} does not produce an integer value when multiplied by key_dim={self.key_dim}. "
+                f"Resulting value_dim would be {self.key_dim * expand_v}, which is invalid for nn.Linear."
+            )
+        if not math.isclose(head_dim * expand_v, self.head_v_dim, rel_tol=1e-5):
+            raise ValueError(
+                f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}. "
+                f"Resulting head_v_dim would be {head_dim * expand_v}, which is invalid for FusedRMSNormSwishGate."
+            )
         assert mode in ['chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
 
         self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
@@ -126,6 +138,8 @@ class GatedDeltaNet(nn.Module):
         A_log = torch.log(A)
         self.A_log = nn.Parameter(A_log)
         self.A_log._no_weight_decay = True
+        self.D = nn.Parameter(torch.ones(self.num_heads))
+        self.D._no_weight_decay = True
         # hard coded for now
         dt_min = 0.001
         dt_max = 0.1
@@ -205,27 +219,21 @@ class GatedDeltaNet(nn.Module):
                 if position_ids is None:
                     position_ids = prepare_position_ids(cu_seqlens)
                 seq_idx = prepare_sequence_ids(position_ids).to(torch.int32).unsqueeze(0)
-            q, conv_state_q = self.q_conv1d(
-                x=self.q_proj(hidden_states),
-                mask=conv_mask,
-                cache=conv_state_q,
-                output_final_state=use_cache,
-                seq_idx=seq_idx
-            )
-            k, conv_state_k = self.k_conv1d(
-                x=self.k_proj(hidden_states),
-                mask=conv_mask,
-                cache=conv_state_k,
-                output_final_state=use_cache,
-                seq_idx=seq_idx
-            )
-            v, conv_state_v = self.v_conv1d(
-                x=self.v_proj(hidden_states),
-                mask=conv_mask,
-                cache=conv_state_v,
-                output_final_state=use_cache,
-                seq_idx=seq_idx
-            )
+            q, conv_state_q = self.q_conv1d(x=self.q_proj(hidden_states),
+                                            mask=conv_mask,
+                                            cache=conv_state_q,
+                                            output_final_state=use_cache,
+                                            seq_idx=seq_idx)
+            k, conv_state_k = self.k_conv1d(x=self.k_proj(hidden_states),
+                                            mask=conv_mask,
+                                            cache=conv_state_k,
+                                            output_final_state=use_cache,
+                                            seq_idx=seq_idx)
+            v, conv_state_v = self.v_conv1d(x=self.v_proj(hidden_states),
+                                            mask=conv_mask,
+                                            cache=conv_state_v,
+                                            output_final_state=use_cache,
+                                            seq_idx=seq_idx)
         else:
             q = self.silu(self.q_proj(hidden_states))
             k = self.silu(self.k_proj(hidden_states))


### PR DESCRIPTION
Ensure integer dimensions for `value_dim` and `head_v_dim`:

- Explicitly cast `self.value_dim` and `self.head_v_dim` to integers when using `expand_v`.
- Added consistency checks to validate `expand_v` produces integer dimensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new public configuration parameter to enhance stability.

- **Refactor**
  - Improved reliability through stricter type validation and consistency checks.
  - Enhanced robustness of dimension calculations for linear layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->