### PR TITLE
[Simple GLA] Remove unnecessary dg for data-independent decay

### DIFF
--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -35,6 +35,7 @@ def chunk_fwd_kernel_h(
     v,
     h,
     g,
+    g_gamma,
     gk,
     gv,
     h0,
@@ -50,6 +51,7 @@ def chunk_fwd_kernel_h(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
@@ -69,6 +71,13 @@ def chunk_fwd_kernel_h(
         NT = tl.cdiv(T, BT)
         NS = tl.cdiv(T, BS)
         boh = i_n * NS
+
+    if USE_G_GAMMA:
+        # decay rate given the head index
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+        b_g_last = b_gamma * BT
+        b_gk = exp(b_g_last - b_g)
 
     # [BK, BV]
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
@@ -96,8 +105,14 @@ def chunk_fwd_kernel_h(
         if USE_G:
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
             p_g = g + bos*H + (i_t * BT + tl.arange(0, BT)) * H + i_h
-            b_h *= exp(b_g_last)
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
+            b_h *= exp(b_g_last)
+            b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+
+        if USE_G_GAMMA:
+            if i_t == NT - 1 and (T % BT) != 0:
+                b_g_last = b_gamma * (T % BT)
+            b_h *= exp(b_g_last)
             b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
         # vector decay, h = Diag(gk) @ h
@@ -148,6 +163,7 @@ def chunk_fwd_kernel_h(
 def chunk_bwd_kernel_dh(
     q,
     g,
+    g_gamma,
     gk,
     gv,
     do,
@@ -168,6 +184,7 @@ def chunk_bwd_kernel_dh(
     BV: tl.constexpr,
     NG: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
     STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
@@ -188,6 +205,11 @@ def chunk_bwd_kernel_dh(
         NT = tl.cdiv(T, BT)
         NS = tl.cdiv(T, BS)
         boh = i_n * NS
+
+    if USE_G_GAMMA:
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+        b_g_last = b_gamma * BT
 
     # [BK, BV]
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
@@ -216,7 +238,12 @@ def chunk_bwd_kernel_dh(
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
             b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp(b_g_last)
 
+        if USE_G_GAMMA:
+            if i_t == NT - 1 and (T % BT) != 0:
+                b_g_last = b_gamma * (T % BT)
+            b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
             b_dh *= exp(b_g_last)
 
         if USE_GK:
@@ -248,11 +275,12 @@ def chunk_bwd_kernel_dh(
 def chunk_fwd_h(
     k: torch.Tensor,
     v: torch.Tensor,
-    g: torch.Tensor,
-    gk: torch.Tensor,
-    gv: torch.Tensor,
-    h0: torch.Tensor,
-    output_final_state: bool,
+    g: torch.Tensor = None,
+    g_gamma: torch.Tensor = None,
+    gk: torch.Tensor = None,
+    gv: torch.Tensor = None,
+    h0: torch.Tensor = None,
+    output_final_state: bool = False,
     cu_seqlens: Optional[torch.Tensor] = None,
     chunk_size: int = 64,
     split_size: Optional[int] = None,
@@ -277,6 +305,7 @@ def chunk_fwd_h(
         v=v,
         h=h,
         g=g,
+        g_gamma=g_gamma,
         gk=gk,
         gv=gv,
         h0=h0,
@@ -290,6 +319,7 @@ def chunk_fwd_h(
         BT=BT,
         BS=BS,
         USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
     )
@@ -301,6 +331,7 @@ def chunk_bwd_dh(
     k: torch.Tensor,
     v: torch.Tensor,
     g: torch.Tensor,
+    g_gamma: torch.Tensor,
     gk: torch.Tensor,
     gv: torch.Tensor,
     do: torch.Tensor,
@@ -333,6 +364,7 @@ def chunk_bwd_dh(
     chunk_bwd_kernel_dh[grid](
         q=q,
         g=g,
+        g_gamma=g_gamma,
         gk=gk,
         gv=gv,
         do=do,
@@ -351,6 +383,7 @@ def chunk_bwd_dh(
         BS=BS,
         NG=NG,
         USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
     )

--- a/fla/ops/common/fused_recurrent.py
+++ b/fla/ops/common/fused_recurrent.py
@@ -20,9 +20,9 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4]
+        for num_warps in [1, 2, 4, 8]
     ],
-    key=["BK", "BV", "USE_GK", "USE_GV", "USE_G"],
+    key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV'],
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_fwd_kernel(
@@ -30,6 +30,7 @@ def fused_recurrent_fwd_kernel(
     k,
     v,
     g,
+    g_gamma,
     gk,
     gv,
     o,
@@ -46,6 +47,7 @@ def fused_recurrent_fwd_kernel(
     BV: tl.constexpr,
     REVERSE: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
@@ -74,6 +76,8 @@ def fused_recurrent_fwd_kernel(
         p_gk = gk + (bos + ((T-1) if REVERSE else 0)) * H*K + i_h * K + o_k
     if USE_GV:
         p_gv = gv + (bos + ((T-1) if REVERSE else 0)) * H*V + i_h * V + o_v
+    if USE_G_GAMMA:
+        b_g_gamma = tl.load(g_gamma + i_h)
 
     mask_k = o_k < K
     mask_v = o_v < V
@@ -91,6 +95,8 @@ def fused_recurrent_fwd_kernel(
         if USE_G:
             b_g = tl.load(p_g).to(tl.float32)
             b_h = b_h * exp(b_g)
+        if USE_G_GAMMA:
+            b_h = b_h * exp(b_g_gamma)
         if USE_GK:
             b_gk = tl.load(p_gk, mask=mask_k, other=0).to(tl.float32)
             b_h = b_h * exp(b_gk[:, None])
@@ -105,12 +111,12 @@ def fused_recurrent_fwd_kernel(
         p_k += (-1 if REVERSE else 1) * H*K
         p_v += (-1 if REVERSE else 1) * H*V
         p_o += (-1 if REVERSE else 1) * H*V
+        if USE_G:
+            p_g += (-1 if REVERSE else 1) * H
         if USE_GK:
             p_gk += (-1 if REVERSE else 1) * H*K
         if USE_GV:
             p_gv += (-1 if REVERSE else 1) * H*V
-        if USE_G:
-            p_g += (-1 if REVERSE else 1) * H
 
     if STORE_FINAL_STATE:
         p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
@@ -129,7 +135,7 @@ def fused_recurrent_fwd_kernel(
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4]
     ],
-    key=['BK', 'BV', 'USE_GK', 'USE_GV', 'USE_G'],
+    key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV'],
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_bwd_kernel(
@@ -137,6 +143,7 @@ def fused_recurrent_bwd_kernel(
     k,
     v,
     g,
+    g_gamma,
     gk,
     gv,
     h0,
@@ -158,6 +165,7 @@ def fused_recurrent_bwd_kernel(
     BV: tl.constexpr,
     REVERSE: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
@@ -188,6 +196,8 @@ def fused_recurrent_bwd_kernel(
         p_gk = gk + (bos + ((T-1) if REVERSE else 0)) * H*K + i_h * K + o_k
     if USE_GV:
         p_gv = gv + (bos + ((T-1) if REVERSE else 0)) * H*V + i_h * V + o_v
+    if USE_G_GAMMA:
+        b_g_gamma = tl.load(g_gamma + i_h)
 
     mask_k = o_k < K
     mask_v = o_v < V
@@ -205,6 +215,8 @@ def fused_recurrent_bwd_kernel(
         if USE_G:
             b_g = tl.load(p_g).to(tl.float32)
             b_h = b_h * exp(b_g)
+        if USE_G_GAMMA:
+            b_h = b_h * exp(b_g_gamma)
         if USE_GK:
             b_gk = tl.load(p_gk, mask=mask_k, other=0).to(tl.float32)
             b_h = b_h * exp(b_gk[:, None])
@@ -263,6 +275,8 @@ def fused_recurrent_bwd_kernel(
         if USE_G:
             b_g = tl.load(p_g).to(tl.float32)
             b_dh *= exp(b_g)
+        if USE_G_GAMMA:
+            b_dh *= exp(b_g_gamma)
         if USE_GK:
             b_gk = tl.load(p_gk, mask=mask_k, other=0).to(tl.float32)
             b_dh *= exp(b_gk)[:, None]
@@ -295,6 +309,7 @@ def fused_recurrent_fwd(
     k: torch.Tensor,
     v: torch.Tensor,
     g: Optional[torch.Tensor] = None,
+    g_gamma: Optional[torch.Tensor] = None,
     gk: Optional[torch.Tensor] = None,
     gv: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
@@ -333,6 +348,7 @@ def fused_recurrent_fwd(
         BK=BK,
         BV=BV,
         USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
         REVERSE=reverse,
@@ -346,6 +362,7 @@ def fused_recurrent_bwd(
     k: torch.Tensor,
     v: torch.Tensor,
     g: Optional[torch.Tensor] = None,
+    g_gamma: Optional[torch.Tensor] = None,
     gk: Optional[torch.Tensor] = None,
     gv: Optional[torch.Tensor] = None,
     o: Optional[torch.Tensor] = None,
@@ -383,6 +400,7 @@ def fused_recurrent_bwd(
         k,
         v,
         g,
+        g_gamma,
         gk,
         gv,
         h0,
@@ -403,6 +421,7 @@ def fused_recurrent_bwd(
         BK=BK,
         BV=BV,
         USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
         REVERSE=reverse,
@@ -434,6 +453,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
         k: torch.Tensor,
         v: torch.Tensor,
         g: Optional[torch.Tensor] = None,
+        g_gamma: Optional[torch.Tensor] = None,
         gk: Optional[torch.Tensor] = None,
         gv: Optional[torch.Tensor] = None,
         scale: Optional[float] = None,
@@ -447,6 +467,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
             k=k,
             v=v,
             g=g,
+            g_gamma=g_gamma,
             gk=gk,
             gv=gv,
             scale=scale,
@@ -455,7 +476,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
             reverse=reverse,
             cu_seqlens=cu_seqlens,
         )
-        ctx.save_for_backward(q, k, v, g, gk, gv, initial_state, o)
+        ctx.save_for_backward(q, k, v, g, g_gamma, gk, gv, initial_state, o)
         ctx.scale = scale
         ctx.reverse = reverse
         ctx.cu_seqlens = cu_seqlens
@@ -465,12 +486,13 @@ class FusedRecurrentFunction(torch.autograd.Function):
     @input_guard
     @autocast_custom_bwd
     def backward(ctx, do, dht):
-        q, k, v, g, gk, gv, initial_state, o = ctx.saved_tensors
+        q, k, v, g, g_gamma, gk, gv, initial_state, o = ctx.saved_tensors
         dq, dk, dv, dg, dgk, dgv, dh0 = fused_recurrent_bwd(
             q=q,
             k=k,
             v=v,
             g=g,
+            g_gamma=g_gamma,
             gk=gk,
             gv=gv,
             o=o,
@@ -481,7 +503,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
             reverse=ctx.reverse,
             cu_seqlens=ctx.cu_seqlens,
         )
-        return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), dg, dgk, dgv, None, dh0, None, None, None
+        return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), dg, None, dgk, dgv, None, dh0, None, None, None
 
 
 def fused_recurrent(
@@ -489,6 +511,7 @@ def fused_recurrent(
     k: torch.Tensor,
     v: torch.Tensor,
     g: Optional[torch.Tensor] = None,
+    g_gamma: Optional[torch.Tensor] = None,
     gk: Optional[torch.Tensor] = None,
     gv: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
@@ -504,6 +527,7 @@ def fused_recurrent(
         k,
         v,
         g,
+        g_gamma,
         gk,
         gv,
         scale,

--- a/fla/ops/common/fused_recurrent.py
+++ b/fla/ops/common/fused_recurrent.py
@@ -333,6 +333,7 @@ def fused_recurrent_fwd(
         k,
         v,
         g,
+        g_gamma,
         gk,
         gv,
         o,

--- a/fla/ops/lightning_attn/chunk.py
+++ b/fla/ops/lightning_attn/chunk.py
@@ -70,14 +70,13 @@ def chunk_lightning_attn(
         )
 
     H = q.shape[2]
-    s = -(8 / H * (1 - layer_idx / num_layers)) * q.new_tensor(range(H), dtype=torch.float)
-    g = s[None, None, :].expand(q.shape[0], q.shape[1], q.shape[2]).contiguous()
+    g_gamma = -(8 / H * (1 - layer_idx / num_layers)) * q.new_tensor(range(H), dtype=torch.float)
     return chunk_simple_gla(
         q=q,
         k=k,
         v=v,
         scale=scale,
-        g=g,
+        g_gamma=g_gamma,
         initial_state=initial_state,
         output_final_state=output_final_state,
         head_first=head_first,

--- a/fla/ops/lightning_attn/fused_recurrent.py
+++ b/fla/ops/lightning_attn/fused_recurrent.py
@@ -69,13 +69,12 @@ def fused_recurrent_lightning_attn(
             "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
         )
     H = q.shape[2]
-    s = -(8 / H * (1 - layer_idx / num_layers)) * q.new_tensor(range(H), dtype=torch.float)
-    g = s[None, None, :].expand(q.shape[0], q.shape[1], q.shape[2]).contiguous()
+    g_gamma = -(8 / H * (1 - layer_idx / num_layers)) * q.new_tensor(range(H), dtype=torch.float)
     return fused_recurrent_simple_gla(
         q=q,
         k=k,
         v=v,
-        g=g,
+        g_gamma=g_gamma,
         scale=scale,
         initial_state=initial_state,
         output_final_state=output_final_state,

--- a/fla/ops/retention/chunk.py
+++ b/fla/ops/retention/chunk.py
@@ -63,14 +63,13 @@ def chunk_retention(
             "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
         )
-    s = (1 - q.new_tensor(2., dtype=torch.float).pow(-5. - q.new_tensor(range(q.shape[2]), dtype=torch.float))).log()
-    g = s[None, None, :].expand(q.shape[0], q.shape[1], q.shape[2]).contiguous()
+    g_gamma = (1 - q.new_tensor(2., dtype=torch.float).pow(-5. - q.new_tensor(range(q.shape[2]), dtype=torch.float))).log()
     o, final_state = chunk_simple_gla(
         q=q,
         k=k,
         v=v,
         scale=scale,
-        g=g,
+        g_gamma=g_gamma,
         initial_state=initial_state,
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens

--- a/fla/ops/retention/fused_recurrent.py
+++ b/fla/ops/retention/fused_recurrent.py
@@ -18,13 +18,12 @@ def fused_recurrent_retention(
     reverse: bool = False,
     cu_seqlens: Optional[torch.LongTensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    s = (1 - q.new_tensor(2., dtype=torch.float).pow(-5. - q.new_tensor(range(q.shape[2]), dtype=torch.float))).log()
-    g = s[None, None, :].expand(q.shape[0], q.shape[1], q.shape[2]).contiguous()
+    g_gamma = (1 - q.new_tensor(2., dtype=torch.float).pow(-5. - q.new_tensor(range(q.shape[2]), dtype=torch.float))).log()
     o, final_state = fused_recurrent_simple_gla(
         q=q,
         k=k,
         v=v,
-        g=g,
+        g_gamma=g_gamma,
         scale=scale,
         initial_state=initial_state,
         output_final_state=output_final_state,

--- a/fla/ops/simple_gla/fused_recurrent.py
+++ b/fla/ops/simple_gla/fused_recurrent.py
@@ -12,7 +12,8 @@ def fused_recurrent_simple_gla(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    g: torch.Tensor,
+    g: torch.Tensor = None,
+    g_gamma: torch.Tensor = None,
     scale: Optional[float] = None,
     initial_state: Optional[torch.Tensor] = None,
     output_final_state: bool = False,
@@ -30,6 +31,10 @@ def fused_recurrent_simple_gla(
         g (torch.Tensor):
             Forget gates of shape `[B, T, H]`.
             Compared to GLA, the gating is head-wise instead of elementwise.
+        g_gamma (torch.Tensor):
+            Log decay of shape `[H]`.
+            Head-wise data-independent decay is used if `g_gamma` is provided.
+            Only one of `g` or `g_gamma` should be provided.
         scale (Optional[float]):
             Scale factor for the attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
@@ -78,8 +83,6 @@ def fused_recurrent_simple_gla(
             output_final_state=True,
             cu_seqlens=cu_seqlens
         )
-        >>> assert o.allclose(o_var.view(o.shape))
-        >>> assert ht.allclose(ht_var)
     """
     if cu_seqlens is not None:
         if q.shape[0] != 1:
@@ -99,6 +102,7 @@ def fused_recurrent_simple_gla(
         k=k,
         v=v,
         g=g,
+        g_gamma=g_gamma,
         scale=scale,
         initial_state=initial_state,
         output_final_state=output_final_state,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an optional head-wise decay parameter `g_gamma` to enhance gating mechanisms in chunked and fused recurrent attention operations.
  - Users can provide a `g_gamma` tensor to specify decay rates per attention head, complementing the existing gating tensor option.
- **API Changes**
  - Extended multiple attention and recurrent functions to accept the new `g_gamma` parameter.
  - Updated documentation to clarify the distinction and mutual exclusivity between `g` and `g_gamma`.
- **Refactor**
  - Simplified internal gating parameter handling by removing redundant tensor expansions and renaming variables for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->