### PR TITLE
Update fused_recurrent.py for inference with nomalization=true

### DIFF
--- a/fla/ops/linear_attn/fused_recurrent.py
+++ b/fla/ops/linear_attn/fused_recurrent.py
@@ -235,6 +235,7 @@ def fused_recurrent_linear_attn(
     v: torch.Tensor,
     scale: Optional[float] = None,
     initial_state: torch.Tensor = None,
+    cum_K: torch.Tensor = None,
     output_final_state: bool = False,
     normalize: bool = False,
     head_first: bool = True
@@ -245,7 +246,7 @@ def fused_recurrent_linear_attn(
         q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
     o, final_state = FusedRecurrentLinearAttentionFunction.apply(q, k, v, scale, initial_state, output_final_state)
     if normalize:
-        o = normalize_output(q * scale, k, o)
+        o = normalize_output(q * scale, k, o,cum_K)
     if not head_first:
         o = o.transpose(1, 2)
     return o, final_state

--- a/fla/ops/linear_attn/utils.py
+++ b/fla/ops/linear_attn/utils.py
@@ -4,7 +4,9 @@ import torch
 
 
 @torch.jit.script
-def normalize_output(q, k, o):
+def normalize_output(q, k, o, cum_k=None):
     k = k.cumsum(-2)
+    if cum_k is not None:
+        k=k+cum_K
     z = (q * k).sum(-1, keepdim=True)
     return o / (z + 1e-10)


### PR DESCRIPTION
the current linear attention can save a $KV$ state cache. This works when normalization is not enabled. When normalization is enabled. the output should be $\frac{QKV}{QK1}$. we can see that $QK1$ or Q@sum(K) is missing earlier Keys

last pull request only modified one file, not sure why this happen, re-opened this, hope this version does contain two changes