### PR TITLE
[RWKV7]: Remove `head_first` in fused kernel

### DIFF
--- a/fla/ops/rwkv7/fused_recurrent.py
+++ b/fla/ops/rwkv7/fused_recurrent.py
@@ -188,7 +188,6 @@ def fused_recurrent_rwkv7(
     initial_state: torch.Tensor = None,
     output_final_state: bool = True,
     cu_seqlens: Optional[torch.LongTensor] = None,
-    head_first: bool = False,
 ):
     """
     Args:
@@ -213,9 +212,6 @@ def fused_recurrent_rwkv7(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
-        head_first (bool):
-            whether to use head first. Recommended to be False to avoid extra transposes.
-            Default: `False`.
     """
     return fused_recurrent_dplr_delta_rule(
         q=r,
@@ -228,7 +224,6 @@ def fused_recurrent_rwkv7(
         initial_state=initial_state,
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
-        head_first=head_first,
     )
 
 
@@ -244,7 +239,6 @@ def fused_mul_recurrent_rwkv7(
     output_final_state: bool = False,
     reverse: bool = False,
     cu_seqlens: Optional[torch.Tensor] = None,
-    head_first: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""
     This function computes the recurrence S_t = S_t @ (I + a_t b_t^T) + v_t k_t^T in a recurrent manner.
@@ -276,14 +270,7 @@ def fused_mul_recurrent_rwkv7(
         cu_seqlens (Optional[torch.Tensor]):
             Cumulative sequence lengths of shape `[N + 1]` used for variable-length training,
             consistent with the FlashAttention API.
-        head_first (Optional[bool]):
-            Whether the inputs are in the head-first format, which is not supported for variable-length inputs.
-            Default: `False`.
     """
-    assert head_first is False, DeprecationWarning(
-            "head_first is deprecated. "
-            "Please use head_first=False for now instead."
-        )
     if cu_seqlens is not None:
         if r.shape[0] != 1:
             raise ValueError(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified function interfaces by removing the unused `head_first` parameter. No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->