### PR TITLE
[ShortConv] Support cache in prefill

### DIFF
--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -493,7 +493,7 @@ class CausalConv1dFunction(torch.autograd.Function):
     @staticmethod
     @input_guard
     def backward(ctx, dy: torch.Tensor, dht: Optional[torch.Tensor] = None):
-        if dht is None:
+        if dht is not None:
             raise NotImplementedError("The gradient of the final state is not supported yet.")
         x, weight, bias, residual, initial_state = ctx.saved_tensors
         dx, dw, db, dr, dh0 = causal_conv1d_bwd(

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -492,7 +492,9 @@ class CausalConv1dFunction(torch.autograd.Function):
 
     @staticmethod
     @input_guard
-    def backward(ctx, dy: torch.Tensor, dht: torch.Tensor):
+    def backward(ctx, dy: torch.Tensor, dht: Optional[torch.Tensor] = None):
+        if dht is None:
+            raise NotImplementedError("The gradient of the final state is not supported yet.")
         x, weight, bias, residual, initial_state = ctx.saved_tensors
         dx, dw, db, dr, dh0 = causal_conv1d_bwd(
             x=x,

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -797,8 +797,9 @@ class ShortConvolution(nn.Conv1d):
             ((cu_seqlens is not None or seq_idx is not None) and cache is not None) or \
                 (cu_seqlens is not None and output_final_state):
             warnings.warn(
-                "The CUDA backend does not support varlen sequences with cache or output final state. "
-                "Switching to the Triton backend instead."
+                "The CUDA backend does not support both `cu_seqlens` and `cache` being provided, "
+                "or both `cu_seqlens` and `output_final_state` being provided. "
+                "Switching to the Triton backend instead. "
             )
             self.backend = 'triton'
 

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -776,7 +776,10 @@ class ShortConvolution(nn.Conv1d):
                 cu_seqlens=cu_seqlens
             )
             return y, cache
-
+        elif cu_seqlens is None and T < W:
+            raise NotImplementedError("ShortConvolution does not support prefill T < W")
+        elif cu_seqlens is not None and (cu_seqlens[1:] - cu_seqlens[:-1]).min().item() < W:
+            raise NotImplementedError("ShortConvolution does not support prefill T < W")
         # check if cu_seqlens and cache are both provided
         # Sequence index for each token. Used for varlen.
         # Suppose a batch consists of two sequences with lengths 3 and 4,

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -793,7 +793,7 @@ class ShortConvolution(nn.Conv1d):
             else:
                 cache = None
             if residual is not None:
-                y = y + residual
+                y.add_(residual)
 
             return y, cache
 
@@ -830,7 +830,7 @@ class ShortConvolution(nn.Conv1d):
         )
         y = y.view(shape)
         if residual is not None:
-            y = y + residual
+            y.add_(residual)
         return y, cache
 
     @property

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -480,7 +480,8 @@ class CausalConv1dFunction(torch.autograd.Function):
             bias=bias,
             residual=residual,
             activation=ctx.activation,
-            cu_seqlens=ctx.cu_seqlens
+            cu_seqlens=ctx.cu_seqlens,
+            cache=cache
         )
         return dx, dw, db, dr, None, None, None
 

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -748,9 +748,8 @@ class ShortConvolution(nn.Conv1d):
                 B, _, T = cache.shape
                 # To make causal-conv1d happy
                 initial_states = (
-                    cache
-                    .transpose(1, 2)                     # (B, T, C)
-                    .narrow(1, T-(W-1), W-1)             # (B, W-1, C)
+                    cache[:, :, -(W-1):]
+                    .transpose(1, 2)                     # (B, C, W-1)
                     .contiguous()                        # (B, W-1, C) and stride(2)==1
                     .transpose(1, 2)                     # (B, C, W-1) and stride(1)==1
                 )

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -794,7 +794,7 @@ class ShortConvolution(nn.Conv1d):
         # 1. both `cu_seqlens` and `cache` being provided
         # 2. both `cu_seqlens` and `routput_final_state` being provided
         if self.backend == 'cuda' and \
-            (cu_seqlens is not None and seq_idx is not None) or \
+            ((cu_seqlens is not None or seq_idx is not None) and cache is not None) or \
                 (cu_seqlens is not None and output_final_state):
             warnings.warn(
                 "The CUDA backend does not support varlen sequences with cache or output final state. "

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -729,16 +729,6 @@ class ShortConvolution(nn.Conv1d):
         if cache is not None and B * T == N:
             return self.step(x, residual, cache, cu_seqlens)
 
-        def _update_cache(x, cache, cu_seqlens, W):
-            if cache is not None:
-                if cu_seqlens is not None:
-                    return causal_conv1d_varlen_states_fwd(x, cache, cu_seqlens, W)
-                else:
-                    # history keep at rightmost W tokens
-                    cache[:, :, -min(W, T):].copy_(rearrange(x[..., -min(W, T):, :], 'n w d -> n d w'))
-                    return cache
-            return cache
-
         # Check if cu_seqlens and cache are both provided
         if self.backend == 'cuda' and cu_seqlens is not None and cache is not None:
             warnings.warn(

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -716,6 +716,15 @@ class ShortConvolution(nn.Conv1d):
                     return cache
             return cache
 
+        # Check if cu_seqlens and cache are both provided
+        if self.backend == 'cuda' and cu_seqlens is not None and cache is not None:
+            warnings.warn(
+                "Both `cu_seqlens` and `cache` are provided. "
+                "However, the CUDA backend does not support varlen sequences with cache. "
+                "Switching to the Triton backend instead."
+            )
+            self.backend = 'triton'
+
         if self.backend == 'triton':
             y = causal_conv1d(
                 x=x,

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -324,7 +324,7 @@ def test_short_conv_with_cache_prefill_fwd(
         kernel_size=W,
         bias=has_bias,
         activation=activation,
-        backend='triton',
+        backend=backend,
         device=device,
         dtype=dtype
     )
@@ -351,9 +351,9 @@ def test_short_conv_with_cache_prefill_fwd(
 @pytest.mark.parametrize('B', [2])
 @pytest.mark.parametrize('D', [8])
 @pytest.mark.parametrize('W', [3, 4])
-@pytest.mark.parametrize('activation', [None])
-@pytest.mark.parametrize('has_bias', [False])
-@pytest.mark.parametrize('has_residual', [False])
+@pytest.mark.parametrize('activation', [None, 'swish'])
+@pytest.mark.parametrize('has_bias', [False, True])
+@pytest.mark.parametrize('has_residual', [False, True])
 @pytest.mark.parametrize('dtype', [torch.float32])
 @pytest.mark.parametrize('backend', ['triton', 'cuda'])
 def test_short_conv_decoding_with_cache(

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -2,15 +2,98 @@
 
 import pytest
 import torch
+import torch.nn.functional as F
 from einops import rearrange
 
-from fla.modules.convolution import causal_conv1d, causal_conv1d_update
+from fla.modules.convolution import ShortConvolution, causal_conv1d, causal_conv1d_update
 from fla.utils import assert_close, device
 
 try:
     from causal_conv1d import causal_conv1d_fn
 except ImportError:
     causal_conv1d_fn = None
+
+
+def causal_conv1d_ref_torch(
+    x,
+    weight,
+    bias=None,
+    initial_states=None,
+    return_final_states=False,
+    final_states_out=None,
+    activation=None,
+):
+    """
+    x: (batch, dim, seqlen)
+    weight: (dim, width)
+    bias: (dim,)
+    initial_states: (batch, dim, width - 1)
+    final_states_out: (batch, dim, width - 1)
+
+    out: (batch, dim, seqlen)
+    """
+    if activation not in [None, "silu", "swish"]:
+        raise NotImplementedError("activation must be None, silu, or swish")
+    dtype_in = x.dtype
+    x = x.to(weight.dtype)
+    seqlen = x.shape[-1]
+    dim, width = weight.shape
+    if initial_states is None:
+        out = F.conv1d(x, weight.unsqueeze(1), bias, padding=width - 1, groups=dim)
+    else:
+        x = torch.cat([initial_states, x], dim=-1)
+        out = F.conv1d(x, weight.unsqueeze(1), bias, padding=0, groups=dim)
+    out = out[..., :seqlen]
+    if return_final_states:
+        final_states = F.pad(x, (width - 1 - x.shape[-1], 0)).to(
+            dtype_in
+        )  # (batch, dim, width - 1)
+        if final_states_out is not None:
+            final_states_out.copy_(final_states)
+        else:
+            final_states_out = final_states
+    out = (out if activation is None else F.silu(out)).to(dtype=dtype_in)
+    return out if not return_final_states else (out, final_states_out)
+
+
+def causal_conv1d_update_ref_torch(x, conv_state, weight, bias=None, activation=None, cache_seqlens=None):
+    """
+    x: (batch, dim) or (batch, dim, seqlen)
+    conv_state: (batch, dim, state_len), where state_len >= width - 1
+    weight: (dim, width)
+    bias: (dim,)
+    cache_seqlens: (batch,), dtype int32.
+        If not None, the conv_state is treated as a circular buffer.
+        The conv_state will be updated by copying x to the conv_state starting at the index
+        @cache_seqlens % state_len before performing the convolution.
+
+    out: (batch, dim) or (batch, dim, seqlen)
+    """
+    if activation not in [None, "silu", "swish"]:
+        raise NotImplementedError("activation must be None, silu, or swish")
+    dtype_in = x.dtype
+    unsqueeze = x.dim() == 2
+    if unsqueeze:
+        x = x.unsqueeze(-1)
+    batch, dim, seqlen = x.shape
+    width = weight.shape[1]
+    state_len = conv_state.shape[-1]
+    assert conv_state.shape == (batch, dim, state_len)
+    assert weight.shape == (dim, width)
+    if cache_seqlens is None:
+        x_new = torch.cat([conv_state, x], dim=-1).to(weight.dtype)  # (batch, dim, state_len + seqlen)
+        conv_state.copy_(x_new[:, :, -state_len:])
+    else:
+        width_idx = torch.arange(-(width - 1), 0, dtype=torch.long, device=x.device).unsqueeze(0) + cache_seqlens.unsqueeze(1)
+        width_idx = torch.remainder(width_idx, state_len).unsqueeze(1).expand(-1, dim, -1)
+        x_new = torch.cat([conv_state.gather(2, width_idx), x], dim=-1).to(weight.dtype)
+        copy_idx = torch.arange(seqlen, dtype=torch.long, device=x.device).unsqueeze(0) + cache_seqlens.unsqueeze(1)
+        copy_idx = torch.remainder(copy_idx, state_len).unsqueeze(1).expand(-1, dim, -1)
+        conv_state.scatter_(2, copy_idx, x)
+    out = F.conv1d(x_new, weight.unsqueeze(1), bias, padding=0, groups=dim)[:, :, -seqlen:]
+    if unsqueeze:
+        out = out.squeeze(-1)
+    return (out if activation is None else F.silu(out)).to(dtype=dtype_in)
 
 
 @pytest.mark.parametrize('B', [4])
@@ -207,3 +290,114 @@ def test_conv_decoding(
 
     assert_close("    y", ref, tri, 1e-3)
     assert_close("cache", ref_cache, tri_cache, 1e-3)
+
+
+@pytest.mark.parametrize('B', [2])
+@pytest.mark.parametrize('T', [10, 256])
+@pytest.mark.parametrize('D', [128])
+@pytest.mark.parametrize('W', [3, 4])
+@pytest.mark.parametrize('activation', [None, 'swish'])
+@pytest.mark.parametrize('has_bias', [False, True])
+@pytest.mark.parametrize('has_residual', [False, True])
+@pytest.mark.parametrize('dtype', [torch.float32])
+@pytest.mark.parametrize('backend', ['triton', 'cuda'])
+def test_short_conv_with_cache_prefill_fwd(
+    B: int,
+    T: int,
+    D: int,
+    W: int,
+    activation: str,
+    has_bias: bool,
+    has_residual: bool,
+    dtype: torch.dtype,
+    backend: str,
+):
+    if causal_conv1d_fn is None and backend == 'cuda':
+        pytest.skip("causal_conv1d is not installed for CUDA backend")
+    torch.manual_seed(42)
+
+    x = torch.randn(B, T, D).to(device, dtype)
+    residual = torch.randn(B, T, D).to(device, dtype) if has_residual else None
+
+    conv = ShortConvolution(
+        hidden_size=D,
+        kernel_size=W,
+        bias=has_bias,
+        activation=activation,
+        backend='triton',
+        device=device,
+        dtype=dtype
+    )
+
+    cache = torch.randn(B, D, W - 1).to(device, dtype)
+
+    ref = causal_conv1d_ref_torch(
+        x=x.transpose(1, 2),                    # (B, D, T)
+        weight=rearrange(conv.weight, "d 1 w -> d w"),
+        bias=conv.bias,
+        initial_states=cache,                   # (B, D, W-1)
+        activation=activation,
+    ).transpose(1, 2)                           # (B, T, D)
+    if has_residual:
+        ref += residual
+
+    zero_padding = torch.zeros(B, D, 1).to(device, dtype)
+    tri_cache = torch.cat([zero_padding, cache], dim=-1)  # (B, D, W)
+    with torch.no_grad():
+        y, _ = conv(x, residual=residual, cache=tri_cache)
+    assert_close("y", ref, y, 1e-3)
+
+
+@pytest.mark.parametrize('B', [2])
+@pytest.mark.parametrize('D', [8])
+@pytest.mark.parametrize('W', [3, 4])
+@pytest.mark.parametrize('activation', [None])
+@pytest.mark.parametrize('has_bias', [False])
+@pytest.mark.parametrize('has_residual', [False])
+@pytest.mark.parametrize('dtype', [torch.float32])
+@pytest.mark.parametrize('backend', ['triton', 'cuda'])
+def test_short_conv_decoding_with_cache(
+    B: int,
+    D: int,
+    W: int,
+    activation: str,
+    has_bias: bool,
+    has_residual: bool,
+    dtype: torch.dtype,
+    backend: str,
+):
+    if causal_conv1d_fn is None and backend == 'cuda':
+        pytest.skip("causal_conv1d is not installed for CUDA backend")
+    torch.manual_seed(42)
+
+    x = torch.randn(B, 1, D).to(device, dtype)        # (B, 1, D)
+    residual = x.clone() if has_residual else None
+
+    conv = ShortConvolution(
+        hidden_size=D,
+        kernel_size=W,
+        bias=has_bias,
+        activation=activation,
+        backend=backend,
+        device=device,
+        dtype=dtype
+    )
+
+    state = torch.randn(B, D, W).to(device, dtype)
+
+    # reference
+    ref = causal_conv1d_update_ref_torch(
+        x.squeeze(1),                           # (B, D)
+        conv_state=state.clone(),
+        weight=rearrange(conv.weight, "d 1 w -> d w"),
+        bias=conv.bias,
+        activation=activation,
+    ).unsqueeze(1)                             # (B, 1, D)
+    if has_residual:
+        ref += residual
+
+    # ShortConvolution step
+    with torch.no_grad():
+        y, _ = conv.step(x, residual, state.clone())
+
+    assert_close("y", ref, y, 1e-3)

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -397,11 +397,10 @@ def test_conv_varlen_with_cache_prefill_fwd(
         pytest.skip("causal_conv1d is not installed for CUDA backend")
     torch.manual_seed(42)
 
-
     min_len_each = T // N
     lengths = [min_len_each] * N
     lengths[-1] += T % N
-    assert all(l >= W for l in lengths), "need all lengths ≥ W"
+    assert all(length >= W for length in lengths), "need all lengths ≥ W"
     cu_seqlens = torch.tensor([0] + torch.cumsum(torch.tensor(lengths), 0).tolist(), device=device)
 
     x = torch.randn(1, T, D).to(device, dtype)
@@ -439,7 +438,7 @@ def test_conv_varlen_with_cache_prefill_fwd(
     tri_cache = torch.cat([zero_pad, cache], dim=-1)  # (N, D, W)
     tri, _ = conv(x, residual=residual, cache=tri_cache, cu_seqlens=cu_seqlens)
 
-    assert_close("varlen y", ref, tri,1e-3)
+    assert_close("varlen y", ref, tri, 1e-3)
 
 
 @pytest.mark.parametrize(

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -349,7 +349,7 @@ def test_short_conv_with_cache_prefill_fwd(
 
 
 @pytest.mark.parametrize('B', [2])
-@pytest.mark.parametrize('D', [8])
+@pytest.mark.parametrize('D', [128])
 @pytest.mark.parametrize('W', [3, 4])
 @pytest.mark.parametrize('activation', [None, 'swish'])
 @pytest.mark.parametrize('has_bias', [False, True])

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -112,10 +112,6 @@ def causal_conv1d_update_ref_torch(x, conv_state, weight, bias=None, activation=
         ]
     ]
 )
-@pytest.mark.skipif(
-    causal_conv1d_fn is None,
-    reason="causal_conv1d is not installed"
-)
 def test_conv(
     B: int,
     T: int,
@@ -134,7 +130,7 @@ def test_conv(
     residual = x.detach().clone().requires_grad_(True) if has_residual else None
     dy = torch.randn(B, T, D).to(device, dtype)
 
-    ref = causal_conv1d_fn(
+    ref = causal_conv1d_ref_torch(
         x=rearrange(x, "b t d -> b d t"),
         weight=weight,
         bias=bias,
@@ -181,10 +177,6 @@ def test_conv(
         ]
     ]
 )
-@pytest.mark.skipif(
-    causal_conv1d_fn is None,
-    reason="causal_conv1d is not installed"
-)
 def test_conv_varlen(
     N: int,
     T: int,
@@ -210,7 +202,7 @@ def test_conv_varlen(
 
     ref = torch.cat([
         rearrange(
-            causal_conv1d_fn(
+            causal_conv1d_ref_torch(
                 x=rearrange(x[:, bos:eos].contiguous(), "b t d -> b d t"),
                 weight=weight,
                 bias=bias,
@@ -262,10 +254,6 @@ def test_conv_varlen(
         ]
     ]
 )
-@pytest.mark.skipif(
-    causal_conv1d_fn is None,
-    reason="causal_conv1d is not installed"
-)
 def test_conv_decoding(
         B: int,
         T: int,
@@ -283,7 +271,7 @@ def test_conv_decoding(
     bias = torch.randn(D).to(device, dtype) if has_bias else None
     residual = x.clone() if has_residual else None
 
-    ref = causal_conv1d_fn(
+    ref = causal_conv1d_ref_torch(
         x=rearrange(x, "b t d -> b d t"),
         weight=weight,
         bias=bias,
@@ -456,10 +444,6 @@ def test_short_conv_decoding_with_cache(
             (2, 128, 128, 4, False, False, "swish", torch.float32)
         ]
     ]
-)
-@pytest.mark.skipif(
-    causal_conv1d_fn is None,
-    reason="causal_conv1d is not installed"
 )
 def test_mixed_backend(
     B: int,

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -96,14 +96,22 @@ def causal_conv1d_update_ref_torch(x, conv_state, weight, bias=None, activation=
     return (out if activation is None else F.silu(out)).to(dtype=dtype_in)
 
 
-@pytest.mark.parametrize('B', [4])
-@pytest.mark.parametrize('T', [1, 500, 1024])
-@pytest.mark.parametrize('D', [128, 200, 1024])
-@pytest.mark.parametrize('W', [3, 4])
-@pytest.mark.parametrize('activation', [None, 'swish'])
-@pytest.mark.parametrize('has_bias', [False, True])
-@pytest.mark.parametrize('has_residual', [False, True])
-@pytest.mark.parametrize('dtype', [torch.float32, torch.float16])
+@pytest.mark.parametrize(
+    ('B', 'T', 'D', 'W', 'activation', 'has_bias', 'has_residual', 'dtype'),
+    [
+        pytest.param(*test, id="B{0}_T{1}_D{2}_W{3}_activation{4}_has_bias{5}_has_residual{6}_dtype{7}".format(*test))
+        for test in [
+            (2, 64, 128, 3, "swish", True, True, torch.float32),
+            (2, 128, 128, 4, "swish", False, True, torch.float32),
+            (2, 64, 128, 3, "swish", True, False, torch.float32),
+            (2, 128, 128, 4, "swish", False, False, torch.float32),
+            (2, 500, 1024, 3, None, True, True, torch.float32),
+            (2, 1024, 1024, 4, None, False, True, torch.float32),
+            (2, 64, 128, 3, None, True, False, torch.float16),
+            (2, 128, 128, 4, None, False, False, torch.float16),
+        ]
+    ]
+)
 @pytest.mark.skipif(
     causal_conv1d_fn is None,
     reason="causal_conv1d is not installed"
@@ -161,14 +169,18 @@ def test_conv(
         assert_close("dr", ref_dr, tri_dr, 1e-3)
 
 
-@pytest.mark.parametrize("N", [4])
-@pytest.mark.parametrize("T", [500, 1024])
-@pytest.mark.parametrize('D', [128, 200, 1024])
-@pytest.mark.parametrize("W", [3, 4])
-@pytest.mark.parametrize("activation", [None, 'swish'])
-@pytest.mark.parametrize("has_bias", [False, True])
-@pytest.mark.parametrize("has_residual", [False, True])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize(
+    ('N', 'T', 'D', 'W', 'activation', 'has_bias', 'has_residual', 'dtype'),
+    [
+        pytest.param(*test, id="N{0}_T{1}_D{2}_W{3}_activation{4}_has_bias{5}_has_residual{6}_dtype{7}".format(*test))
+        for test in [
+            (4, 500, 128, 3, "swish", True, True, torch.float32),
+            (4, 1024, 200, 4, "swish", False, True, torch.float32),
+            (4, 500, 128, 3, None, True, False, torch.float16),
+            (4, 1024, 1024, 4, None, False, False, torch.float16),
+        ]
+    ]
+)
 @pytest.mark.skipif(
     causal_conv1d_fn is None,
     reason="causal_conv1d is not installed"
@@ -234,14 +246,22 @@ def test_conv_varlen(
         assert_close("dr", ref_dr, tri_dr, 1e-3)
 
 
-@pytest.mark.parametrize('B', [4])
-@pytest.mark.parametrize('T', [1, 500, 1024])
-@pytest.mark.parametrize('D', [128, 200, 1024])
-@pytest.mark.parametrize('W', [3, 4])
-@pytest.mark.parametrize('activation', [None, 'swish'])
-@pytest.mark.parametrize('has_bias', [False, True])
-@pytest.mark.parametrize('has_residual', [False, True])
-@pytest.mark.parametrize('dtype', [torch.float32, torch.float16])
+@pytest.mark.parametrize(
+    ('B', 'T', 'D', 'W', 'activation', 'has_bias', 'has_residual', 'dtype'),
+    [
+        pytest.param(*test, id="B{0}_T{1}_D{2}_W{3}_activation{4}_has_bias{5}_has_residual{6}_dtype{7}".format(*test))
+        for test in [
+            (2, 64, 128, 3, "swish", True, True, torch.float32),
+            (2, 128, 128, 4, "swish", False, True, torch.float32),
+            (2, 64, 128, 3, "swish", True, False, torch.float32),
+            (2, 128, 128, 4, "swish", False, False, torch.float32),
+            (2, 500, 1024, 3, None, True, True, torch.float32),
+            (2, 1024, 1024, 4, None, False, True, torch.float32),
+            (2, 64, 128, 3, None, True, False, torch.float16),
+            (2, 128, 128, 4, None, False, False, torch.float16),
+        ]
+    ]
+)
 @pytest.mark.skipif(
     causal_conv1d_fn is None,
     reason="causal_conv1d is not installed"
@@ -292,15 +312,27 @@ def test_conv_decoding(
     assert_close("cache", ref_cache, tri_cache, 1e-3)
 
 
-@pytest.mark.parametrize('B', [2])
-@pytest.mark.parametrize('T', [10, 256])
-@pytest.mark.parametrize('D', [128])
-@pytest.mark.parametrize('W', [3, 4])
-@pytest.mark.parametrize('activation', [None, 'swish'])
-@pytest.mark.parametrize('has_bias', [False, True])
-@pytest.mark.parametrize('has_residual', [False, True])
-@pytest.mark.parametrize('dtype', [torch.float32])
-@pytest.mark.parametrize('backend', ['triton', 'cuda'])
+@pytest.mark.parametrize(
+    ('B', 'T', 'D', 'W', 'activation', 'has_bias', 'has_residual', 'dtype', 'backend'),
+    [
+        pytest.param(
+            *test, id="B{0}_T{1}_D{2}_W{3}_activation{4}_has_bias{5}_has_residual{6}_dtype{7}_backend{8}".format(*test))
+        for test in [
+            (2, 64, 128, 3, "swish", True, True, torch.float32, 'triton'),
+            (2, 128, 128, 4, "swish", False, True, torch.float32, 'triton'),
+            (2, 64, 128, 3, "swish", True, False, torch.float32, 'triton'),
+            (2, 128, 128, 4, "swish", False, False, torch.float32, 'triton'),
+            (2, 500, 1024, 3, None, True, True, torch.float32, 'triton'),
+            (2, 1024, 1024, 4, None, False, True, torch.float32, 'triton'),
+            (2, 64, 128, 3, None, True, False, torch.float16, 'triton'),
+            (2, 128, 128, 4, None, False, False, torch.float16, 'triton'),
+            (2, 64, 128, 3, "swish", True, True, torch.float32, 'cuda'),
+            (2, 128, 128, 4, "swish", False, True, torch.float32, 'cuda'),
+            (2, 64, 128, 3, "swish", True, False, torch.float32, 'cuda'),
+            (2, 128, 128, 4, "swish", False, False, torch.float32, 'cuda'),
+        ]
+    ]
+)
 def test_short_conv_with_cache_prefill_fwd(
     B: int,
     T: int,
@@ -348,14 +380,24 @@ def test_short_conv_with_cache_prefill_fwd(
     assert_close("y", ref, y, 1e-3)
 
 
-@pytest.mark.parametrize('B', [2])
-@pytest.mark.parametrize('D', [128])
-@pytest.mark.parametrize('W', [3, 4])
-@pytest.mark.parametrize('activation', [None, 'swish'])
-@pytest.mark.parametrize('has_bias', [False, True])
-@pytest.mark.parametrize('has_residual', [False, True])
-@pytest.mark.parametrize('dtype', [torch.float32])
-@pytest.mark.parametrize('backend', ['triton', 'cuda'])
+@pytest.mark.parametrize(
+    ('B', 'D', 'W', 'has_bias', 'has_residual', 'activation', 'dtype', 'backend'),
+    [
+        pytest.param(*test, id="B{0}_D{1}_W{2}_has_bias{3}_has_residual{4}_activation{5}_dtype{6}_backend{7}".format(*test))
+        for test in [
+            (2, 128, 3, True, True, "swish", torch.float32, 'triton'),
+            (2, 128, 4, False, True, "swish", torch.float32, 'triton'),
+            (2, 128, 3, True, False, "swish", torch.float32, 'triton'),
+            (2, 128, 4, False, False, "swish", torch.float32, 'triton'),
+            (2, 128, 3, True, True, "swish", torch.float32, 'cuda'),
+            (2, 128, 4, False, True, "swish", torch.float32, 'cuda'),
+            (2, 128, 3, True, False, "swish", torch.float32, 'cuda'),
+            (2, 128, 4, False, False, "swish", torch.float32, 'cuda'),
+            (2, 128, 4, False, False, None, torch.float32, 'cuda'),
+            (2, 128, 4, False, False, None, torch.float32, 'triton'),
+        ]
+    ]
+)
 def test_short_conv_decoding_with_cache(
     B: int,
     D: int,
@@ -403,21 +445,25 @@ def test_short_conv_decoding_with_cache(
     assert_close("y", ref, y, 1e-3)
 
 
-@pytest.mark.parametrize("B", [2])
-@pytest.mark.parametrize("T_prefill", [64, 128])
-@pytest.mark.parametrize("D", [128])
-@pytest.mark.parametrize("W", [3, 4])
-@pytest.mark.parametrize("has_bias", [True, False])
-@pytest.mark.parametrize("has_residual", [True, False])
-@pytest.mark.parametrize("activation", ["swish"])
-@pytest.mark.parametrize("dtype", [torch.float32])
+@pytest.mark.parametrize(
+    ('B', 'T', 'D', 'W', 'has_bias', 'has_residual', 'activation', 'dtype'),
+    [
+        pytest.param(*test, id="B{0}_T{1}_D{2}_W{3}_has_bias{4}_has_residual{5}_activation{6}_dtype{7}".format(*test))
+        for test in [
+            (2, 64, 128, 3, True, True, "swish", torch.float32),
+            (2, 128, 128, 4, False, True, "swish", torch.float32),
+            (2, 64, 128, 3, True, False, "swish", torch.float32),
+            (2, 128, 128, 4, False, False, "swish", torch.float32)
+        ]
+    ]
+)
 @pytest.mark.skipif(
     causal_conv1d_fn is None,
     reason="causal_conv1d is not installed"
 )
 def test_mixed_backend(
     B: int,
-    T_prefill: int,
+    T: int,
     D: int,
     W: int,
     has_bias: bool,
@@ -427,7 +473,7 @@ def test_mixed_backend(
 ):
     torch.manual_seed(1234)
     T_decode = 1
-    x = torch.randn(B, T_prefill + T_decode, D, device=device, dtype=dtype)
+    x = torch.randn(B, T + T_decode, D, device=device, dtype=dtype)
     residual = torch.randn_like(x) if has_residual else None
 
     conv = ShortConvolution(
@@ -442,15 +488,15 @@ def test_mixed_backend(
 
     cache = torch.zeros(B, D, W, device=device, dtype=dtype)
     y_cuda_prefill, cache = conv(
-        x[:, :T_prefill],
-        residual=residual[:, :T_prefill] if has_residual else None,
+        x[:, :T],
+        residual=residual[:, :T] if has_residual else None,
         cache=cache,
     )
 
     conv.backend = "triton"
     y_triton_decode, _ = conv(
-        x[:, T_prefill:],
-        residual=residual[:, T_prefill:] if has_residual else None,
+        x[:, T:],
+        residual=residual[:, T:] if has_residual else None,
         cache=cache,
     )
 
@@ -464,15 +510,15 @@ def test_mixed_backend(
     conv.backend = "triton"
     cache = torch.zeros(B, D, W, device=device, dtype=dtype)
     y_triton_prefill, cache = conv(
-        x[:, :T_prefill],
-        residual=residual[:, :T_prefill] if has_residual else None,
+        x[:, :T],
+        residual=residual[:, :T] if has_residual else None,
         cache=cache,
     )
 
     conv.backend = "cuda"
     y_cuda_decode, _ = conv(
-        x[:, T_prefill:],
-        residual=residual[:, T_prefill:] if has_residual else None,
+        x[:, T:],
+        residual=residual[:, T:] if has_residual else None,
         cache=cache,
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional cache tensor in causal 1D convolution, enabling use of initial state for incremental or streaming scenarios.
  * Updated the ShortConvolution module to accept and update a cache during the forward pass.

* **Tests**
  * Introduced new internal reference implementations and comprehensive tests for ShortConvolution with cache prefill and incremental decoding.
  * Added tests verifying mixed backend usage to ensure consistent outputs across different convolution backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->