### PR TITLE
[Refactor] Apply GradientCheckpointingLayer to all model layers

### DIFF
--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
 
 
-class ABCBlock(nn.Module):
+class ABCBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: ABCConfig, layer_idx: int):
         super().__init__()
 
@@ -229,25 +231,14 @@ class ABCModel(ABCPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -221,10 +221,6 @@ class ABCModel(ABCPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -250,13 +250,6 @@ class BitNetModel(BitNetPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        if self.gradient_checkpointing and self.training:
-            if use_cache:
-                logger.warning_once(
-                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
-                )
-                use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         next_cache = None

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -35,7 +36,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class CombaBlock(nn.Module):
+class CombaBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: CombaConfig, layer_idx: int):
         super().__init__()
 
@@ -262,25 +264,14 @@ class CombaModel(CombaPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -254,10 +254,6 @@ class CombaModel(CombaPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
 
 
-class DeltaNetBlock(nn.Module):
+class DeltaNetBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: DeltaNetConfig, layer_idx: int):
         super().__init__()
 
@@ -226,25 +228,14 @@ class DeltaNetModel(DeltaNetPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -218,10 +218,6 @@ class DeltaNetModel(DeltaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -214,13 +214,6 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        if self.gradient_checkpointing and self.training:
-            if use_cache:
-                logger.warning_once(
-                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
-                )
-                use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         next_cache = None

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class ForgettingTransformerBlock(nn.Module):
+class ForgettingTransformerBlock(GradientCheckpointingLayer):
 
     def __init__(self, config: ForgettingTransformerConfig, layer_idx: int):
         super().__init__()
@@ -228,25 +229,14 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                layer_outputs = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    output_attentions,
-                    use_cache,
-                    **kwargs
-                )
-            else:
-                layer_outputs = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    output_attentions=output_attentions,
-                    use_cache=use_cache,
-                    **kwargs
-                )
+            layer_outputs = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                **kwargs
+            )
 
             hidden_states = layer_outputs[0]
 

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -35,7 +36,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class GatedDeltaNetBlock(nn.Module):
+class GatedDeltaNetBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: GatedDeltaNetConfig, layer_idx: int):
         super().__init__()
 
@@ -263,25 +265,14 @@ class GatedDeltaNetModel(GatedDeltaNetPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -255,10 +255,6 @@ class GatedDeltaNetModel(GatedDeltaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -221,10 +221,6 @@ class GatedDeltaProductModel(GatedDeltaProductPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -30,7 +31,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class GatedDeltaProductBlock(nn.Module):
+class GatedDeltaProductBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: GatedDeltaProductConfig, layer_idx: int):
         super().__init__()
 
@@ -229,25 +231,14 @@ class GatedDeltaProductModel(GatedDeltaProductPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class GLABlock(nn.Module):
+class GLABlock(GradientCheckpointingLayer):
+
     def __init__(self, config: GLAConfig, layer_idx: int):
         super().__init__()
 
@@ -228,25 +230,14 @@ class GLAModel(GLAPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -220,10 +220,6 @@ class GLAModel(GLAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class GSABlock(nn.Module):
+class GSABlock(GradientCheckpointingLayer):
+
     def __init__(self, config: GSAConfig, layer_idx: int):
         super().__init__()
 
@@ -229,25 +231,14 @@ class GSAModel(GSAPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -221,10 +221,6 @@ class GSAModel(GSAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class HGRNBlock(nn.Module):
+class HGRNBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: HGRNConfig, layer_idx: int):
         super().__init__()
 
@@ -229,27 +231,15 @@ class HGRNModel(HGRNPreTrainedModel):
                 all_hidden_states += (hidden_states,)
 
             lower_bound = lower_bounds[i] if self.config.use_lower_bound else None
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    lower_bound,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    lower_bound=lower_bound,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                lower_bound=lower_bound,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -216,10 +216,6 @@ class HGRNModel(HGRNPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -217,10 +217,6 @@ class HGRN2Model(HGRN2PreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class HGRN2Block(nn.Module):
+class HGRN2Block(GradientCheckpointingLayer):
+
     def __init__(self, config: HGRN2Config, layer_idx: int):
         super().__init__()
 
@@ -230,27 +232,15 @@ class HGRN2Model(HGRN2PreTrainedModel):
                 all_hidden_states += (hidden_states,)
 
             lower_bound = lower_bounds[i] if self.config.use_lower_bound else None
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    lower_bound,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    lower_bound=lower_bound,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                lower_bound=lower_bound,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class LightNetBlock(nn.Module):
+class LightNetBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: LightNetConfig, layer_idx: int):
         super().__init__()
 
@@ -221,25 +223,14 @@ class LightNetModel(LightNetPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -212,10 +212,6 @@ class LightNetModel(LightNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -216,10 +216,6 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -30,7 +31,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class LinearAttentionBlock(nn.Module):
+class LinearAttentionBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: LinearAttentionConfig, layer_idx: int):
         super().__init__()
 
@@ -225,23 +227,13 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/mamba/modeling_mamba.py
+++ b/fla/models/mamba/modeling_mamba.py
@@ -347,9 +347,6 @@ class MambaModel(MambaPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embeddings(input_ids)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            use_cache = False
-
         if use_cache:
             if cache_params is None:
                 cache_params = MambaCache(

--- a/fla/models/mamba/modeling_mamba.py
+++ b/fla/models/mamba/modeling_mamba.py
@@ -20,6 +20,7 @@ import torch
 from torch import nn
 from transformers.configuration_utils import PretrainedConfig
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput, logging
 from transformers.utils.deprecation import deprecate_kwarg
@@ -140,7 +141,8 @@ class MambaCache:
         self.ssm_states.zero_()
 
 
-class MambaBlock(nn.Module):
+class MambaBlock(GradientCheckpointingLayer):
+
     def __init__(self, config, layer_idx):
         super().__init__()
         self.config = config
@@ -369,17 +371,12 @@ class MambaModel(MambaPreTrainedModel):
         hidden_states = inputs_embeds
         all_hidden_states = () if output_hidden_states else None
         for mixer_block in self.layers:
-            if self.gradient_checkpointing and self.training:
-                hidden_states = self._gradient_checkpointing_func(
-                    mixer_block.__call__, hidden_states, cache_params, cache_position, attention_mask
-                )
-            else:
-                hidden_states = mixer_block(
-                    hidden_states,
-                    cache_params=cache_params,
-                    cache_position=cache_position,
-                    attention_mask=attention_mask,
-                )
+            hidden_states = mixer_block(
+                hidden_states,
+                cache_params=cache_params,
+                cache_position=cache_position,
+                attention_mask=attention_mask,
+            )
 
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -370,9 +370,6 @@ class Mamba2Model(Mamba2PreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embeddings(input_ids)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            use_cache = False
-
         if use_cache:
             if cache_params is None:
                 cache_params = Mamba2Cache(

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -19,6 +19,7 @@ from typing import Optional, Tuple, Union
 import torch
 from torch import nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput, logging
 from transformers.utils.deprecation import deprecate_kwarg
@@ -121,7 +122,8 @@ class Mamba2Cache:
         self.ssm_states.zero_()
 
 
-class Mamba2Block(nn.Module):
+class Mamba2Block(GradientCheckpointingLayer):
+
     def __init__(self, config, layer_idx):
         super().__init__()
         self.config = config
@@ -392,21 +394,12 @@ class Mamba2Model(Mamba2PreTrainedModel):
         hidden_states = inputs_embeds
         all_hidden_states = () if output_hidden_states else None
         for mixer_block in self.layers:
-            if self.gradient_checkpointing and self.training:
-                hidden_states = self._gradient_checkpointing_func(
-                    mixer_block.__call__,
-                    hidden_states,
-                    cache_params,
-                    cache_position,
-                    attention_mask,
-                )
-            else:
-                hidden_states = mixer_block(
-                    hidden_states,
-                    cache_params=cache_params,
-                    cache_position=cache_position,
-                    attention_mask=attention_mask,
-                )
+            hidden_states = mixer_block(
+                hidden_states,
+                cache_params=cache_params,
+                cache_position=cache_position,
+                attention_mask=attention_mask,
+            )
 
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class MesaNetBlock(nn.Module):
+class MesaNetBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: MesaNetConfig, layer_idx: int):
         super().__init__()
 
@@ -224,25 +226,14 @@ class MesaNetModel(MesaNetPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -216,10 +216,6 @@ class MesaNetModel(MesaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/mla/modeling_mla.py
+++ b/fla/models/mla/modeling_mla.py
@@ -204,10 +204,6 @@ class MLAModel(MLAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -295,10 +295,6 @@ class MomModel(MomPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         all_router_logits = ()

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -111,7 +112,8 @@ def load_balancing_loss_func(
     return overall_loss * num_experts
 
 
-class MomBlock(nn.Module):
+class MomBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: MomConfig, layer_idx: int):
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -305,25 +307,14 @@ class MomModel(MomPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values, router_logits = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values, router_logits = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values, router_logits = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -201,10 +201,6 @@ class NSAModel(NSAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -28,7 +29,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class NSABlock(nn.Module):
+class NSABlock(GradientCheckpointingLayer):
+
     def __init__(self, config: NSAConfig, layer_idx: int):
         super().__init__()
 
@@ -209,25 +211,14 @@ class NSAModel(NSAPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -213,13 +213,6 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        if self.gradient_checkpointing and self.training:
-            if use_cache:
-                logger.warning_once(
-                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
-                )
-                use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         next_cache = None

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class PaTHAttentionBlock(nn.Module):
+class PaTHAttentionBlock(GradientCheckpointingLayer):
 
     def __init__(self, config: PaTHAttentionConfig, layer_idx: int):
         super().__init__()
@@ -227,25 +228,14 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                layer_outputs = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    output_attentions,
-                    use_cache,
-                    **kwargs
-                )
-            else:
-                layer_outputs = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    output_attentions=output_attentions,
-                    use_cache=use_cache,
-                    **kwargs
-                )
+            layer_outputs = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                **kwargs
+            )
 
             hidden_states = layer_outputs[0]
 

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class RetNetBlock(nn.Module):
+class RetNetBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: RetNetConfig, layer_idx: int):
         super().__init__()
 
@@ -233,25 +235,14 @@ class RetNetModel(RetNetPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -225,10 +225,6 @@ class RetNetModel(RetNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/rodimus/modeling_rodimus.py
+++ b/fla/models/rodimus/modeling_rodimus.py
@@ -394,10 +394,6 @@ class RodimusModel(RodimusPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         residual = None

--- a/fla/models/rodimus/modeling_rodimus.py
+++ b/fla/models/rodimus/modeling_rodimus.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -35,7 +36,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class RodimusBlock(nn.Module):
+class RodimusBlock(GradientCheckpointingLayer):
+
     def __init__(self, config: RodimusConfig, layer_idx: int):
         super().__init__()
 
@@ -403,27 +405,15 @@ class RodimusModel(RodimusPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    residual,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    residual=residual,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                residual=residual,
+                **kwargs
+            )
 
             if self.block_residual_in_fp32:
                 hidden_states, residual = hidden_states

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -294,10 +294,6 @@ class RWKV6Model(RWKV6PreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -89,7 +90,8 @@ class RWKV6FeedForward(nn.Module):
         return receptance.sigmoid() * value, state
 
 
-class RWKV6Block(nn.Module):
+class RWKV6Block(GradientCheckpointingLayer):
+
     def __init__(self, config: RWKV6Config, layer_idx: int):
         super().__init__()
 
@@ -302,27 +304,15 @@ class RWKV6Model(RWKV6PreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    cu_seqlens,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    cu_seqlens=cu_seqlens,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                cu_seqlens=cu_seqlens,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -105,7 +106,7 @@ class RWKV7FeedForward(nn.Module):
         return self.value(self.act_fn(self.key(x.addcmul(delta, self.x_k)))), state
 
 
-class RWKV7Block(nn.Module):
+class RWKV7Block(GradientCheckpointingLayer):
 
     def __init__(
         self,
@@ -394,29 +395,16 @@ class RWKV7Model(RWKV7PreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values, v_first = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    use_cache,
-                    output_attentions,
-                    v_first,
-                    cu_seqlens,
-                    **kwargs
-                )
-            else:
-                hidden_states, attentions, past_key_values, v_first = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    use_cache=use_cache,
-                    output_attentions=output_attentions,
-                    v_first=v_first,
-                    cu_seqlens=cu_seqlens,
-                    **kwargs
-                )
+            hidden_states, attentions, past_key_values, v_first = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                v_first=v_first,
+                cu_seqlens=cu_seqlens,
+                **kwargs
+            )
 
             if output_attentions:
                 all_attns += (attentions,)

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -383,10 +383,6 @@ class RWKV7Model(RWKV7PreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...")
-            use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -249,9 +249,6 @@ class SambaModel(SambaPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embeddings(input_ids)
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            use_cache = False
-
         if cache_params is None and use_cache:
             cache_params = MambaCache(
                 self.config, inputs_embeds.size(0), device=inputs_embeds.device, dtype=inputs_embeds.dtype

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -211,13 +211,6 @@ class TransformerModel(TransformerPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        if self.gradient_checkpointing and self.training:
-            if use_cache:
-                logger.warning_once(
-                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
-                )
-                use_cache = False
-
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         next_cache = None

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-class TransformerBlock(nn.Module):
+class TransformerBlock(GradientCheckpointingLayer):
 
     def __init__(self, config: TransformerConfig, layer_idx: int):
         super().__init__()
@@ -225,25 +226,14 @@ class TransformerModel(TransformerPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            if self.gradient_checkpointing and self.training:
-                layer_outputs = self._gradient_checkpointing_func(
-                    layer.__call__,
-                    hidden_states,
-                    attention_mask,
-                    past_key_values,
-                    output_attentions,
-                    use_cache,
-                    **kwargs
-                )
-            else:
-                layer_outputs = layer(
-                    hidden_states,
-                    attention_mask=attention_mask,
-                    past_key_values=past_key_values,
-                    output_attentions=output_attentions,
-                    use_cache=use_cache,
-                    **kwargs
-                )
+            layer_outputs = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                **kwargs
+            )
 
             hidden_states = layer_outputs[0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.5",
-    "transformers>=4.45.0",
+    "transformers>=4.53.0",
     "datasets>=3.3.0",
     "einops",
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         'torch>=2.5',
-        'transformers>=4.45.0',
+        'transformers>=4.53.0',
         'datasets>=3.3.0',
         'einops',
         'pytest'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified, built‑in gradient checkpointing across model families (ABC, BitNet, Comba, DeltaNet, Forgetting Transformer, Gated DeltaNet/DeltaProduct, GLA, GSA, HGRN/HGRN2, LightNet, Linear Attention, Mamba/Mamba2, MesaNet, MLA, MoM, NSA, PaTH Attention, RetNet, Rodimus, RWKV6/7, Samba, Transformer).
  - Consistent activation and behavior across layers; no changes to outputs or APIs.
  - Potentially lower memory usage during training when enabled.

- Chores
  - Bumped minimum Transformers version requirement to 4.53.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->