### PR TITLE
[chore] switched to `processing_class` kwarg inside Trainer invocation 

### DIFF
--- a/legacy/training/run.py
+++ b/legacy/training/run.py
@@ -58,7 +58,7 @@ def main():
     trainer = Trainer(
         model=model,
         args=args,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         data_collator=data_collator,
         callbacks=[LogCallback()],
         train_dataset=dataset


### PR DESCRIPTION
fixes the deprecation warning for the `tokenizer` kwarg in the invocation of `Trainer` in `run.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal parameter naming for improved clarity during model training setup. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->