### PR TITLE
[RWKV] Make `torch.compile` decorator compatible with python3.10

### DIFF
--- a/fla/ops/rwkv7/fused_addcmul.py
+++ b/fla/ops/rwkv7/fused_addcmul.py
@@ -21,7 +21,7 @@ def identity_decorator(fn):
     return fn
 
 
-current_python_version = Version(sys.version)
+current_python_version = Version(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
 min_torch_compile_version = Version("3.11")
 
 if current_python_version >= min_torch_compile_version:

--- a/fla/ops/rwkv7/fused_addcmul.py
+++ b/fla/ops/rwkv7/fused_addcmul.py
@@ -7,6 +7,7 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
+from packaging.version import Version
 
 from fla.utils import check_pytorch_version, input_guard, is_amd, use_cuda_graph
 
@@ -20,7 +21,10 @@ def identity_decorator(fn):
     return fn
 
 
-if sys.version_info > (3, 10):
+current_python_version = Version(sys.version)
+min_torch_compile_version = Version("3.11")
+
+if current_python_version >= min_torch_compile_version:
     torch_compile = torch.compile(fullgraph=True)
 else:
     logger.warning('torch.compile is not available in Python 3.10, using identity decorator instead')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal version checking for compatibility with different Python versions. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->