### PR TITLE
[OP] replace `tl.exp`, `tl.log`, `tl.log2` with fast ops when `FLA_USE_FAST_OPS=1`

### DIFF
--- a/fla/modules/activations.py
+++ b/fla/modules/activations.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
+from fla.ops.utils.op import exp, log
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, get_multiprocessor_count, input_guard
 
 sigmoid_fwd_codestring = """
@@ -72,8 +73,8 @@ def logsigmoid_fwd_kernel(
 
     b_x = tl.load(x + o_i, mask=m_i, other=0.).to(tl.float32)
     b_m = tl.minimum(0., b_x)
-    b_z = 1. + tl.exp(-tl.abs(b_x))
-    b_y = (b_m - tl.log(b_z)) / temperature
+    b_z = 1. + exp(-tl.abs(b_x))
+    b_y = (b_m - log(b_z)) / temperature
     tl.store(y + o_i, b_y.to(y.dtype.element_ty), mask=m_i)
 
 

--- a/fla/modules/fused_linear_cross_entropy.py
+++ b/fla/modules/fused_linear_cross_entropy.py
@@ -15,6 +15,7 @@ from torch.distributed.tensor import DeviceMesh, DTensor, Replicate, Shard, dist
 from torch.distributed.tensor.parallel import ParallelStyle
 
 from fla.ops.utils import logsumexp_fwd
+from fla.ops.utils.op import exp
 from fla.utils import input_guard
 
 # The hard limit of TRITON_MAX_TENSOR_NUMEL is 1048576
@@ -118,7 +119,7 @@ def cross_entropy_kernel(
         if label_smoothing > 0:
             # scale X beforehand to avoid overflow
             b_z += tl.sum(tl.where(o_v < V, -eps * b_logits, 0.0))
-        b_p = (tl.exp(b_logits - b_lse) - eps) * logit_scale
+        b_p = (exp(b_logits - b_lse) - eps) * logit_scale
         if reduction == "mean":
             b_p = b_p / total
         tl.store(logits + o_v, b_p, mask=o_v < V)

--- a/fla/ops/fox/parallel.py
+++ b/fla/ops/fox/parallel.py
@@ -11,7 +11,7 @@ from einops import rearrange, reduce
 from fla.ops.common.utils import prepare_chunk_indices
 from fla.ops.utils import chunk_global_cumsum, chunk_local_cumsum
 from fla.ops.utils.op import div, exp, log
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, input_guard
 
 
 @triton.heuristics({
@@ -458,12 +458,12 @@ def parallel_fox_fwd(
     G = HQ // H
     BT = chunk_size
     BK = max(16, triton.next_power_of_2(K))
+    assert V <= 256, "V must be less than or equal to 256"
     if check_shared_mem('hopper'):
         BS = min(64, max(16, triton.next_power_of_2(T)))
-        BV = min(256, max(16, triton.next_power_of_2(V)))
     else:
         BS = min(32, max(16, triton.next_power_of_2(T)))
-        BV = min(128, max(16, triton.next_power_of_2(V)))
+    BV = min(256, max(16, triton.next_power_of_2(V)))
     NV = triton.cdiv(V, BV)
     NT = triton.cdiv(T, BT) if offsets is None else len(indices)
 
@@ -606,12 +606,14 @@ def parallel_fox_bwd(
 class ParallelFoxFunction(torch.autograd.Function):
 
     @staticmethod
-    @contiguous
+    @input_guard
     @autocast_custom_fwd
     def forward(ctx, q, k, v, g, scale, offsets):
         ctx.dtype = q.dtype
-
-        chunk_size = min(128, max(16, triton.next_power_of_2(q.shape[1])))
+        if check_shared_mem('hopper'):
+            chunk_size = min(128, max(16, triton.next_power_of_2(q.shape[1])))
+        else:
+            chunk_size = min(64, max(16, triton.next_power_of_2(q.shape[1])))
         # 2-d indices denoting the offsets of chunks in each sequence
         # for example, if the passed `offsets` is [0, 100, 356] and `chunk_size` is 64,
         # then there are 2 and 4 chunks in the 1st and 2nd sequences respectively, and `indices` will be
@@ -637,7 +639,7 @@ class ParallelFoxFunction(torch.autograd.Function):
         return o.to(q.dtype)
 
     @staticmethod
-    @contiguous
+    @input_guard
     @autocast_custom_bwd
     def backward(ctx, do):
         q, k, v, g, o, lse = ctx.saved_tensors

--- a/fla/ops/fox/parallel.py
+++ b/fla/ops/fox/parallel.py
@@ -10,6 +10,7 @@ from einops import rearrange, reduce
 
 from fla.ops.common.utils import prepare_chunk_indices
 from fla.ops.utils import chunk_global_cumsum, chunk_local_cumsum
+from fla.ops.utils.op import div, exp, log
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, contiguous
 
 
@@ -98,9 +99,9 @@ def parallel_fox_fwd_kernel(
 
         # [BT]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
-        b_r = tl.exp(b_mp - b_m)
+        b_r = exp(b_mp - b_m)
         # [BT, BS]
-        b_p = tl.exp(b_s - b_m[:, None])
+        b_p = exp(b_s - b_m[:, None])
         # [BT]
         b_acc = b_acc * b_r + tl.sum(b_p, 1)
         # [BT, BV]
@@ -127,9 +128,9 @@ def parallel_fox_fwd_kernel(
 
         b_gq += b_gn - b_gp
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
-        b_r = tl.exp(b_mp - b_m)
+        b_r = exp(b_mp - b_m)
         # [BT, BS]
-        b_p = tl.exp(b_s - b_m[:, None])
+        b_p = exp(b_s - b_m[:, None])
         # [BT]
         b_acc = b_acc * b_r + tl.sum(b_p, 1)
         # [BT, BV]
@@ -137,8 +138,8 @@ def parallel_fox_fwd_kernel(
 
         b_mp = b_m
 
-    b_o = b_o / b_acc[:, None]
-    b_m += tl.log(b_acc)
+    b_o = div(b_o, b_acc[:, None])
+    b_m += log(b_acc)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_lse, b_m.to(p_lse.dtype.element_ty), boundary_check=(0,))
 
@@ -251,7 +252,7 @@ def parallel_fox_bwd_kernel_dq(
         b_gk = tl.load(p_gk, boundary_check=(0,))
         # [BT, BS]
         b_s = tl.dot(b_q, b_k) + (b_gq - b_lse)[:, None] - b_gk[None, :]
-        b_p = tl.exp(tl.where(o_q[:, None] >= o_k[None, :], b_s, float('-inf')))
+        b_p = exp(tl.where(o_q[:, None] >= o_k[None, :], b_s, float('-inf')))
 
         # [BT, BV] @ [BV, BS] -> [BT, BS]
         b_dp = tl.dot(b_do, b_v)
@@ -277,7 +278,7 @@ def parallel_fox_bwd_kernel_dq(
         b_gp = tl.load(g + (bos + i_s - 1) * HQ + i_hq).to(tl.float32) if i_s % BT > 0 else 0.
         # [BT, BS]
         b_s = tl.dot(b_q, b_k) + (b_gq - b_lse)[:, None] + (b_gn - b_gk)[None, :]
-        b_p = tl.exp(b_s)
+        b_p = exp(b_s)
         # [BT, BV] @ [BV, BS] -> [BT, BS]
         b_dp = tl.dot(b_do, b_v)
         b_ds = b_p * (b_dp - b_delta[:, None])
@@ -387,7 +388,7 @@ def parallel_fox_bwd_kernel_dkv(
         m_s = (o_k[:, None] <= o_q[None, :]) & m_k[:, None] & m_q[None, :]
         # [BT, BS]
         b_s = tl.dot(b_k, tl.trans(b_q)) - b_gk[:, None] + (b_gq - b_lse)[None, :]
-        b_p = tl.where(m_s, tl.exp(b_s), 0)
+        b_p = tl.where(m_s, exp(b_s), 0)
         # [BT, BS] @ [BS, BV] -> [BT, BV]
         b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
         # [BT, BV] @ [BV, BS] -> [BT, BS]
@@ -423,7 +424,7 @@ def parallel_fox_bwd_kernel_dkv(
         b_gp = tl.load(g + (bos + i_s - 1) * HQ + i_hq).to(tl.float32) if i_s % BT > 0 else 0.
         # [BT, BS]
         b_s = tl.dot(b_k, tl.trans(b_q)) + (b_gp - b_gk)[:, None] + (b_gq - b_lse)[None, :]
-        b_p = tl.exp(b_s)
+        b_p = exp(b_s)
         # [BT, BS] @ [BS, BV] -> [BT, BV]
         b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
         # [BT, BV] @ [BV, BS] -> [BT, BS]

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -8,6 +8,7 @@ import triton
 import triton.language as tl
 from einops import rearrange
 
+from fla.ops.utils.op import exp
 from fla.utils import input_guard
 
 
@@ -83,7 +84,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
             b_k = b_k / (tl.sqrt(tl.sum(b_k * b_k)) + 1e-6)
         b_q = b_q * scale
         # [BK, BV]
-        b_h *= tl.exp(b_g)
+        b_h *= exp(b_g)
         # [BV]
         b_v -= tl.sum(b_h * b_k[:, None], 0)
         if IS_BETA_HEADWISE:

--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -7,7 +7,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.exp import safe_exp
+from fla.ops.utils.op import safe_exp
 from fla.utils import check_shared_mem
 
 

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
@@ -7,7 +7,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.exp import exp
+from fla.ops.utils.op import exp
 from fla.utils import check_shared_mem, use_cuda_graph
 
 

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
@@ -7,7 +7,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.exp import exp
+from fla.ops.utils.op import exp
 from fla.utils import use_cuda_graph
 
 

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.common.utils import prepare_chunk_offsets
-from fla.ops.utils.exp import exp
+from fla.ops.utils.op import exp
 from fla.utils import check_shared_mem, use_cuda_graph
 
 

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.common.utils import prepare_chunk_offsets
-from fla.ops.utils.exp import exp
+from fla.ops.utils.op import exp
 from fla.utils import check_shared_mem, use_cuda_graph
 
 

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
@@ -7,7 +7,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.exp import exp
+from fla.ops.utils.op import exp
 from fla.utils import check_shared_mem, use_cuda_graph
 
 BK_LIST = [64, 128] if check_shared_mem() else [16, 32]

--- a/fla/ops/generalized_delta_rule/dplr/fused_recurrent.py
+++ b/fla/ops/generalized_delta_rule/dplr/fused_recurrent.py
@@ -7,7 +7,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.exp import exp
+from fla.ops.utils.op import exp
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, use_cuda_graph
 
 

--- a/fla/ops/generalized_delta_rule/dplr/naive.py
+++ b/fla/ops/generalized_delta_rule/dplr/naive.py
@@ -3,7 +3,6 @@
 import torch
 from einops import rearrange
 
-
 # S_t = S_t @ (I + alpha_t beta_t^T) + v_t k_t^T
 # q, k, alpha, beta [B, H, L, D_K]
 # v [B, H, L, D_V]

--- a/fla/ops/gsa/fused_recurrent.py
+++ b/fla/ops/gsa/fused_recurrent.py
@@ -9,6 +9,7 @@ import triton.language as tl
 
 from fla.ops.common.fused_recurrent import fused_recurrent_bwd_kernel, fused_recurrent_fwd_kernel
 from fla.ops.utils import chunk_global_cumsum
+from fla.ops.utils.op import exp
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
 
@@ -37,7 +38,7 @@ def fused_recurrent_gsa_inference_kernel(
 
     b_s = tl.load(s + i_bg * M + tl.arange(0, M)).to(tl.float32)
     b_g = tl.load(g + i_bg * M + tl.arange(0, M)).to(tl.float32)
-    b_g = tl.exp(b_g)
+    b_g = exp(b_g)
 
     b_ok = tl.zeros([M], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):

--- a/fla/ops/hgrn/fused_recurrent.py
+++ b/fla/ops/hgrn/fused_recurrent.py
@@ -7,6 +7,7 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.ops.utils.op import exp
 from fla.utils import input_guard
 
 
@@ -59,7 +60,7 @@ def fused_recurrent_hgrn_fwd_kernel(
     for _ in range(0, T):
         b_x = tl.load(p_x, mask=mask, other=0).to(tl.float32)
         b_g = tl.load(p_g, mask=mask, other=0).to(tl.float32)
-        b_h = tl.exp(b_g) * b_h + b_x
+        b_h = exp(b_g) * b_h + b_x
         tl.store(p_o, b_h.to(p_o.dtype.element_ty), mask=mask)
 
         p_x += D
@@ -135,7 +136,7 @@ def fused_recurrent_hgrn_bwd_kernel(
 
         b_dh = b_dh + b_do
         b_dx = b_dh
-        b_dh = b_dh * tl.exp(b_g)
+        b_dh = b_dh * exp(b_g)
         b_dg = b_dh * b_o
         tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), mask=mask)
         tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=mask)

--- a/fla/ops/nsa/utils.py
+++ b/fla/ops/nsa/utils.py
@@ -10,6 +10,8 @@
 import triton
 import triton.language as tl
 
+from fla.ops.utils.op import log2
+
 
 @triton.jit
 def _compare_and_swap(
@@ -83,7 +85,7 @@ def argsort(
     _dim: tl.constexpr = len(x.shape) - 1 if dim is None else dim
     tl.static_assert(_dim == len(x.shape) - 1, "only minor dimension is currently supported")
     # iteratively run bitonic merge-sort steps
-    n_dims: tl.constexpr = tl.log2(x.shape[_dim])
+    n_dims: tl.constexpr = log2(x.shape[_dim])
 
     for i in tl.static_range(1, n_dims + 1):
         x, ids = _bitonic_merge(x, ids, i, 2 if i < n_dims else descending, n_dims)

--- a/fla/ops/simple_gla/parallel.py
+++ b/fla/ops/simple_gla/parallel.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import chunk_global_cumsum, chunk_local_cumsum
-from fla.ops.utils.exp import safe_exp
+from fla.ops.utils.op import safe_exp
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, input_guard, is_intel_alchemist
 
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/3449

--- a/fla/ops/utils/logsumexp.py
+++ b/fla/ops/utils/logsumexp.py
@@ -7,6 +7,8 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.ops.utils.op import exp, log
+
 
 @triton.heuristics({
     'HAS_SCALE': lambda args: args['scale'] is not None
@@ -35,7 +37,7 @@ def logsumexp_fwd_kernel(
     if HAS_SCALE:
         b_x = b_x * scale
     b_m = tl.max(b_x, 0)
-    b_z = tl.log(tl.sum(tl.exp(b_x - b_m), 0)) + b_m
+    b_z = log(tl.sum(exp(b_x - b_m), 0)) + b_m
     tl.store(z + i_n * tl.cdiv(D, B) + i_d, b_z)
 
 

--- a/fla/ops/utils/matmul.py
+++ b/fla/ops/utils/matmul.py
@@ -10,7 +10,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.exp import exp
+from fla.ops.utils.op import exp
 from fla.utils import input_guard
 
 

--- a/fla/ops/utils/op.py
+++ b/fla/ops/utils/op.py
@@ -8,11 +8,20 @@ import triton.language as tl
 import triton.language.extra.libdevice as tldevice
 
 if os.environ.get('FLA_USE_FAST_OPS', '0') == '1':
+    div = tldevice.fast_dividef
     exp = tldevice.fast_expf
+    log = tldevice.fast_logf
+    log2 = tldevice.fast_log2f
 else:
+    @triton.jit
+    def div_normal(x, y):
+        return x / y
+    div = div_normal
     exp = tl.exp
+    log = tl.log
+    log2 = tl.log2
 
 
 @triton.jit
 def safe_exp(x):
-    return tl.exp(tl.where(x <= 0, x, float('-inf')))
+    return exp(tl.where(x <= 0, x, float('-inf')))

--- a/fla/ops/utils/softmax.py
+++ b/fla/ops/utils/softmax.py
@@ -7,6 +7,8 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.ops.utils.op import exp
+
 
 @triton.autotune(
     configs=[
@@ -32,7 +34,7 @@ def softmax_fwd_kernel(
 
     b_x = tl.load(x + i_n * D + o_d, mask=m_d, other=-float('inf'))
     b_m = tl.max(b_x, 0)
-    b_x = tl.exp(b_x - b_m)
+    b_x = exp(b_x - b_m)
     b_p = b_x / tl.sum(b_x, 0)
 
     tl.store(p + i_n * D + o_d, b_p.to(p.dtype.element_ty), mask=m_d)

--- a/fla/ops/utils/testing.py
+++ b/fla/ops/utils/testing.py
@@ -5,7 +5,7 @@ ci_env = os.getenv("CI_ENV") == "1"
 
 
 def get_abs_err(x, y):
-    return (x-y).flatten().abs().max().item()
+    return (x.detach()-y.detach()).flatten().abs().max().item()
 
 
 def get_err_ratio(x, y):

--- a/scripts/find_dependent_tests.py
+++ b/scripts/find_dependent_tests.py
@@ -81,7 +81,8 @@ if __name__ == "__main__":
     changed_files = [Path(file) for file in sys.argv[1].split()]
     # Skip fla/utils.py
     BLACKLIST = [
-        'fla/utils.py'
+        'fla/utils.py',
+        'fla/ops/utils/testing.py',
     ]
     changed_files = [
         file for file in changed_files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized internal mathematical operations for key computations, ensuring consistent handling of exponential, logarithmic, and division operations.
  - Enabled conditional, optimized pathways for these operations to improve numerical stability and performance.

- **Chore**
  - Updated import structures and dependency references for a cleaner, more maintainable codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->