### PR TITLE
Update fused_recurrent.py for inference with nomalization=true

### DIFF
--- a/fla/ops/linear_attn/fused_recurrent.py
+++ b/fla/ops/linear_attn/fused_recurrent.py
@@ -235,6 +235,7 @@ def fused_recurrent_linear_attn(
     v: torch.Tensor,
     scale: Optional[float] = None,
     initial_state: torch.Tensor = None,
+    cum_k: torch.Tensor = None,
     output_final_state: bool = False,
     normalize: bool = False,
     head_first: bool = True
@@ -245,7 +246,7 @@ def fused_recurrent_linear_attn(
         q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
     o, final_state = FusedRecurrentLinearAttentionFunction.apply(q, k, v, scale, initial_state, output_final_state)
     if normalize:
-        o = normalize_output(q * scale, k, o)
+        o = normalize_output(q * scale, k, o, cum_k)
     if not head_first:
         o = o.transpose(1, 2)
     return o, final_state


### PR DESCRIPTION
the current linear attention can save a $KV$ state cache. This works when normalization is not enabled. When normalization is enabled. the output should be $\frac{QKV}{QK1}$. we can see that $QK1$ or Q@sum(K) is missing earlier Keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the attention module with an additional optional parameter for output normalization. This update offers improved control over how outputs are normalized when the feature is enabled, while maintaining overall compatibility with previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->