### PR TITLE
[GroupNorm] Add argument `is_rms_norm` to GroupNorm

### DIFF
--- a/fla/modules/layernorm.py
+++ b/fla/modules/layernorm.py
@@ -18,12 +18,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 import triton
 import triton.language as tl
+from einops import rearrange
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor, Replicate, Shard, distribute_module
 from torch.distributed.tensor.parallel import ParallelStyle
 
 from fla.utils import get_multiprocessor_count, input_guard
-from einops import rearrange
 
 
 def layer_norm_ref(
@@ -73,6 +73,7 @@ def rms_norm_ref(
     out = out.to(dtype)
     return out if not prenorm else (out, x)
 
+
 def group_norm_ref(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -106,6 +107,7 @@ def group_norm_ref(
     out = rearrange(out, "... g d -> ... (g d)")
     out = out.to(dtype)
     return out if not prenorm else (out, x)
+
 
 class GroupNormRef(nn.Module):
 


### PR DESCRIPTION
This is needed for the QK-norm component in the Forgetting Transformer. Feel free to suggest a different interface (e.g., use a variable name other than `is_rms_norm` or create a separate `GroupRMSNorm` class).

Also, I'm not sure whether `upcast` should be `True` or `False` in my reference implementation. Both passed the test. I just used `True`, which seems to be consistent with the layer norm implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced normalization functionality now supports group normalization with an optional RMS normalization variant for improved performance.

- **Tests**
  - Expanded test coverage to conditionally verify the new RMS normalization option in the normalization tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->