### PR TITLE
require transformers <= 4.53.3

### DIFF
--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -21,7 +21,7 @@ class Cache(transformers.cache_utils.Cache):
         self,
         seen_tokens: int = 0
     ) -> Cache:
-        super().__init__()
+        super().__init__(layer_classes=transformers.cache_utils.DynamicLayer)
 
         self.states: List[Dict[str, Any]] = []
 

--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -21,7 +21,7 @@ class Cache(transformers.cache_utils.Cache):
         self,
         seen_tokens: int = 0
     ) -> Cache:
-        super().__init__(layer_classes=transformers.cache_utils.DynamicLayer)
+        super().__init__()
 
         self.states: List[Dict[str, Any]] = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.5",
-    "transformers>=4.45.0",
+    "transformers>=4.45.0,<=4.53.3",
     "datasets>=3.3.0",
     "einops",
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         'torch>=2.5',
-        'transformers>=4.45.0',
+        'transformers>=4.45.0,<=4.53.3',
         'datasets>=3.3.0',
         'einops',
         'pytest'


### PR DESCRIPTION
require transformers <= 4.53.3, otherwise transformers will raise an error when generate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated dependency constraints to bound the transformers package to versions 4.45.0–4.53.3 (inclusive).
  * This affects installation and environment resolution only; existing features and behavior remain unchanged.
  * No impact on configuration, APIs, or user workflows.
  * No action required unless you manage pinned dependencies; ensure your environment uses a transformers version within this range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->