### PR TITLE
[CI] auto-cancel workflows on PR merge via concurrency group

### DIFF
--- a/.github/workflows/intel-a770.yml
+++ b/.github/workflows/intel-a770.yml
@@ -7,6 +7,7 @@ concurrency:
 on:
   pull_request:
     branches: [ '*' ]
+    types: [opened, synchronize, reopened, closed]
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: 'intel-a770'
     env:
       CI_ENV: 1

--- a/.github/workflows/nvidia-4090.yml
+++ b/.github/workflows/nvidia-4090.yml
@@ -7,6 +7,7 @@ concurrency:
 on:
   pull_request:
     branches: [ '*' ]
+    types: [opened, synchronize, reopened, closed]
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: 'nvidia-4090'
     env:
       CI_ENV: 1

--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -7,6 +7,7 @@ concurrency:
 on:
   pull_request:
     branches: [ '*' ]
+    types: [opened, synchronize, reopened, closed]
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: 'nvidia-h100'
     env:
       CI_ENV: 1


### PR DESCRIPTION
- Skip jobs on `pull_request: closed` events to trigger cancellation
- Existing runs for same PR will be automatically canceled