### PR TITLE
[Test] Skip some tests on arcA770

### DIFF
--- a/tests/ops/test_delta.py
+++ b/tests/ops/test_delta.py
@@ -185,6 +185,10 @@ def test_chunk_varlen(
 @pytest.mark.parametrize("D", test_d_list)
 @pytest.mark.parametrize("scale", [0.1])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.skipif(
+    device_platform == 'intel',
+    reason="Intel Triton Failure"
+)
 def test_l2_in_kernel(
     B: int,
     T: int,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added hardware-based skip rules to ensure certain tests do not run under unsupported Intel hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->