### PR TITLE
[FIX] Correct cumsum dimension in normalize_output

### DIFF
--- a/fla/ops/linear_attn/utils.py
+++ b/fla/ops/linear_attn/utils.py
@@ -5,6 +5,6 @@ import torch
 
 @torch.jit.script
 def normalize_output(q, k, o):
-    k = k.cumsum(-2)
+    k = k.cumsum(1)
     z = (q * k).sum(-1, keepdim=True)
     return o / (z + 1e-10)

--- a/fla/ops/linear_attn/utils.py
+++ b/fla/ops/linear_attn/utils.py
@@ -4,7 +4,7 @@ import torch
 
 
 @torch.jit.script
-def normalize_output(q, k, o):
+def normalize_output(q: torch.Tensor, k: torch.Tensor, o: torch.Tensor) -> torch.Tensor:
     k = k.cumsum(1)
     z = (q * k).sum(-1, keepdim=True)
     return o / (z + 1e-10)


### PR DESCRIPTION
This pull request addresses a bug in the `normalize_output` utility function used for vanilla linear attention.

The current implementation calculates the cumulative sum of the key tensor k along dim=-2. For an input tensor with shape [B, T, H, K], this corresponds to the heads (H) dimension.

However, for causal linear attention, the normalization factor at each time step t must be based on the sum of all keys up to and including that time step. This requires the cumulative sum to be performed along the sequence length (T) dimension, which is dim=1.

The fix is a one-line change in the normalize_output function:

- Before: `k = k.cumsum(-2)`
- After: `k = k.cumsum(1)`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the normalization behavior in linear attention to aggregate over the intended dimension, improving consistency of outputs across sequences.
  * Reduces numerical discrepancies and eliminates subtle artifacts that could appear in attention-derived results for multi-token inputs.
  * No changes to public APIs; existing workflows continue to work as before with more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->