### PR TITLE
Correct types of constructor arguments with issues for configuration classes

### DIFF
--- a/fla/models/gla/configuration_gla.py
+++ b/fla/models/gla/configuration_gla.py
@@ -14,7 +14,7 @@ class GLAConfig(PretrainedConfig):
         self,
         hidden_size: int = 2048,
         expand_k: float = 0.5,
-        expand_v: int = 1,
+        expand_v: float = 1.,
         hidden_ratio: Optional[int] = 4,
         intermediate_size: Optional[int] = None,
         num_hidden_layers: int = 24,

--- a/fla/models/gla/configuration_gla.py
+++ b/fla/models/gla/configuration_gla.py
@@ -13,7 +13,7 @@ class GLAConfig(PretrainedConfig):
     def __init__(
         self,
         hidden_size: int = 2048,
-        expand_k: int = 0.5,
+        expand_k: float = 0.5,
         expand_v: int = 1,
         hidden_ratio: Optional[int] = 4,
         intermediate_size: Optional[int] = None,


### PR DESCRIPTION
Ran into a type mismatch issue with the PyTorch Lightning CLI where the type in the config didnt match the default argument for GLA. Fixed the issue across all configs to prevent it for other models as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated parameter types for configuration settings to improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->