### PR TITLE
[Tests] Enable tests with `causal_conv1d` on H100 CIs

### DIFF
--- a/.github/workflows/nvidia-4090.yml
+++ b/.github/workflows/nvidia-4090.yml
@@ -63,8 +63,10 @@ jobs:
         if: steps.find-dependent-tests.outputs.test_files && steps.check_skip.outputs.skip_tests == 'false'
         run: |
           pip uninstall -y flash-linear-attention
-          pip install -U pytest setuptools wheel ninja torch triton
-          MAX_JOBS=4 pip install -U flash-attn --no-build-isolation
+          # Installed by hand to avoid issues with pip
+          # pip install -U pytest setuptools wheel ninja torch triton
+          # MAX_JOBS=4 pip install -U flash-attn --no-build-isolation
+          # pip install git+https://github.com/Dao-AILab/causal-conv1d.git --no-build-isolation
           pip install --no-use-pep517 .
 
       - name: Check GPU status

--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -63,8 +63,10 @@ jobs:
         if: steps.find-dependent-tests.outputs.test_files && steps.check_skip.outputs.skip_tests == 'false'
         run: |
           pip uninstall -y flash-linear-attention
-          pip install -U pytest setuptools wheel ninja torch triton
-          MAX_JOBS=4 pip install -U flash-attn --no-build-isolation
+          # Installed by hand to avoid issues with pip
+          # pip install -U pytest setuptools wheel ninja torch triton
+          # MAX_JOBS=4 pip install -U flash-attn --no-build-isolation
+          # pip install git+https://github.com/Dao-AILab/causal-conv1d.git --no-build-isolation
           pip install --no-use-pep517 .
 
       - name: Check GPU status

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -27,7 +27,7 @@ from fla.models import (
     SambaConfig,
     TransformerConfig
 )
-from fla.utils import assert_close, device, device_platform
+from fla.utils import assert_close, device, is_nvidia_hopper
 
 
 @pytest.mark.parametrize("L", [2])
@@ -60,8 +60,8 @@ from fla.utils import assert_close, device, device_platform
 ])
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.skipif(
-    device_platform == 'intel',
-    reason="Intel Triton Failure"
+    is_nvidia_hopper is False,
+    reason="Only run on Hopper GPUs"
 )
 def test_generation(
     L: int,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,7 +26,7 @@ from fla.models import (
     SambaConfig,
     TransformerConfig
 )
-from fla.utils import assert_close, device, device_platform
+from fla.utils import assert_close, device, is_nvidia_hopper
 
 
 @pytest.mark.parametrize("L", [4])
@@ -58,8 +58,8 @@ from fla.utils import assert_close, device, device_platform
 ])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.skipif(
-    device_platform == 'intel',
-    reason="Intel Triton Failure"
+    is_nvidia_hopper is False,
+    reason="Only run on Hopper GPUs"
 )
 def test_model(
     L: int,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configurations to change how Python dependencies are installed during automated runs.
- **Tests**
  - Adjusted test conditions to ensure certain tests only run on NVIDIA Hopper GPUs, improving test relevance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->