### PR TITLE
[ABC] Add `use_rope` parameter to ABCAttention and ABCConfig & Fix compiler bugs in kernels

### DIFF
--- a/fla/layers/abc.py
+++ b/fla/layers/abc.py
@@ -35,6 +35,7 @@ class ABCAttention(nn.Module):
         norm_eps: float = 1e-5,
         gate_low_rank_dim: int = 16,
         gate_logit_normalizer: int = 16,
+        use_rope: bool = True,
         use_input_gate: bool = False,
         use_output_gate: bool = True,
         use_norm: bool = True,
@@ -61,6 +62,7 @@ class ABCAttention(nn.Module):
         self.gate_low_rank_dim = gate_low_rank_dim
         self.gate_logit_normalizer = gate_logit_normalizer
 
+        self.use_rope = use_rope
         self.use_input_gate = use_input_gate
         self.use_output_gate = use_output_gate
         self.use_norm = use_norm
@@ -135,6 +137,8 @@ class ABCAttention(nn.Module):
             last_state = past_key_values[self.layer_idx]
 
         cu_seqlens, position_ids, seq_idx = kwargs.get('cu_seqlens', None), kwargs.get('position_ids', None), None
+        if cu_seqlens is not None:
+            raise NotImplementedError("Training with cu_seqlens is not supported yet for ABCAttention")
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
             if last_state is not None:

--- a/fla/models/abc/configuration_abc.py
+++ b/fla/models/abc/configuration_abc.py
@@ -29,6 +29,7 @@ class ABCConfig(PretrainedConfig):
         max_position_embeddings: int = 2048,
         elementwise_affine: Optional[bool] = True,
         norm_eps: float = 1e-6,
+        use_rope: bool = True,
         attn: Optional[Dict] = None,
         use_cache: bool = True,
         pad_token_id: int = None,
@@ -59,6 +60,7 @@ class ABCConfig(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
+        self.use_rope = use_rope
         self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range

--- a/fla/ops/abc/chunk.py
+++ b/fla/ops/abc/chunk.py
@@ -289,7 +289,7 @@ def chunk_abc_fwd_kernel_V(
     b_v = tl.load(p_v, boundary_check=(0, 1))
     # [BT, BT]
     b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_o += tl.dot(b_A, b_v, allow_tf32=False)
+    b_o += tl.dot(b_A.to(b_v.dtype), b_v, allow_tf32=False)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -412,7 +412,7 @@ def chunk_abc_bwd_kernel_V(
         # [BT, BV]
         b_dv = tl.dot(b_k, b_dh, allow_tf32=False)
         if i_k == 0:
-            b_dv += tl.dot(b_A, b_do, allow_tf32=False)
+            b_dv += tl.dot(b_A.to(b_do.dtype), b_do, allow_tf32=False)
         b_do = (b_do * scale).to(b_do.dtype)
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
         # [BT, BT]

--- a/fla/ops/utils/logcumsumexp.py
+++ b/fla/ops/utils/logcumsumexp.py
@@ -35,9 +35,7 @@ def logcumsumexp_fwd_kernel(
         b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
         # [S,]
         b_mc = tl.max(b_s, 0)
-        # workaround for compiler bugs
-        if i_t > 0:
-            b_mc = tl.maximum(b_mp, b_mc)
+        b_mc = tl.maximum(b_mp, b_mc)
         b_zp = b_zp * tl.exp(b_mp - b_mc)
         # [BT, S]
         b_s = tl.exp(b_s - b_mc)


### PR DESCRIPTION
- Introduced `use_rope` parameter in `ABCAttention` and `ABCConfig` classes to enhance model flexibility.
- Updated relevant methods to accommodate the new parameter.
- Added error handling for unsupported `cu_seqlens` in `ABCAttention`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable option to enable enhanced behavior in attention components.
  - Expanded API flexibility by supporting structured additional parameters for model methods.

- **Bug Fixes**
  - Improved error messaging to clearly indicate unsupported training configurations.
  - Enhanced numerical stability with better data type handling in core computations.
  - Streamlined cumulative operations for more consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->