### PR TITLE
Make RWKV-7 init match official RWKV-LM

### DIFF
--- a/fla/layers/rwkv7.py
+++ b/fla/layers/rwkv7.py
@@ -190,9 +190,13 @@ class RWKV7Attention(nn.Module):
                 self.v_lora._initialize_weights(self.v_lora)
                 self.v_lora.set_bias_value(0.73 - linear*0.4)
 
-            self.r_proj.weight.data.uniform_(-0.5/(self.hidden_size**0.5), 0.5/(self.hidden_size**0.5))
-            self.k_proj.weight.data.uniform_(-0.05/(self.hidden_size**0.5), 0.05/(self.hidden_size**0.5))
-            self.v_proj.weight.data.uniform_(-0.5/(self.hidden_size**0.5), 0.5/(self.hidden_size**0.5))
+            # Initialize GroupNorm
+            self.g_norm.weight.data[:] = ((self.layer_idx + 1) / self.num_hidden_layers) ** 0.7
+
+            # Initialize Linear projections
+            nn.init.orthogonal_(self.r_proj.weight)
+            nn.init.orthogonal_(self.k_proj.weight, gain=0.1)
+            nn.init.orthogonal_(self.v_proj.weight)
             self.o_proj.weight.data.zero_()
 
             # Clean up temporary tensors to free memory

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -62,6 +62,13 @@ class RWKV7FeedForward(nn.Module):
 
         self.layer_idx = layer_idx
         self.num_hidden_layers = num_hidden_layers
+
+        try:
+            from transformers.modeling_utils import _init_weights
+        except ImportError:
+            _init_weights = True
+        if _init_weights:
+            self.apply(self._initialize_weights)
         for name, module in self.named_modules():
             module._in_rwkv_module = True
 
@@ -75,7 +82,7 @@ class RWKV7FeedForward(nn.Module):
                 module.x_k.data = 1.0 - torch.pow(ddd, ratio_1_to_almost0**4).squeeze()
 
             # Initialize key and value weights as in CMix_x070
-            module.key.weight.data.uniform_(-0.5/(module.hidden_size**0.5), 0.5/(module.hidden_size**0.5))
+            torch.nn.init.orthogonal_(module.key.weight)
             module.value.weight.data.zero_()
 
     def forward(


### PR DESCRIPTION
The commit removes the following discrepancies with RWKV-LM:

1. Use _initialize_weights in RWKV7FeedForward. The init function for RWKV7FeedForward was implemented, but never called.
2. Initialize GroupNorms in RWKV7Attention. These were given default inits, while RWKV-LM uses a layer_idx-dependent scale.
3. nn.init.orthogonal_ instead of Tensor.uniform_ for RWKV7Attention's `r_proj`, `k_proj`, `v_proj` and RWKV7FeedForward's `key`.

After these changes, the initializations match. I verified it through monkeypatching torch.manual_seed(0) before torch random calls, which gives agreement between https://github.com/johanwind/wind_rwkv/blob/main/tests/train.py , https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v7/train_temp/src/model.py , and https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v5/src/model.py with
`args = SimpleNamespace(vocab_size = 65536 , n_layer = 12, n_embd = 768, head_size = 64, dim_ffn = 768*4)`,
and the updated FLA with 
`RWKV7ForCausalLM(RWKV7Config(hidden_size = 768, num_hidden_layers = 12, vocab_size = 65536, v_low_rank_dim = 32))`.

To further verify agreement, I did a training run with 1.5G tokens, by running https://github.com/johanwind/wind_rwkv/blob/main/tests/train.py with the model replaced by the corresponding FLA RWKV-7 (`RWKV7ForCausalLM(RWKV7Config(hidden_size = 768, num_hidden_layers = 12, vocab_size = 65536, v_low_rank_dim = 32))`) after the update. This gave a loss which is typical for the default RWKV. Before the updated inits, the results were slightly worse than the worst of the 8 runs I did with the default RWKV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the initialization strategy for certain model layers to use orthogonal initialization, potentially improving model training stability.
  * Adjusted group normalization layer initialization for more consistent starting values.
  * Added conditional logic for weight initialization to enhance compatibility with different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->