### PR TITLE
[Misc] Fix `Boolean value of Tensor with more than one value is ambiguous`

### DIFF
--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -383,7 +383,7 @@ class ABCForCausalLM(ABCPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -409,7 +409,7 @@ class BitNetForCausalLM(BitNetPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
         logits = None if fuse_linear_and_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
 
         loss = None

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -380,7 +380,7 @@ class DeltaNetForCausalLM(DeltaNetPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -373,7 +373,7 @@ class ForgettingTransformerForCausalLM(ForgettingTransformerPreTrainedModel, Gen
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
         logits = None if fuse_linear_and_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
 
         loss = None

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -410,7 +410,7 @@ class GatedDeltaNetForCausalLM(GatedDeltaNetPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -383,7 +383,7 @@ class GatedDeltaProductForCausalLM(GatedDeltaProductPreTrainedModel, GenerationM
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -382,7 +382,7 @@ class GLAForCausalLM(GLAPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -384,7 +384,7 @@ class GSAForCausalLM(GSAPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -385,7 +385,7 @@ class HGRNForCausalLM(HGRNPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -386,7 +386,7 @@ class HGRN2ForCausalLM(HGRN2PreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -375,7 +375,7 @@ class LightNetForCausalLM(LightNetPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -371,7 +371,7 @@ class LinearAttentionForCausalLM(LinearAttentionPreTrainedModel, GenerationMixin
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/mamba/modeling_mamba.py
+++ b/fla/models/mamba/modeling_mamba.py
@@ -530,7 +530,7 @@ class MambaForCausalLM(MambaPreTrainedModel, GenerationMixin):
             attention_mask=attention_mask,
         )
         hidden_states = mamba_outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -528,7 +528,7 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
             attention_mask=attention_mask,
         )
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -363,7 +363,7 @@ class NSAForCausalLM(NSAPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -371,7 +371,7 @@ class PaTHAttentionForCausalLM(PaTHAttentionPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
         logits = None if fuse_linear_and_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
 
         loss = None

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -390,7 +390,7 @@ class RetNetForCausalLM(RetNetPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -451,7 +451,7 @@ class RWKV6ForCausalLM(RWKV6PreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -543,7 +543,7 @@ class RWKV7ForCausalLM(RWKV7PreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         has_labels = (labels is not None) or (shift_labels is not None)

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -388,7 +388,7 @@ class SambaForCausalLM(SambaPreTrainedModel, GenerationMixin):
             **kwargs
         )
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -370,7 +370,7 @@ class TransformerForCausalLM(TransformerPreTrainedModel, GenerationMixin):
         )
 
         hidden_states = outputs[0]
-        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
         logits = None if fuse_linear_and_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
 
         loss = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for enabling fused linear and cross-entropy loss computation across multiple model types. The fusion flag is now set based on configuration and training mode, regardless of whether labels are provided. This change may affect the internal flow of loss computation but does not alter user-facing behavior or outputs. No changes were made to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->