### PR TITLE
Add L2_norm for p in Recurrent ops to fix generation error

### DIFF
--- a/fla/ops/comba/fused_recurrent.py
+++ b/fla/ops/comba/fused_recurrent.py
@@ -20,8 +20,8 @@ from fla.utils import input_guard
 def fused_recurrent_comba_fwd_kernel(
     q,
     k,
-    v,
     p,
+    v,
     g,
     beta,
     o,
@@ -148,8 +148,8 @@ def fused_recurrent_comba_fwd(
     fused_recurrent_comba_fwd_kernel[grid](
         q=q,
         k=k,
-        v=v,
         p=p,
+        v=v,
         g=g,
         beta=beta,
         o=o,
@@ -182,8 +182,8 @@ class FusedRecurrentFunction(torch.autograd.Function):
         ctx,
         q: torch.Tensor,
         k: torch.Tensor,
-        v: torch.Tensor,
         p: torch.Tensor,
+        v: torch.Tensor,
         g: torch.Tensor,
         beta: torch.Tensor,
         scale: float,
@@ -195,8 +195,8 @@ class FusedRecurrentFunction(torch.autograd.Function):
         o, final_state = fused_recurrent_comba_fwd(
             q=q,
             k=k,
-            v=v,
             p=p,
+            v=v,
             g=g,
             beta=beta,
             scale=scale,
@@ -221,8 +221,8 @@ class FusedRecurrentFunction(torch.autograd.Function):
 def fused_recurrent_comba(
     q: torch.Tensor,
     k: torch.Tensor,
-    v: torch.Tensor,
     p: torch.Tensor,
+    v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor = None,
     scale: float = None,
@@ -237,11 +237,11 @@ def fused_recurrent_comba(
             queries of shape `[B, T, H, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
+        p (torch.Tensor):
+            auxiliary keys of shape `[B, T, H, K]`.
         v (torch.Tensor):
             values of shape `[B, T, HV, V]`.
             GVA is applied if `HV > H`.
-        p (torch.Tensor):
-            auxiliary keys of shape `[B, T, H, K]`.
         g (torch.Tensor):
             g (decays) of shape `[B, T, HV]`.
         beta (torch.Tensor):
@@ -290,7 +290,7 @@ def fused_recurrent_comba(
         # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
         >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
         >>> o_var, ht_var = fused_recurrent_comba(
-            q, k, v, p, g, beta,
+            q, k, p, v, g, beta,
             initial_state=h0,
             output_final_state=True,
             cu_seqlens=cu_seqlens
@@ -316,8 +316,8 @@ def fused_recurrent_comba(
     o, final_state = FusedRecurrentFunction.apply(
         q,
         k,
-        v,
         p,
+        v,
         g,
         beta,
         scale,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added L2 normalization for improved stability when processing data, activated by a specific setting.
- **Chores**
  - Updated argument order in function signatures and calls for consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->