### PR TITLE
[RWKV7] fix `RWKV7Attention.__init__`

### DIFF
--- a/fla/layers/rwkv7.py
+++ b/fla/layers/rwkv7.py
@@ -54,7 +54,7 @@ class RWKV7Attention(nn.Module):
         elif num_heads is not None:
             self.head_dim = int(hidden_size // num_heads)
             self.num_heads = num_heads
-        self.head_v_dim = int(self.value_dim // num_heads)
+        self.head_v_dim = int(self.value_dim // self.num_heads)
 
         self.decay_low_rank_dim = decay_low_rank_dim
         self.gate_low_rank_dim = gate_low_rank_dim


### PR DESCRIPTION
In the` __init__` function of `RWKV7Attention`, the `num_heads` parameter might be `None`, which causes an error in the calculation of `self.head_v_dim`. This issue can be resolved by changing it to use `self.num_heads` instead.

Test code is as follows:
```python
from fla.layers.rwkv7 import RWKV7Attention

attn = RWKV7Attention(
    mode='chunk',
    hidden_size=384,
    head_dim=64,
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal calculation logic to ensure consistent dimension assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->