### PR TITLE
[Misc.] Use `logger.info` instead of `print` in `fla.utils.py`

### DIFF
--- a/fla/utils.py
+++ b/fla/utils.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import functools
+import logging
 import os
 from enum import Enum
 from functools import lru_cache
@@ -11,6 +12,7 @@ import torch
 import triton
 from packaging import version
 
+logger = logging.getLogger(__name__)
 COMPILER_MODE = os.getenv("FLA_COMPILER_MODE") == "1"
 FLA_CI_ENV = os.getenv("FLA_CI_ENV") == "1"
 
@@ -28,7 +30,7 @@ def get_err_ratio(x, y):
 def assert_close(prefix, ref, tri, ratio, warning=False, err_atol=1e-6):
     abs_atol = get_abs_err(ref, tri)
     msg = f"{prefix} diff: {abs_atol:.6f} ratio: {get_err_ratio(ref, tri):.6f}"
-    print(msg)
+    logger.info(msg)
     error_rate = get_err_ratio(ref, tri)
     if abs_atol <= err_atol:
         return

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -13,6 +13,7 @@ import triton
 from packaging import version
 
 logger = logging.getLogger(__name__)
+
 COMPILER_MODE = os.getenv("FLA_COMPILER_MODE") == "1"
 FLA_CI_ENV = os.getenv("FLA_CI_ENV") == "1"
 

--- a/scripts/find_dependent_tests.py
+++ b/scripts/find_dependent_tests.py
@@ -100,7 +100,6 @@ if __name__ == "__main__":
     # Skip fla/utils.py
     BLACKLIST = [
         'fla/utils.py',
-        'fla/ops/utils/testing.py',
     ]
     changed_files = [
         file for file in changed_files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal message handling to use logging instead of print statements.
  - Adjusted test processing to include additional files that were previously excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->