### PR TITLE
Add DeltaFormer: pre-attention with fused chunk Triton kernels

### DIFF
--- a/fla/__init__.py
+++ b/fla/__init__.py
@@ -34,6 +34,8 @@ from fla.models import (
     BitNetModel,
     CombaForCausalLM,
     CombaModel,
+    DeltaFormerForCausalLM,
+    DeltaFormerModel,
     DeltaNetForCausalLM,
     DeltaNetModel,
     GatedDeltaNetForCausalLM,
@@ -102,6 +104,7 @@ __all__ = [
     'RodimusAttention', 'RodimusForCausalLM', 'RodimusModel',
     'RWKV6Attention', 'RWKV6ForCausalLM', 'RWKV6Model',
     'RWKV7Attention', 'RWKV7ForCausalLM', 'RWKV7Model',
+    'DeltaFormerForCausalLM', 'DeltaFormerModel',
 ]
 
 __version__ = '0.3.1'

--- a/fla/layers/__init__.py
+++ b/fla/layers/__init__.py
@@ -7,6 +7,7 @@ from .based import BasedLinearAttention
 from .bitattn import BitAttention
 from .comba import Comba
 from .delta_net import DeltaNet
+from .deltaformer import DeltaFormerAttention
 from .forgetting_attn import ForgettingAttention
 from .gated_deltanet import GatedDeltaNet
 from .gated_deltaproduct import GatedDeltaProduct
@@ -60,4 +61,5 @@ __all__ = [
     'RWKV6Attention',
     'RWKV7Attention',
     'SlidingWindowSharedKeyAttention',
+    'DeltaFormerAttention',
 ]

--- a/fla/layers/deltaformer.py
+++ b/fla/layers/deltaformer.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from einops import rearrange, repeat
+from transformers.utils import logging
+
+from fla.layers.utils import pad_input, unpad_input
+from fla.modules import RMSNorm
+from fla.ops.deltaformer import delta_pre_attn
+
+if TYPE_CHECKING:
+    from fla.models.utils import Cache
+
+try:
+    from flash_attn import flash_attn_func, flash_attn_varlen_func
+except ImportError:
+    flash_attn_func = None
+
+logger = logging.get_logger(__name__)
+
+
+class DeltaFormerAttention(nn.Module):
+
+    r"""
+    The layer implementation for DeltaFormer,
+    [Understanding Transformer from the Perspective of Associative Memory]
+    (https://arxiv.org/pdf/2505.19488).
+
+    Notes
+        - Pre-attention is implemented with Triton kernels in `fla.ops.deltaformer` and is tuned
+          for typical head dimensions (e.g., 64/128). It currently supports fixed-length inputs.
+        - For variable-length inputs (padding masks), the pre-attention falls back to using the
+          fixed-length path, while the second stage (softmax attention over U) uses FlashAttention's
+          varlen path when an attention mask is provided.
+        - K/V grouping (GQA) is supported via `num_kv_heads` by repeating K/V groups.
+
+    Args:
+        hidden_size (int, Optional):
+            The hidden size of the input. Default: 2048.
+        num_heads (int, Optional):
+            The number of attention heads. Default: 32.
+        num_kv_heads (int, Optional):
+            The number of key/value heads for grouped-query attention. If None, equals `num_heads`.
+            Default: None.
+        qkv_bias (bool, Optional):
+            Whether to use bias for Q/K/V projections. Default: False.
+        qk_norm (bool, Optional):
+            Whether to apply per-head RMSNorm to Q and K before attention. Default: False.
+        layer_idx (int, Optional):
+            The index of the layer (used for cache compatibility). Default: None.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        num_heads: int = 32,
+        num_kv_heads: Optional[int] = None,
+        qkv_bias: bool = False,
+        qk_norm: bool = False,
+        layer_idx: int | None = None,
+    ):
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        self.num_kv_groups = num_heads // self.num_kv_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.kv_dim = self.num_kv_heads * self.head_dim
+        self.qkv_bias = qkv_bias
+        self.qk_norm = qk_norm
+        self.layer_idx = layer_idx
+
+        if flash_attn_func is None:
+            raise ImportError("Please install Flash Attention via `pip install flash-attn --no-build-isolation` first")
+
+        self.q_proj = nn.Linear(self.hidden_size, self.hidden_size, bias=self.qkv_bias)
+        self.k_proj = nn.Linear(self.hidden_size, self.kv_dim, bias=self.qkv_bias)
+        self.v_proj = nn.Linear(self.hidden_size, self.kv_dim, bias=self.qkv_bias)
+        self.beta_proj = nn.Linear(self.hidden_size, self.num_heads, bias=True)
+        self.o_proj = nn.Linear(self.hidden_size, self.hidden_size, bias=False)
+
+        if qk_norm:
+            self.q_norm = RMSNorm(self.head_dim)
+            self.k_norm = RMSNorm(self.head_dim)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        attentions = None
+        if attention_mask is not None:
+            assert len(attention_mask.shape) == 2, (
+                "Expected attention_mask as a 0-1 matrix with shape [batch_size, seq_len] "
+                "for padding purposes (0 indicating padding). "
+                "Arbitrary attention masks of shape [batch_size, seq_len, seq_len] are not allowed."
+            )
+
+        batch_size, q_len, _ = hidden_states.size()
+
+        q = rearrange(self.q_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
+        k = rearrange(self.k_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
+        v = rearrange(self.v_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
+        beta = rearrange(self.beta_proj(hidden_states), 'b t h -> b h t')
+
+        if self.num_kv_groups > 1:
+            k = repeat(k, 'b t h d -> b t (h g) d', g=self.num_kv_groups)
+            v = repeat(v, 'b t h d -> b t (h g) d', g=self.num_kv_groups)
+
+        if self.qk_norm:
+            q, k = self.q_norm(q), self.k_norm(k)
+
+        if attention_mask is not None:
+            # Use varlen FlashAttention path. Pre-attention currently supports fixed length only → fallback by padding.
+            q_full = q
+            k_full = k
+            v_full = v
+            beta_full = beta
+        else:
+            q_full, k_full, v_full, beta_full = q, k, v, beta
+
+        # Compute u via DeltaFormer pre-attention (fixed-length kernel).
+        u = delta_pre_attn(
+            rearrange(q_full, 'b t h d -> b h t d'),
+            rearrange(k_full, 'b t h d -> b h t d'),
+            rearrange(v_full, 'b t h d -> b h t d'),
+            beta_full,
+        )
+        u = rearrange(u, 'b h t d -> b t h d')
+
+        # Second stage: standard FlashAttention but using u as values
+        if attention_mask is not None:
+            q_padded, (k_padded, u_padded), indices_q, cu_seqlens, max_seq_lens = unpad_input(q, (k, u), attention_mask, q_len)
+            cu_seqlens_q, cu_seqlens_k = cu_seqlens
+            max_seqlen_q, max_seqlen_k = max_seq_lens
+            o = flash_attn_varlen_func(
+                q_padded, k_padded, u_padded,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                causal=True,
+                window_size=(-1, -1)
+            )
+            o = pad_input(o, indices_q, batch_size, q_len)
+        else:
+            o = flash_attn_func(q, k, u, causal=True, window_size=(-1, -1))
+
+        o = o.reshape(batch_size, q_len, -1)
+        o = self.o_proj(o)
+
+        return o, attentions, past_key_values

--- a/fla/models/__init__.py
+++ b/fla/models/__init__.py
@@ -4,6 +4,7 @@ from fla.models.abc import ABCConfig, ABCForCausalLM, ABCModel
 from fla.models.bitnet import BitNetConfig, BitNetForCausalLM, BitNetModel
 from fla.models.comba import CombaConfig, CombaForCausalLM, CombaModel
 from fla.models.delta_net import DeltaNetConfig, DeltaNetForCausalLM, DeltaNetModel
+from fla.models.deltaformer import DeltaFormerConfig, DeltaFormerForCausalLM, DeltaFormerModel
 from fla.models.forgetting_transformer import (
     ForgettingTransformerConfig,
     ForgettingTransformerForCausalLM,
@@ -60,4 +61,5 @@ __all__ = [
     'RWKV7Config', 'RWKV7ForCausalLM', 'RWKV7Model',
     'SambaConfig', 'SambaForCausalLM', 'SambaModel',
     'TransformerConfig', 'TransformerForCausalLM', 'TransformerModel',
+    'DeltaFormerConfig', 'DeltaFormerForCausalLM', 'DeltaFormerModel',
 ]

--- a/fla/models/deltaformer/__init__.py
+++ b/fla/models/deltaformer/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+
+from fla.models.deltaformer.configuration_deltaformer import DeltaFormerConfig
+from fla.models.deltaformer.modeling_deltaformer import DeltaFormerForCausalLM, DeltaFormerModel
+
+AutoConfig.register(DeltaFormerConfig.model_type, DeltaFormerConfig, exist_ok=True)
+AutoModel.register(DeltaFormerConfig, DeltaFormerModel, exist_ok=True)
+AutoModelForCausalLM.register(DeltaFormerConfig, DeltaFormerForCausalLM, exist_ok=True)
+
+__all__ = ['DeltaFormerConfig', 'DeltaFormerForCausalLM', 'DeltaFormerModel']

--- a/fla/models/deltaformer/configuration_deltaformer.py
+++ b/fla/models/deltaformer/configuration_deltaformer.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class DeltaFormerConfig(PretrainedConfig):
+    model_type = 'deltaformer'
+    keys_to_ignore_at_inference = ['past_key_values']
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        hidden_ratio: Optional[int] = 4,
+        intermediate_size: Optional[int] = None,
+        num_hidden_layers: int = 24,
+        num_heads: int = 8,
+        num_kv_heads: Optional[int] = None,
+        attn_mode: str = "chunk",
+        hidden_act: str = "swish",
+        max_position_embeddings: int = 2048,
+        elementwise_affine: Optional[bool] = True,
+        norm_eps: float = 1e-6,
+        qkv_bias: bool = False,
+        qk_norm: bool = False,
+        attn: Optional[Dict] = None,
+        use_cache: bool = True,
+        pad_token_id: Optional[int] = None,
+        bos_token_id: int = 1,
+        eos_token_id: int = 2,
+        tie_word_embeddings: bool = False,
+        initializer_range: float = 0.02,
+        fuse_norm: bool = True,
+        fuse_swiglu: bool = True,
+        fuse_cross_entropy: bool = True,
+        fuse_linear_cross_entropy: bool = False,
+        use_l2warp: bool = False,
+        vocab_size: int = 32000,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        use_return_dict: bool = True,
+        **kwargs
+    ):
+        self.hidden_size = hidden_size
+        self.hidden_ratio = hidden_ratio
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.attn_mode = attn_mode
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.elementwise_affine = elementwise_affine
+        self.norm_eps = norm_eps
+        self.qkv_bias = qkv_bias
+        self.qk_norm = qk_norm
+        self.attn = attn
+        self.use_cache = use_cache
+        self.initializer_range = initializer_range
+
+        self.fuse_norm = fuse_norm
+        self.fuse_swiglu = fuse_swiglu
+        self.fuse_cross_entropy = fuse_cross_entropy
+        self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
+        self.use_l2warp = use_l2warp
+        self.vocab_size = vocab_size
+
+        self.output_attentions = output_attentions
+        self.output_hidden_states = output_hidden_states
+        self.use_return_dict = use_return_dict
+
+        if fuse_cross_entropy and fuse_linear_cross_entropy:
+            raise ValueError("`fuse_cross_entropy` and `fuse_linear_cross_entropy` cannot be True at the same time.")
+
+        if attn is not None:
+            if not isinstance(attn, Dict):
+                raise ValueError("attn must be a dictionary")
+            if 'layers' not in attn:
+                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
+            if 'num_heads' not in attn:
+                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
+            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
+            attn['qkv_bias'] = attn.get('qkv_bias', False)
+            attn['window_size'] = attn.get('window_size', None)
+            attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/fla/models/deltaformer/modeling_deltaformer.py
+++ b/fla/models/deltaformer/modeling_deltaformer.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from transformers.generation import GenerationMixin
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import logging
+from transformers.utils.deprecation import deprecate_kwarg
+
+from fla.layers.deltaformer import DeltaFormerAttention
+from fla.models.deltaformer.configuration_deltaformer import DeltaFormerConfig
+from fla.models.utils import Cache
+from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss
+from fla.modules import GatedMLP as DeltaFormerMLP
+from fla.modules import RMSNorm
+from fla.modules.l2warp import l2_warp
+
+try:
+    from transformers.modeling_layers import GradientCheckpointingLayer
+except ImportError:
+    from fla.models.modeling_layers import GradientCheckpointingLayer
+
+logger = logging.get_logger(__name__)
+
+if TYPE_CHECKING:
+    from transformers.processing_utils import Unpack
+
+
+class DeltaFormerBlock(GradientCheckpointingLayer):
+
+    def __init__(self, config: DeltaFormerConfig, layer_idx: int):
+        super().__init__()
+
+        self.config = config
+        self.layer_idx = layer_idx
+
+        self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        self.attn = DeltaFormerAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_heads,
+            num_kv_heads=config.num_kv_heads,
+            qkv_bias=config.qkv_bias,
+            qk_norm=config.qk_norm,
+            layer_idx=layer_idx,
+        )
+        self.mlp_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        self.mlp = DeltaFormerMLP(
+            hidden_size=config.hidden_size,
+            hidden_ratio=config.hidden_ratio,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            fuse_swiglu=config.fuse_swiglu
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+        use_cache: Optional[bool] = False,
+        output_attentions: Optional[bool] = False,
+        **kwargs: Unpack[Dict]
+    ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+        residual = hidden_states
+        hidden_states = self.attn_norm(hidden_states)
+        hidden_states, _, past_key_values = self.attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            **kwargs,
+        )
+        if self.config.fuse_norm:
+            hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
+        else:
+            hidden_states = residual + hidden_states
+            residual = hidden_states
+            hidden_states = self.mlp_norm(hidden_states)
+        hidden_states = self.mlp(hidden_states, **kwargs)
+        hidden_states = residual + hidden_states
+        outputs = (hidden_states, None, past_key_values)
+        return outputs
+
+
+class DeltaFormerPreTrainedModel(PreTrainedModel):
+
+    config_class = DeltaFormerConfig
+    base_model_prefix = 'model'
+    supports_gradient_checkpointing = True
+    _no_split_modules = ['DeltaFormerBlock']
+    _supports_cache_class = True
+
+    def __init__(self, *inputs, **kwargs):
+        super().__init__(*inputs, **kwargs)
+
+    def _init_weights(
+        self,
+        module: nn.Module,
+        prenorm_residual_strategy: Optional[str] = None,
+        num_residuals_per_layer: int = 2,
+    ):
+        if isinstance(module, (nn.Linear, nn.Conv1d)):
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+        elif hasattr(module, 'reset_parameters'):
+            module.reset_parameters()
+
+
+class DeltaFormerModel(DeltaFormerPreTrainedModel):
+
+    def __init__(self, config: DeltaFormerConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([DeltaFormerBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
+        self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embeddings
+
+    def set_input_embeddings(self, value):
+        self.embeddings = value
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,  # noqa
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        **kwargs: Unpack[Dict]
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        if output_attentions:
+            warnings.warn(
+                "`DeltaFormerModel` does not support output attention weights now, "
+                "so `output_attentions` is set to `False`."
+            )
+            output_attentions = False
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        use_cache = use_cache if use_cache is not None else (self.config.use_cache if not self.training else False)
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embeddings(input_ids)
+        hidden_states = inputs_embeds
+
+        if use_cache and not isinstance(past_key_values, Cache):
+            past_key_values = Cache.from_legacy_cache(past_key_values)
+
+        all_hidden_states = () if output_hidden_states else None
+        all_attns = () if output_attentions else None
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs
+            )
+
+            if output_attentions:
+                all_attns += (attentions,)
+
+        hidden_states = self.norm(hidden_states)
+
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(i for i in [hidden_states, past_key_values, all_hidden_states, all_attns] if i is not None)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            hidden_states=all_hidden_states,
+            attentions=all_attns
+        )
+
+
+class DeltaFormerForCausalLM(DeltaFormerPreTrainedModel, GenerationMixin):
+
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: DeltaFormerConfig):
+        super().__init__(config)
+        self.model = DeltaFormerModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.criterion = None
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def tie_weights(self):
+        self._tie_or_clone_weights(self.lm_head, self.get_input_embeddings())
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def generate(self, *args, **kwargs):
+        try:
+            return super().generate(*args, **kwargs)
+        except AttributeError as exception:
+            if 'past_key_values' in str(exception):
+                raise AttributeError(
+                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
+                    f"which is not supported for {self.__class__.__name__}. "
+                    f"Try another generation strategy instead. "
+                    f"For the available generation strategies, check this doc: "
+                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies"
+                )
+            else:
+                raise exception
+
+    @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
+    def prepare_inputs_for_generation(
+        self,
+        input_ids: torch.LongTensor = None,
+        past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        use_cache: bool = True,
+        logits_to_keep: Optional[int] = None,
+        **kwargs
+    ):
+        # only last token for `inputs_ids` if the `past_key_values` is not empty.
+        if past_key_values is not None and len(past_key_values) > 0:
+            input_ids = input_ids[:, -1:]
+        # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
+        if inputs_embeds is not None and len(past_key_values) == 0:
+            model_inputs = {'inputs_embeds': inputs_embeds}
+        else:
+            # The `contiguous()` here is necessary to have a static stride during decoding. torchdynamo otherwise
+            # recompiles graphs as the stride of the inputs is a guard.
+            model_inputs = {'input_ids': input_ids.contiguous()}
+
+        if logits_to_keep is not None:
+            model_inputs['logits_to_keep'] = logits_to_keep
+
+        model_inputs.update({
+            'past_key_values': past_key_values,
+            'use_cache': use_cache,
+            'attention_mask': attention_mask,
+        })
+        return model_inputs
+
+    @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        labels: Optional[torch.LongTensor] = None,
+        logits_to_keep: Optional[int] = 0,
+        **kwargs: Unpack[Dict]
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs
+        )
+
+        hidden_states = outputs[0]
+        # For fused linear cross-entropy we do not materialize logits for the full sequence
+        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
+
+        loss = None
+        if labels is not None:
+            if getattr(self, 'criterion', None) is None:
+                if self.config.fuse_linear_cross_entropy:
+                    criterion = FusedLinearCrossEntropyLoss(use_l2warp=self.config.use_l2warp)
+                elif self.config.fuse_cross_entropy:
+                    criterion = FusedCrossEntropyLoss(inplace_backward=True)
+                else:
+                    criterion = nn.CrossEntropyLoss()
+            else:
+                criterion = self.criterion
+            labels = labels.to(hidden_states.device)
+            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            if self.config.fuse_linear_cross_entropy:
+                loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
+            else:
+                loss = criterion(logits.view(labels.numel(), -1), labels.view(-1))
+                loss = l2_warp(loss, logits) if self.config.use_l2warp else loss
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return ((loss,) + output) if loss is not None else output
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )

--- a/fla/ops/deltaformer/__init__.py
+++ b/fla/ops/deltaformer/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from .fused_chunk import delta_pre_attn
+from .naive import delta_pre_attn_naive
+
+__all__ = [
+    'delta_pre_attn',
+    'delta_pre_attn_naive',
+]

--- a/fla/ops/deltaformer/fused_chunk.py
+++ b/fla/ops/deltaformer/fused_chunk.py
@@ -1,0 +1,899 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import math
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from . import invcum
+
+BLOCK_SIZE_C = 512
+
+
+def forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    u: torch.Tensor,
+    qk_scale: float,
+    beta: torch.Tensor
+):
+    B, C, D = q.size()
+    _B, T, _D = k.size()
+    __B, __C = beta.size()
+    assert B == _B and D == _D and B == __B and __C == C
+    w = torch.empty(B, C, C, device=q.device, dtype=q.dtype)
+    lse = torch.empty(B, C, device=q.device, dtype=torch.float)
+    delta_flash_attn_compileable(q, k, v, u, w, lse, qk_scale, beta)
+    return w, lse
+
+
+def backward_u_chunk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    lse: torch.Tensor,
+    grad_v: torch.Tensor,
+    fa_scale: float,
+    beta: torch.Tensor
+):
+    B, C, D = q.size()
+    _B, T, _D = k.size()
+    grad_u = torch.empty_like(q)
+
+    def grid(META):
+        return (triton.cdiv(C, META['BLOCK_C']), B)
+
+    backward_u_chunk_kernel[grid](
+        grad_u,
+        grad_u.stride(0), grad_u.stride(1), grad_u.stride(2),
+        q,
+        q.stride(0), q.stride(1), q.stride(2),
+        k,
+        k.stride(0), k.stride(1), k.stride(2),
+        grad_v,
+        grad_v.stride(0), grad_v.stride(1), grad_v.stride(2),
+        lse,
+        lse.stride(0), lse.stride(1),
+        beta,
+        beta.stride(0), beta.stride(1),
+        B, T, C, D, fa_scale
+    )
+    return grad_u
+
+
+def backward_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    u: torch.Tensor,
+    lse: torch.Tensor,
+    grad_v: torch.Tensor,
+    qk_scale: float,
+    fa_scale: float,
+    beta: torch.Tensor
+):
+    B, T, D = k.size()
+    row_dot_sum = torch.empty_like(lse)
+
+    def grid_bp(META):
+        return (triton.cdiv(T, META['BLOCK_C']), B)
+
+    backward_p_row_sum_kernel[grid_bp](
+        row_dot_sum,
+        row_dot_sum.stride(0), row_dot_sum.stride(1),
+        q,
+        q.stride(0), q.stride(1), q.stride(2),
+        k,
+        k.stride(0), k.stride(1), k.stride(2),
+        grad_v,
+        grad_v.stride(0), grad_v.stride(1), grad_v.stride(2),
+        u,
+        u.stride(0), u.stride(1), u.stride(2),
+        lse,
+        lse.stride(0), lse.stride(1),
+        B, T, D,
+        fa_scale
+    )
+    grad_k = torch.empty_like(k)
+    grad_q = torch.empty_like(q)
+
+    backward_qk_kernel[grid_bp](
+        grad_q,
+        grad_q.stride(0), grad_q.stride(1), grad_q.stride(2),
+        grad_k,
+        grad_k.stride(0), grad_k.stride(1), grad_k.stride(2),
+        q,
+        q.stride(0), q.stride(1), q.stride(2),
+        k,
+        k.stride(0), k.stride(1), k.stride(2),
+        grad_v,
+        grad_v.stride(0), grad_v.stride(1), grad_v.stride(2),
+        u,
+        u.stride(0), u.stride(1), u.stride(2),
+        lse,
+        lse.stride(0), lse.stride(1),
+        beta,
+        beta.stride(0), beta.stride(1),
+        row_dot_sum,
+        row_dot_sum.stride(0), row_dot_sum.stride(1),
+        B, T, D,
+        fa_scale, qk_scale
+    )
+    return grad_q, grad_k, row_dot_sum
+
+
+def delta_flash_attn_compileable(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    u: torch.Tensor,
+    w: torch.Tensor,
+    lse: torch.Tensor,
+    qk_scale: float,
+    beta: torch.Tensor
+) -> None:
+    B, C, D = q.size()
+    _B, T, _D = k.size()
+
+    def grid(META):
+        return (triton.cdiv(C, META['BLOCK_C']), B)
+
+    flash_attn_kernel[grid](
+        q,
+        q.stride(0), q.stride(1), q.stride(2),
+        k,
+        k.stride(0), k.stride(1), k.stride(2),
+        v,
+        v.stride(0), v.stride(1), v.stride(2),
+        u,
+        u.stride(0), u.stride(1), u.stride(2),
+        w,
+        w.stride(0), w.stride(1),
+        lse,
+        lse.stride(0),
+        beta,
+        beta.stride(0),
+        B, T, C, D, qk_scale
+    )
+
+
+def _config_delta_flash_attn():
+    return [triton.Config({'BLOCK_C': BC, 'BLOCK_T': BT}, num_stages=3, num_warps=8) for BC in [128] for BT in [64]]
+
+
+@triton.autotune(configs=_config_delta_flash_attn(), key=['C', 'D'])
+@triton.jit
+def flash_attn_kernel(
+    q_ptr,
+    stride_qh,
+    stride_qc,
+    stride_qd,
+    k_ptr,
+    stride_kh,
+    stride_kt,
+    stride_kd,
+    v_ptr,
+    stride_vh,
+    stride_vc,
+    stride_vd,
+    u_ptr,
+    stride_uh,
+    stride_ut,
+    stride_ud,
+    w_ptr,
+    stride_wh,
+    stride_wc,
+    lse_ptr,
+    stride_lse_r,
+    beta_ptr,
+    beta_stride_r,
+    B,
+    T,
+    C,
+    D: tl.constexpr,
+    qk_scale: float,
+    BLOCK_C: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    pid_c = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+
+    rowid_block = tl.arange(0, BLOCK_C) + pid_c * BLOCK_C
+    colid_block = tl.arange(0, BLOCK_T)
+
+    rowmax = tl.zeros([BLOCK_C], dtype=tl.float32) - float('inf')
+    rowsum = tl.zeros([BLOCK_C], dtype=tl.float32) + 1
+    acc = tl.zeros([BLOCK_C, D], dtype=tl.float32)
+
+    q_blk_ptr = tl.make_block_ptr(
+        base=q_ptr + pid_b * stride_qh,
+        shape=(C, D),
+        strides=(stride_qc, stride_qd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    q = tl.load(q_blk_ptr, boundary_check=(0,))
+
+    for kv_i in range(0, T, BLOCK_T):
+        k_blk_ptr = tl.make_block_ptr(
+            base=k_ptr + pid_b * stride_kh,
+            shape=(D, T),
+            strides=(stride_kd, stride_kt),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_T),
+            order=(0, 1),
+        )
+        k = tl.load(k_blk_ptr, boundary_check=(1,))
+        qk = tl.dot(q, k) * qk_scale
+
+        if kv_i >= T - C:
+            mask = (T - C - kv_i + rowid_block[:, None] - colid_block[None, :] < 1)
+            qk = tl.where(mask, -1e6, qk)
+
+        rowmax_i = tl.maximum(rowmax, tl.max(qk, axis=1))
+        qk -= rowmax_i[:, None]
+        p = tl.math.exp2(qk)
+
+        rowsum_i = tl.sum(p, axis=1)
+        alpha = tl.math.exp2(rowmax - rowmax_i)
+        rowsum = rowsum * alpha + rowsum_i
+        acc = acc * alpha[:, None]
+        rowmax = rowmax_i
+
+        if kv_i < T - C:
+            u_blk_ptr = tl.make_block_ptr(
+                base=u_ptr + pid_b * stride_uh,
+                shape=(T, D),
+                strides=(stride_ut, stride_ud),
+                offsets=(kv_i, 0),
+                block_shape=(BLOCK_T, D),
+                order=(1, 0),
+            )
+            u = tl.load(u_blk_ptr, boundary_check=(0,))
+            acc = tl.dot(p.to(u_ptr.dtype.element_ty), u, acc)
+
+    lse = rowmax + tl.math.log2(rowsum)
+    lse_block_ptr = lse_ptr + stride_lse_r * pid_b + rowid_block
+    lse_mask = rowid_block < C
+    tl.store(lse_block_ptr, lse, mask=lse_mask)
+
+    v_ptr = tl.make_block_ptr(
+        base=v_ptr + pid_b * stride_vh,
+        shape=(C, D),
+        strides=(stride_vc, stride_vd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    acc = acc / rowsum[:, None]
+
+    beta_ptr = tl.make_block_ptr(
+        base=beta_ptr + pid_b * beta_stride_r,
+        shape=(C,),
+        strides=(1,),
+        offsets=(pid_c * BLOCK_C,),
+        block_shape=(BLOCK_C,),
+        order=(0,)
+    )
+    beta = tl.load(beta_ptr, boundary_check=(0,))
+    acc = acc * beta[:, None]
+
+    v = tl.load(v_ptr, boundary_check=(0,))
+    u = v - acc.to(v_ptr.dtype.element_ty)
+    u_block_ptr = tl.make_block_ptr(
+        base=u_ptr + pid_b * stride_uh,
+        shape=(T, D),
+        strides=(stride_ut, stride_ud),
+        offsets=(T - C + pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    tl.store(u_block_ptr, u, boundary_check=(0, 1))
+
+    for kv_i in range(T - C, T, BLOCK_T):
+        k_blk_ptr = tl.make_block_ptr(
+            base=k_ptr + pid_b * stride_kh,
+            shape=(D, T),
+            strides=(stride_kd, stride_kt),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_T),
+            order=(0, 1),
+        )
+        k = tl.load(k_blk_ptr, boundary_check=(1,))
+        qk = tl.dot(q, k) * qk_scale
+
+        mask = (T - C - kv_i + rowid_block[:, None] - colid_block[None, :] < 1)
+        qk -= rowmax[:, None]
+        p = tl.math.exp2(qk) / rowsum[:, None]
+        p = tl.where(mask, 0, p)
+        w_blk_ptr = tl.make_block_ptr(
+            base=w_ptr + pid_b * stride_wh,
+            shape=(C, C),
+            strides=(stride_wc, 1),
+            offsets=(pid_c * BLOCK_C, kv_i - (T - C)),
+            block_shape=(BLOCK_C, BLOCK_T),
+            order=(1, 0)
+        )
+        tl.store(w_blk_ptr, p.to(w_ptr.dtype.element_ty), boundary_check=(0, 1))
+
+
+def _config_backward_u_chunk():
+    return [triton.Config({'BLOCK_C': 128, 'BLOCK_T': 64}, num_stages=3, num_warps=8)]
+
+
+@triton.autotune(configs=_config_backward_u_chunk(), key=['C', 'D'])
+@triton.jit
+def backward_u_chunk_kernel(
+    o_ptr,
+    stride_oh,
+    stride_oc,
+    stride_od,
+    q_ptr,
+    stride_qh,
+    stride_qc,
+    stride_qd,
+    k_ptr,
+    stride_kh,
+    stride_kt,
+    stride_kd,
+    v_ptr,
+    stride_vh,
+    stride_vt,
+    stride_vd,
+    lse_ptr,
+    stride_lse_h,
+    stride_lse_t,
+    beta_ptr,
+    stride_beta_h,
+    stride_beta_t,
+    B,
+    T,
+    C,
+    D: tl.constexpr,
+    fa_scale,
+    BLOCK_C: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    pid_c = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+
+    acc = tl.zeros([BLOCK_C, D], dtype=tl.float32)
+
+    q_blk_ptr = tl.make_block_ptr(
+        base=q_ptr + pid_b * stride_qh,
+        shape=(C, D),
+        strides=(stride_qc, stride_qd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    q = tl.load(q_blk_ptr)
+
+    for kv_i in range(0, T, BLOCK_T):
+        k_blk_ptr = tl.make_block_ptr(
+            base=k_ptr + pid_b * stride_kh,
+            shape=(D, T),
+            strides=(stride_kd, stride_kt),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_T),
+            order=(0, 1),
+        )
+        k = tl.load(k_blk_ptr)
+        qk = tl.dot(q, k) * fa_scale
+
+        lse_blk_ptr = tl.make_block_ptr(
+            base=lse_ptr + pid_b * stride_lse_h,
+            shape=(T,),
+            strides=(stride_lse_t,),
+            offsets=(kv_i,),
+            block_shape=(BLOCK_T,),
+            order=(0,),
+        )
+        lse = tl.load(lse_blk_ptr)
+        beta_blk_ptr = tl.make_block_ptr(
+            base=beta_ptr + pid_b * stride_beta_h,
+            shape=(T,),
+            strides=(stride_beta_t,),
+            offsets=(kv_i,),
+            block_shape=(BLOCK_T,),
+            order=(0,),
+        )
+        beta = tl.load(beta_blk_ptr)
+
+        p = tl.math.exp2(qk - lse[None, :]) * beta[None, :]
+
+        v_blk_ptr = tl.make_block_ptr(
+            base=v_ptr + pid_b * stride_vh,
+            shape=(T, D),
+            strides=(stride_vt, stride_vd),
+            offsets=(kv_i, 0),
+            block_shape=(BLOCK_T, D),
+            order=(1, 0),
+        )
+        v = tl.load(v_blk_ptr)
+        acc = tl.dot(p.to(v_ptr.dtype.element_ty), v, acc)
+
+    o_blk_ptr = tl.make_block_ptr(
+        base=o_ptr + pid_b * stride_oh,
+        shape=(C, D),
+        strides=(stride_oc, stride_od),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    tl.store(o_blk_ptr, acc.to(o_ptr.dtype.element_ty))
+
+
+def _config_backward_p_row_sum():
+    return [triton.Config({'BLOCK_C': 128, 'BLOCK_T': 64}, num_stages=4, num_warps=8)]
+
+
+@triton.autotune(configs=_config_backward_p_row_sum(), key=['T', 'D'])
+@triton.jit
+def backward_p_row_sum_kernel(
+    row_dot_ptr,
+    stride_row_dot_h,
+    stride_row_dot_t,
+    q_ptr,
+    stride_qh,
+    stride_qt,
+    stride_qd,
+    k_ptr,
+    stride_kh,
+    stride_kt,
+    stride_kd,
+    grad_v_ptr,
+    stride_grad_vh,
+    stride_grad_vt,
+    stride_grad_vd,
+    u_ptr,
+    stride_uh,
+    stride_ut,
+    stride_ud,
+    lse_ptr,
+    stride_lse_h,
+    stride_lse_t,
+    B,
+    T,
+    D: tl.constexpr,
+    fa_scale,
+    BLOCK_C: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    pid_c = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+
+    rowid_block = tl.arange(0, BLOCK_C) + pid_c * BLOCK_C
+    colid_block = tl.arange(0, BLOCK_T)
+
+    acc = tl.zeros([BLOCK_C], dtype=tl.float32)
+
+    k_row_blk_ptr = tl.make_block_ptr(
+        base=q_ptr + pid_b * stride_qh,
+        shape=(T, D),
+        strides=(stride_qt, stride_qd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    k_row = tl.load(k_row_blk_ptr)
+    lse_blk_ptr = tl.make_block_ptr(
+        base=lse_ptr + pid_b * stride_lse_h,
+        shape=(T,),
+        strides=(stride_lse_t,),
+        offsets=(pid_c * BLOCK_C,),
+        block_shape=(BLOCK_C,),
+        order=(0,),
+    )
+    lse = tl.load(lse_blk_ptr)
+    grad_v_blk_ptr = tl.make_block_ptr(
+        base=grad_v_ptr + pid_b * stride_grad_vh,
+        shape=(T, D),
+        strides=(stride_grad_vt, stride_grad_vd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    grad_v_row = -tl.load(grad_v_blk_ptr)
+
+    for kv_i in range(0, (pid_c + 1) * BLOCK_C, BLOCK_T):
+        k_blk_ptr = tl.make_block_ptr(
+            base=k_ptr + pid_b * stride_kh,
+            shape=(D, T),
+            strides=(stride_kd, stride_kt),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_T),
+            order=(0, 1),
+        )
+        k = tl.load(k_blk_ptr)
+        qk = tl.dot(k_row, k) * fa_scale
+        p = tl.math.exp2(qk - lse[:, None])
+
+        u_blk_ptr = tl.make_block_ptr(
+            base=u_ptr + pid_b * stride_uh,
+            shape=(D, T),
+            strides=(stride_ud, stride_ut),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_T),
+            order=(0, 1),
+        )
+        ut = tl.load(u_blk_ptr)
+        dp = tl.dot(grad_v_row, ut)
+        if kv_i + BLOCK_T >= pid_c * BLOCK_C:
+            mask = (rowid_block[:, None] <= colid_block[None, :] + kv_i)
+            p = tl.where(mask, 0., p)
+            dp = tl.where(mask, 0., dp)
+        acc += tl.sum(p * dp, axis=1)
+    row_dot_block_ptr = tl.make_block_ptr(
+        base=row_dot_ptr + pid_b * stride_row_dot_h,
+        shape=(T,),
+        strides=(stride_row_dot_t,),
+        offsets=(pid_c * BLOCK_C,),
+        block_shape=(BLOCK_C,),
+        order=(0,),
+    )
+    tl.store(row_dot_block_ptr, acc)
+
+
+def _config_backward_k():
+    return [triton.Config({'BLOCK_C': 64}, num_stages=4, num_warps=4)]
+
+
+@triton.autotune(configs=_config_backward_k(), key=['T', 'D'])
+@triton.jit
+def backward_qk_kernel(
+    grad_q_ptr,
+    stride_grad_qh,
+    stride_grad_qt,
+    stride_grad_qd,
+    grad_k_ptr,
+    stride_grad_kh,
+    stride_grad_kt,
+    stride_grad_kd,
+    q_ptr,
+    stride_qh,
+    stride_qt,
+    stride_qd,
+    k_ptr,
+    stride_kh,
+    stride_kt,
+    stride_kd,
+    grad_v_ptr,
+    stride_grad_vh,
+    stride_grad_vt,
+    stride_grad_vd,
+    u_ptr,
+    stride_uh,
+    stride_ut,
+    stride_ud,
+    lse_ptr,
+    stride_lse_h,
+    stride_lse_t,
+    beta_ptr,
+    stride_beta_h,
+    stride_beta_t,
+    row_dot_ptr,
+    stride_row_dot_h,
+    stride_row_dot_t,
+    B,
+    T,
+    D: tl.constexpr,
+    fa_scale: tl.constexpr,
+    qk_scale: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_c = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    block_i = tl.arange(0, BLOCK_C)
+
+    acc = tl.zeros([BLOCK_C, D], dtype=tl.float32)
+
+    k_row_blk_ptr = tl.make_block_ptr(
+        base=q_ptr + pid_b * stride_qh,
+        shape=(T, D),
+        strides=(stride_qt, stride_qd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    k_row = tl.load(k_row_blk_ptr)
+    lse_blk_ptr = tl.make_block_ptr(
+        base=lse_ptr + pid_b * stride_lse_h,
+        shape=(T,),
+        strides=(stride_lse_t,),
+        offsets=(pid_c * BLOCK_C,),
+        block_shape=(BLOCK_C,),
+        order=(0,),
+    )
+    lse = tl.load(lse_blk_ptr)
+    beta_blk_ptr = tl.make_block_ptr(
+        base=beta_ptr + pid_b * stride_beta_h,
+        shape=(T,),
+        strides=(stride_beta_t,),
+        offsets=(pid_c * BLOCK_C,),
+        block_shape=(BLOCK_C,),
+        order=(0,),
+    )
+    beta = tl.load(beta_blk_ptr)
+    grad_v_blk_ptr = tl.make_block_ptr(
+        base=grad_v_ptr + pid_b * stride_grad_vh,
+        shape=(T, D),
+        strides=(stride_grad_vt, stride_grad_vd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    grad_v_row = -tl.load(grad_v_blk_ptr)
+    row_dot_blk_ptr = tl.make_block_ptr(
+        base=row_dot_ptr + pid_b * stride_row_dot_h,
+        shape=(T,),
+        strides=(stride_row_dot_t,),
+        offsets=(pid_c * BLOCK_C,),
+        block_shape=(BLOCK_C,),
+        order=(0,),
+    )
+    row_dot_row = tl.load(row_dot_blk_ptr).to(k_ptr.dtype.element_ty)
+
+    for kv_i in range(0, pid_c * BLOCK_C, BLOCK_C):
+        k_blk_ptr = tl.make_block_ptr(
+            base=k_ptr + pid_b * stride_kh,
+            shape=(D, T),
+            strides=(stride_kd, stride_kt),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_C),
+            order=(0, 1),
+        )
+        kt = tl.load(k_blk_ptr)
+        qk = tl.dot(k_row, kt) * fa_scale
+        p = tl.math.exp2(qk - lse[:, None]) * beta[:, None]
+
+        u_blk_ptr = tl.make_block_ptr(
+            base=u_ptr + pid_b * stride_uh,
+            shape=(D, T),
+            strides=(stride_ud, stride_ut),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_C),
+            order=(0, 1),
+        )
+        ut = tl.load(u_blk_ptr)
+        dp = tl.dot(grad_v_row, ut)
+        da = p * (dp - row_dot_row[:, None])
+        k = tl.trans(kt, 1, 0)
+        acc = tl.dot(da.to(k.dtype), k, acc)
+
+    k_row_blk_ptr = tl.make_block_ptr(
+        base=k_ptr + pid_b * stride_kh,
+        shape=(T, D),
+        strides=(stride_kt, stride_kd),
+        offsets=(pid_c * BLOCK_C, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    k_row_true = tl.load(k_row_blk_ptr)
+    qk = tl.dot(k_row, tl.trans(k_row_true, 1, 0)) * fa_scale
+    p = tl.math.exp2(qk - lse[:, None]) * beta[:, None]
+    u_blk_ptr = tl.make_block_ptr(
+        base=u_ptr + pid_b * stride_uh,
+        shape=(D, T),
+        strides=(stride_ud, stride_ut),
+        offsets=(0, pid_c * BLOCK_C),
+        block_shape=(D, BLOCK_C),
+        order=(0, 1),
+    )
+    ut = tl.load(u_blk_ptr)
+    dp = tl.dot(grad_v_row, ut)
+    dpm = dp - row_dot_row[:, None]
+    mask = block_i[None, :] < block_i[:, None]
+    p = tl.where(mask, p, 0.)
+    dpm = tl.where(mask, dpm, 0.)
+    da = p * dpm
+    daat = da
+    acc = tl.dot(daat.to(k_row.dtype), k_row_true, acc)
+
+    grad_q_blk_ptr = tl.make_block_ptr(
+        base=grad_q_ptr + pid_b * stride_grad_qh,
+        shape=(T, D),
+        strides=(stride_grad_qt, stride_grad_qd),
+        offsets=(BLOCK_C * pid_c, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    acc = acc * qk_scale
+    tl.store(grad_q_blk_ptr, acc.to(grad_q_ptr.dtype.element_ty))
+
+    daat = tl.trans(da, 1, 0)
+    acc = tl.dot(daat.to(k_row.dtype), k_row)
+    k_row = k_row_true
+    nu = -tl.trans(ut, 1, 0)
+    for kv_i in range((pid_c + 1) * BLOCK_C, T, BLOCK_C):
+        k_blk_ptr = tl.make_block_ptr(
+            base=q_ptr + pid_b * stride_qh,
+            shape=(D, T),
+            strides=(stride_qd, stride_qt),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_C),
+            order=(0, 1),
+        )
+        kt = tl.load(k_blk_ptr)
+        lse_blk_ptr = tl.make_block_ptr(
+            base=lse_ptr + pid_b * stride_lse_h,
+            shape=(T,),
+            strides=(stride_lse_t,),
+            offsets=(kv_i,),
+            block_shape=(BLOCK_C,),
+            order=(0,),
+        )
+        lse = tl.load(lse_blk_ptr)
+        beta_blk_ptr = tl.make_block_ptr(
+            base=beta_ptr + pid_b * stride_beta_h,
+            shape=(T,),
+            strides=(stride_beta_t,),
+            offsets=(kv_i,),
+            block_shape=(BLOCK_C,),
+            order=(0,),
+        )
+        beta = tl.load(beta_blk_ptr)
+        qk = tl.dot(k_row, kt) * fa_scale
+        p = tl.math.exp2(qk - lse[None, :]) * beta[None, :]
+
+        grad_vt_blk_ptr = tl.make_block_ptr(
+            base=grad_v_ptr + pid_b * stride_grad_vh,
+            shape=(D, T),
+            strides=(stride_grad_vd, stride_grad_vt),
+            offsets=(0, kv_i),
+            block_shape=(D, BLOCK_C),
+            order=(0, 1),
+        )
+        grad_vt = tl.load(grad_vt_blk_ptr)
+        row_dot_blk_ptr = tl.make_block_ptr(
+            base=row_dot_ptr + pid_b * stride_row_dot_h,
+            shape=(T,),
+            strides=(stride_row_dot_t,),
+            offsets=(kv_i,),
+            block_shape=(BLOCK_C,),
+            order=(0,),
+        )
+        row_dot = tl.load(row_dot_blk_ptr).to(k_ptr.dtype.element_ty)
+        dp = tl.dot(nu, grad_vt)
+        da = p * (dp - row_dot[None, :])
+        k = tl.trans(kt, 1, 0)
+        acc = tl.dot(da.to(k.dtype), k, acc)
+
+    grad_k_blk_ptr = tl.make_block_ptr(
+        base=grad_k_ptr + pid_b * stride_grad_kh,
+        shape=(T, D),
+        strides=(stride_grad_kt, stride_grad_kd),
+        offsets=(BLOCK_C * pid_c, 0),
+        block_shape=(BLOCK_C, D),
+        order=(1, 0),
+    )
+    acc = acc * qk_scale
+    tl.store(grad_k_blk_ptr, acc.to(grad_k_ptr.dtype.element_ty))
+
+
+# ===================================================================================
+# Autograd wrapper and user-facing API (migrated from preattn.py)
+# ===================================================================================
+
+
+class _DeltaPreAttnFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        qo: torch.Tensor,
+        ko: torch.Tensor,
+        vo: torch.Tensor,
+        betao: Optional[torch.Tensor] = None,
+        C: int = BLOCK_SIZE_C
+    ):
+        u, ws, lses = _DeltaPreAttnFunction._forward_impl(qo, ko, vo, betao, C, need_aux=True)
+        BS, NH, T, _ = ko.size()
+        saved_beta = betao if betao is not None else torch.ones(BS, NH, T, device=ko.device, dtype=ko.dtype)
+        ctx.save_for_backward(qo, ko, vo, u, ws, lses, saved_beta)
+        ctx.C = C
+        ctx.beta_is_none = betao is None
+        return u
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_u: torch.Tensor
+    ):
+        qo, ko, vo, u, ws, lses, betao = ctx.saved_tensors
+        q = qo.flatten(0, 1)
+        k = ko.flatten(0, 1)
+        v = vo.flatten(0, 1)
+        beta = betao.flatten(0, 1)
+        grad_o = grad_u.flatten(0, 1)
+
+        C = ctx.C
+        BS, NH, T, D = ko.size()
+        grad_v = torch.empty_like(v)
+
+        qk_scale = 1.0 / math.sqrt(D)
+        fa_scale = qk_scale / math.log(2)
+        for i in range(T - C, -1, -C):
+            do = grad_o[:, i:i + C, :]
+            if i < T - C:
+                qi = k[:, i:i + C, :]
+                ki = q[:, i + C:, :]
+                lse = lses[:, i + C:]
+                beta_single = beta[:, i + C:]
+                du = backward_u_chunk(qi, ki, lse, grad_v[:, i + C:, :], fa_scale, beta_single)
+                do = grad_o[:, i:i + C, :] - du
+            else:
+                do = grad_o[:, i:i + C, :]
+            du = invcum.backward_x(do, ws[i // C])
+            grad_v[:, i:i + C, :].copy_(du)
+
+        grad_q, grad_k, grad_beta = backward_qk(q, k, u.flatten(0, 1), lses, grad_v, qk_scale, fa_scale, beta)
+        grad_beta_out = None if ctx.beta_is_none else grad_beta.view_as(betao)
+        return grad_q.view_as(ko), grad_k.view_as(ko), grad_v.view_as(vo), grad_beta_out, None
+
+    @staticmethod
+    def _forward_impl(
+        qo: torch.Tensor,
+        ko: torch.Tensor,
+        vo: torch.Tensor,
+        betao: Optional[torch.Tensor],
+        C: int,
+        need_aux: bool,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        BS, NH, T, D = ko.size()
+        q = qo.flatten(0, 1)
+        k = ko.flatten(0, 1)
+        v = vo.flatten(0, 1)
+        if betao is None:
+            beta = torch.ones(BS, NH, T, device=k.device, dtype=k.dtype)
+        else:
+            beta = betao
+        beta = beta.flatten(0, 1)
+
+        u = torch.empty_like(v)
+        qk_scale = 1.0 / math.sqrt(D)
+        fa_scale = qk_scale / math.log(2)
+        ws = torch.empty(T // C, BS * NH, C, C, device=k.device, dtype=k.dtype) if need_aux else None
+        lses = torch.empty(BS * NH, T, device=k.device, dtype=torch.float) if need_aux else None
+
+        for i in range(0, T, C):
+            qi = q[:, i:i + C, :]
+            ki = k[:, :i + C, :]
+            vi = v[:, i:i + C, :]
+            ui_prev = u[:, :i + C, :]
+            betai = beta[:, i:i + C]
+            w, lse_chunk = forward(qi, ki, vi, ui_prev, fa_scale, betai)
+            w = w * betai.unsqueeze(-1)
+            if need_aux:
+                ws[i // C].copy_(w)
+                lses[:, i:i + C].copy_(lse_chunk)
+            invcum.forward_inplace(u[:, i:i + C, :], w)
+
+        u = u.view(BS, NH, T, D)
+        return u, ws, lses
+
+
+def delta_pre_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: Optional[torch.Tensor] = None,
+    C: int = BLOCK_SIZE_C
+) -> torch.Tensor:
+    """
+    Fixed-length DeltaFormer pre-attention. Computes u given q, k, v, beta.
+    q,k,v: [B, H, T, D]
+    beta: [B, H, T]
+    Returns u with shape [B, H, T, D]
+    """
+    if k.requires_grad or q.requires_grad or v.requires_grad or (beta is not None and beta.requires_grad):
+        return _DeltaPreAttnFunction.apply(q, k, v, beta, C)
+    u, _, _ = _DeltaPreAttnFunction._forward_impl(q, k, v, beta, C, need_aux=False)
+    return u
+
+
+__all__ = [
+    'delta_pre_attn',
+]

--- a/fla/ops/deltaformer/invcum.py
+++ b/fla/ops/deltaformer/invcum.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+
+
+def forward(u, w):
+    return torch.linalg.solve_triangular(
+        w.float(),
+        u.float(),
+        upper=False,
+        unitriangular=True
+    ).to(u.dtype)
+
+
+def forward_inplace(u, w):
+    u.copy_(forward(u, w))
+
+
+def backward_x(do, w):
+    return torch.linalg.solve_triangular(
+        w.tril(-1).mH.float(),
+        do.float(),
+        upper=True,
+        unitriangular=True
+    ).to(do.dtype)
+
+
+def backward(do, w, x):
+    du = torch.linalg.solve_triangular(
+        w.tril(-1).mH.float(),
+        do.float(),
+        upper=True,
+        unitriangular=True
+    ).to(do.dtype)
+    dw = torch.bmm(-du, x.mH)
+    dw = dw.tril(-1)
+    return du, dw

--- a/fla/ops/deltaformer/naive.py
+++ b/fla/ops/deltaformer/naive.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import math
+from typing import Optional
+
+import torch
+
+
+def tril_softmax(scores: torch.Tensor, strict: bool = True) -> torch.Tensor:
+    """
+    Row-wise causal softmax over strictly lower-triangular (j < i) positions.
+
+    Args:
+        scores: [B, H, T, T] raw attention scores (q @ k^T).
+        strict: if True, mask out diagonal as well (strictly causal). Otherwise include diagonal.
+
+    Returns:
+        probs: [B, H, T, T] with probabilities on j < i (or j <= i if strict=False), zeros elsewhere.
+    """
+    T = scores.size(-1)
+    device = scores.device
+    i = torch.arange(T, device=device).view(1, 1, T, 1)
+    j = torch.arange(T, device=device).view(1, 1, 1, T)
+    if strict:
+        mask = (j < i)
+    else:
+        mask = (j <= i)
+
+    masked = scores.masked_fill(~mask, float('-inf'))
+    max_per_row = masked.max(dim=-1, keepdim=True).values
+    exp = (masked - max_per_row).exp()
+    exp = exp.masked_fill(~mask, 0.0)
+    denom = exp.sum(dim=-1, keepdim=True).clamp_min_(1e-20)
+    probs = exp / denom
+    return probs
+
+
+def delta_pre_attn_naive(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Naive reference implementation of DeltaFormer pre-attention.
+
+    Computes u[i] = v[i] - beta[i] * sum_{j<i} softmax(q[i] @ k[:i]^T) @ u[:i]
+
+    Args:
+        q: [B, H, T, D]
+        k: [B, H, T, D]
+        v: [B, H, T, D]
+        beta: [B, H, T] or None (defaults to ones)
+
+    Returns:
+        u: [B, H, T, D]
+    """
+    assert q.dim() == 4 and k.dim() == 4 and v.dim() == 4, "q,k,v must be [B,H,T,D]"
+    B, H, T, D = q.shape
+    assert k.shape == (B, H, T, D) and v.shape == (B, H, T, D)
+    if beta is None:
+        beta = q.new_ones((B, H, T))
+    else:
+        assert beta.shape == (B, H, T)
+
+    qk_scale = 1.0 / math.sqrt(D)
+    # [B,H,T,T] = [B,H,T,D] @ [B,H,D,T]
+    scores = torch.matmul(q, k.transpose(-1, -2)) * qk_scale
+    probs = tril_softmax(scores, strict=True)  # [B,H,T,T], zeros where j>=i
+
+    u = torch.empty_like(v)
+    for t in range(T):
+        if t == 0:
+            u[:, :, t, :] = v[:, :, t, :]
+        else:
+            w = probs[:, :, t, :t]  # [B,H,t]
+            uprev = u[:, :, :t, :]  # [B,H,t,D]
+            weighted_sum = (w.unsqueeze(-1) * uprev).sum(dim=-2)  # [B,H,D]
+            u[:, :, t, :] = v[:, :, t, :] - beta[:, :, t].unsqueeze(-1) * weighted_sum
+    return u
+
+
+__all__ = [
+    'delta_pre_attn_naive',
+    'tril_softmax',
+]

--- a/tests/models/test_modeling_deltaformer.py
+++ b/tests/models/test_modeling_deltaformer.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import torch
+
+from fla.models import DeltaFormerConfig
+
+from .test_modeling_base import run_test_generation, run_test_model_forward_backward
+
+
+# ===================================================================================
+# Test for Modeling (Forward/Backward Pass)
+# ===================================================================================
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        for test in [
+            (4, 4, 1024, 4, 64, True, torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+        ]
+    ]
+)
+def test_modeling(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    use_l2warp: bool,
+    dtype: torch.dtype,
+):
+    run_test_model_forward_backward(L, B, T, H, D, DeltaFormerConfig, use_l2warp=use_l2warp, dtype=dtype)
+
+
+# ===================================================================================
+# Test for Generation
+# ===================================================================================
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 4, 2000, 8, 64, torch.float16),
+        ]
+    ]
+)
+def test_generation(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    run_test_generation(L, B, T, H, D, DeltaFormerConfig, dtype)

--- a/tests/models/test_modeling_utils.py
+++ b/tests/models/test_modeling_utils.py
@@ -10,7 +10,7 @@ from fla.utils import device
 
 # Models that do not yet support variable sequence lengths (for modeling tests)
 MODELING_UNSUPPORTED_VARLEN = [
-    "ABCConfig", "ForgettingTransformerConfig", "LinearAttentionConfig", "LightNetConfig",
+    "ABCConfig", "ForgettingTransformerConfig", "LinearAttentionConfig", "LightNetConfig", "DeltaFormerConfig",
     "Mamba2Config", "MambaConfig", "MesaNetConfig", "SambaConfig",
     "RodimusConfig",
 ]
@@ -24,6 +24,7 @@ HOPPER_EXCLUSIVE = []
 GENERATION_UNSUPPORTED = [
     "ABCConfig", "LinearAttentionConfig", "LightNetConfig",
     "Mamba2Config", "MambaConfig", "NSAConfig", "SambaConfig", "RWKV6Config", "RWKV7Config",
+    "DeltaFormerConfig",
 ]
 
 


### PR DESCRIPTION
- Introduces [DeltaFormer](https://arxiv.org/pdf/2505.19488) layer and model.
- Adds fused Triton ops for chunked pre-attention: `fla/ops/deltaformer/fused_chunk.py`, `invcum.py`, and `naive.py`. The pre-attention calculates the u vector, which is a substitute for v that can be directly integrated into flash attention func.
- Kernels 1 and 2 are both softmax in this version, omitted alpha scaling factor for v in u's calculation.
- The current similarity calculation comes in the form of dot products between q and k. To recover kk similarity or kw similarity (as in the paper), one only needs to change the parameter being passed into the pre-attention stage.
- Includes unit tests and integration updates for the new model.
- Preserves backward compatibility. The optional `beta` defaults to all ones when not provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced the DeltaFormer model family (config, base model, and causal LM) with generation support and top-level availability via auto-loading.
  - Added a DeltaFormer attention mechanism with optional per-head normalization and grouped KV heads.
  - Included high-performance pre-attention operators with a naive reference; Flash Attention recommended for best performance.

- Tests
  - Added forward/backward and generation tests for DeltaFormer.
  - Updated test configuration to skip unsupported variable-length and certain generation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->