### PR TITLE
[DeltaProduct] fix query conv cache, remove extraneous query convs

### DIFF
--- a/fla/layers/gated_deltaproduct.py
+++ b/fla/layers/gated_deltaproduct.py
@@ -119,15 +119,10 @@ class GatedDeltaProduct(nn.Module):
             ]
         )
         if use_short_conv:
-            self.q_conv1ds = nn.ModuleList(
-                [
-                    ShortConvolution(
-                        hidden_size=self.key_dim,
-                        kernel_size=conv_size,
-                        activation="silu",
-                    )
-                    for _ in range(num_householder)
-                ]
+            self.q_conv1d = ShortConvolution(
+                hidden_size=self.key_dim,
+                kernel_size=conv_size,
+                activation="silu",
             )
             self.k_conv1ds = nn.ModuleList(
                 [
@@ -229,6 +224,13 @@ class GatedDeltaProduct(nn.Module):
                     if attention_mask is not None
                     else None
                 )
+                if i == self.num_householder - 1:
+                    q, conv_state_q = self.q_conv1d(
+                        x=self.q_proj(hidden_states),
+                        mask=conv_mask,
+                        cache=conv_state_q,
+                        output_final_state=use_cache,
+                    )
 
                 k, conv_state_k = self.k_conv1ds[i](
                     x=self.k_projs[i](hidden_states),
@@ -246,6 +248,8 @@ class GatedDeltaProduct(nn.Module):
             else:
                 k = self.silu(self.k_projs[i](hidden_states))
                 v = self.silu(self.v_projs[i](hidden_states))
+                if i == self.num_householder - 1:
+                    q = self.silu(self.q_proj(hidden_states))
 
             ks.append(k)
             vs.append(v)
@@ -259,15 +263,6 @@ class GatedDeltaProduct(nn.Module):
                 beta = beta * 2
             betas.append(beta)
 
-        if self.use_short_conv:
-            q, conv_state_q = self.q_conv1ds[0](
-                x=self.q_proj(hidden_states),
-                mask=conv_mask,
-                cache=conv_state_q,
-                output_final_state=use_cache,
-            )
-        else:
-            q = self.silu(self.q_proj(hidden_states))
         q = interleave_multiple_sequences(
             [torch.zeros_like(q)] * (self.num_householder - 1) + [q]
         )


### PR DESCRIPTION
This PR fixes an issue where the query convolutional cache is never set which leads to incorrect text generation. It also removes unused query convs since we only need one (right now we initialise n_h query convs but only use the last one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized query processing in the GatedDeltaProduct module to reduce redundant computations, resulting in improved efficiency with no changes to the user interface or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->