### PR TITLE
[Fix]: reshape o before o_proj in linear_attn layer.

### DIFF
--- a/fla/layers/linear_attn.py
+++ b/fla/layers/linear_attn.py
@@ -104,6 +104,7 @@ class LinearAttention(nn.Module):
             raise NotImplementedError(f"Not supported output norm `{output_norm}`.")
 
         self.o_proj = nn.Linear(self.value_dim, hidden_size, bias=False)
+        
 
         self.norm_q = norm_q
         self.norm_k = norm_k
@@ -155,5 +156,6 @@ class LinearAttention(nn.Module):
         else:
             raise NotImplementedError
         o = self.norm(o)
+        o = rearrange(o, '... h d -> ... (h d)')
         o = self.o_proj(o)
         return o

--- a/fla/layers/linear_attn.py
+++ b/fla/layers/linear_attn.py
@@ -104,7 +104,6 @@ class LinearAttention(nn.Module):
             raise NotImplementedError(f"Not supported output norm `{output_norm}`.")
 
         self.o_proj = nn.Linear(self.value_dim, hidden_size, bias=False)
-        
 
         self.norm_q = norm_q
         self.norm_k = norm_k


### PR DESCRIPTION
Origin code forgot to reshape `o` before performing `self.o_proj(o)`, which causes error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the processing of attention outputs to improve tensor structure, ensuring efficient performance while maintaining existing functionality.
- **Chore**
  - Made minor formatting improvements for better code readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->