### PR TITLE
[Attn] Remove `head_first` & rename `offsets` to `cu_seqlens`

### DIFF
--- a/fla/layers/rwkv6.py
+++ b/fla/layers/rwkv6.py
@@ -160,10 +160,10 @@ class RWKV6Attention(nn.Module):
             )
         elif mode == 'chunk':
             o, recurrent_state = chunk_rwkv6(
-                q=r,
+                r=r,
                 k=k,
                 v=v,
-                g=w,
+                w=w,
                 u=u,
                 scale=1.,
                 initial_state=recurrent_state,

--- a/fla/ops/based/fused_chunk.py
+++ b/fla/ops/based/fused_chunk.py
@@ -27,7 +27,6 @@ def fused_chunk_based_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
 ):
-    # indices
     i_v, i_k, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
 
     o_i = tl.arange(0, BT)

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -16,7 +16,7 @@ from fla.utils import input_guard
 @triton.heuristics({
     'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
     'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_gated_delta_rule_fwd_kernel(
@@ -28,7 +28,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     o,
     h0,
     ht,
-    offsets,
+    cu_seqlens,
     scale,
     T,
     B: tl.constexpr,
@@ -46,7 +46,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
-        bos, eos = tl.load(offsets + i_n).to(tl.int64), tl.load(offsets + i_n + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         all = T
         T = eos - bos
     else:
@@ -121,10 +121,10 @@ def fused_recurrent_gated_delta_rule_fwd(
     initial_state: torch.Tensor,
     output_final_state: bool,
     use_qk_l2norm_in_kernel: bool = False,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
-    N = B if offsets is None else len(offsets) - 1
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 8)
     NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
     assert NK == 1, "NK > 1 is not supported yet"
@@ -147,7 +147,7 @@ def fused_recurrent_gated_delta_rule_fwd(
         o=o,
         h0=initial_state,
         ht=final_state,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         scale=scale,
         T=T,
         B=B,
@@ -179,7 +179,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
         scale: float,
         initial_state: torch.Tensor,
         output_final_state: bool,
-        offsets: Optional[torch.LongTensor] = None,
+        cu_seqlens: Optional[torch.LongTensor] = None,
         use_qk_l2norm_in_kernel: bool = False
     ):
         o, final_state = fused_recurrent_gated_delta_rule_fwd(
@@ -192,7 +192,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
             initial_state=initial_state,
             output_final_state=output_final_state,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-            offsets=offsets
+            cu_seqlens=cu_seqlens
         )
 
         return o, final_state

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
@@ -13,7 +13,7 @@ from fla.utils import check_shared_mem, is_gather_supported, use_cuda_graph
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -46,8 +46,8 @@ def chunk_dplr_bwd_kernel_intra(
     dbg,
     dgk,
     dgk_offset,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     scale: tl.constexpr,
     T,
     H: tl.constexpr,
@@ -63,8 +63,8 @@ def chunk_dplr_bwd_kernel_intra(
     i_b, i_h = i_bh // H, i_bh % H
     i_t, i_i = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
     T = eos - bos
@@ -289,7 +289,7 @@ def chunk_dplr_bwd_kernel_intra(
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.autotune(
     configs=[
@@ -307,8 +307,8 @@ def chunk_dplr_bwd_dgk_kernel(
     dgk_offset,
     dgk_last,
     dgk_output,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     T,
     H: tl.constexpr,
     K: tl.constexpr,
@@ -320,8 +320,8 @@ def chunk_dplr_bwd_dgk_kernel(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
@@ -366,8 +366,8 @@ def chunk_dplr_bwd_dqk_intra(
     dag: torch.Tensor,
     dbg: torch.Tensor,
     dgk_last: torch.Tensor,
-    offsets: Optional[torch.LongTensor] = None,
     scale: float = 1.0,
+    cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_size: int = 64,
 ):
     B, T, H, K = q.shape
@@ -375,8 +375,8 @@ def chunk_dplr_bwd_dqk_intra(
     BC = min(16, BT)
     BK = min(64, triton.next_power_of_2(K)) if check_shared_mem() else min(32, triton.next_power_of_2(K))
 
-    indices = prepare_chunk_indices(offsets, BT) if offsets is not None else None
-    NT = triton.cdiv(T, BT) if offsets is None else len(indices)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
     NK = triton.cdiv(K, BK)
 
@@ -409,8 +409,8 @@ def chunk_dplr_bwd_dqk_intra(
         dbg=dbg,
         da=da,
         db=db,
-        offsets=offsets,
-        indices=indices,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
         scale=scale,
         T=T,
         H=H,
@@ -422,16 +422,16 @@ def chunk_dplr_bwd_dqk_intra(
         GATHER_SUPPORTED=is_gather_supported
     )
 
-    def grid2(meta): return (NT, triton.cdiv(K, meta['BK']), B * H)
     dgk_output = torch.empty_like(dgk)
 
-    chunk_dplr_bwd_dgk_kernel[grid2](
+    def grid(meta): return (NT, triton.cdiv(K, meta['BK']), B * H)
+    chunk_dplr_bwd_dgk_kernel[grid](
         dgk=dgk,
         dgk_offset=dgk_offset,
         dgk_last=dgk_last,
         dgk_output=dgk_output,
-        offsets=offsets,
-        indices=indices,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
         T=T,
         H=H,
         K=K,

--- a/fla/ops/generalized_delta_rule/dplr/fused_recurrent.py
+++ b/fla/ops/generalized_delta_rule/dplr/fused_recurrent.py
@@ -16,7 +16,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, use
 @triton.heuristics({
     'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
     'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -39,7 +39,7 @@ def fused_recurrent_dplr_delta_rule_fwd_kernel(
     o,
     h0,
     ht,
-    offsets,
+    cu_seqlens,
     scale,
     T,
     B: tl.constexpr,
@@ -57,7 +57,7 @@ def fused_recurrent_dplr_delta_rule_fwd_kernel(
     i_n, i_h = i_nh // H, i_nh % H
 
     if IS_VARLEN:
-        bos, eos = tl.load(offsets + i_n).to(tl.int64), tl.load(offsets + i_n + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos, eos = i_n * T, i_n * T + T
@@ -118,10 +118,10 @@ def fused_recurrent_dplr_delta_rule_fwd(
     initial_state: Optional[torch.Tensor] = None,
     output_final_state: bool = False,
     reverse: bool = False,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
-    N = B if offsets is None else len(offsets) - 1
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK = triton.next_power_of_2(K)
 
     h0 = initial_state
@@ -142,7 +142,7 @@ def fused_recurrent_dplr_delta_rule_fwd(
         o,
         h0,
         ht,
-        offsets,
+        cu_seqlens,
         scale,
         T=T,
         B=B,
@@ -172,7 +172,7 @@ class FusedRecurrentDPLRDeltaRuleFunction(torch.autograd.Function):
         initial_state: Optional[torch.Tensor] = None,
         output_final_state: bool = False,
         reverse: bool = False,
-        offsets: Optional[torch.LongTensor] = None,
+        cu_seqlens: Optional[torch.LongTensor] = None,
     ):
         o, ht = fused_recurrent_dplr_delta_rule_fwd(
             q=q,
@@ -185,7 +185,7 @@ class FusedRecurrentDPLRDeltaRuleFunction(torch.autograd.Function):
             initial_state=initial_state,
             output_final_state=output_final_state,
             reverse=reverse,
-            offsets=offsets,
+            cu_seqlens=cu_seqlens,
         )
         return o, ht
 
@@ -213,7 +213,6 @@ def fused_recurrent_dplr_delta_rule(
     reverse: bool = False,
     cu_seqlens: Optional[torch.Tensor] = None,
     head_first: bool = False,
-    input_precision: Optional[torch.dtype] = torch.bfloat16,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""
     This function computes the recurrence S_t = S_t @ (I + a_t b_t^T) + v_t k_t^T in a recurrent manner.
@@ -248,9 +247,6 @@ def fused_recurrent_dplr_delta_rule(
         head_first (Optional[bool]):
             Whether the inputs are in the head-first format, which is not supported for variable-length inputs.
             Default: `False`.
-        input_precision (Optional[torch.dtype]):
-            The precision of the input tensors. Default: `torch.bfloat16`.
-            Note: The output tensors will be in the same precision as the input tensors. Use torch.float16 with caution.
     """
     if head_first:
         warnings.warn(
@@ -265,8 +261,7 @@ def fused_recurrent_dplr_delta_rule(
             "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
         )
-    # use pytorch fast path here, if q, k, v are already in input_precision, nothing to do
-    q, k, v = q.to(input_precision), k.to(input_precision), v.to(input_precision)
+
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(

--- a/fla/ops/gla/fused_chunk.py
+++ b/fla/ops/gla/fused_chunk.py
@@ -131,7 +131,6 @@ def fused_chunk_gla_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     CHECK: tl.constexpr
 ):
-    # indices
     i_v, i_k, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
 
     b_h = tl.zeros([BK, BV], dtype=tl.float32)

--- a/fla/ops/linear_attn/fused_chunk.py
+++ b/fla/ops/linear_attn/fused_chunk.py
@@ -46,7 +46,6 @@ def fused_chunk_linear_attn_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     CHECK: tl.constexpr
 ):
-    # indices
     i_v, i_k, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 

--- a/fla/ops/linear_attn/fused_recurrent.py
+++ b/fla/ops/linear_attn/fused_recurrent.py
@@ -35,7 +35,6 @@ def fused_recurrent_linear_attn_fwd_kernel(
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
 ):
-    # indices
     i_v, i_k, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
 
     p_q = q + i_bh * T*K + i_k * BK + tl.arange(0, BK)

--- a/fla/ops/retention/fused_chunk.py
+++ b/fla/ops/retention/fused_chunk.py
@@ -32,7 +32,6 @@ def fused_chunk_retention_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     CHECK: tl.constexpr
 ):
-    # indices
     i_v, i_k, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_h = i_bh % H
 

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -10,7 +10,7 @@ import triton.language as tl
 from einops import rearrange
 
 from fla.ops.common.chunk_h import chunk_fwd_h
-from fla.ops.common.utils import prepare_chunk_indices
+from fla.ops.common.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.gla.chunk import chunk_gla_bwd_dA, chunk_gla_bwd_dv, chunk_gla_fwd_o_gk
 from fla.ops.utils.op import exp
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, input_guard, use_cuda_graph
@@ -20,7 +20,7 @@ BV_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -37,8 +37,8 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     s,
     oi,
     oe,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     T,
     H: tl.constexpr,
     S: tl.constexpr,
@@ -49,8 +49,8 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -73,12 +73,12 @@ def chunk_rwkv6_fwd_cumsum_kernel(
 def chunk_rwkv6_fwd_cumsum(
     g: torch.Tensor,
     chunk_size: int,
-    offsets: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     B, T, H, S = g.shape
     BT = chunk_size
-    indices = prepare_chunk_indices(offsets, chunk_size) if offsets is not None else None
-    NT = triton.cdiv(T, BT) if offsets is None else len(indices)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
     gi, ge = torch.empty_like(g, dtype=torch.float), torch.empty_like(g, dtype=torch.float)
     def grid(meta): return (triton.cdiv(meta['S'], meta['BS']), NT, B * H)
@@ -87,8 +87,8 @@ def chunk_rwkv6_fwd_cumsum(
         g,
         gi,
         ge,
-        offsets,
-        indices,
+        cu_seqlens,
+        chunk_indices,
         T=T,
         H=H,
         S=S,
@@ -98,7 +98,7 @@ def chunk_rwkv6_fwd_cumsum(
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -117,8 +117,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
     gi,  # cumulative decay inclusive
     ge,  # cumulative decay exclusive
     A,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     scale,
     T,
     H: tl.constexpr,
@@ -133,8 +133,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
     i_b, i_h = i_bh // H, i_bh % H
     i_i, i_j = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -175,14 +175,12 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
-        triton.Config({}, num_warps=1),
-        triton.Config({}, num_warps=2),
-        triton.Config({}, num_warps=4),
-        triton.Config({}, num_warps=8),
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4, 8]
     ],
     key=['BK', 'BT'],
     use_cuda_graph=use_cuda_graph,
@@ -195,8 +193,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
     ge,
     u,
     A,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     scale,
     T,
     H: tl.constexpr,
@@ -210,8 +208,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
     i_b, i_h = i_bh // H, i_bh % H
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -249,7 +247,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -269,8 +267,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
     ge,
     u,
     A,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     scale,
     B: tl.constexpr,
     T,
@@ -287,8 +285,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
     i_t, i_i = i_tc // NC, i_tc % NC
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
     else:
@@ -329,7 +327,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -345,8 +343,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
 def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge(
     A,
     A2,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     T,
     B: tl.constexpr,
     H: tl.constexpr,
@@ -358,8 +356,8 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge(
     i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
     else:
@@ -380,7 +378,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge(
 @triton.heuristics({
     'STORE_INITIAL_STATE_GRADIENT': lambda args: args['dh0'] is not None,
     'USE_FINAL_STATE_GRADIENT': lambda args: args['dht'] is not None,
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -402,7 +400,7 @@ def chunk_rwkv6_bwd_kernel_dh(
     dh,
     dht,
     dh0,
-    offsets,
+    cu_seqlens,
     chunk_offsets,
     scale,
     T,
@@ -422,7 +420,7 @@ def chunk_rwkv6_bwd_kernel_dh(
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // NG
     if IS_VARLEN:
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
         boh = tl.load(chunk_offsets + i_n).to(tl.int32)
@@ -463,7 +461,7 @@ def chunk_rwkv6_bwd_kernel_dh(
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -482,8 +480,8 @@ def chunk_rwkv6_bwd_kernel_intra(
     dA,
     dq,
     dk,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     T,
     H: tl.constexpr,
     K: tl.constexpr,
@@ -497,8 +495,8 @@ def chunk_rwkv6_bwd_kernel_intra(
     i_b, i_h = i_bh // H, i_bh % H
     i_t, i_i = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
     T = eos - bos
@@ -601,7 +599,7 @@ def chunk_rwkv6_bwd_kernel_intra(
 
 
 @triton.heuristics({
-    'IS_VARLEN': lambda args: args['offsets'] is not None
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
 })
 @triton.autotune(
     configs=[
@@ -631,8 +629,8 @@ def chunk_rwkv6_bwd_kernel_inter(
     dk2,
     dg,
     du,
-    offsets,
-    indices,
+    cu_seqlens,
+    chunk_indices,
     scale,
     T,
     H: tl.constexpr,
@@ -648,8 +646,8 @@ def chunk_rwkv6_bwd_kernel_inter(
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(offsets + i_n).to(tl.int32), tl.load(offsets + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
@@ -731,14 +729,14 @@ def chunk_rwkv6_fwd_intra(
     ge: torch.Tensor,
     u: torch.Tensor,
     scale: float,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_size: int = 64
 ):
     B, T, H, K = k.shape
     BT = min(chunk_size, max(16, triton.next_power_of_2(T)))
 
-    indices = prepare_chunk_indices(offsets, chunk_size) if offsets is not None else None
-    NT = triton.cdiv(T, BT) if offsets is None else len(indices)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BC = min(16, BT)
     NC = triton.cdiv(BT, BC)
 
@@ -750,8 +748,8 @@ def chunk_rwkv6_fwd_intra(
         gi,
         ge,
         A,
-        offsets,
-        indices,
+        cu_seqlens,
+        chunk_indices,
         scale,
         T=T,
         H=H,
@@ -772,8 +770,8 @@ def chunk_rwkv6_fwd_intra(
             ge,
             u,
             A,
-            offsets,
-            indices,
+            cu_seqlens,
+            chunk_indices,
             scale,
             T=T,
             H=H,
@@ -796,8 +794,8 @@ def chunk_rwkv6_fwd_intra(
             ge,
             u,
             A_intra,
-            offsets,
-            indices,
+            cu_seqlens,
+            chunk_indices,
             scale,
             B=B,
             T=T,
@@ -813,8 +811,8 @@ def chunk_rwkv6_fwd_intra(
         chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge[grid](
             A_intra,
             A,
-            offsets,
-            indices,
+            cu_seqlens,
+            chunk_indices,
             B=B,
             T=T,
             H=H,
@@ -835,7 +833,7 @@ def chunk_rwkv6_bwd_dh(
     h0: torch.Tensor,
     dht: torch.Tensor,
     scale: float,
-    offsets: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
     chunk_size: int = 64,
     states_in_fp32: bool = False
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -844,12 +842,12 @@ def chunk_rwkv6_bwd_dh(
     BT = min(chunk_size, max(16, triton.next_power_of_2(T)))
     # N: the actual number of sequences in the batch with either equal or variable lengths
     # NG: number of groups in GQA
-    indices = prepare_chunk_indices(offsets, chunk_size) if offsets is not None else None
-    if offsets is None:
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
+    if cu_seqlens is None:
         N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
     else:
-        N, NT = len(offsets) - 1, len(indices)
-        chunk_offsets = torch.cat([offsets.new_tensor([0]), triton.cdiv(offsets[1:] - offsets[:-1], BT)]).cumsum(-1)
+        N, NT = len(cu_seqlens) - 1, len(chunk_indices)
+        chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
     NG = HQ // H
 
     dh = k.new_empty(B, NT, HQ, K, V, dtype=k.dtype if not states_in_fp32 else torch.float)
@@ -864,7 +862,7 @@ def chunk_rwkv6_bwd_dh(
         dh=dh,
         dht=dht,
         dh0=dh0,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_offsets=chunk_offsets,
         scale=scale,
         T=T,
@@ -884,7 +882,7 @@ def chunk_rwkv6_bwd_dqk_intra(
     gi: torch.Tensor,
     ge: torch.Tensor,
     dA: torch.Tensor,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_size: int = 64
 ):
     B, T, H, K = q.shape
@@ -892,8 +890,8 @@ def chunk_rwkv6_bwd_dqk_intra(
     BC = min(16, BT)
     BK = min(64, triton.next_power_of_2(K))
 
-    indices = prepare_chunk_indices(offsets, chunk_size) if offsets is not None else None
-    NT = triton.cdiv(T, BT) if offsets is None else len(indices)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
     NK = triton.cdiv(K, BK)
 
@@ -908,8 +906,8 @@ def chunk_rwkv6_bwd_dqk_intra(
         dA,
         dq,
         dk,
-        offsets,
-        indices,
+        cu_seqlens,
+        chunk_indices,
         T=T,
         H=H,
         K=K,
@@ -936,14 +934,14 @@ def chunk_rwkv6_bwd_dqkgu(
     dq: torch.Tensor,
     dk: torch.Tensor,
     scale: float,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_size: int = 64
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = min(chunk_size, max(16, triton.next_power_of_2(T)))
 
-    indices = prepare_chunk_indices(offsets, chunk_size) if offsets is not None else None
-    NT = triton.cdiv(T, BT) if offsets is None else len(indices)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
     dq2 = torch.empty_like(dq)
     dk2 = torch.empty_like(dk)
@@ -967,8 +965,8 @@ def chunk_rwkv6_bwd_dqkgu(
         dk2,
         dg,
         du,
-        offsets,
-        indices,
+        cu_seqlens,
+        chunk_indices,
         scale,
         T=T,
         H=H,
@@ -989,10 +987,10 @@ def chunk_rwkv6_fwd(
     scale: float,
     initial_state: torch.Tensor,
     output_final_state: bool,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_size: int = 64
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, offsets=offsets)
+    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens)
     h, ht = chunk_fwd_h(
         k=k,
         v=v,
@@ -1001,7 +999,7 @@ def chunk_rwkv6_fwd(
         gv=None,
         h0=initial_state,
         output_final_state=output_final_state,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         states_in_fp32=True
     )
@@ -1014,7 +1012,7 @@ def chunk_rwkv6_fwd(
         ge=ge,
         u=u,
         scale=scale,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size
     )
 
@@ -1025,7 +1023,7 @@ def chunk_rwkv6_fwd(
         A=A,
         h=h,
         scale=scale,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size
     )
     return A, h, ht, o
@@ -1042,10 +1040,10 @@ def chunk_rwkv6_bwd(
     A: torch.Tensor,
     do: torch.Tensor,
     dht: torch.Tensor,
-    offsets: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_size: int = 64
 ):
-    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, offsets=offsets)
+    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens)
     h, _ = chunk_fwd_h(
         k=k,
         v=v,
@@ -1054,7 +1052,7 @@ def chunk_rwkv6_bwd(
         gv=None,
         h0=initial_state,
         output_final_state=False,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         states_in_fp32=True
     )
@@ -1068,7 +1066,7 @@ def chunk_rwkv6_bwd(
         h0=initial_state,
         dht=dht,
         scale=scale,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         states_in_fp32=True
     )
@@ -1078,7 +1076,7 @@ def chunk_rwkv6_bwd(
         v=v,
         do=do,
         scale=scale,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size
     )
     dv = chunk_gla_bwd_dv(
@@ -1087,7 +1085,7 @@ def chunk_rwkv6_bwd(
         A=A,
         do=do,
         dh=dh,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size
     )
     dq, dk = chunk_rwkv6_bwd_dqk_intra(
@@ -1096,7 +1094,7 @@ def chunk_rwkv6_bwd(
         gi=gi,
         ge=ge,
         dA=dA,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size
     )
     dq, dk, dg, du = chunk_rwkv6_bwd_dqkgu(
@@ -1114,7 +1112,7 @@ def chunk_rwkv6_bwd(
         dq=dq,
         dk=dk,
         scale=scale,
-        offsets=offsets,
+        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size
     )
     return dq, dk, dv, dg, du, dh0
@@ -1135,7 +1133,7 @@ class ChunkRWKV6Function(torch.autograd.Function):
         scale,
         initial_state,
         output_final_state,
-        offsets,
+        cu_seqlens,
     ):
         T = q.shape[1]
         if check_shared_mem():
@@ -1152,7 +1150,7 @@ class ChunkRWKV6Function(torch.autograd.Function):
             scale=scale,
             initial_state=initial_state,
             output_final_state=output_final_state,
-            offsets=offsets,
+            cu_seqlens=cu_seqlens,
             chunk_size=chunk_size
         )
 
@@ -1160,7 +1158,7 @@ class ChunkRWKV6Function(torch.autograd.Function):
 
         ctx.chunk_size = chunk_size
         ctx.scale = scale
-        ctx.offsets = offsets
+        ctx.cu_seqlens = cu_seqlens
         return o, ht
 
     @staticmethod
@@ -1168,7 +1166,7 @@ class ChunkRWKV6Function(torch.autograd.Function):
     @autocast_custom_bwd
     def backward(ctx, do, dht):
         q, k, v, g, initial_state, A, u = ctx.saved_tensors
-        chunk_size, scale, offsets = ctx.chunk_size, ctx.scale, ctx.offsets
+        chunk_size, scale, cu_seqlens = ctx.chunk_size, ctx.scale, ctx.cu_seqlens
         dq, dk, dv, dg, du, dh0 = chunk_rwkv6_bwd(
             q=q,
             k=k,
@@ -1180,7 +1178,7 @@ class ChunkRWKV6Function(torch.autograd.Function):
             A=A,
             do=do,
             dht=dht,
-            offsets=offsets,
+            cu_seqlens=cu_seqlens,
             chunk_size=chunk_size
         )
         return dq.to(q), dk.to(k), dv.to(v), dg.to(g), du.to(u), None, dh0, None, None
@@ -1188,10 +1186,10 @@ class ChunkRWKV6Function(torch.autograd.Function):
 
 @torch.compiler.disable
 def chunk_rwkv6(
-    q: torch.Tensor,
+    r: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    g: torch.Tensor,
+    w: torch.Tensor,
     u: torch.Tensor,
     scale: Optional[int] = None,
     initial_state: torch.Tensor = None,
@@ -1201,13 +1199,13 @@ def chunk_rwkv6(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""
     Args:
-        q (torch.Tensor):
+        r (torch.Tensor):
             queries of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
         v (torch.Tensor):
             values of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
-        g (torch.Tensor):
+        w (torch.Tensor):
             Forget gates of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]` applied to keys.
         u (torch.Tensor):
             bonus representations of shape `[H]`.
@@ -1240,23 +1238,23 @@ def chunk_rwkv6(
         >>> from fla.ops.rwkv6 import chunk_rwkv6
         # inputs with equal lengths
         >>> B, T, H, K, V = 4, 2048, 4, 512, 512
-        >>> q = torch.randn(B, T, H, K, device='cuda')
+        >>> r = torch.randn(B, T, H, K, device='cuda')
         >>> k = torch.randn(B, T, H, K, device='cuda')
         >>> v = torch.randn(B, T, H, V, device='cuda')
-        >>> g = F.logsigmoid(torch.randn(B, T, H, K, device='cuda'))
+        >>> w = F.logsigmoid(torch.randn(B, T, H, K, device='cuda'))
         >>> u = torch.randn(H, K, device='cuda')
         >>> h0 = torch.randn(B, H, K, V, device='cuda')
         >>> o, ht = chunk_rwkv6(
-            q, k, v, g, u,
+            r, k, v, w, u,
             initial_state=h0,
             output_final_state=True
         )
         # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
-        >>> q, k, v, g = map(lambda x: rearrange(x, 'b t h d -> 1 (b t) h d'), (q, k, v, g))
+        >>> r, k, v, w = map(lambda x: rearrange(x, 'b t h d -> 1 (b t) h d'), (r, k, v, w))
         # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
-        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> cu_seqlens = r.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
         >>> o_var, ht_var = chunk_rwkv6(
-            q, k, v, g, u,
+            r, k, v, w, u,
             initial_state=h0,
             output_final_state=True,
             cu_seqlens=cu_seqlens
@@ -1269,18 +1267,18 @@ def chunk_rwkv6(
             "head_first is deprecated and will be removed in a future version. "
             "Please use head_first=False for now instead."
         )
-        q, k, v, g = map(lambda x: rearrange(x, 'b h t ... -> b t h ...'), (q, k, v, g))
-    if not head_first and q.shape[1] < q.shape[2]:
+        r, k, v, w = map(lambda x: rearrange(x, 'b h t ... -> b t h ...'), (r, k, v, w))
+    if not head_first and r.shape[1] < r.shape[2]:
         warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+            f"Input tensor shape suggests potential format mismatch: seq_len ({r.shape[1]}) < num_heads ({r.shape[2]}). "
             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
             "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
         )
     if cu_seqlens is not None:
-        if q.shape[0] != 1:
+        if r.shape[0] != 1:
             raise ValueError(
-                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"The batch size is expected to be 1 rather than {r.shape[0]} when using `cu_seqlens`."
                 f"Please flatten variable-length inputs before processing."
             )
         if head_first:
@@ -1293,12 +1291,12 @@ def chunk_rwkv6(
                 f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
             )
     if scale is None:
-        scale = q.shape[-1] ** -0.5
+        scale = r.shape[-1] ** -0.5
     o, final_state = ChunkRWKV6Function.apply(
-        q,
+        r,
         k,
         v,
-        g,
+        w,
         u,
         scale,
         initial_state,

--- a/tests/ops/test_attn.py
+++ b/tests/ops/test_attn.py
@@ -31,13 +31,13 @@ test_hq_list = [8, 16]
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("HQ", test_hq_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [0.1])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('HQ', test_hq_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [0.1])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
     not HAS_FLASH,
     reason="Skipping test because flash-attn is not installed"
@@ -79,12 +79,12 @@ def test_parallel(
     assert_close("dv", ref_dv, tri_dv, 0.005)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("HQ", test_hq_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('HQ', test_hq_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
     not HAS_FLASH,
     reason="Skipping test because flash-attn is not installed"
@@ -104,7 +104,7 @@ def test_parallel_varlen(
 
     N = min(1, N) if T < 64 else N
     # randomly split the sequence into N segments
-    offsets = torch.cat([
+    cu_seqlens = torch.cat([
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 16)[:N-1]],
         torch.tensor([T], dtype=torch.long)
@@ -119,10 +119,10 @@ def test_parallel_varlen(
         q=q.squeeze(0),
         k=k.squeeze(0),
         v=v.squeeze(0),
-        cu_seqlens_q=offsets,
-        cu_seqlens_k=offsets,
-        max_seqlen_q=prepare_lens(offsets).max(),
-        max_seqlen_k=prepare_lens(offsets).max(),
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=prepare_lens(cu_seqlens).max(),
+        max_seqlen_k=prepare_lens(cu_seqlens).max(),
         causal=True
     )
     ref.backward(do.squeeze(0))
@@ -134,14 +134,14 @@ def test_parallel_varlen(
         q=q,
         k=k,
         v=v,
-        cu_seqlens=offsets
+        cu_seqlens=cu_seqlens
     )
     tri.backward(do)
     tri_dq, q.grad = q.grad.clone(), None
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.004)
-    assert_close(" dq", ref_dq.squeeze(), tri_dq.squeeze(), 0.005)
-    assert_close(" dk", ref_dk.squeeze(), tri_dk.squeeze(), 0.005)
-    assert_close(" dv", ref_dv.squeeze(), tri_dv.squeeze(), 0.005)
+    assert_close(" o", ref, tri, 0.004)
+    assert_close("dq", ref_dq.squeeze(), tri_dq.squeeze(), 0.005)
+    assert_close("dk", ref_dk.squeeze(), tri_dk.squeeze(), 0.005)
+    assert_close("dv", ref_dv.squeeze(), tri_dv.squeeze(), 0.005)

--- a/tests/ops/test_attn.py
+++ b/tests/ops/test_attn.py
@@ -21,12 +21,12 @@ if COMPILER_MODE:
     test_b_list = [2]
     test_t_list = [2048]
     test_t_varlen_list = test_t_list
-    test_d_list = [64, 100, 128, 256]
+    test_d_list = [64, 100, 128]
 else:
     test_b_list = [2, 4]
     test_t_list = [1, 15, 63, 286, 300, 1024, 2048]
     test_t_varlen_list = [63, 286, 300, 512]
-    test_d_list = [64, 32, 100, 256]
+    test_d_list = [32, 64, 100]
 test_hq_list = [8, 16]
 test_h_list = [2]
 

--- a/tests/ops/test_based.py
+++ b/tests/ops/test_based.py
@@ -21,14 +21,14 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.bfloat16, torch.float32])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_based(
     B: int,

--- a/tests/ops/test_delta.py
+++ b/tests/ops/test_delta.py
@@ -23,19 +23,19 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [1])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [1])
+@pytest.mark.parametrize('dtype', [torch.bfloat16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_chunk(
     B: int,
@@ -80,28 +80,28 @@ def test_chunk(
     ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
     ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, h0.grad
 
-    assert_close("  o", ref, tri, 0.006)
-    assert_close(" ht", ref_ht, tri_ht, 0.006)
-    assert_close(" dq", ref_dq, tri_dq, 0.008)
-    assert_close(" dk", ref_dk, tri_dk, 0.008)
-    assert_close(" dv", ref_dv, tri_dv, 0.008)
-    assert_close(" db", ref_dbeta, tri_dbeta, 0.008)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.008)
+    assert_close('  o', ref, tri, 0.006)
+    assert_close(' ht', ref_ht, tri_ht, 0.006)
+    assert_close(' dq', ref_dq, tri_dq, 0.008)
+    assert_close(' dk', ref_dk, tri_dk, 0.008)
+    assert_close(' dv', ref_dv, tri_dv, 0.008)
+    assert_close(' db', ref_dbeta, tri_dbeta, 0.008)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.008)
 
 
-@pytest.mark.parametrize("N", [4])
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [1])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize('N', [4])
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [1])
+@pytest.mark.parametrize('dtype', [torch.bfloat16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_chunk_varlen(
     N: int,
@@ -156,24 +156,24 @@ def test_chunk_varlen(
     ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
     ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, h0.grad
 
-    assert_close("  o", ref, tri, 0.005)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.008)
-    assert_close(" dk", ref_dk, tri_dk, 0.008)
-    assert_close(" dv", ref_dv, tri_dv, 0.008)
-    assert_close(" db", ref_dbeta, tri_dbeta, 0.008)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.008)
+    assert_close('  o', ref, tri, 0.005)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.008)
+    assert_close(' dk', ref_dk, tri_dk, 0.008)
+    assert_close(' dv', ref_dv, tri_dv, 0.008)
+    assert_close(' db', ref_dbeta, tri_dbeta, 0.008)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.008)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [0.1])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [0.1])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_l2_in_kernel(
     B: int,
@@ -219,13 +219,13 @@ def test_l2_in_kernel(
     ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
     ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, h0.grad
     q.grad = k.grad = v.grad = beta.grad = h0.grad = None
-    assert_close("  o", ref, tri, 0.01)
-    assert_close(" ht", ref_ht, tri_ht, 0.01)
-    assert_close(" dq", ref_dq, tri_dq, 0.01)
-    assert_close(" dk", ref_dk, tri_dk, 0.01)
-    assert_close(" dv", ref_dv, tri_dv, 0.01)
-    assert_close(" db", ref_dbeta, tri_dbeta, 0.01)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.01)
+    assert_close('  o', ref, tri, 0.01)
+    assert_close(' ht', ref_ht, tri_ht, 0.01)
+    assert_close(' dq', ref_dq, tri_dq, 0.01)
+    assert_close(' dk', ref_dk, tri_dk, 0.01)
+    assert_close(' dv', ref_dv, tri_dv, 0.01)
+    assert_close(' db', ref_dbeta, tri_dbeta, 0.01)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.01)
 
     tri, tri_ht = fused_recurrent_delta_rule(
         F.normalize(q.clone().float(), p=2, dim=-1).to(dtype),
@@ -254,13 +254,13 @@ def test_l2_in_kernel(
     ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, h0.grad
     q.grad = k.grad = v.grad = beta.grad = h0.grad = None
 
-    assert_close("  o", ref, tri, 0.002)
-    assert_close(" ht", ref_ht, tri_ht, 0.002)
-    assert_close(" dq", ref_dq, tri_dq, 0.002)
-    assert_close(" dk", ref_dk, tri_dk, 0.002)
-    assert_close(" dv", ref_dv, tri_dv, 0.002)
-    assert_close(" db", ref_dbeta, tri_dbeta, 0.002)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.002)
+    assert_close('  o', ref, tri, 0.002)
+    assert_close(' ht', ref_ht, tri_ht, 0.002)
+    assert_close(' dq', ref_dq, tri_dq, 0.002)
+    assert_close(' dk', ref_dk, tri_dk, 0.002)
+    assert_close(' dv', ref_dv, tri_dv, 0.002)
+    assert_close(' db', ref_dbeta, tri_dbeta, 0.002)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.002)
 
     tri, tri_ht = fused_recurrent_delta_rule(
         F.normalize(q.float().clone(), p=2, dim=-1).to(dtype),
@@ -288,10 +288,10 @@ def test_l2_in_kernel(
     ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
     ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, h0.grad
     q.grad = k.grad = v.grad = beta.grad = h0.grad = None
-    assert_close("  o", ref, tri, 0.002)
-    assert_close(" ht", ref_ht, tri_ht, 0.002)
-    assert_close(" dq", ref_dq, tri_dq, 0.002)
-    assert_close(" dk", ref_dk, tri_dk, 0.002)
-    assert_close(" dv", ref_dv, tri_dv, 0.002)
-    assert_close(" db", ref_dbeta, tri_dbeta, 0.002)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.002)
+    assert_close('  o', ref, tri, 0.002)
+    assert_close(' ht', ref_ht, tri_ht, 0.002)
+    assert_close(' dq', ref_dq, tri_dq, 0.002)
+    assert_close(' dk', ref_dk, tri_dk, 0.002)
+    assert_close(' dv', ref_dv, tri_dv, 0.002)
+    assert_close(' db', ref_dbeta, tri_dbeta, 0.002)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.002)

--- a/tests/ops/test_dplr_delta.py
+++ b/tests/ops/test_dplr_delta.py
@@ -36,28 +36,21 @@ def recurrent_dplr_delta_rule_ref(
     scale: float = None,
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
-    head_first=False,
 ):
-    q, k, v, a, b, gk = map(lambda x: x.to(torch.float32), [q, k, v, a, b, gk])
-    if not head_first:
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
-        a = a.transpose(1, 2)
-        b = b.transpose(1, 2)
-        gk = gk.transpose(1, 2)
-    B, H, L, DK = q.shape
-    DV = v.shape[-1]
+    q, k, v, a, b, gk = map(lambda x: x.transpose(1, 2).to(torch.float), (q, k, v, a, b, gk))
+
+    B, H, T, K, V = *q.shape, v.shape[-1]
     o = torch.zeros_like(v)
-    S = torch.zeros(B, H, DK, DV).to(v)
+    S = torch.zeros(B, H, K, V).to(v)
     if initial_state is not None:
         S = initial_state
     if scale is None:
-        scale = 1 / (q.shape[-1] ** 0.5)
+        scale = K ** -0.5
     q = q * scale
-    for i in range(L):
-        _k = k[:, :, i]
+
+    for i in range(T):
         _q = q[:, :, i]
+        _k = k[:, :, i]
         _v = v[:, :, i].clone()
         a_i = a[:, :, i]
         b_i = b[:, :, i]
@@ -68,8 +61,7 @@ def recurrent_dplr_delta_rule_ref(
         o[:, :, i] = torch.einsum('bhd,bhdm->bhm', _q, S)
     if not output_final_state:
         S = None
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o.transpose(1, 2)
     return o, S
 
 
@@ -84,59 +76,57 @@ def chunk_dplr_delta_rule_ref(
     output_final_state: bool = True,
     scale: float = None,
     chunk_size: int = 64,
-    head_first: bool = True,
 ):
+    q, k, v, a, b, gk = map(lambda x: x.transpose(1, 2).to(torch.float), (q, k, v, a, b, gk))
     BT = chunk_size
-    if scale is None:
-        scale = 1 / (q.shape[-1] ** 0.5)
-    if not head_first:
-        q, k, v, a, b, gk = map(lambda x: rearrange(x, 'b t h ... -> b h t ...'), (q, k, v, a, b, gk))
     T = q.shape[-2]
     pad_len = (BT - (T % BT)) % BT
 
-    q, k, v, a, b, gk = map(lambda x: F.pad(x, (0, 0, 0, pad_len)).to(torch.float32), [q, k, v, a, b, gk])
-    B, H, L, DK = q.shape
-    DV = v.shape[-1]
+    q, k, v, a, b, gk = map(lambda x: F.pad(x, (0, 0, 0, pad_len)).to(torch.float), [q, k, v, a, b, gk])
+    B, H, _, K, V = *q.shape, v.shape[-1]
+    NT = q.shape[-2] // BT
+    if scale is None:
+        scale = K ** -0.5
     q = q * scale
 
-    S = k.new_zeros(B, H, DK, DV)
+    S = k.new_zeros(B, H, K, V)
     if initial_state is not None:
         S += initial_state
 
     # note that diagonal is masked.
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=0)
-    q, k, v, a, b, gk = map(lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=chunk_size), [q, k, v, a, b, gk])
+    mask = torch.triu(torch.ones(BT, BT, dtype=torch.bool, device=q.device), diagonal=0)
+    q, k, v, a, b, gk = map(lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=BT), [q, k, v, a, b, gk])
     gk_cumsum = gk.cumsum(-2)
-    A_ab = torch.zeros(B, H, L // chunk_size, chunk_size, chunk_size).to(q.device)
-    A_qk = torch.zeros(B, H, L // chunk_size, chunk_size, chunk_size).to(q.device)
-    A_ak = torch.zeros(B, H, L // chunk_size, chunk_size, chunk_size).to(q.device)
-    A_qb = torch.zeros(B, H, L // chunk_size, chunk_size, chunk_size).to(q.device)
+    A_ab = torch.zeros(B, H, NT, BT, BT).to(q.device)
+    A_qk = torch.zeros(B, H, NT, BT, BT).to(q.device)
+    A_ak = torch.zeros(B, H, NT, BT, BT).to(q.device)
+    A_qb = torch.zeros(B, H, NT, BT, BT).to(q.device)
 
-    for i in range(chunk_size):
+    for i in range(BT):
         a_i = a[:, :, :, i, None]
         q_i = q[:, :, :, i, None]
         gk_i = gk_cumsum[:, :, :, i, None]
-        mask = (torch.arange(chunk_size) <= i).to(q.device)
+        mask = (torch.arange(BT) <= i).to(q.device)
         attn_i = (gk_i - gk_cumsum).masked_fill(~mask.unsqueeze(-1), float('-inf')).exp()
         A_qk[:, :, :, i, :] = (q_i * k * attn_i).sum(-1).clone()
         A_qb[:, :, :, i, :] = (q_i * b * attn_i).sum(-1).clone()
-        mask = (torch.arange(chunk_size) < i).to(q.device)
+        mask = (torch.arange(BT) < i).to(q.device)
         # shift by one.
         attn_i = (gk_i - gk[:, :, :, i, None] - gk_cumsum).masked_fill(~mask.unsqueeze(-1), float('-inf')).exp()
         A_ab[:, :, :, i, :] = (a_i * b * attn_i).sum(-1).clone()
         A_ak[:, :, :, i, :] = (a_i * k * attn_i).sum(-1).clone()
 
     A_ab = A_ab
-    for i in range(1, chunk_size):
+    for i in range(1, BT):
         A_ab[..., i, :i] = A_ab[..., i, :i].clone() + (A_ab[..., i, :, None].clone() * A_ab[..., :, :i].clone()).sum(-2)
 
-    A_ab = A_ab + torch.eye(chunk_size, dtype=torch.float, device=q.device)
+    A_ab = A_ab + torch.eye(BT, dtype=torch.float, device=q.device)
     u = A_ab @ (A_ak @ v)
     w = A_ab @ ((gk_cumsum-gk).exp() * a)
 
     o = torch.zeros_like(v)
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=1)
-    for i in range(0, L // chunk_size):
+    mask = torch.triu(torch.ones(BT, BT, dtype=torch.bool, device=q.device), diagonal=1)
+    for i in range(0, NT):
         q_i, k_i, v_i, u_i, w_i, b_i = q[:, :, i], k[:, :, i], v[:, :, i], u[:, :, i], w[:, :, i], b[:, :, i]
         v2_i = u_i + w_i @ S
         o_1 = A_qk[:, :, i] @ v_i
@@ -149,23 +139,21 @@ def chunk_dplr_delta_rule_ref(
 
     S = None if output_final_state is False else S
     o = rearrange(o, 'b h n c d -> b h (n c) d')
-    o = o[:, :, :T]
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o[:, :, :T].transpose(1, 2)
     return o, S
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [0.25])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [0.25])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
-def test_recurrent_forward(
+def test_recurrent_fwd(
     B: int,
     T: int,
     H: int,
@@ -173,27 +161,20 @@ def test_recurrent_forward(
     scale: float,
     dtype: torch.dtype,
 ):
-    head_first = True
+    torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     os.environ['TORCH_CUDA_MATMUL_PRECISION'] = 'highest'
-    if head_first:
-        q = torch.randn(B, H, T, D, dtype=dtype)
-        k = torch.randn(B, H, T, D, dtype=dtype)
-        v = torch.randn(B, H, T, D, dtype=dtype)
-        a = torch.rand(B, H, T, D, dtype=dtype)
-        gk = (torch.randn(B, H, T, D, dtype=torch.float))
-    else:
-        q = torch.randn(B, T, H, D, dtype=dtype)
-        k = torch.randn(B, T, H, D, dtype=dtype)
-        v = torch.randn(B, T, H, D, dtype=dtype)
-        a = torch.rand(B, T, H, D, dtype=dtype)
-        gk = torch.randn(B, T, H, D, dtype=torch.float)
+    q = torch.randn(B, T, H, D, dtype=dtype)
+    k = torch.randn(B, T, H, D, dtype=dtype)
+    v = torch.randn(B, T, H, D, dtype=dtype)
+    a = torch.rand(B, T, H, D, dtype=dtype)
+    gk = torch.randn(B, T, H, D, dtype=torch.float)
 
     a = F.normalize(a, p=2, dim=-1)
     b = -a
-    gk = torch.nn.functional.logsigmoid(gk) / 16
+    gk = F.logsigmoid(gk) / 16
 
-    h0 = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0 = torch.randn(B, H, D, D, dtype=torch.float)
     q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(False), (q, k, v, a, b, gk, h0))
     ref, ref_ht = chunk_dplr_delta_rule_ref(
         q=q.clone(),
@@ -205,7 +186,6 @@ def test_recurrent_forward(
         scale=scale,
         initial_state=h0.clone(),
         output_final_state=True,
-        head_first=head_first
     )
     tri, tri_ht = recurrent_dplr_delta_rule_ref(
         q=q.clone(),
@@ -217,23 +197,20 @@ def test_recurrent_forward(
         scale=scale,
         initial_state=h0.clone(),
         output_final_state=True,
-        head_first=head_first
     )
-    assert_close("  o", ref, tri, 0.001)
-    assert_close(" ht", ref_ht, tri_ht, 0.001)
+    assert_close(' o', ref, tri, 0.001)
+    assert_close('ht', ref_ht, tri_ht, 0.001)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [0.25])
-@pytest.mark.parametrize("dtype", [torch.float16])
-@pytest.mark.parametrize("head_first", [True, False])
-@pytest.mark.parametrize("compile", [False, True])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [0.25])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_fused_recurrent_fwd(
     B: int,
@@ -242,27 +219,19 @@ def test_fused_recurrent_fwd(
     D: int,
     scale: float,
     dtype: torch.dtype,
-    head_first: bool,
-    compile: bool,
 ):
-    if head_first:
-        q = torch.randn(B, H, T, D, dtype=dtype)
-        k = torch.randn(B, H, T, D, dtype=dtype)
-        v = torch.randn(B, H, T, D, dtype=dtype)
-        a = torch.rand(B, H, T, D, dtype=dtype)
-        gk = (torch.randn(B, H, T, D, dtype=torch.float))
-    else:
-        q = torch.randn(B, T, H, D, dtype=dtype)
-        k = torch.randn(B, T, H, D, dtype=dtype)
-        v = torch.randn(B, T, H, D, dtype=dtype)
-        a = torch.rand(B, T, H, D, dtype=dtype)
-        gk = torch.randn(B, T, H, D, dtype=torch.float)
+    torch.manual_seed(42)
+    q = torch.randn(B, T, H, D, dtype=dtype)
+    k = torch.randn(B, T, H, D, dtype=dtype)
+    v = torch.randn(B, T, H, D, dtype=dtype)
+    a = torch.rand(B, T, H, D, dtype=dtype)
+    gk = torch.randn(B, T, H, D, dtype=torch.float)
 
     a = F.normalize(a, p=2, dim=-1)
     b = -a
-    gk = torch.nn.functional.logsigmoid(gk) / 4
+    gk = F.logsigmoid(gk) / 4
 
-    h0 = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0 = torch.randn(B, H, D, D, dtype=torch.float)
     q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(False), (q, k, v, a, b, gk, h0))
     ref, ref_ht = recurrent_dplr_delta_rule_ref(
         q=q.clone(),
@@ -274,12 +243,9 @@ def test_fused_recurrent_fwd(
         scale=scale,
         initial_state=h0.clone(),
         output_final_state=True,
-        head_first=head_first
     )
 
-    fused_compiled = torch.compile(fused_recurrent_dplr_delta_rule) if compile else fused_recurrent_dplr_delta_rule
-
-    tri, tri_ht = fused_compiled(
+    tri, tri_ht = fused_recurrent_dplr_delta_rule(
         q=q.clone(),
         k=k.clone(),
         v=v.clone(),
@@ -289,28 +255,26 @@ def test_fused_recurrent_fwd(
         scale=scale,
         initial_state=h0.clone(),
         output_final_state=True,
-        head_first=head_first
     )
-    assert_close("  o", ref, tri, 0.002)
-    assert_close(" ht", ref_ht, tri_ht, 0.002)
+    assert_close(' o', ref, tri, 0.002)
+    assert_close('ht', ref_ht, tri_ht, 0.002)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("gate_logit_normalizer", test_gate_list)
-@pytest.mark.parametrize("scale", [0.25])
-@pytest.mark.parametrize("dtype", [torch.float16])
-@pytest.mark.parametrize("head_first", [False, True])
-@pytest.mark.parametrize("compile", [False, True])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('gate_logit_normalizer', test_gate_list)
+@pytest.mark.parametrize('scale', [0.25])
+@pytest.mark.parametrize('dtype', [torch.float16])
+@pytest.mark.parametrize('compile', [False, True])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_chunk(
     B: int,
@@ -320,27 +284,20 @@ def test_chunk(
     scale: float,
     gate_logit_normalizer: float,
     dtype: torch.dtype,
-    head_first: bool,
     compile: bool,
 ):
-    if head_first:
-        q = torch.randn(B, H, T, D, dtype=dtype)
-        k = torch.randn(B, H, T, D, dtype=dtype)
-        v = torch.randn(B, H, T, D, dtype=dtype)
-        a = torch.rand(B, H, T, D, dtype=dtype)
-        gk = (torch.randn(B, H, T, D, dtype=torch.float))
-    else:
-        q = torch.randn(B, T, H, D, dtype=dtype)
-        k = torch.randn(B, T, H, D, dtype=dtype)
-        v = torch.randn(B, T, H, D, dtype=dtype)
-        a = torch.rand(B, T, H, D, dtype=dtype)
-        gk = torch.randn(B, T, H, D, dtype=torch.float)
+    torch.manual_seed(42)
+    q = torch.randn(B, T, H, D, dtype=dtype)
+    k = torch.randn(B, T, H, D, dtype=dtype)
+    v = torch.randn(B, T, H, D, dtype=dtype)
+    a = torch.rand(B, T, H, D, dtype=dtype)
+    gk = torch.randn(B, T, H, D, dtype=torch.float)
 
     a = F.normalize(a, p=2, dim=-1)
     b = -a
     gk = F.logsigmoid(gk) / gate_logit_normalizer
 
-    h0 = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0 = torch.randn(B, H, D, D, dtype=torch.float)
     q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, a, b, gk, h0))
     ref, ref_ht = chunk_dplr_delta_rule_ref(
         q=q.clone(),
@@ -352,7 +309,6 @@ def test_chunk(
         scale=scale,
         initial_state=h0.clone(),
         output_final_state=True,
-        head_first=head_first
     )
     do = torch.randn_like(v)
     dht = torch.randn_like(h0)
@@ -372,37 +328,36 @@ def test_chunk(
         scale=scale,
         initial_state=h0.clone(),
         output_final_state=True,
-        head_first=head_first
     )
     ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
     tri_dq, tri_dk, tri_dv, tri_da, tri_db, tri_dg, tri_dh0 = q.grad, k.grad, v.grad, a.grad, b.grad, gk.grad, h0.grad
     q.grad = k.grad = v.grad = a.grad = b.grad = gk.grad = h0.grad = None
 
-    assert_close("  o", ref, tri, 0.007)
-    assert_close(" ht", ref_ht, tri_ht, 0.008)
-    assert_close(" dq", ref_dq, tri_dq, 0.008)
-    assert_close(" dk", ref_dk, tri_dk, 0.008)
-    assert_close(" dv", ref_dv, tri_dv, 0.008)
-    assert_close(" da", ref_da, tri_da, 0.008)
-    assert_close(" db", ref_db, tri_db, 0.008)
+    assert_close('  o', ref, tri, 0.007)
+    assert_close(' ht', ref_ht, tri_ht, 0.008)
+    assert_close(' dq', ref_dq, tri_dq, 0.008)
+    assert_close(' dk', ref_dk, tri_dk, 0.008)
+    assert_close(' dv', ref_dv, tri_dv, 0.008)
+    assert_close(' da', ref_da, tri_da, 0.008)
+    assert_close(' db', ref_db, tri_db, 0.008)
     if gate_logit_normalizer >= 1 and ref_dg.norm() > 0.01:  # otherwise it is meaningless
-        assert_close(" dg", ref_dg, tri_dg, 0.008)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.008)
+        assert_close(' dg', ref_dg, tri_dg, 0.008)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.008)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [0.25])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [0.25])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_chunk_varlen(
     N: int,
@@ -415,7 +370,7 @@ def test_chunk_varlen(
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     # randomly split the sequence into N segments
-    offsets = torch.cat([
+    cu_seqlens = torch.cat([
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 16)[:N-1]],
         torch.tensor([T], dtype=torch.long)
@@ -428,8 +383,8 @@ def test_chunk_varlen(
     gk = torch.randn(1, T, H, D, dtype=torch.float)
     a = F.normalize(a, p=2, dim=-1)
     b = -a
-    gk = torch.nn.functional.logsigmoid(gk)
-    h0 = torch.randn(N, H, D, D, dtype=torch.float32)
+    gk = F.logsigmoid(gk)
+    h0 = torch.randn(N, H, D, D, dtype=torch.float)
     q, k, v, a, b, gk, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, a, b, gk, h0))
 
     tri, tri_ht = chunk_dplr_delta_rule(
@@ -442,8 +397,7 @@ def test_chunk_varlen(
         scale=scale,
         output_final_state=True,
         initial_state=h0.clone(),
-        cu_seqlens=offsets,
-        head_first=False
+        cu_seqlens=cu_seqlens,
     )
     do = torch.randn_like(v)
     dht = torch.randn_like(h0)
@@ -455,16 +409,15 @@ def test_chunk_varlen(
     ref_ht = []
     for i in range(N):
         ref_i, ref_ht_i = chunk_dplr_delta_rule_ref(
-            q=q[:, offsets[i]:offsets[i+1]],
-            k=k[:, offsets[i]:offsets[i+1]],
-            v=v[:, offsets[i]:offsets[i+1]],
-            a=a[:, offsets[i]:offsets[i+1]],
-            b=b[:, offsets[i]:offsets[i+1]],
-            gk=gk[:, offsets[i]:offsets[i+1]],
+            q=q[:, cu_seqlens[i]:cu_seqlens[i+1]],
+            k=k[:, cu_seqlens[i]:cu_seqlens[i+1]],
+            v=v[:, cu_seqlens[i]:cu_seqlens[i+1]],
+            a=a[:, cu_seqlens[i]:cu_seqlens[i+1]],
+            b=b[:, cu_seqlens[i]:cu_seqlens[i+1]],
+            gk=gk[:, cu_seqlens[i]:cu_seqlens[i+1]],
             scale=scale,
             initial_state=h0[i, None],
             output_final_state=True,
-            head_first=False
         )
         ref.append(ref_i)
         ref_ht.append(ref_ht_i)
@@ -474,12 +427,12 @@ def test_chunk_varlen(
     ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
     ref_dq, ref_dk, ref_dv, ref_da, ref_db, ref_dg, ref_dh0 = q.grad, k.grad, v.grad, a.grad, b.grad, gk.grad, h0.grad
 
-    assert_close("  o", ref, tri, 0.007)
-    assert_close(" ht", ref_ht, tri_ht, 0.008)
-    assert_close(" dq", ref_dq, tri_dq, 0.008)
-    assert_close(" dk", ref_dk, tri_dk, 0.008)
-    assert_close(" dv", ref_dv, tri_dv, 0.008)
-    assert_close(" da", ref_da, tri_da, 0.008)
-    assert_close(" db", ref_db, tri_db, 0.008)
-    assert_close(" dg", ref_dg, tri_dg, 0.008)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.008)
+    assert_close('  o', ref, tri, 0.007)
+    assert_close(' ht', ref_ht, tri_ht, 0.008)
+    assert_close(' dq', ref_dq, tri_dq, 0.008)
+    assert_close(' dk', ref_dk, tri_dk, 0.008)
+    assert_close(' dv', ref_dv, tri_dv, 0.008)
+    assert_close(' da', ref_da, tri_da, 0.008)
+    assert_close(' db', ref_db, tri_db, 0.008)
+    assert_close(' dg', ref_dg, tri_dg, 0.008)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.008)

--- a/tests/ops/test_gated_delta.py
+++ b/tests/ops/test_gated_delta.py
@@ -141,17 +141,17 @@ def chunk_gated_delta_rule_ref(
     return o, S
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("gate_logit_normalizer", test_gate_list)
-@pytest.mark.parametrize("scale", [1])
-@pytest.mark.parametrize("use_qk_l2norm_in_kernel", [True, False])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('gate_logit_normalizer', test_gate_list)
+@pytest.mark.parametrize('scale', [1])
+@pytest.mark.parametrize('use_qk_l2norm_in_kernel', [True, False])
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_recurrent_forward(
     B: int,
@@ -193,20 +193,20 @@ def test_recurrent_forward(
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
         output_final_state=True,
     )
-    assert_close("  o", ref, tri, 0.002)
-    assert_close(" ht", ref_ht, tri_ht, 0.002)
+    assert_close('  o', ref, tri, 0.002)
+    assert_close(' ht', ref_ht, tri_ht, 0.002)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("gate_logit_normalizer", test_gate_list)
-@pytest.mark.parametrize("scale", [1, 0.1])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('gate_logit_normalizer', test_gate_list)
+@pytest.mark.parametrize('scale', [1, 0.1])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_chunk(
     B: int,
@@ -218,7 +218,7 @@ def test_chunk(
     gate_logit_normalizer: float
 ):
     if is_intel_alchemist and D > 128:
-        pytest.skip(reason="chunk_gated_delta_rule is not supported on alchemist for D>128")
+        pytest.skip(reason='chunk_gated_delta_rule is not supported on alchemist for D>128')
 
     q = torch.randn(B, T, H, D, dtype=dtype)
     k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
@@ -258,26 +258,26 @@ def test_chunk(
 
     ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
     ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dg, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad
-    assert_close("  o", ref, tri, 0.005)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.008)
-    assert_close(" dk", ref_dk, tri_dk, 0.008)
-    assert_close(" dv", ref_dv, tri_dv, 0.008)
-    assert_close(" db", ref_dbeta, tri_dbeta, 0.02)
+    assert_close('  o', ref, tri, 0.005)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.008)
+    assert_close(' dk', ref_dk, tri_dk, 0.008)
+    assert_close(' dv', ref_dv, tri_dv, 0.008)
+    assert_close(' db', ref_dbeta, tri_dbeta, 0.02)
     if gate_logit_normalizer >= 1 and ref_dg.norm() > 0.01:
-        assert_close(" dg", ref_dg, tri_dg, 0.02)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.008)
+        assert_close(' dg', ref_dg, tri_dg, 0.02)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.008)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("scale", [1, 0.1])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('scale', [1, 0.1])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_chunk_varlen(
     N: int,
@@ -288,7 +288,7 @@ def test_chunk_varlen(
     dtype: torch.dtype,
 ):
     if is_intel_alchemist and D > 128:
-        pytest.skip(reason="chunk_gated_delta_rule is not supported on alchemist for D>128")
+        pytest.skip(reason='chunk_gated_delta_rule is not supported on alchemist for D>128')
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     # randomly split the sequence into N segments
@@ -345,11 +345,11 @@ def test_chunk_varlen(
     ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
     ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dg, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad
 
-    assert_close("  o", ref, tri, 0.005)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.007)
-    assert_close(" dk", ref_dk, tri_dk, 0.008)
-    assert_close(" dv", ref_dv, tri_dv, 0.007)
-    assert_close(" db", ref_dbeta, tri_dbeta, 0.015)
-    assert_close(" dg", ref_dg, tri_dg, 0.015)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.007)
+    assert_close('  o', ref, tri, 0.005)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.007)
+    assert_close(' dk', ref_dk, tri_dk, 0.008)
+    assert_close(' dv', ref_dv, tri_dv, 0.007)
+    assert_close(' db', ref_dbeta, tri_dbeta, 0.015)
+    assert_close(' dg', ref_dg, tri_dg, 0.015)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.007)

--- a/tests/ops/test_gla.py
+++ b/tests/ops/test_gla.py
@@ -26,18 +26,18 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_fused_recurrent(
     B: int,
@@ -85,28 +85,28 @@ def test_fused_recurrent(
     tri_dg, g.grad = g.grad.clone(), None
     tri_dh0, h0.grad = h0.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.005)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.005)
-    assert_close(" dk", ref_dk, tri_dk, 0.005)
-    assert_close(" dv", ref_dv, tri_dv, 0.005)
-    assert_close(" dg", ref_dg, tri_dg, 0.005)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+    assert_close('  o', ref, tri, 0.005)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
+    assert_close(' dg', ref_dg, tri_dg, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.005)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("gate_logit_normalizer", test_gate_list)
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.bfloat16])
+@pytest.mark.parametrize('gate_logit_normalizer', test_gate_list)
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_chunk(
     B: int,
@@ -165,23 +165,23 @@ def test_chunk(
     ref_dg, g.grad = g.grad.clone(), None
     ref_dh0, h0.grad = h0.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.004)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.005)
-    assert_close(" dk", ref_dk, tri_dk, 0.005)
-    assert_close(" dv", ref_dv, tri_dv, 0.005)
-    assert_close(" dg", ref_dg, tri_dg, 0.005)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+    assert_close('  o', ref, tri, 0.004)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
+    assert_close(' dg', ref_dg, tri_dg, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.005)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.bfloat16, torch.float])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_chunk_varlen(
     N: int,
@@ -242,10 +242,10 @@ def test_chunk_varlen(
     tri_dg, g.grad = g.grad.clone(), None
     tri_dh0, h0.grad = h0.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.004)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.005)
-    assert_close(" dk", ref_dk, tri_dk, 0.005)
-    assert_close(" dv", ref_dv, tri_dv, 0.005)
-    assert_close(" dg", ref_dg, tri_dg, 0.005)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+    assert_close('  o', ref, tri, 0.004)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
+    assert_close(' dg', ref_dg, tri_dg, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.005)

--- a/tests/ops/test_gsa.py
+++ b/tests/ops/test_gsa.py
@@ -28,19 +28,19 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("M", test_m_list)
-@pytest.mark.parametrize("dtype", [torch.float])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('M', test_m_list)
+@pytest.mark.parametrize('dtype', [torch.float])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_fused_recurrent(
     B: int,
@@ -98,31 +98,31 @@ def test_fused_recurrent(
     tri_dhk0, hk0.grad = hk0.grad.clone(), None
     tri_dhv0, hv0.grad = hv0.grad.clone(), None
 
-    assert_close("   o", ref, tri, 0.005)
-    assert_close(" hkt", ref_hkt, tri_hkt, 0.005)
-    assert_close(" hvt", ref_hvt, tri_hvt, 0.005)
-    assert_close("  dq", ref_dq, tri_dq, 0.005)
-    assert_close("  dk", ref_dk, tri_dk, 0.005)
-    assert_close("  dv", ref_dv, tri_dv, 0.005)
-    assert_close("  ds", ref_ds, tri_ds, 0.005)
-    assert_close("  dg", ref_dg, tri_dg, 0.005)
-    assert_close("dhk0", ref_dhk0, tri_dhk0, 0.005)
-    assert_close("dhv0", ref_dhv0, tri_dhv0, 0.005)
+    assert_close('   o', ref, tri, 0.005)
+    assert_close(' hkt', ref_hkt, tri_hkt, 0.005)
+    assert_close(' hvt', ref_hvt, tri_hvt, 0.005)
+    assert_close('  dq', ref_dq, tri_dq, 0.005)
+    assert_close('  dk', ref_dk, tri_dk, 0.005)
+    assert_close('  dv', ref_dv, tri_dv, 0.005)
+    assert_close('  ds', ref_ds, tri_ds, 0.005)
+    assert_close('  dg', ref_dg, tri_dg, 0.005)
+    assert_close('dhk0', ref_dhk0, tri_dhk0, 0.005)
+    assert_close('dhv0', ref_dhv0, tri_dhv0, 0.005)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("M", test_m_list)
-@pytest.mark.parametrize("dtype", [torch.float])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('M', test_m_list)
+@pytest.mark.parametrize('dtype', [torch.float])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_fused_recurrent_varlen(
     N: int,
@@ -205,32 +205,32 @@ def test_fused_recurrent_varlen(
     tri_dhk0, hk0.grad = hk0.grad.clone(), None
     tri_dhv0, hv0.grad = hv0.grad.clone(), None
 
-    assert_close("   o", ref, tri, 0.005)
-    assert_close(" hkt", ref_hkt, tri_hkt, 0.005)
-    assert_close(" hvt", ref_hvt, tri_hvt, 0.005)
-    assert_close("  dq", ref_dq, tri_dq, 0.005)
-    assert_close("  dk", ref_dk, tri_dk, 0.005)
-    assert_close("  dv", ref_dv, tri_dv, 0.005)
-    assert_close("  ds", ref_ds, tri_ds, 0.005)
-    assert_close("  dg", ref_dg, tri_dg, 0.005)
-    assert_close("dhk0", ref_dhk0, tri_dhk0, 0.005)
-    assert_close("dhv0", ref_dhv0, tri_dhv0, 0.005)
+    assert_close('   o', ref, tri, 0.005)
+    assert_close(' hkt', ref_hkt, tri_hkt, 0.005)
+    assert_close(' hvt', ref_hvt, tri_hvt, 0.005)
+    assert_close('  dq', ref_dq, tri_dq, 0.005)
+    assert_close('  dk', ref_dk, tri_dk, 0.005)
+    assert_close('  dv', ref_dv, tri_dv, 0.005)
+    assert_close('  ds', ref_ds, tri_ds, 0.005)
+    assert_close('  dg', ref_dg, tri_dg, 0.005)
+    assert_close('dhk0', ref_dhk0, tri_dhk0, 0.005)
+    assert_close('dhv0', ref_dhv0, tri_dhv0, 0.005)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("M", test_m_list)
-@pytest.mark.parametrize("dtype", [torch.float])
-@pytest.mark.parametrize("gate_logit_normalizer", [1, 0.05, 20])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('M', test_m_list)
+@pytest.mark.parametrize('dtype', [torch.float])
+@pytest.mark.parametrize('gate_logit_normalizer', [1, 0.05, 20])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_chunk(
     B: int,
@@ -242,7 +242,7 @@ def test_chunk(
     gate_logit_normalizer: float,
 ):
     if (D > 64 or M > 64) and check_shared_mem('hopper') is False:
-        pytest.skip(reason="Current CI do not support this config")
+        pytest.skip(reason='Current CI do not support this config')
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
@@ -271,27 +271,27 @@ def test_chunk(
     tri_ds, s.grad = s.grad.clone(), None
     tri_dg, s.grad = g.grad.clone(), None
 
-    assert_close(" o", ref, tri, 0.005)
-    assert_close("dq", ref_dq, tri_dq, 0.005)
-    assert_close("dk", ref_dk, tri_dk, 0.005)
-    assert_close("dv", ref_dv, tri_dv, 0.005)
-    assert_close("ds", ref_ds, tri_ds, 0.008)
-    assert_close("dg", ref_dg, tri_dg, 0.008)
+    assert_close(' o', ref, tri, 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)
+    assert_close('ds', ref_ds, tri_ds, 0.008)
+    assert_close('dg', ref_dg, tri_dg, 0.008)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("M", test_m_list)
-@pytest.mark.parametrize("dtype", [torch.float])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('M', test_m_list)
+@pytest.mark.parametrize('dtype', [torch.float])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_chunk_varlen(
     N: int,
@@ -302,7 +302,7 @@ def test_chunk_varlen(
     dtype: torch.dtype,
 ):
     if (D > 64 or M > 64) and check_shared_mem('hopper') is False:
-        pytest.skip(reason="Current CI do not support this config")
+        pytest.skip(reason='Current CI do not support this config')
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     # randomly split the sequence into N segments
@@ -357,32 +357,32 @@ def test_chunk_varlen(
     tri_dhk0, hk0.grad = hk0.grad.clone(), None
     tri_dhv0, hv0.grad = hv0.grad.clone(), None
 
-    assert_close("   o", ref, tri, 0.004)
-    assert_close(" hkt", ref_hkt, tri_hkt, 0.005)
-    assert_close(" hvt", ref_hvt, tri_hvt, 0.005)
-    assert_close("  dq", ref_dq, tri_dq, 0.005)
-    assert_close("  dk", ref_dk, tri_dk, 0.005)
-    assert_close("  dv", ref_dv, tri_dv, 0.005)
-    assert_close("  ds", ref_ds, tri_ds, 0.005)
-    assert_close("  dg", ref_dg, tri_dg, 0.005)
-    assert_close("dhk0", ref_dhk0, tri_dhk0, 0.005)
-    assert_close("dhv0", ref_dhv0, tri_dhv0, 0.005)
+    assert_close('   o', ref, tri, 0.004)
+    assert_close(' hkt', ref_hkt, tri_hkt, 0.005)
+    assert_close(' hvt', ref_hvt, tri_hvt, 0.005)
+    assert_close('  dq', ref_dq, tri_dq, 0.005)
+    assert_close('  dk', ref_dk, tri_dk, 0.005)
+    assert_close('  dv', ref_dv, tri_dv, 0.005)
+    assert_close('  ds', ref_ds, tri_ds, 0.005)
+    assert_close('  dg', ref_dg, tri_dg, 0.005)
+    assert_close('dhk0', ref_dhk0, tri_dhk0, 0.005)
+    assert_close('dhv0', ref_dhv0, tri_dhv0, 0.005)
 
 
-@pytest.mark.parametrize("HQ", [8, 16])
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("M", test_m_list)
-@pytest.mark.parametrize("dtype", [torch.float])
+@pytest.mark.parametrize('HQ', [8, 16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('M', test_m_list)
+@pytest.mark.parametrize('dtype', [torch.float])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Triton Failure"
+    reason='Intel Triton Failure'
 )
 def test_inference(
     B: int,
@@ -416,5 +416,5 @@ def test_inference(
             output_final_state=True
         )
         tri[:, i] = o.squeeze(1)
-        assert_close(f"o{i}", ref[:, i], tri[:, i], 0.005)
+        assert_close(f'o{i}', ref[:, i], tri[:, i], 0.005)
         h0 = ht

--- a/tests/ops/test_linear_attn.py
+++ b/tests/ops/test_linear_attn.py
@@ -25,14 +25,14 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_fused_recurrent(
     B: int,
@@ -59,20 +59,20 @@ def test_fused_recurrent(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.001)
-    assert_close(" dq", ref_dq, tri_dq, 0.001)
-    assert_close(" dk", ref_dk, tri_dk, 0.001)
-    assert_close(" dv", ref_dv, tri_dv, 0.001)
+    assert_close(' o', ref, tri, 0.001)
+    assert_close('dq', ref_dq, tri_dq, 0.001)
+    assert_close('dk', ref_dk, tri_dk, 0.001)
+    assert_close('dv', ref_dv, tri_dv, 0.001)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_chunk(
     B: int,
@@ -115,21 +115,21 @@ def test_chunk(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.001)
-    assert_close(" ht", ref_ht, tri_ht, 0.001)
-    assert_close(" dq", ref_dq, tri_dq, 0.001)
-    assert_close(" dk", ref_dk, tri_dk, 0.001)
-    assert_close(" dv", ref_dv, tri_dv, 0.001)
+    assert_close(' o', ref, tri, 0.001)
+    assert_close('ht', ref_ht, tri_ht, 0.001)
+    assert_close('dq', ref_dq, tri_dq, 0.001)
+    assert_close('dk', ref_dk, tri_dk, 0.001)
+    assert_close('dv', ref_dv, tri_dv, 0.001)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_fused_chunk(
     B: int,
@@ -172,8 +172,8 @@ def test_fused_chunk(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.001)
-    assert_close(" ht", ref_ht, tri_ht, 0.001)
-    assert_close(" dq", ref_dq, tri_dq, 0.001)
-    assert_close(" dk", ref_dk, tri_dk, 0.001)
-    assert_close(" dv", ref_dv, tri_dv, 0.001)
+    assert_close(' o', ref, tri, 0.001)
+    assert_close('ht', ref_ht, tri_ht, 0.001)
+    assert_close('dq', ref_dq, tri_dq, 0.001)
+    assert_close('dk', ref_dk, tri_dk, 0.001)
+    assert_close('dv', ref_dv, tri_dv, 0.001)

--- a/tests/ops/test_retention.py
+++ b/tests/ops/test_retention.py
@@ -23,15 +23,15 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("K", test_d_list)
-@pytest.mark.parametrize("expand_ratio", [1, 2])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('K', test_d_list)
+@pytest.mark.parametrize('expand_ratio', [1, 2])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_chunk(
     B: int,
@@ -64,22 +64,22 @@ def test_chunk(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close(" o", ref, tri, 0.005)
-    assert_close("ht", ref_ht, tri_ht, 0.005)
-    assert_close("dq", ref_dq, tri_dq, 0.005)
-    assert_close("dk", ref_dk, tri_dk, 0.005)
-    assert_close("dv", ref_dv, tri_dv, 0.005)
+    assert_close(' o', ref, tri, 0.005)
+    assert_close('ht', ref_ht, tri_ht, 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("K", test_d_list)
-@pytest.mark.parametrize("expand_ratio", [1, 2])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('K', test_d_list)
+@pytest.mark.parametrize('expand_ratio', [1, 2])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_chunk_varlen(
     N: int,
@@ -135,23 +135,23 @@ def test_chunk_varlen(
     tri_dv, v.grad = v.grad.clone(), None
     tri_dh0, h0.grad = h0.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.004)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.005)
-    assert_close(" dk", ref_dk, tri_dk, 0.005)
-    assert_close(" dv", ref_dv, tri_dv, 0.005)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+    assert_close('  o', ref, tri, 0.004)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.005)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("K", test_d_list)
-@pytest.mark.parametrize("expand_ratio", [1, 2])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('K', test_d_list)
+@pytest.mark.parametrize('expand_ratio', [1, 2])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_parallel(
     B: int,
@@ -181,7 +181,7 @@ def test_parallel(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close(" o", ref, tri, 0.005)
-    assert_close("dq", ref_dq, tri_dq, 0.005)
-    assert_close("dk", ref_dk, tri_dk, 0.005)
-    assert_close("dv", ref_dv, tri_dv, 0.005)
+    assert_close(' o', ref, tri, 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)

--- a/tests/ops/test_rwkv6.py
+++ b/tests/ops/test_rwkv6.py
@@ -26,13 +26,12 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("gate_logit_normalizer", test_gate_list)
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("head_first", [True, False])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('gate_logit_normalizer', test_gate_list)
+@pytest.mark.parametrize('dtype', [torch.bfloat16])
 @pytest.mark.skipif(
     os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
     reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
@@ -48,43 +47,38 @@ def test_chunk(
     D: int,
     dtype: torch.dtype,
     gate_logit_normalizer: float,
-    head_first: bool
 ):
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
-    if head_first:
-        q = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
-        k = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
-        v = torch.randn((B, H, T, D), dtype=dtype, device=device).requires_grad_()
-        w = F.logsigmoid(torch.randn((B, H, T, D), dtype=dtype, device=device)) / gate_logit_normalizer
-    else:
-        q = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
-        k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
-        v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
-        w = F.logsigmoid(torch.randn((B, T, H, D), dtype=dtype, device=device)) / gate_logit_normalizer
+    q = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_()
+    w = F.logsigmoid(torch.randn((B, T, H, D), dtype=dtype, device=device)) / gate_logit_normalizer
 
     u = torch.randn(H, D, dtype=dtype, device=device).requires_grad_(True)
     h0 = torch.randn(B, H, D, D, dtype=dtype, device=device).requires_grad_()
     w = w.requires_grad_()
     do = torch.randn_like(v)
 
-    ref, ref_ht = fused_recurrent_rwkv6(q.clone(),
-                                        k.clone(),
-                                        v.clone(),
-                                        w.clone(),
-                                        u.clone(),
-                                        initial_state=h0.clone(),
-                                        output_final_state=True,
-                                        head_first=head_first)
-    ref, _ = fused_recurrent_rwkv6(q.clone(),
-                                   k.clone(),
-                                   v.clone(),
-                                   w.clone(),
-                                   u.clone(),
-                                   initial_state=h0.clone(),
-                                   output_final_state=False,
-                                   head_first=head_first)
+    ref, ref_ht = fused_recurrent_rwkv6(
+        q.clone(),
+        k.clone(),
+        v.clone(),
+        w.clone(),
+        u.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+    )
+    ref, _ = fused_recurrent_rwkv6(
+        q.clone(),
+        k.clone(),
+        v.clone(),
+        w.clone(),
+        u.clone(),
+        initial_state=h0.clone(),
+        output_final_state=False,
+    )
 
     ((ref * do).sum()).backward()
     ref_dq, q.grad = q.grad.clone(), None
@@ -95,14 +89,15 @@ def test_chunk(
     ref_dh0, h0.grad = h0.grad.clone(), None
 
     # triton implementation
-    tri, tri_ht = chunk_rwkv6(q.clone(),
-                              k.clone(),
-                              v.clone(),
-                              w.clone(),
-                              u.clone(),
-                              initial_state=h0.clone(),
-                              output_final_state=True,
-                              head_first=head_first)
+    tri, tri_ht = chunk_rwkv6(
+        q.clone(),
+        k.clone(),
+        v.clone(),
+        w.clone(),
+        u.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+    )
     ((tri * do).sum()).backward()
     tri_dq, q.grad = q.grad.clone(), None
     tri_dk, k.grad = k.grad.clone(), None
@@ -140,7 +135,7 @@ def test_chunk_varlen(
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     # randomly split the sequence into N segments
-    offsets = torch.cat([
+    cu_seqlens = torch.cat([
         torch.tensor([0], dtype=torch.long),
         torch.arange(16, T)[torch.randperm(T - 16)[:N-1]],
         torch.tensor([T], dtype=torch.long)
@@ -162,8 +157,7 @@ def test_chunk_varlen(
         u.clone(),
         initial_state=h0.clone(),
         output_final_state=True,
-        cu_seqlens=offsets,
-        head_first=False
+        cu_seqlens=cu_seqlens,
     )
     ref, _ = fused_recurrent_rwkv6(
         q.clone(),
@@ -173,8 +167,7 @@ def test_chunk_varlen(
         u.clone(),
         initial_state=h0.clone(),
         output_final_state=False,
-        cu_seqlens=offsets,
-        head_first=False
+        cu_seqlens=cu_seqlens,
     )
     ref.backward(do)
     ref_dq, q.grad = q.grad.clone(), None
@@ -192,8 +185,7 @@ def test_chunk_varlen(
         u.clone(),
         initial_state=h0.clone(),
         output_final_state=True,
-        cu_seqlens=offsets,
-        head_first=False
+        cu_seqlens=cu_seqlens,
     )
     tri.backward(do)
     tri_dq, q.grad = q.grad.clone(), None

--- a/tests/ops/test_simple_gla.py
+++ b/tests/ops/test_simple_gla.py
@@ -108,16 +108,16 @@ def parallel_simple_gla_ref(
     return o.to(original_dtype), A
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("gate_logit_normalizer", test_gate_list)
-@pytest.mark.parametrize("dtype", [torch.float])
-@pytest.mark.parametrize("scale", [1, 0.1])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('gate_logit_normalizer', test_gate_list)
+@pytest.mark.parametrize('dtype', [torch.float])
+@pytest.mark.parametrize('scale', [1, 0.1])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_chunk(
     B: int,
@@ -165,23 +165,23 @@ def test_chunk(
     tri_dg, g.grad = g.grad.clone(), None
     tri_dh0, h0.grad = h0.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.004)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.005)
-    assert_close(" dk", ref_dk, tri_dk, 0.005)
-    assert_close(" dv", ref_dv, tri_dv, 0.005)
-    assert_close(" dg", ref_dg, tri_dg, 0.005)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+    assert_close('  o', ref, tri, 0.004)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
+    assert_close(' dg', ref_dg, tri_dg, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.005)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_chunk_varlen(
     N: int,
@@ -239,23 +239,23 @@ def test_chunk_varlen(
     tri_dg, g.grad = g.grad.clone(), None
     tri_dh0, h0.grad = h0.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.004)
-    assert_close(" ht", ref_ht, tri_ht, 0.005)
-    assert_close(" dq", ref_dq, tri_dq, 0.005)
-    assert_close(" dk", ref_dk, tri_dk, 0.005)
-    assert_close(" dv", ref_dv, tri_dv, 0.005)
-    assert_close(" dg", ref_dg, tri_dg, 0.005)
-    assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+    assert_close('  o', ref, tri, 0.004)
+    assert_close(' ht', ref_ht, tri_ht, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
+    assert_close(' dg', ref_dg, tri_dg, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.005)
 
 
-@pytest.mark.parametrize("N", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('N', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_parallel_varlen(
     N: int,
@@ -306,23 +306,23 @@ def test_parallel_varlen(
     tri_dv, v.grad = v.grad.clone(), None
     tri_dg, g.grad = g.grad.clone(), None
 
-    assert_close("  o", ref, tri, 0.004)
-    assert_close(" dq", ref_dq, tri_dq, 0.005)
-    assert_close(" dk", ref_dk, tri_dk, 0.005)
-    assert_close(" dv", ref_dv, tri_dv, 0.005)
-    assert_close(" dg", ref_dg, tri_dg, 0.005)
+    assert_close('  o', ref, tri, 0.004)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
+    assert_close(' dg', ref_dg, tri_dg, 0.005)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("gate_logit_normalizer", test_gate_list)
-@pytest.mark.parametrize("scale", [0.1])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('gate_logit_normalizer', test_gate_list)
+@pytest.mark.parametrize('scale', [0.1])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_parallel(
     B: int,
@@ -358,36 +358,27 @@ def test_parallel(
     tri_dv, v.grad = v.grad.clone(), None
     if USE_G:
         tri_dg, g.grad = g.grad.clone(), None
-    assert_close(" o", ref, tri, 0.005)
-    assert_close(" A", ref_A, tri_A, 0.005)
-    assert_close("dq", ref_dq, tri_dq, 0.005)
-    assert_close("dk", ref_dk, tri_dk, 0.005)
-    assert_close("dv", ref_dv, tri_dv, 0.005)
+    assert_close(' o', ref, tri, 0.005)
+    assert_close(' A', ref_A, tri_A, 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)
     if USE_G:
-        assert_close("dg", ref_dg, tri_dg, 0.015)
+        assert_close('dg', ref_dg, tri_dg, 0.015)
 
 
-@pytest.mark.parametrize("vary_A", [True, False])
-@pytest.mark.parametrize("dtype", [torch.float, torch.float16])
+@pytest.mark.parametrize('vary_A', [True, False])
+@pytest.mark.parametrize('dtype', [torch.float, torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_simple_gla_to_mamba2(vary_A, dtype):
-    r"""
-    Map Mamba-2's `mamba_chunk_scan_combined` kernel to FLA's `simple_gla` kernel
-
-    Dependencies:
-    $ pip install mamba-ssm==2.2.2 triton==2.3.1
-
-    Reference: `ssd_minimal_discrete` and `test_correctness` in mamba repository:
-    https://github.com/state-spaces/mamba/blob/v2.2.2/mamba_ssm/modules/ssd_minimal.py#L82
-    """
     try:
         from mamba_ssm.modules.ssd_minimal import ssd_minimal_discrete
         from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
     except ImportError:
-        pytest.skip("mamba_ssm is not installed.")
+        pytest.skip('mamba_ssm is not installed.')
     torch.manual_seed(42)
 
     # Dimensions, Denoted (B, T, Q, D, P) in Mamba2 paper
@@ -413,11 +404,11 @@ def test_simple_gla_to_mamba2(vary_A, dtype):
     if not vary_A:
         # NOTE: fused kernel does not support varying A with time
         y_fuse, final_fuse = mamba_chunk_scan_combined(x, dt, A, B, C, chunk_size, D=None, return_final_states=True)
-        assert y_ssd.allclose(y_fuse, 0, atol), f"y diff: {torch.abs(y_ssd - y_fuse).max()}"
+        assert y_ssd.allclose(y_fuse, 0, atol), f'y diff: {torch.abs(y_ssd - y_fuse).max()}'
         # fused kernel upcasts state to float32
         # https://github.com/state-spaces/mamba/blob/v2.2.2/mamba_ssm/ops/triton/ssd_combined.py#L650
         final_fuse = final_fuse.to(dtype)
-        assert final_ssd.allclose(final_fuse, 0, atol), f"final diff: {torch.abs(final_ssd - final_fuse).max()}"
+        assert final_ssd.allclose(final_fuse, 0, atol), f'final diff: {torch.abs(final_ssd - final_fuse).max()}'
 
     # mapping inputs Mamba2 -> FLA
     # C, B, X: [batch, seq, head, hidden] -> [batch, head, seq, hidden]
@@ -433,6 +424,6 @@ def test_simple_gla_to_mamba2(vary_A, dtype):
 
     # comparing output results between FLA kernel and Mamba2 kernel
     outputs_gla_fuse, final_gla_fuse = chunk_simple_gla(q, k, v, g, scale=1.0, output_final_state=True)
-    assert y_rearrange.allclose(outputs_gla_fuse, 0, atol), f"y diff: {torch.abs(y_rearrange - outputs_gla_fuse).max()}"
+    assert y_rearrange.allclose(outputs_gla_fuse, 0, atol), f'y diff: {torch.abs(y_rearrange - outputs_gla_fuse).max()}'
     final_gla_fuse = final_gla_fuse.to(dtype)  # states hard-coded to float32 in FLA kernel
-    assert final_rearrange.allclose(final_gla_fuse, 0, atol), f"final diff: {torch.abs(final_ssd - final_gla_fuse).max()}"
+    assert final_rearrange.allclose(final_gla_fuse, 0, atol), f'final diff: {torch.abs(final_ssd - final_gla_fuse).max()}'

--- a/tests/ops/test_solve_tril.py
+++ b/tests/ops/test_solve_tril.py
@@ -22,17 +22,17 @@ else:
 test_h_list = [2]
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("chunk_size", [16, 32, 64])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('chunk_size', [16, 32, 64])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Pytorch Failure"
+    reason='Intel Pytorch Failure'
 )
 def test_solve_tril(B, T, H, chunk_size):
     # do not randomly intiialize A otherwise the inverse is not stable
@@ -46,19 +46,19 @@ def test_solve_tril(B, T, H, chunk_size):
 
     Ai_ref = torch.inverse(A + torch.eye(A.shape[-1], device=A.device)[None, None, None, ...])
     Ai_ref = Ai_ref.reshape(B, H, -1, chunk_size)[:, :, :T, :]
-    assert_close("solve_tril", Ai, Ai_ref, 0.0001)
+    assert_close('solve_tril', Ai, Ai_ref, 0.0001)
 
 
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("cu_seqlens", test_t_varlen_list)
-@pytest.mark.parametrize("chunk_size", [64, 32, 16])
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('cu_seqlens', test_t_varlen_list)
+@pytest.mark.parametrize('chunk_size', [64, 32, 16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 @pytest.mark.skipif(
     device_platform == 'intel',
-    reason="Intel Pytorch Failure"
+    reason='Intel Pytorch Failure'
 )
 def test_solve_tril_varlen(H, cu_seqlens, chunk_size):
     T = cu_seqlens[-1]
@@ -77,4 +77,4 @@ def test_solve_tril_varlen(H, cu_seqlens, chunk_size):
                 A[:, j:j+actual_size, :, :actual_size].transpose(1, 2) +
                 torch.eye(actual_size, device=A.device, dtype=A.dtype)[None, None, ...]
             ).transpose(1, 2)
-    assert_close("solve_tril_varlen", Ai, Ai_ref, 0.0001)
+    assert_close('solve_tril_varlen', Ai, Ai_ref, 0.0001)

--- a/tests/ops/test_utils.py
+++ b/tests/ops/test_utils.py
@@ -30,14 +30,14 @@ def reversed_cumsum(x, dim=-1):
     return y.to(dtype)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_global_cumsum(
     B: int,
@@ -58,14 +58,14 @@ def test_global_cumsum(
     torch.testing.assert_close(ref, tri.to(ref.dtype), rtol=1.6e-2, atol=3e-5)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_global_cumsum_varlen(
     B: int,
@@ -91,14 +91,14 @@ def test_global_cumsum_varlen(
     torch.testing.assert_close(ref, tri.to(ref.dtype), rtol=1.6e-2, atol=3e-5)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_global_reversed_cumsum(
     B: int,
@@ -119,14 +119,14 @@ def test_global_reversed_cumsum(
     torch.testing.assert_close(ref, tri.to(ref.dtype), rtol=1.6e-2, atol=3e-5)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_global_reversed_cumsum_varlen(
     B: int,
@@ -152,12 +152,12 @@ def test_global_reversed_cumsum_varlen(
     torch.testing.assert_close(ref, tri.to(ref.dtype), rtol=1.6e-2, atol=3e-5)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("C", [32, 64])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('C', [32, 64])
+@pytest.mark.parametrize('dtype', [torch.float16])
 def test_local_cumsum(
     B: int,
     T: int,
@@ -178,15 +178,15 @@ def test_local_cumsum(
     torch.testing.assert_close(ref, tri.to(ref.dtype), rtol=1.6e-2, atol=3e-5)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_varlen_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("C", [32, 64])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_varlen_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('C', [32, 64])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_local_cumsum_varlen(
     B: int,
@@ -219,15 +219,15 @@ def test_local_cumsum_varlen(
     torch.testing.assert_close(ref, tri.to(ref.dtype), rtol=1.6e-2, atol=3e-5)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("C", [32, 64])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('C', [32, 64])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '0',
+    reason='Skipping test because TEST_CHUNK_VARLEN is enabled'
 )
 def test_mean_pooling(
     B: int,
@@ -253,15 +253,15 @@ def test_mean_pooling(
     torch.testing.assert_close(ref_dx, tri_dx.to(ref_dx.dtype), rtol=1.6e-2, atol=3e-5)
 
 
-@pytest.mark.parametrize("B", test_b_list)
-@pytest.mark.parametrize("T", test_t_list)
-@pytest.mark.parametrize("H", test_h_list)
-@pytest.mark.parametrize("D", test_d_list)
-@pytest.mark.parametrize("C", [32, 64])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize('B', test_b_list)
+@pytest.mark.parametrize('T', test_t_list)
+@pytest.mark.parametrize('H', test_h_list)
+@pytest.mark.parametrize('D', test_d_list)
+@pytest.mark.parametrize('C', [32, 64])
+@pytest.mark.parametrize('dtype', [torch.float16])
 @pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set"
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
 def test_mean_pooling_varlen(
     B: int,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the attention mechanism’s API for variable-length inputs by standardizing parameter naming from `offsets` to `cu_seqlens` and `indices` to `chunk_indices`.
  - Introduced runtime warnings to alert users about deprecated options and potential input shape mismatches.

- **Tests**
  - Updated test parameters and variable names for consistency and clarity in the attention tests, including stylistic changes to string delimiters. 
  - Adjusted the logic in test functions to reflect the new parameter names and ensure uniform tensor shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->