### PR TITLE
[README] Add `--no-use-pep517` flag for faster installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ The following requirements should be satisfied
 
 You can install `fla` with pip:
 ```sh
-pip install flash-linear-attention --no-build-isolation
+pip install --no-use-pep517 flash-linear-attention
 ```
 As `fla` is actively developed now, for the latest features and updates, an alternative way is to install the package from source
 ```sh
 # uninstall `fla` first to ensure a successful upgrade
-pip uninstall flash-linear-attention && pip install -U git+https://github.com/fla-org/flash-linear-attention
+pip uninstall flash-linear-attention && pip install -U --no-use-pep517 git+https://github.com/fla-org/flash-linear-attention
 ```
 or manage `fla` with submodules
 ```sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for the flash-linear-attention package.
  - Revised pip commands now utilize the `--no-use-pep517` flag for a consistent installation and reinstallation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->