### PR TITLE
[CI] Upgrade to latest casual-conv1d and fix triton build for 3.4.x

### DIFF
--- a/.github/workflows/reusable-build-triton.yml
+++ b/.github/workflows/reusable-build-triton.yml
@@ -17,7 +17,7 @@ on:
         description: 'Job timeout in minutes'
         required: false
         type: number
-        default: 120
+        default: 720
 
       checkout-ref:
         description: 'The branch, tag, or SHA to checkout. Defaults to the "main" branch.'

--- a/.github/workflows/reusable-build-triton.yml
+++ b/.github/workflows/reusable-build-triton.yml
@@ -16,8 +16,8 @@ on:
       timeout:
         description: 'Job timeout in minutes'
         required: false
-        type: number
-        default: 720
+        type: string
+        default: '720'
 
       checkout-ref:
         description: 'The branch, tag, or SHA to checkout. Defaults to the "main" branch.'
@@ -52,7 +52,7 @@ on:
 jobs:
   build-and-publish:
     runs-on: ${{ fromJson(inputs.runner) }}
-    timeout-minutes: ${{ inputs.timeout }}
+    timeout-minutes: ${{ fromJson(inputs.timeout) }}
 
     steps:
       - name: Prune stale docker containers

--- a/.github/workflows/reusable-build-triton.yml
+++ b/.github/workflows/reusable-build-triton.yml
@@ -189,6 +189,7 @@ jobs:
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_aarch64:latest"
             docker pull "${CIBW_MANYLINUX_AARCH64_IMAGE}"
           fi
+          docker image prune -f
 
           # Set build/skip from inputs. This is the core of the customization.
           export CIBW_BUILD="${{ inputs.cibw-build }}"

--- a/.github/workflows/reusable-build-triton.yml
+++ b/.github/workflows/reusable-build-triton.yml
@@ -184,14 +184,15 @@ jobs:
           # Image selection based on architecture input
           if [[ "${{ inputs.arch }}" == 'x86_64' ]]; then
             export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux_2_28_x86_64:latest"
+            docker pull "${CIBW_MANYLINUX_X86_64_IMAGE}"
           else
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_aarch64:latest"
+            docker pull "${CIBW_MANYLINUX_AARCH64_IMAGE}"
           fi
 
           # Set build/skip from inputs. This is the core of the customization.
           export CIBW_BUILD="${{ inputs.cibw-build }}"
           export CIBW_SKIP="${{ inputs.cibw-skip }}"
-          export CIBW_FREE_THREADED_SUPPORT=1
 
           echo "--- CIBW Settings ---"
           echo "CIBW_BUILD: ${CIBW_BUILD}"

--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -330,7 +330,7 @@ jobs:
               $CONDA_BIN_PATH/pip install .
               if [[ "${{ inputs.runner }}" == nvidia-h100* ]]; then
                 echo "Installing causal-conv1d for H100"
-                $CONDA_BIN_PATH/pip install git+https://github.com/Dao-AILab/causal-conv1d.git@e940ead --no-build-isolation
+                $CONDA_BIN_PATH/pip install -U causal-conv1d --no-build-isolation
                 echo "Installing flash-attn for NVIDIA"
                 $CONDA_BIN_PATH/pip install -U flash-attn --no-cache-dir --no-build-isolation
               fi

--- a/.github/workflows/triton-builder.yml
+++ b/.github/workflows/triton-builder.yml
@@ -54,8 +54,8 @@ jobs:
           arch_choice="${{ github.event.inputs.build_architecture }}"
 
           # Define configurations for each architecture
-          x64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'x64-docker']\", \"arch\": \"x86_64\", \"timeout\": 360}}"
-          aarch64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'aarch64-docker']\", \"arch\": \"aarch64\", \"timeout\": 1200}}"
+          x64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'x64-docker']\", \"arch\": \"x86_64\", \"timeout\": \"360\""}}"
+          aarch64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'aarch64-docker']\", \"arch\": \"aarch64\", \"timeout\": \"1200\""}}"
 
           # Build the final JSON matrix string
           matrix_content=""

--- a/.github/workflows/triton-builder.yml
+++ b/.github/workflows/triton-builder.yml
@@ -54,8 +54,8 @@ jobs:
           arch_choice="${{ github.event.inputs.build_architecture }}"
 
           # Define configurations for each architecture
-          x64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'x64-docker']\", \"arch\": \"x86_64\", \"timeout\": 120}}"
-          aarch64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'aarch64-docker']\", \"arch\": \"aarch64\", \"timeout\": 720}}"
+          x64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'x64-docker']\", \"arch\": \"x86_64\", \"timeout\": 360}}"
+          aarch64_config="{\"config\": {\"runs_on\": \"['self-hosted', 'aarch64-docker']\", \"arch\": \"aarch64\", \"timeout\": 1200}}"
 
           # Build the final JSON matrix string
           matrix_content=""

--- a/.github/workflows/triton-builder.yml
+++ b/.github/workflows/triton-builder.yml
@@ -91,6 +91,6 @@ jobs:
       timeout: ${{ matrix.config.timeout }}
       checkout-ref: ${{ needs.prepare-release-build.outputs.tag }} # Use output from the single 'needs' job
       package-name: 'triton'
-      cibw-build: 'cp3*-manylinux_${{ matrix.config.arch }}'
+      cibw-build: 'cp3{10,11,12,13}-manylinux_${{ matrix.config.arch }}'
       cibw-skip: 'cp{35,36,37,38,39}-*'
     secrets: inherit

--- a/.github/workflows/triton-nightly.yml
+++ b/.github/workflows/triton-nightly.yml
@@ -36,8 +36,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {runs_on: "['self-hosted', 'x64-docker']", arch: 'x86_64', timeout: 120}
-        - {runs_on: "['self-hosted', 'aarch64-docker']", arch: 'aarch64', timeout: 720}
+        - {runs_on: "['self-hosted', 'x64-docker']", arch: 'x86_64', timeout: 360}
+        - {runs_on: "['self-hosted', 'aarch64-docker']", arch: 'aarch64', timeout: 1200}
     uses: ./.github/workflows/reusable-build-triton.yml
     with:
       runner: ${{ matrix.config.runs_on }}
@@ -99,4 +99,5 @@ jobs:
       checkout-ref: 'main'
       package-name: 'triton-nightly'
       cibw-build: ${{ matrix.cibw_build_spec }}
+      cibw-skip: 'cp{35,36,37,38,39}-*'
     secrets: inherit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker image handling and cleanup in build workflow.
  * Updated package installation method for testing, switching to standard PyPI installation for a dependency.
  * Refined Python version targeting for builds to focus on versions 3.10 through 3.13.
  * Increased timeout limits for nightly and release builds to enhance stability.
  * Added skip parameters to streamline test build processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->