### PR TITLE
[ShortConv] Fix bad conv weight input shape during inference

### DIFF
--- a/tests/models/test_modeling_gated_deltaproduct.py
+++ b/tests/models/test_modeling_gated_deltaproduct.py
@@ -8,7 +8,7 @@ from fla.models import GatedDeltaProductConfig
 from fla.utils import device
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
-from .testing_utils import init_weights_recursively
+from .test_modeling_utils import init_weights_recursively
 
 
 # ===================================================================================

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -35,8 +35,6 @@ def test_conv(
     has_residual: bool,
     dtype: torch.dtype
 ):
-    if has_bias is False:
-        pytest.skip("causal_conv1d_fn has a bug with no bias")
     torch.manual_seed(42)
 
     x = torch.randn(B, T, D).to(device, dtype).requires_grad_(True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the arrangement of the weight tensor to ensure compatibility with convolution operations during updates.
  * Removed test condition to run convolution tests regardless of bias presence.

* **Documentation**
  * Updated comments to accurately describe the shape of loaded weight tensors in convolution kernels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->