### PR TITLE
[FoX] Fix class inheritance for ForgettingTransformerForCausalLM

### DIFF
--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -273,7 +273,7 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
         )
 
 
-class ForgettingTransformerForCausalLM(ForgettingTransformerModel, GenerationMixin):
+class ForgettingTransformerForCausalLM(ForgettingTransformerPreTrainedModel, GenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the underlying causal language model module to leverage enhanced pre-trained model handling, ensuring consistent initialization and performance while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->