### PR TITLE
Fix typo: suppoerted -> supported

### DIFF
--- a/fla/layers/comba.py
+++ b/fla/layers/comba.py
@@ -134,7 +134,7 @@ class Comba(nn.Module):
                 f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}. "
                 f"Resulting head_v_dim would be {head_dim * expand_v}, which is invalid for FusedRMSNormGated."
             )
-        assert mode in ['chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
 
         self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
         self.k_proj = nn.Linear(hidden_size, self.key_dim, bias=False)

--- a/fla/layers/delta_net.py
+++ b/fla/layers/delta_net.py
@@ -119,7 +119,7 @@ class DeltaNet(nn.Module):
 
         if mode == 'fused_chunk':
             raise NotImplementedError("fused_chunk_delta_rule is now deprecated. Please use `chunk_delta_rule` instead.")
-        assert mode in ['chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
         assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
 

--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -141,7 +141,7 @@ class GatedDeltaNet(nn.Module):
                 f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}. "
                 f"Resulting head_v_dim would be {head_dim * expand_v}, which is invalid for FusedRMSNormGated."
             )
-        assert mode in ['chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
 
         self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
         self.k_proj = nn.Linear(hidden_size, self.key_dim, bias=False)

--- a/fla/layers/gated_deltaproduct.py
+++ b/fla/layers/gated_deltaproduct.py
@@ -89,7 +89,7 @@ class GatedDeltaProduct(nn.Module):
                 f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}. "
                 f"Resulting head_v_dim would be {head_dim * expand_v}, which is invalid for FusedRMSNormGated."
             )
-        assert mode in ['chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
 
         self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
         self.k_proj = nn.Linear(hidden_size, self.key_dim * num_householder, bias=False)

--- a/fla/layers/gla.py
+++ b/fla/layers/gla.py
@@ -114,7 +114,7 @@ class GatedLinearAttention(nn.Module):
         self.clamp_min = clamp_min
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_recurrent', 'fused_chunk'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent', 'fused_chunk'], f"Not supported mode `{mode}`."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
         assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
 

--- a/fla/layers/hgrn.py
+++ b/fla/layers/hgrn.py
@@ -48,7 +48,7 @@ class HGRNAttention(nn.Module):
 
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
 
         self.i_proj = nn.Linear(hidden_size, self.input_dim, bias=False)
         self.f_proj = nn.Linear(hidden_size, self.input_dim, bias=False)

--- a/fla/layers/hgrn2.py
+++ b/fla/layers/hgrn2.py
@@ -61,7 +61,7 @@ class HGRN2Attention(nn.Module):
         self.input_dim = hidden_size
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_recurrent', 'fused_chunk'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent', 'fused_chunk'], f"Not supported mode `{mode}`."
         assert self.forget_dim % num_heads == 0, f"forget dim must be divisible by num_heads of {num_heads}"
         assert self.input_dim % num_heads == 0, f"input dim must be divisible by num_heads of {num_heads}"
 

--- a/fla/layers/lightnet.py
+++ b/fla/layers/lightnet.py
@@ -61,7 +61,7 @@ class LightNetAttention(nn.Module):
         self.gate_low_rank_dim = gate_low_rank_dim
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_chunk'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_chunk'], f"Not supported mode `{mode}`."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
         assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
 

--- a/fla/layers/linear_attn.py
+++ b/fla/layers/linear_attn.py
@@ -45,7 +45,7 @@ class LinearAttention(nn.Module):
         self.key_dim_per_group = self.key_dim // self.num_kv_groups
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
 
-        assert mode in ['chunk', 'fused_chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
         assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
 

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -105,7 +105,7 @@ class MultiScaleRetention(nn.Module):
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_chunk', 'parallel', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_chunk', 'parallel', 'fused_recurrent'], f"Not supported mode `{mode}`."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
         assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
 

--- a/fla/layers/rodimus.py
+++ b/fla/layers/rodimus.py
@@ -85,7 +85,7 @@ class RodimusAttention(nn.Module):
         self.residual_in_fp32 = residual_in_fp32
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_recurrent', 'fused_chunk'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent', 'fused_chunk'], f"Not supported mode `{mode}`."
 
         self.gate_proj = nn.Linear(self.hidden_size, self.d_inner, bias=False)
         self.up_proj = nn.Linear(self.hidden_size, self.d_inner, bias=False)

--- a/fla/layers/rwkv6.py
+++ b/fla/layers/rwkv6.py
@@ -54,7 +54,7 @@ class RWKV6Attention(nn.Module):
         self.value_dim = int(hidden_size * expand_v)
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_recurrent'], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
         assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
 

--- a/fla/layers/simple_gla.py
+++ b/fla/layers/simple_gla.py
@@ -100,7 +100,7 @@ class SimpleGatedLinearAttention(nn.Module):
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', "fused_recurrent"], f"Not suppoerted mode `{mode}`."
+        assert mode in ['chunk', "fused_recurrent"], f"Not supported mode `{mode}`."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
         assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
 


### PR DESCRIPTION
Fixed typo in error messages across 13 files. Changed 'suppoerted' to 'supported' in assertion error messages in various attention layer implementations.

## Summary
- Corrected spelling mistake in assertion error messages
- Affects 13 files in the fla/layers/ directory
- Improves user experience with proper error messaging

## Files changed
- fla/layers/simple_gla.py
- fla/layers/rwkv6.py
- fla/layers/rodimus.py
- fla/layers/multiscale_retention.py
- fla/layers/linear_attn.py
- fla/layers/lightnet.py
- fla/layers/hgrn2.py
- fla/layers/hgrn.py
- fla/layers/gla.py
- fla/layers/gated_deltaproduct.py
- fla/layers/gated_deltanet.py
- fla/layers/delta_net.py
- fla/layers/comba.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in assertion error messages across multiple components, ensuring the message now reads "Not supported mode" instead of "Not suppoerted mode". No changes were made to functionality or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->