### PR TITLE
[CI] Only cancel in-progress CI for pull requests

### DIFF
--- a/.github/workflows/intel-a770.yml
+++ b/.github/workflows/intel-a770.yml
@@ -2,7 +2,7 @@ name: intel-a770-ci
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:

--- a/.github/workflows/nvidia-4090.yml
+++ b/.github/workflows/nvidia-4090.yml
@@ -2,7 +2,7 @@ name: nvidia-4090-ci
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:

--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -2,7 +2,7 @@ name: nvidia-h100-ci
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:


### PR DESCRIPTION
- Modify concurrency group to use 'push' as fallback instead of branch name
- Set 'cancel-in-progress: true' only for pull_request events
- Ensure main branch pushes always run independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved workflow execution by updating the cancellation logic: in-progress jobs are now stopped only for pull request events, allowing other triggers to complete uninterrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->