### PR TITLE
[CI] Revert causal-conv1d to `2a288a1`

### DIFF
--- a/.github/workflows/nvidia-a100.yml
+++ b/.github/workflows/nvidia-a100.yml
@@ -65,12 +65,12 @@ jobs:
           # Installed by hand to avoid issues with pip
           # pip install -U pytest setuptools wheel ninja torch triton
           # MAX_JOBS=4 pip install -U flash-attn --no-build-isolation
-          # pip install git+https://github.com/Dao-AILab/causal-conv1d.git@a4b40 --no-build-isolation
+          # pip install git+https://github.com/Dao-AILab/causal-conv1d.git@2a288a1 --no-build-isolation
           pip install -U uv
           pip uninstall -y flash-linear-attention
           uv pip install -U pytest setuptools wheel ninja
           uv pip install torch~=2.7.0 triton -U --index-url https://download.pytorch.org/whl/cu128
-          uv pip install git+https://github.com/Dao-AILab/causal-conv1d.git@a4b40 -U --no-cache-dir --no-build-isolation
+          # uv pip install git+https://github.com/Dao-AILab/causal-conv1d.git@2a288a1 -U --no-cache-dir --no-build-isolation
           uv pip install flash-attn -U --no-cache-dir --no-build-isolation
           pip install .
 

--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -65,12 +65,12 @@ jobs:
           # Installed by hand to avoid issues with pip
           # pip install -U pytest setuptools wheel ninja torch triton
           # MAX_JOBS=4 pip install -U flash-attn --no-build-isolation
-          # pip install git+https://github.com/Dao-AILab/causal-conv1d.git@a4b40 --no-build-isolation
+          # pip install git+https://github.com/Dao-AILab/causal-conv1d.git@2a288a1 --no-build-isolation
           pip install -U uv
           pip uninstall -y flash-linear-attention
           uv pip install -U pytest setuptools wheel ninja
           uv pip install torch~=2.7.0 triton -U --index-url https://download.pytorch.org/whl/cu128
-          uv pip install git+https://github.com/Dao-AILab/causal-conv1d.git@a4b40 -U --no-cache-dir --no-build-isolation
+          # uv pip install git+https://github.com/Dao-AILab/causal-conv1d.git@2a288a1 -U --no-cache-dir --no-build-isolation
           uv pip install flash-attn -U --no-cache-dir --no-build-isolation
           pip install .
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow configuration for dependency installation in CI jobs.
  - Disabled installation of the causal-conv1d package in certain CI workflows. 

No user-facing changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->