### PR TITLE
[TokenShift] support `fused_token_shift` with `varlen`

### DIFF
--- a/benchmarks/modules/benchmark_tokenshift.py
+++ b/benchmarks/modules/benchmark_tokenshift.py
@@ -1,0 +1,57 @@
+import torch
+import torch.nn as nn
+import triton
+
+from fla.modules.token_shift import fused_token_shift
+
+
+def token_shift(x):
+    shifted = nn.functional.pad(x, (0, 0, 1, -1))
+    delta = shifted - x
+    return delta
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        # argument names to use as an x-axis for the plot
+        x_names=['T'],
+        # different possible values for `x_name`
+        x_vals=[128 * 2 ** i for i in range(0, 8)],
+        # argument name whose value corresponds to a different line in the plot
+        line_arg='provider',
+        # possible values for `line_arg``
+        line_vals=['naive_token_shift',  'fused_token_shift', 'naive_token_shift_bwd',  'fused_token_shift_bwd'],
+        # label name for the lines
+        line_names=['naive_token_shift',  'fused_token_shift', 'naive_token_shift_bwd',  'fused_token_shift_bwd'],
+        # line styles
+        styles=[('green', '-'), ('blue', '--'), ('red', '-.'),
+                ('cyan', ':')],
+        ylabel="Execution Time (ms)",  # label name for the y-axis
+        # name for the plot. Used also as a file name for saving the plot.
+        plot_name="Performance",
+        args={},
+    )
+)
+def benchmark(T, provider):
+    from fla.utils import device
+    dtype = torch.bfloat16
+    requires_grad = True
+    B, D = 8, 4096
+
+    x = torch.randn(B, T, D, device=device, requires_grad=requires_grad, dtype=dtype)
+
+    quantiles = [0.5, 0.2, 0.8]
+    results = 0, 0, 0
+    if provider.startswith('naive_token_shift'):
+        results = triton.testing.do_bench(lambda: token_shift(x), quantiles=quantiles)
+    if provider.startswith('fused_token_shift'):
+        results = triton.testing.do_bench(lambda: fused_token_shift(x), quantiles=quantiles)
+    if provider.startswith('naive_token_shift_bwd'):
+        grad_output = torch.randn_like(x)
+        results = triton.testing.do_bench(lambda: token_shift(x).backward(grad_output), quantiles=quantiles)
+    if provider.startswith('fused_token_shift_bwd'):
+        grad_output = torch.randn_like(x)
+        results = triton.testing.do_bench(lambda: fused_token_shift(x).backward(grad_output), quantiles=quantiles)
+    return results
+
+if __name__ == '__main__':
+    benchmark.run(print_data=True)

--- a/benchmarks/modules/benchmark_tokenshift.py
+++ b/benchmarks/modules/benchmark_tokenshift.py
@@ -10,6 +10,7 @@ def token_shift(x):
     delta = shifted - x
     return delta
 
+
 @triton.testing.perf_report(
     triton.testing.Benchmark(
         # argument names to use as an x-axis for the plot
@@ -52,6 +53,7 @@ def benchmark(T, provider):
         grad_output = torch.randn_like(x)
         results = triton.testing.do_bench(lambda: fused_token_shift(x).backward(grad_output), quantiles=quantiles)
     return results
+
 
 if __name__ == '__main__':
     benchmark.run(print_data=True)

--- a/fla/layers/rwkv6.py
+++ b/fla/layers/rwkv6.py
@@ -14,6 +14,7 @@ from einops import rearrange
 
 from fla.modules import GroupNorm
 from fla.modules.activations import ACT2FN
+from fla.modules.token_shift import fused_token_shift
 from fla.ops.rwkv6 import chunk_rwkv6, fused_recurrent_rwkv6
 
 if TYPE_CHECKING:
@@ -123,23 +124,26 @@ class RWKV6Attention(nn.Module):
 
         if attention_mask is not None:
             hidden_states = hidden_states.mul_(attention_mask[:, -hidden_states.shape[-2]:, None])
+        cu_seqlens = kwargs.get('cu_seqlens', None)
         if hidden_states.shape[1] == 1 and last_state is not None:
             shifted = last_state['conv_state'].unsqueeze(1)
+            delta = shifted - hidden_states
+        elif last_state is None:
+            delta = fused_token_shift(hidden_states, cu_seqlens)
         else:
             shifted = self.time_shift(hidden_states)
-            if last_state is not None:
-                shifted[:, 0] = last_state['conv_state']
+            shifted[:, 0] = last_state['conv_state']
+            delta = shifted - hidden_states
 
-        delta = shifted - hidden_states
-        x = self.x_proj[0](hidden_states, delta).view(batch_size, seq_len, -1, self.proj_low_rank_dim)
+        x = self.x_proj[0](hidden_states, delta, cu_seqlens).view(batch_size, seq_len, -1, self.proj_low_rank_dim)
         x = torch.einsum('b t n r, h n r-> b t n h', self.x_proj[1](x), self.x_proj[2].weight.view(hidden_size, 5, -1))
 
         r, w, k, v, g = x.add_(self.x_bias).unbind(-2)
-        r = self.r_proj(hidden_states, r, delta)
-        w = self.w_proj(hidden_states, w, delta)
-        k = self.k_proj(hidden_states, k, delta)
-        v = self.v_proj(hidden_states, v, delta)
-        g = self.g_proj(hidden_states, g, delta)
+        r = self.r_proj(hidden_states, r, delta, cu_seqlens)
+        w = self.w_proj(hidden_states, w, delta, cu_seqlens)
+        k = self.k_proj(hidden_states, k, delta, cu_seqlens)
+        v = self.v_proj(hidden_states, v, delta, cu_seqlens)
+        g = self.g_proj(hidden_states, g, delta, cu_seqlens)
 
         # dealing with left-padding
         if attention_mask is not None:
@@ -150,7 +154,7 @@ class RWKV6Attention(nn.Module):
         u = self.bonus
 
         recurrent_state = last_state['recurrent_state'] if last_state is not None else None
-        cu_seqlens = kwargs.get('cu_seqlens', None)
+
         if mode == 'fused_recurrent':
             o, recurrent_state = fused_recurrent_rwkv6(
                 r=r,
@@ -307,12 +311,10 @@ class LerpLinear(nn.Module):
         s += ")"
         return s
 
-    def forward(self, x: torch.Tensor, delta: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, delta: Optional[torch.Tensor] = None,
+                cu_seqlens: Optional[torch.Tensor] = None) -> torch.Tensor:
         if delta is None:
-            shifted = self.time_shift(x)
-            if len(shifted.shape) == 2:
-                shifted = shifted.unsqueeze(1)
-            delta = shifted - x
+            delta = fused_token_shift(x, cu_seqlens)
         return self.linear(x + delta * self.mu)
 
 
@@ -343,10 +345,9 @@ class DDLerpLinear(nn.Module):
         s += ")"
         return s
 
-    def forward(self, x: torch.Tensor, mu: torch.Tensor, delta: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, mu: torch.Tensor,
+                delta: Optional[torch.Tensor] = None,
+                cu_seqlens: Optional[torch.Tensor] = None) -> torch.Tensor:
         if delta is None:
-            shifted = self.time_shift(x)
-            if len(shifted.shape) == 2:
-                shifted = shifted.unsqueeze(1)
-            delta = shifted - x
+            delta = fused_token_shift(x, cu_seqlens)
         return self.linear(x + delta * mu)

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -21,6 +21,7 @@ from fla.models.rwkv6.configuration_rwkv6 import RWKV6Config
 from fla.models.utils import Cache
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
 from fla.modules.activations import ACT2FN
+from fla.modules.token_shift import fused_token_shift
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -62,17 +63,22 @@ class RWKV6FeedForward(nn.Module):
         self,
         x: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
-        state: Optional[Cache] = None
+        state: Optional[Cache] = None,
+        **kwargs
     ) -> torch.Tensor:
         if attention_mask is not None:
             x = x.mul_(attention_mask[:, -x.shape[-2]:, None])
         if x.shape[1] == 1 and state is not None and state[self.layer_idx]['ffn_state'] is not None:
             shifted = state[self.layer_idx]['ffn_state'].unsqueeze(1)
-        else:
+            delta = shifted - x
+        elif state is not None and state[self.layer_idx]['ffn_state'] is not None:
             shifted = self.time_shift(x)
             if state is not None and state[self.layer_idx]['ffn_state'] is not None:
                 shifted[:, 0] = state[self.layer_idx]['ffn_state']
-        delta = shifted - x
+            delta = shifted - x
+        else:
+            cu_seqlens = kwargs.get('cu_seqlens', None)
+            delta = fused_token_shift(x, cu_seqlens)
         key = self.act_fn(self.key(x, delta))
         value = self.value(key)
         receptance = self.receptance(x, delta)
@@ -163,7 +169,7 @@ class RWKV6Block(nn.Module):
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.ffn_norm(hidden_states)
-        hidden_states, past_key_values = self.ffn(hidden_states, attention_mask, past_key_values)
+        hidden_states, past_key_values = self.ffn(hidden_states, attention_mask, past_key_values, **kwargs)
         hidden_states = residual + hidden_states
 
         outputs = (hidden_states, attentions, past_key_values)

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -21,6 +21,7 @@ from fla.models.rwkv7.configuration_rwkv7 import RWKV7Config
 from fla.models.utils import Cache
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
 from fla.modules.activations import ACT2FN
+from fla.modules.token_shift import fused_token_shift
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -78,20 +79,25 @@ class RWKV7FeedForward(nn.Module):
         self,
         x: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
-        state: Optional[Cache] = None
+        state: Optional[Cache] = None,
+        **kwargs
     ) -> torch.Tensor:
         if attention_mask is not None:
             x = x.mul(attention_mask[:, -x.shape[-2]:, None])
         if x.shape[1] == 1 and state is not None and state[self.layer_idx]['ffn_state'] is not None:
             shifted = state[self.layer_idx]['ffn_state'].unsqueeze(1)
-        else:
+            delta = shifted - x
+        elif state is not None and state[self.layer_idx]['ffn_state'] is not None:
             shifted = self.time_shift(x)
-            if state is not None and state[self.layer_idx]['ffn_state'] is not None:
-                shifted[:, 0] = state[self.layer_idx]['ffn_state'][-1]
+            shifted[:, 0] = state[self.layer_idx]['ffn_state'][-1]
+            delta = shifted - x
+        else:
+            cu_seqlens = kwargs.get('cu_seqlens', None)
+            delta = fused_token_shift(x, cu_seqlens)
         if state is not None:
             # no need to update the offset twice
             state.update(ffn_state=x[:, -1], layer_idx=self.layer_idx, offset=0)
-        return self.value(self.act_fn(self.key(x.addcmul(shifted - x, self.x_k)))), state
+        return self.value(self.act_fn(self.key(x.addcmul(delta, self.x_k)))), state
 
 
 class RWKV7Block(nn.Module):
@@ -185,7 +191,7 @@ class RWKV7Block(nn.Module):
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.ffn_norm(hidden_states)
-        hidden_states, past_key_values = self.ffn(hidden_states, attention_mask, past_key_values)
+        hidden_states, past_key_values = self.ffn(hidden_states, attention_mask, past_key_values, **kwargs)
         hidden_states = residual + hidden_states
 
         outputs = (hidden_states, attentions, past_key_values, v_first)

--- a/fla/modules/__init__.py
+++ b/fla/modules/__init__.py
@@ -17,6 +17,7 @@ from fla.modules.l2norm import L2Norm
 from fla.modules.layernorm import GroupNorm, GroupNormLinear, LayerNorm, LayerNormLinear, RMSNorm, RMSNormLinear
 from fla.modules.mlp import GatedMLP
 from fla.modules.rotary import RotaryEmbedding
+from fla.modules.token_shift import TokenShift
 
 __all__ = [
     'ImplicitLongConvolution', 'LongConvolution', 'ShortConvolution',
@@ -27,5 +28,6 @@ __all__ = [
     'FusedLayerNormGated', 'FusedLayerNormSwishGate', 'FusedLayerNormSwishGateLinear',
     'FusedRMSNormGated', 'FusedRMSNormSwishGate', 'FusedRMSNormSwishGateLinear',
     'GatedMLP',
-    'RotaryEmbedding'
+    'RotaryEmbedding',
+    'TokenShift'
 ]

--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8, 16, 32]
+        for num_stages in [1, 2, 3, 4]
+    ],
+    key=['BLOCK_SIZE'],
+)
+@triton.jit
+def token_shift_fwd_kernel(
+    x_ptr,
+    y_ptr,
+    H,
+    cu_seqlens_ptr,
+    stride_b,
+    stride_t,
+    stride_h,
+    IS_VARLEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    i_b, i_t = tl.program_id(0), tl.program_id(1)
+
+    if IS_VARLEN:
+        seq_idx = i_b
+
+        seq_start = tl.load(cu_seqlens_ptr + seq_idx).to(tl.int32)
+        seq_end = tl.load(cu_seqlens_ptr + seq_idx + 1).to(tl.int32)
+
+        # i_t is the global position index
+        # Check if this thread should process data
+        if i_t < seq_start or i_t >= seq_end:
+            return
+
+        # Calculate local position within sequence
+        local_pos = i_t - seq_start
+        t_idx = i_t  # t_idx is the global position
+
+        # Check if this is the first position in the sequence
+        is_first_pos = (local_pos == 0)
+    else:
+        b_idx = i_b
+        t_idx = i_t
+
+        is_first_pos = (t_idx == 0)
+    # Process the entire hidden dimension
+    h_offsets = tl.arange(0, BLOCK_SIZE)
+    h_mask = h_offsets < H
+
+    # Calculate offset to current position
+    if IS_VARLEN:
+        base_offset = t_idx * stride_t + h_offsets * stride_h
+    else:
+        base_offset = b_idx * stride_b + t_idx * stride_t + h_offsets * stride_h
+
+    # Load current values
+    curr_values = tl.load(x_ptr + base_offset, mask=h_mask)
+
+    if is_first_pos:
+        # First position in sequence: delta = -hidden_states
+        tl.store(y_ptr + base_offset, -curr_values, mask=h_mask)
+    else:
+        # Other positions: delta = prev - curr
+        if IS_VARLEN:
+            prev_offset = (t_idx-1) * stride_t + h_offsets * stride_h
+        else:
+            prev_offset = b_idx * stride_b + (t_idx-1) * stride_t + h_offsets * stride_h
+
+        prev_values = tl.load(x_ptr + prev_offset, mask=h_mask)
+        delta = prev_values - curr_values
+        tl.store(y_ptr + base_offset, delta, mask=h_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8, 16, 32]
+        for num_stages in [1, 2, 3, 4]
+    ],
+    key=['BLOCK_SIZE'],
+)
+@triton.jit
+def token_shift_bwd_kernel(
+    grad_input_ptr,
+    grad_output_ptr,
+    H,
+    T,
+    cu_seqlens_ptr,
+    stride_b,
+    stride_t,
+    stride_h,
+    IS_VARLEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    i_b, i_t = tl.program_id(0), tl.program_id(1)
+    if IS_VARLEN:
+        seq_idx = i_b
+
+        seq_start = tl.load(cu_seqlens_ptr + seq_idx).to(tl.int32)
+        seq_end = tl.load(cu_seqlens_ptr + seq_idx + 1).to(tl.int32)
+        seq_len = seq_end - seq_start
+
+        if i_t < seq_start or i_t >= seq_end:
+            return
+
+        local_pos = i_t - seq_start
+        t_idx = i_t  # t_idx is the global position
+
+        # Check if this is the first position in the sequence
+        is_last_pos = (local_pos == seq_len-1)
+    else:
+        b_idx = i_b
+        t_idx = i_t
+
+        is_last_pos = (t_idx == T - 1)
+
+    # Process the entire hidden dimension
+    h_offsets = tl.arange(0, BLOCK_SIZE)
+    h_mask = h_offsets < H
+
+    # Calculate offset to current position
+    if IS_VARLEN:
+        base_offset = t_idx * stride_t + h_offsets * stride_h
+    else:
+        base_offset = b_idx * stride_b + t_idx * stride_t + h_offsets * stride_h
+
+    # Load current gradient
+    curr_grad = tl.load(grad_output_ptr + base_offset, mask=h_mask)
+
+    if is_last_pos:
+        # Last position: grad = -grad_delta[t]
+        grad = -curr_grad
+    else:
+        # Other positions: grad = -grad_delta[t] + grad_delta[t+1]
+        if IS_VARLEN:
+            next_offset = (t_idx+1) * stride_t + h_offsets * stride_h
+        else:
+            next_offset = b_idx * stride_b + (t_idx+1) * stride_t + h_offsets * stride_h
+
+        next_grad = tl.load(grad_output_ptr + next_offset, mask=h_mask)
+        grad = -curr_grad + next_grad
+
+    # Store the result
+    tl.store(grad_input_ptr + base_offset, grad, mask=h_mask)
+
+
+def token_shift_forward_triton(
+    x: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    """
+    Implementation of token shift using Triton kernels
+
+    Args:
+        x: Input tensor of shape [batch_size, seq_len, hidden_size]
+        cu_seqlens: Cumulative sequence lengths (optional)
+
+    Returns:
+        Tensor of same shape as input with token shift applied
+    """
+    assert x.dim() == 3, "Input must be [batch_size, seq_len, hidden_size]"
+    B, T, H = x.shape
+
+    if cu_seqlens is not None:
+        # Variable length mode
+        n_seqs = cu_seqlens.shape[0] - 1
+        IS_VARLEN = True
+    else:
+        # Fixed length mode
+        n_seqs = B  # Not used in fixed length mode
+        IS_VARLEN = False
+
+    # Calculate block size as power of 2 >= H
+    block_size = triton.next_power_of_2(H)
+
+    # Allocate output tensor with same shape and dtype as input
+    y = torch.empty_like(x)
+
+    # Launch kernel
+    grid = (n_seqs, T)
+    token_shift_fwd_kernel[grid](
+        x_ptr=x,
+        y_ptr=y,
+        H=H,
+        cu_seqlens_ptr=cu_seqlens,
+        stride_b=x.stride(0),
+        stride_t=x.stride(1),
+        stride_h=x.stride(2),
+        IS_VARLEN=IS_VARLEN,
+        BLOCK_SIZE=block_size,
+    )
+
+    return y
+
+
+def token_shift_backward_triton(
+    grad_output: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    """
+    Backward pass for token shift using Triton kernels
+
+    Args:
+        grad_output: Gradient tensor of shape [batch_size, seq_len, hidden_size]
+        cu_seqlens: Cumulative sequence lengths (optional)
+
+    Returns:
+        Gradient tensor for input of same shape
+    """
+    assert grad_output.dim() == 3, "Input must be [batch_size, seq_len, hidden_size]"
+    B, T, H = grad_output.shape
+
+    if cu_seqlens is not None:
+        # Variable length mode
+        n_seqs = cu_seqlens.shape[0] - 1
+        IS_VARLEN = True
+    else:
+        # Fixed length mode
+        n_seqs = B  # Not used in fixed length mode
+        IS_VARLEN = False
+
+    # Calculate block size as power of 2 >= H
+    block_size = triton.next_power_of_2(H)
+
+    # Allocate output tensor with same shape and dtype as input
+    grad_input = torch.empty_like(grad_output)
+
+    # Launch kernel
+    grid = (n_seqs, T)
+    token_shift_bwd_kernel[grid](
+        grad_output_ptr=grad_output,
+        grad_input_ptr=grad_input,
+        H=H,
+        T=T,
+        cu_seqlens_ptr=cu_seqlens,
+        stride_b=grad_output.stride(0),
+        stride_t=grad_output.stride(1),
+        stride_h=grad_output.stride(2),
+        IS_VARLEN=IS_VARLEN,
+        BLOCK_SIZE=block_size,
+    )
+
+    return grad_input
+
+
+def token_shift_forward_pytorch(
+    x: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    """
+    Implementation of token shift using PyTorch
+
+    Args:
+        x: Input tensor of shape [batch_size, seq_len, hidden_size]
+        cu_seqlens: Cumulative sequence lengths (optional)
+
+    Returns:
+        Tensor of same shape as input with token shift applied
+    """
+    if cu_seqlens is not None:
+        # Variable length mode with cu_seqlens
+        assert x.dim() == 3, "Input must be [batch_size, seq_len, hidden_size]"
+        B, T, H = x.shape
+        assert B == 1, "Batch size must be 1 when using cu_seqlens"
+
+        result = torch.zeros_like(x)
+        n_seqs = cu_seqlens.shape[0] - 1
+
+        for i in range(n_seqs):
+            start = cu_seqlens[i].item()
+            end = cu_seqlens[i+1].item()
+            seq_len = end - start
+
+            if seq_len <= 1:
+                # For sequences of length 1 or 0, delta is simply -x
+                result[0, start:end] = -x[0, start:end]
+            else:
+                # For longer sequences, handle padding manually
+                shifted = torch.zeros_like(x[0, start:end])
+                shifted[1:] = x[0, start:end-1]  # Shift all but first token
+                delta = shifted - x[0, start:end]
+                result[0, start:end] = delta
+
+        return result
+    else:
+        # Fixed length mode - use ZeroPad2d
+        time_shift = torch.nn.ZeroPad2d((0, 0, 1, -1))
+        shifted = time_shift(x)
+        delta = shifted - x
+        return delta
+
+
+class TokenShift(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, cu_seqlens=None):
+        # Save for backward
+        ctx.save_for_backward(cu_seqlens)
+        return token_shift_forward_triton(x, cu_seqlens)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        cu_seqlens, = ctx.saved_tensors
+        grad_input = token_shift_backward_triton(grad_output, cu_seqlens)
+        return grad_input, None  # None for cu_seqlens gradient
+
+
+def fused_token_shift(x, cu_seqlens=None):
+    """
+    Custom autograd function for token shift operation
+    """
+    return TokenShift.apply(x, cu_seqlens)

--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -7,6 +7,8 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, custom_device_ctx
+
 
 @triton.autotune(
     configs=[
@@ -18,10 +20,10 @@ import triton.language as tl
 )
 @triton.jit
 def token_shift_fwd_kernel(
-    x_ptr,
-    y_ptr,
+    x,
+    y,
     H,
-    cu_seqlens_ptr,
+    cu_seqlens,
     stride_b,
     stride_t,
     stride_h,
@@ -31,53 +33,42 @@ def token_shift_fwd_kernel(
     i_b, i_t = tl.program_id(0), tl.program_id(1)
 
     if IS_VARLEN:
-        seq_idx = i_b
+        i_n = i_b
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
 
-        seq_start = tl.load(cu_seqlens_ptr + seq_idx).to(tl.int32)
-        seq_end = tl.load(cu_seqlens_ptr + seq_idx + 1).to(tl.int32)
-
-        # i_t is the global position index
-        # Check if this thread should process data
-        if i_t < seq_start or i_t >= seq_end:
+        if i_t < bos or i_t >= eos:
             return
 
-        # Calculate local position within sequence
-        local_pos = i_t - seq_start
-        t_idx = i_t  # t_idx is the global position
-
-        # Check if this is the first position in the sequence
-        is_first_pos = (local_pos == 0)
+        is_first_pos = (i_t - bos == 0)
     else:
-        b_idx = i_b
-        t_idx = i_t
+        is_first_pos = (i_t == 0)
 
-        is_first_pos = (t_idx == 0)
     # Process the entire hidden dimension
     h_offsets = tl.arange(0, BLOCK_SIZE)
     h_mask = h_offsets < H
 
     # Calculate offset to current position
     if IS_VARLEN:
-        base_offset = t_idx * stride_t + h_offsets * stride_h
+        base_offset = i_t * stride_t + h_offsets * stride_h
     else:
-        base_offset = b_idx * stride_b + t_idx * stride_t + h_offsets * stride_h
+        base_offset = i_b * stride_b + i_t * stride_t + h_offsets * stride_h
 
     # Load current values
-    curr_values = tl.load(x_ptr + base_offset, mask=h_mask)
+    curr_values = tl.load(x + base_offset, mask=h_mask)
 
     if is_first_pos:
         # First position in sequence: delta = -hidden_states
-        tl.store(y_ptr + base_offset, -curr_values, mask=h_mask)
+        tl.store(y + base_offset, -curr_values, mask=h_mask)
     else:
         # Other positions: delta = prev - curr
         if IS_VARLEN:
-            prev_offset = (t_idx-1) * stride_t + h_offsets * stride_h
+            prev_offset = (i_t-1) * stride_t + h_offsets * stride_h
         else:
-            prev_offset = b_idx * stride_b + (t_idx-1) * stride_t + h_offsets * stride_h
+            prev_offset = i_b * stride_b + (i_t-1) * stride_t + h_offsets * stride_h
 
-        prev_values = tl.load(x_ptr + prev_offset, mask=h_mask)
+        prev_values = tl.load(x + prev_offset, mask=h_mask)
         delta = prev_values - curr_values
-        tl.store(y_ptr + base_offset, delta, mask=h_mask)
+        tl.store(y + base_offset, delta, mask=h_mask)
 
 
 @triton.autotune(
@@ -90,11 +81,11 @@ def token_shift_fwd_kernel(
 )
 @triton.jit
 def token_shift_bwd_kernel(
-    grad_input_ptr,
-    grad_output_ptr,
+    grad_input,
+    grad_output,
     H,
     T,
-    cu_seqlens_ptr,
+    cu_seqlens,
     stride_b,
     stride_t,
     stride_h,
@@ -103,25 +94,16 @@ def token_shift_bwd_kernel(
 ):
     i_b, i_t = tl.program_id(0), tl.program_id(1)
     if IS_VARLEN:
-        seq_idx = i_b
+        i_n = i_b
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
 
-        seq_start = tl.load(cu_seqlens_ptr + seq_idx).to(tl.int32)
-        seq_end = tl.load(cu_seqlens_ptr + seq_idx + 1).to(tl.int32)
-        seq_len = seq_end - seq_start
-
-        if i_t < seq_start or i_t >= seq_end:
+        if i_t < bos or i_t >= eos:
             return
 
-        local_pos = i_t - seq_start
-        t_idx = i_t  # t_idx is the global position
-
-        # Check if this is the first position in the sequence
-        is_last_pos = (local_pos == seq_len-1)
+        local_pos = i_t - bos
+        is_last_pos = (local_pos == eos - bos - 1)
     else:
-        b_idx = i_b
-        t_idx = i_t
-
-        is_last_pos = (t_idx == T - 1)
+        is_last_pos = (i_t == T - 1)
 
     # Process the entire hidden dimension
     h_offsets = tl.arange(0, BLOCK_SIZE)
@@ -129,12 +111,12 @@ def token_shift_bwd_kernel(
 
     # Calculate offset to current position
     if IS_VARLEN:
-        base_offset = t_idx * stride_t + h_offsets * stride_h
+        base_offset = i_t * stride_t + h_offsets * stride_h
     else:
-        base_offset = b_idx * stride_b + t_idx * stride_t + h_offsets * stride_h
+        base_offset = i_b * stride_b + i_t * stride_t + h_offsets * stride_h
 
     # Load current gradient
-    curr_grad = tl.load(grad_output_ptr + base_offset, mask=h_mask)
+    curr_grad = tl.load(grad_output + base_offset, mask=h_mask)
 
     if is_last_pos:
         # Last position: grad = -grad_delta[t]
@@ -142,15 +124,15 @@ def token_shift_bwd_kernel(
     else:
         # Other positions: grad = -grad_delta[t] + grad_delta[t+1]
         if IS_VARLEN:
-            next_offset = (t_idx+1) * stride_t + h_offsets * stride_h
+            next_offset = (i_t+1) * stride_t + h_offsets * stride_h
         else:
-            next_offset = b_idx * stride_b + (t_idx+1) * stride_t + h_offsets * stride_h
+            next_offset = i_b * stride_b + (i_t+1) * stride_t + h_offsets * stride_h
 
-        next_grad = tl.load(grad_output_ptr + next_offset, mask=h_mask)
+        next_grad = tl.load(grad_output + next_offset, mask=h_mask)
         grad = -curr_grad + next_grad
 
     # Store the result
-    tl.store(grad_input_ptr + base_offset, grad, mask=h_mask)
+    tl.store(grad_input + base_offset, grad, mask=h_mask)
 
 
 def token_shift_forward_triton(
@@ -171,27 +153,21 @@ def token_shift_forward_triton(
     B, T, H = x.shape
 
     if cu_seqlens is not None:
-        # Variable length mode
         n_seqs = cu_seqlens.shape[0] - 1
         IS_VARLEN = True
     else:
-        # Fixed length mode
-        n_seqs = B  # Not used in fixed length mode
+        n_seqs = B
         IS_VARLEN = False
 
-    # Calculate block size as power of 2 >= H
     block_size = triton.next_power_of_2(H)
-
-    # Allocate output tensor with same shape and dtype as input
     y = torch.empty_like(x)
 
-    # Launch kernel
     grid = (n_seqs, T)
     token_shift_fwd_kernel[grid](
-        x_ptr=x,
-        y_ptr=y,
+        x=x,
+        y=y,
         H=H,
-        cu_seqlens_ptr=cu_seqlens,
+        cu_seqlens=cu_seqlens,
         stride_b=x.stride(0),
         stride_t=x.stride(1),
         stride_h=x.stride(2),
@@ -220,28 +196,22 @@ def token_shift_backward_triton(
     B, T, H = grad_output.shape
 
     if cu_seqlens is not None:
-        # Variable length mode
         n_seqs = cu_seqlens.shape[0] - 1
         IS_VARLEN = True
     else:
-        # Fixed length mode
-        n_seqs = B  # Not used in fixed length mode
+        n_seqs = B
         IS_VARLEN = False
 
-    # Calculate block size as power of 2 >= H
     block_size = triton.next_power_of_2(H)
-
-    # Allocate output tensor with same shape and dtype as input
     grad_input = torch.empty_like(grad_output)
 
-    # Launch kernel
     grid = (n_seqs, T)
     token_shift_bwd_kernel[grid](
-        grad_output_ptr=grad_output,
-        grad_input_ptr=grad_input,
+        grad_output=grad_output,
+        grad_input=grad_input,
         H=H,
         T=T,
-        cu_seqlens_ptr=cu_seqlens,
+        cu_seqlens=cu_seqlens,
         stride_b=grad_output.stride(0),
         stride_t=grad_output.stride(1),
         stride_h=grad_output.stride(2),
@@ -286,13 +256,12 @@ def token_shift_forward_pytorch(
             else:
                 # For longer sequences, handle padding manually
                 shifted = torch.zeros_like(x[0, start:end])
-                shifted[1:] = x[0, start:end-1]  # Shift all but first token
+                shifted[1:] = x[0, start:end-1]
                 delta = shifted - x[0, start:end]
                 result[0, start:end] = delta
 
         return result
     else:
-        # Fixed length mode - use ZeroPad2d
         time_shift = torch.nn.ZeroPad2d((0, 0, 1, -1))
         shifted = time_shift(x)
         delta = shifted - x
@@ -301,16 +270,20 @@ def token_shift_forward_pytorch(
 
 class TokenShift(torch.autograd.Function):
     @staticmethod
+    @autocast_custom_fwd
     def forward(ctx, x, cu_seqlens=None):
-        # Save for backward
         ctx.save_for_backward(cu_seqlens)
-        return token_shift_forward_triton(x, cu_seqlens)
+        with custom_device_ctx(x.device.index):
+            delta = token_shift_forward_triton(x, cu_seqlens)
+        return delta
 
     @staticmethod
+    @autocast_custom_bwd
     def backward(ctx, grad_output):
         cu_seqlens, = ctx.saved_tensors
-        grad_input = token_shift_backward_triton(grad_output, cu_seqlens)
-        return grad_input, None  # None for cu_seqlens gradient
+        with custom_device_ctx(grad_output.device.index):
+            grad_input = token_shift_backward_triton(grad_output, cu_seqlens)
+        return grad_input, None
 
 
 def fused_token_shift(x, cu_seqlens=None):

--- a/tests/modules/test_token_shift.py
+++ b/tests/modules/test_token_shift.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+from fla.modules.token_shift import fused_token_shift, token_shift_forward_pytorch
+from fla.utils import device
+
+
+@pytest.mark.parametrize(
+    "test_case,batch_size,seq_len,hidden_size,cu_seqlens,dtype",
+    [
+        ("fixed_length_standard", 8, 128, 128, None, torch.float32),
+        ("fixed_length_different_dims", 4, 256, 64, None, torch.float32),
+        ("var_length_standard", 1, 128, 128, [0, 4, 7, 40, 128], torch.float32),
+        ("var_length_fewer_seqs", 1, 64, 64, [0, 10, 20, 64], torch.float32),
+        ("var_length_single_seq", 1, 32, 32, [0, 32], torch.float32),
+        ("edge_case_len_1", 1, 4, 64, [0, 1, 3, 4], torch.float32),
+        ("dtype_float16", 2, 32, 64, None, torch.float16),
+        ("dtype_bfloat16", 2, 32, 64, None, torch.bfloat16)
+    ]
+)
+def test_token_shift(test_case, batch_size, seq_len, hidden_size, cu_seqlens, dtype):
+    """Comprehensive test for token shift operation"""
+
+    # Set random seed for reproducibility
+    torch.manual_seed(42)
+
+    # Create test tensors
+    x_pytorch = torch.randn(batch_size, seq_len, hidden_size, device=device).to(dtype).requires_grad_(True)
+    x_triton = x_pytorch.clone().detach().requires_grad_(True)
+
+    # Convert cu_seqlens to tensor if provided
+    cu_seqlens_tensor = None
+    if cu_seqlens is not None:
+        cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+    # Forward pass
+    out_pytorch = token_shift_forward_pytorch(x_pytorch, cu_seqlens_tensor)
+    out_triton = fused_token_shift(x_triton, cu_seqlens_tensor)
+
+    # Check forward results - use higher tolerance for lower precision dtypes
+    rtol = 1e-5 if dtype == torch.float32 else 1e-3
+    atol = 1e-5 if dtype == torch.float32 else 1e-3
+
+    torch.testing.assert_close(
+        out_pytorch, out_triton,
+        rtol=rtol, atol=atol,
+        msg=f"Forward pass failed for {test_case}"
+    )
+
+    # Backward pass - create a dummy gradient
+    grad_output = torch.randn_like(out_pytorch)
+
+    # Compute gradients
+    out_pytorch.backward(grad_output)
+    out_triton.backward(grad_output)
+
+    # Check backward results
+    torch.testing.assert_close(
+        x_pytorch.grad, x_triton.grad,
+        rtol=rtol, atol=atol,
+        msg=f"Backward pass failed for {test_case}"
+    )
+
+    # Print result for debugging
+    print(f"Test case '{test_case}' PASSED")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optimized token shift operation with GPU acceleration and PyTorch fallback, supporting both fixed and variable-length sequences.
  - Added public access to the token shift module for easier integration.
  - Integrated the fused token shift operation into multiple model components, improving delta computation and enabling sequence length flexibility.

- **Tests**
  - Added comprehensive tests to verify the correctness of the token shift operation across different scenarios and data types.

- **Chores**
  - Added benchmarking tools to compare performance between naive and optimized token shift implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->