### PR TITLE
[Triton] Add autotune caching support for Triton kernels

### DIFF
--- a/ENVs.md
+++ b/ENVs.md
@@ -5,5 +5,5 @@
 | `FLA_NO_USE_TMA` | `0` | `0` or `1` | Set to `1` to disable Tensor Memory Accelerator (TMA) on Hopper or Blackwell GPUs. |
 | `FLA_CONV_BACKEND` | `cuda` | `triton` or `cuda` | Choose the convolution backend. `cuda` is the default and preferred for most cases. |
 | `FLA_USE_FAST_OPS` | `0` | `0` or `1` | Enable faster, but potentially less accurate, operations when set to `1`. |
-| `FLA_CACHE_RESULTS` | `1` | `0` or `1` | whether to cache autotune timings to disk. Defaults to True |
+| `FLA_CACHE_RESULTS` | `1` | `0` or `1` | Whether to cache autotune timings to disk. Defaults to `1` (enabled). |
 | `FLA_TRIL_PRECISION` | `ieee` | `ieee`, `tf32`, `tf32x3` | Controls the precision for triangular operations. `tf32x3` is only available on NV GPUs. |

--- a/ENVs.md
+++ b/ENVs.md
@@ -5,4 +5,5 @@
 | `FLA_NO_USE_TMA` | `0` | `0` or `1` | Set to `1` to disable Tensor Memory Accelerator (TMA) on Hopper or Blackwell GPUs. |
 | `FLA_CONV_BACKEND` | `cuda` | `triton` or `cuda` | Choose the convolution backend. `cuda` is the default and preferred for most cases. |
 | `FLA_USE_FAST_OPS` | `0` | `0` or `1` | Enable faster, but potentially less accurate, operations when set to `1`. |
+| `FLA_CACHE_RESULTS` | `1` | `0` or `1` | whether to cache autotune timings to disk. Defaults to True |
 | `FLA_TRIL_PRECISION` | `ieee` | `ieee`, `tf32`, `tf32x3` | Controls the precision for triangular operations. `tf32x3` is only available on NV GPUs. |

--- a/fla/modules/activations.py
+++ b/fla/modules/activations.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp, log
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, is_amd
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard, is_amd
 
 try:
     from torch.distributed.tensor import DTensor
@@ -23,7 +23,8 @@ NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def sigmoid_fwd_kernel(
@@ -46,7 +47,8 @@ def sigmoid_fwd_kernel(
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def sigmoid_bwd_kernel(
@@ -101,7 +103,8 @@ sigmoid = SigmoidFunction.apply
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def logsigmoid_fwd_kernel(
@@ -129,7 +132,8 @@ def logsigmoid_fwd_kernel(
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def logsigmoid_bwd_kernel(
@@ -204,7 +208,8 @@ def logsigmoid(x: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def swish_fwd_kernel(
@@ -228,7 +233,8 @@ def swish_fwd_kernel(
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def swish_bwd_kernel(
@@ -400,7 +406,8 @@ sqrelu = SquaredReLUFunction.apply
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def swiglu_fwd_kernel(
@@ -428,7 +435,8 @@ def swiglu_fwd_kernel(
         for bs in [512, 1024, 2048, 4096, 8192]
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def swiglu_fwdbwd_kernel(

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -13,7 +13,7 @@ import triton.language as tl
 from einops import rearrange
 
 from fla.ops.utils import prepare_chunk_indices, prepare_sequence_ids
-from fla.utils import get_multiprocessor_count, input_guard, is_amd
+from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard, is_amd
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [4, 8, 16, 32]
 STATIC_WARPS = 32 if not is_amd else 16
@@ -41,6 +41,7 @@ except ImportError:
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
     key=['D', 'W', 'NB'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def causal_conv1d_fwd_kernel(
@@ -148,6 +149,7 @@ def causal_conv1d_fwd_kernel(
         for num_warps in [4, 8, 16, 32]
     ],
     key=['D', 'W', 'NB'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def causal_conv1d_bwd_kernel(

--- a/fla/modules/fused_bitlinear.py
+++ b/fla/modules/fused_bitlinear.py
@@ -18,7 +18,7 @@ import triton
 import triton.language as tl
 
 from fla.modules.layernorm import RMSNorm
-from fla.utils import get_multiprocessor_count, input_guard, is_amd, require_version
+from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard, is_amd, require_version
 
 NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
 
@@ -63,6 +63,7 @@ def weight_quant(w):
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
     key=["N", "HAS_RESIDUAL", "STORE_RESIDUAL_OUT", "IS_RMS_NORM", "HAS_BIAS"],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_fwd_kernel_quant(
@@ -197,6 +198,7 @@ def layer_norm_fwd_quant(
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
     key=["N", "HAS_DRESIDUAL", "STORE_DRESIDUAL", "IS_RMS_NORM", "HAS_BIAS"],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_bwd_kernel(

--- a/fla/modules/fused_norm_gate.py
+++ b/fla/modules/fused_norm_gate.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
-from fla.utils import get_multiprocessor_count, input_guard
+from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard
 
 
 @triton.heuristics({
@@ -28,6 +28,7 @@ from fla.utils import get_multiprocessor_count, input_guard
         for num_warps in [4, 8, 16]
     ],
     key=['D', 'NB', 'IS_RMS_NORM', 'STORE_RESIDUAL_OUT', 'HAS_RESIDUAL', 'HAS_WEIGHT'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_gated_fwd_kernel(
@@ -116,6 +117,7 @@ def layer_norm_gated_fwd_kernel(
         for num_warps in [2, 4, 8, 16]
     ],
     key=['D', 'IS_RMS_NORM', 'STORE_RESIDUAL_OUT', 'HAS_RESIDUAL', 'HAS_WEIGHT'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_gated_fwd_kernel1(
@@ -200,6 +202,7 @@ def layer_norm_gated_fwd_kernel1(
         for num_warps in [4, 8, 16]
     ],
     key=['D', 'NB', 'IS_RMS_NORM', 'HAS_DRESIDUAL', 'HAS_WEIGHT'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_gated_bwd_kernel(
@@ -325,6 +328,7 @@ def layer_norm_gated_bwd_kernel(
         for num_warps in [2, 4, 8, 16]
     ],
     key=['D', 'IS_RMS_NORM', 'STORE_DRESIDUAL', 'HAS_DRESIDUAL', 'HAS_WEIGHT'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_gated_bwd_kernel1(

--- a/fla/modules/grpo.py
+++ b/fla/modules/grpo.py
@@ -55,7 +55,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp, log
-from fla.utils import input_guard, is_amd
+from fla.utils import autotune_cache_kwargs, input_guard, is_amd
 
 NUM_WARPS_AUTOTUNE = [4, 8, 16] if is_amd else [4, 8, 16, 32]
 
@@ -67,7 +67,8 @@ NUM_WARPS_AUTOTUNE = [4, 8, 16] if is_amd else [4, 8, 16, 32]
         for NUM_WARPS in NUM_WARPS_AUTOTUNE
         for NUM_STAGES in [1, 2, 4]
     ],
-    key=['B', 'N']
+    key=['B', 'N'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def grpo_fwd_kernel(
@@ -142,7 +143,8 @@ def grpo_fwd_kernel(
         for NUM_WARPS in [32]
         for NUM_STAGES in [4]
     ],
-    key=['B', 'N']
+    key=['B', 'N'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def grpo_bwd_kernel(

--- a/fla/modules/l2norm.py
+++ b/fla/modules/l2norm.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 
-from fla.utils import input_guard, is_amd
+from fla.utils import autotune_cache_kwargs, input_guard, is_amd
 
 BT_LIST = [8, 16, 32, 64, 128]
 NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
@@ -19,7 +19,8 @@ NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
         triton.Config({}, num_warps=num_warps)
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def l2norm_fwd_kernel1(
@@ -49,7 +50,8 @@ def l2norm_fwd_kernel1(
         triton.Config({}, num_warps=num_warps)
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def l2norm_bwd_kernel1(
@@ -81,7 +83,8 @@ def l2norm_bwd_kernel1(
         for num_warps in [1, 2, 4, 8, 16]
         for BT in BT_LIST
     ],
-    key=['D', 'NB']
+    key=['D', 'NB'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def l2norm_fwd_kernel(
@@ -114,7 +117,8 @@ def l2norm_fwd_kernel(
         for num_warps in [1, 2, 4, 8, 16]
         for BT in BT_LIST
     ],
-    key=['D', 'NB']
+    key=['D', 'NB'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def l2norm_bwd_kernel(

--- a/fla/modules/layernorm.py
+++ b/fla/modules/layernorm.py
@@ -24,7 +24,7 @@ from torch.distributed import DeviceMesh
 from torch.distributed.tensor import Replicate, Shard, distribute_module
 from torch.distributed.tensor.parallel import ParallelStyle
 
-from fla.utils import get_multiprocessor_count, input_guard
+from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard
 
 try:
     from torch.distributed.tensor import DTensor
@@ -184,6 +184,7 @@ class GroupNormRef(nn.Module):
         for num_warps in [2, 4, 8]
     ],
     key=['D', 'NB', 'HAS_RESIDUAL', 'STORE_RESIDUAL_OUT', 'IS_RMS_NORM'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_fwd_kernel(
@@ -257,6 +258,7 @@ def layer_norm_fwd_kernel(
         for num_warps in [2, 4, 8, 16]
     ],
     key=['D', 'HAS_RESIDUAL', 'STORE_RESIDUAL_OUT', 'IS_RMS_NORM'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_fwd_kernel1(
@@ -329,6 +331,7 @@ def layer_norm_fwd_kernel1(
         for num_warps in [2, 4, 8]
     ],
     key=['D', 'NB', 'HAS_DRESIDUAL', 'STORE_DRESIDUAL', 'IS_RMS_NORM'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_bwd_kernel(
@@ -438,6 +441,7 @@ def layer_norm_bwd_kernel(
         for num_warps in [2, 4, 8]
     ],
     key=['D', 'HAS_DRESIDUAL', 'STORE_DRESIDUAL', 'IS_RMS_NORM'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def layer_norm_bwd_kernel1(

--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -10,7 +10,7 @@ import triton.language as tl
 from einops import rearrange, repeat
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.utils import get_multiprocessor_count, input_guard, is_amd
+from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard, is_amd
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -39,6 +39,7 @@ def rotary_embedding_ref(x, cos, sin, interleaved=False):
         for num_stages in [2, 3, 4]
     ],
     key=['B', 'H', 'D', 'INTERLEAVED'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def rotary_embedding_kernel(

--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.utils import get_multiprocessor_count, input_guard, is_amd, tensor_cache
+from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard, is_amd, tensor_cache
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -59,6 +59,7 @@ def token_shift_ref(
         for num_stages in [1, 2, 3]
     ],
     key=['BD'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def token_shift_fwd_kernel_short(
@@ -149,7 +150,8 @@ def token_shift_fwd_kernel_short(
         for num_warps in NUM_WARPS_AUTOTUNE
         for num_stages in [1, 2, 3]
     ],
-    key=['BD', 'NB']
+    key=['BD', 'NB'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def token_shift_fwd_kernel_long(
@@ -223,6 +225,7 @@ def token_shift_fwd_kernel_long(
         for num_stages in [1, 2, 3]
     ],
     key=['BD'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def token_shift_bwd_kernel_short(
@@ -299,7 +302,8 @@ def token_shift_bwd_kernel_short(
         for num_warps in NUM_WARPS_AUTOTUNE
         for num_stages in [1, 2, 3]
     ],
-    key=['BD', 'NB']
+    key=['BD', 'NB'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def token_shift_bwd_kernel_long(

--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils.cumsum import chunk_global_cumsum
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem
+from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 
 @triton.heuristics({
@@ -22,6 +22,7 @@ from fla.utils import check_shared_mem
         for num_stages in [2, 3, 4, 5]
     ],
     key=['H', 'G', 'K', 'V', 'BK', 'BV', 'USE_G'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def naive_attn_decoding_kernel(

--- a/fla/ops/comba/utils.py
+++ b/fla/ops/comba/utils.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.index import prepare_chunk_indices
+from fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics({
@@ -15,7 +16,8 @@ from fla.ops.utils.index import prepare_chunk_indices
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['B', 'H', 'BT', 'IS_VARLEN']
+    key=['B', 'H', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_comba_cumsum_scalar_fwd_kernel(
@@ -96,7 +98,8 @@ def chunk_comba_cumsum_scalar_fwd(
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['B', 'H', 'BT', 'IS_VARLEN']
+    key=['B', 'H', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_comba_cumsum_scalar_bwd_kernel(

--- a/fla/ops/comba/wy_fast.py
+++ b/fla/ops/comba/wy_fast.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem
+from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 
 @triton.heuristics({
@@ -24,6 +24,7 @@ from fla.utils import check_shared_mem
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'BT', 'IS_VARLEN', 'USE_G'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_scaled_dot_comba_pkt_fwd_kernel(
@@ -147,7 +148,8 @@ def chunk_scaled_dot_comba_pkt_fwd(
         for num_warps in [2, 4]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN']
+    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_bwd_kernel(
@@ -276,6 +278,7 @@ def prepare_wy_repr_bwd_kernel(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def recompute_w_u_fwd_kernel(

--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp
-from fla.utils import is_nvidia_hopper, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, is_nvidia_hopper, use_cuda_graph
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
 
@@ -31,6 +31,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
     ],
     key=['H', 'K', 'V', 'BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
@@ -235,6 +236,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     ],
     key=['H', 'K', 'V', 'BT', 'BV', 'USE_G'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_offsets
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem
+from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
@@ -27,7 +27,8 @@ BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV']
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_fwd_kernel_h(
@@ -153,7 +154,8 @@ def chunk_fwd_kernel_h(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV']
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dh(

--- a/fla/ops/common/chunk_h_parallel.py
+++ b/fla/ops/common/chunk_h_parallel.py
@@ -13,6 +13,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp
+from fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics({
@@ -28,7 +29,8 @@ from fla.ops.utils.op import exp
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV']
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_fwd_kernel_h_parallel(
@@ -142,7 +144,8 @@ def chunk_fwd_kernel_h_parallel(
         for num_warps in [2, 4, 8, 16]
         for num_stages in [2, 3]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV']
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_fwd_kernel_h_reduction(
@@ -227,7 +230,8 @@ def chunk_fwd_kernel_h_reduction(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV']
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dh_parallel(
@@ -330,7 +334,8 @@ def chunk_bwd_kernel_dh_parallel(
         for num_warps in [2, 4, 8, 16]
         for num_stages in [2, 3]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV']
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dh_reduction(

--- a/fla/ops/common/chunk_h_split.py
+++ b/fla/ops/common/chunk_h_split.py
@@ -8,6 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
+from fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics({
@@ -24,6 +25,7 @@ from fla.ops.utils.op import exp
         for num_stages in [2, 3]
     ],
     key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_fwd_kernel_h_split(
@@ -143,6 +145,7 @@ def chunk_fwd_kernel_h_split(
         for num_stages in [2, 3, 4]
     ],
     key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_fwd_kernel_h_reduction(
@@ -229,6 +232,7 @@ def chunk_fwd_kernel_h_reduction(
         for num_stages in [2, 3]
     ],
     key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dh_split(
@@ -347,6 +351,7 @@ def chunk_bwd_kernel_dh_split(
         for num_stages in [2, 3, 4]
     ],
     key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dh_reduction(

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem, is_nvidia_hopper
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_nvidia_hopper
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
@@ -27,6 +27,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         triton.Config({'BK': 32, 'BV': 32}, num_warps=2, num_stages=3),
     ],
     key=['H', 'K', 'V', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_fwd_kernel_o(
@@ -132,6 +133,7 @@ def chunk_fwd_kernel_o(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_DW'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dqkwg(
@@ -314,6 +316,7 @@ def chunk_bwd_kernel_dqkwg(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'USE_G', 'USE_G_GAMMA'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dv(
@@ -408,6 +411,7 @@ def chunk_bwd_kernel_dv(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'USE_G'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dv_local(

--- a/fla/ops/common/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/chunk_scaled_dot_kkt.py
@@ -9,6 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
+from fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics({
@@ -23,6 +24,7 @@ from fla.ops.utils.op import exp
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_scaled_dot_kkt_fwd_kernel(
@@ -83,7 +85,8 @@ def chunk_scaled_dot_kkt_fwd_kernel(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BC"]
+    key=["BC"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
@@ -159,7 +162,8 @@ def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
         triton.Config({}, num_warps=4),
         triton.Config({}, num_warps=8),
     ],
-    key=["BK", "BT"]
+    key=["BK", "BT"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_intra(

--- a/fla/ops/common/fused_chunk.py
+++ b/fla/ops/common/fused_chunk.py
@@ -9,7 +9,14 @@ import triton.language as tl
 
 from fla.ops.utils import chunk_local_cumsum
 from fla.ops.utils.op import exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, input_guard, is_nvidia_hopper
+from fla.utils import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    autotune_cache_kwargs,
+    check_shared_mem,
+    input_guard,
+    is_nvidia_hopper
+)
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
@@ -30,6 +37,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_chunk_fwd_kernel(
@@ -163,6 +171,7 @@ def fused_chunk_fwd_kernel(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_chunk_bwd_kernel(

--- a/fla/ops/common/fused_recurrent.py
+++ b/fla/ops/common/fused_recurrent.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -22,6 +22,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
         for num_warps in [4, 8]
     ],
     key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['B', 'T'])
 def fused_recurrent_fwd_kernel(
@@ -134,6 +135,7 @@ def fused_recurrent_fwd_kernel(
         for num_warps in [4]
     ],
     key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['B', 'T'])
 def fused_recurrent_bwd_kernel(

--- a/fla/ops/delta_rule/parallel.py
+++ b/fla/ops/delta_rule/parallel.py
@@ -10,7 +10,7 @@ import triton.language as tl
 from einops import rearrange
 
 from fla.ops.delta_rule.wy_fast import fwd_prepare_T
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 
 @triton.autotune(
@@ -19,6 +19,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
         for num_warps in [1, 2, 4]
     ],
     key=['BT', 'K', 'V'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_transform_qk_fwd_kernel(
@@ -126,6 +127,7 @@ def chunk_transform_qk_fwd(
         triton.Config({}, num_warps=2),
     ],
     key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def save_intra_chunk_attn(

--- a/fla/ops/delta_rule/wy_fast.py
+++ b/fla/ops/delta_rule/wy_fast.py
@@ -10,7 +10,7 @@ import triton.language as tl
 from fla.ops.common.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.solve_tril import solve_tril
-from fla.utils import check_shared_mem, is_nvidia_hopper
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_nvidia_hopper
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
 
@@ -25,6 +25,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def recompute_w_u_fwd_kernel(
@@ -86,6 +87,7 @@ def recompute_w_u_fwd_kernel(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_bwd_kernel(

--- a/fla/ops/gated_delta_product/chunk_deltaproduct_h.py
+++ b/fla/ops/gated_delta_product/chunk_deltaproduct_h.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp
-from fla.utils import is_nvidia_hopper, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, is_nvidia_hopper, use_cuda_graph
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
 
@@ -30,6 +30,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
     ],
     key=['H', 'K', 'V', 'BT', 'USE_G'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gated_delta_product_fwd_kernel_h_blockdim64(
@@ -208,6 +209,7 @@ def chunk_gated_delta_product_fwd_kernel_h_blockdim64(
     ],
     key=['H', 'K', 'V', 'BT', 'BV', 'USE_G'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gated_delta_product_bwd_kernel_dhu_blockdim64(

--- a/fla/ops/gated_delta_product/chunk_deltaproduct_o.py
+++ b/fla/ops/gated_delta_product/chunk_deltaproduct_o.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem, is_nvidia_hopper
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_nvidia_hopper
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
@@ -28,6 +28,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_fwd_kernel_o(

--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem
+from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 
 @triton.heuristics({
@@ -21,7 +21,8 @@ from fla.utils import check_shared_mem
         for num_warps in [2, 4]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN']
+    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_bwd_kernel(
@@ -139,6 +140,7 @@ def prepare_wy_repr_bwd_kernel(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def recompute_w_u_fwd_kernel(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp, gather
-from fla.utils import check_shared_mem, is_amd, is_gather_supported, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_amd, is_gather_supported, use_cuda_graph
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -25,6 +25,7 @@ NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
     ],
     key=['BK', 'BT', 'K'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_bwd_kernel_intra(
@@ -230,6 +231,7 @@ def chunk_dplr_bwd_kernel_intra(
     ],
     key=['BK', 'BT', 'K'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_bwd_dgk_kernel(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp, gather
-from fla.utils import is_amd, is_gather_supported, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, is_amd, is_gather_supported, use_cuda_graph
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -25,6 +25,7 @@ NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
     ],
     key=['BK', 'BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_fwd_A_kernel_intra_sub_intra(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem, is_amd, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_amd, use_cuda_graph
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -27,6 +27,7 @@ NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
     ],
     key=['BT', 'BK', 'BV', "V"],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_bwd_kernel_dhu(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem, is_amd, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_amd, use_cuda_graph
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -27,6 +27,7 @@ NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
     ],
     key=['BT', 'BK', 'BV'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_fwd_kernel_h(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem, is_amd, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_amd, use_cuda_graph
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -27,6 +27,7 @@ BK_LIST = [32, 64, 128] if check_shared_mem() else [16, 32]
     ],
     key=['BV', 'BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_bwd_kernel_dAu(
@@ -99,6 +100,7 @@ def chunk_dplr_bwd_kernel_dAu(
     ],
     key=['BT', 'BK', 'BV'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit
 def chunk_dplr_bwd_o_kernel(
@@ -228,6 +230,7 @@ def chunk_dplr_bwd_o_kernel(
     ],
     key=['BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit
 def chunk_dplr_bwd_kernel_dv(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.utils import check_shared_mem, is_amd, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_amd, use_cuda_graph
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -28,6 +28,7 @@ BK_LIST = [32, 64, 128] if check_shared_mem() else [16, 32]
     ],
     key=['BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_dplr_fwd_kernel_o(

--- a/fla/ops/generalized_delta_rule/dplr/fused_recurrent.py
+++ b/fla/ops/generalized_delta_rule/dplr/fused_recurrent.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, use_cuda_graph
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard, use_cuda_graph
 
 
 @triton.heuristics({
@@ -25,6 +25,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, use
     ],
     key=['BK'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_dplr_delta_rule_fwd_kernel(

--- a/fla/ops/generalized_delta_rule/dplr/wy_fast_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/wy_fast_bwd.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.utils import check_shared_mem, is_intel_alchemist, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_intel_alchemist, use_cuda_graph
 
 # https://github.com/intel/intel-xpu-backend-for-triton/issues/3449
 triton_config = {'grf_mode': 'large'} if is_intel_alchemist else {}
@@ -25,6 +25,7 @@ triton_config = {'grf_mode': 'large'} if is_intel_alchemist else {}
     ],
     key=['BT', 'BK', 'BV'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_bwd_kernel(

--- a/fla/ops/generalized_delta_rule/dplr/wy_fast_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/wy_fast_fwd.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import gather
-from fla.utils import is_gather_supported, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, is_gather_supported, use_cuda_graph
 
 
 @triton.heuristics({
@@ -22,6 +22,7 @@ from fla.utils import is_gather_supported, use_cuda_graph
     ],
     key=['BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_fwd_kernel_chunk32(
@@ -67,6 +68,7 @@ def prepare_wy_repr_fwd_kernel_chunk32(
     ],
     key=['BC'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_fwd_kernel_chunk64(
@@ -146,6 +148,7 @@ def prepare_wy_repr_fwd_kernel_chunk64(
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def wu_fwd_kernel(

--- a/fla/ops/generalized_delta_rule/iplr/chunk.py
+++ b/fla/ops/generalized_delta_rule/iplr/chunk.py
@@ -10,7 +10,14 @@ import triton.language as tl
 
 from fla.ops.generalized_delta_rule.iplr.wy_fast import prepare_wy_repr_fwd
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, input_guard, use_cuda_graph
+from fla.utils import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    autotune_cache_kwargs,
+    check_shared_mem,
+    input_guard,
+    use_cuda_graph
+)
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 
@@ -27,6 +34,7 @@ BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
     ],
     key=['BT', 'BK', 'BV'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_generalized_iplr_delta_rule_fwd_kernel_h(
@@ -111,6 +119,7 @@ def chunk_generalized_iplr_delta_rule_fwd_kernel_h(
     ],
     key=['BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_generalized_iplr_delta_rule_fwd_kernel_o(

--- a/fla/ops/generalized_delta_rule/iplr/fused_recurrent.py
+++ b/fla/ops/generalized_delta_rule/iplr/fused_recurrent.py
@@ -7,7 +7,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.utils import input_guard
+from fla.utils import autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -23,6 +23,7 @@ from fla.utils import input_guard
         for num_stages in [2, 3, 4]
     ],
     key=["BK"],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def fused_recurrent_fwd_kernel(
@@ -113,6 +114,7 @@ def fused_recurrent_fwd_kernel(
         for num_stages in [2, 3]
     ],
     key=["BK", "BV"],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def fused_recurrent_bwd_kernel(

--- a/fla/ops/generalized_delta_rule/iplr/wy_fast.py
+++ b/fla/ops/generalized_delta_rule/iplr/wy_fast.py
@@ -9,7 +9,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.utils import check_shared_mem, is_nvidia_hopper
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_nvidia_hopper
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
 
@@ -22,7 +22,8 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8, 16]
     ],
-    key=['BK']
+    key=['BK'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_fwd_kernel_chunk32(
@@ -76,7 +77,8 @@ def prepare_wy_repr_fwd_kernel_chunk32(
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8, 16]
     ],
-    key=['BK']
+    key=['BK'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def prepare_wy_repr_fwd_kernel_chunk64(
@@ -156,7 +158,8 @@ def prepare_wy_repr_fwd_kernel_chunk64(
         triton.Config({}, num_warps=num_warps)
         for num_warps in NUM_WARPS
     ],
-    key=['BT', 'BK', 'BV']
+    key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def wu_fwd_kernel(

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -11,7 +11,7 @@ from fla.ops.common.chunk_h import chunk_bwd_dh, chunk_fwd_h
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cumsum import chunk_local_cumsum
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem, input_guard
+from fla.utils import autotune_cache_kwargs, check_shared_mem, input_guard
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
@@ -27,7 +27,8 @@ BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BC"]
+    key=["BC"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_fwd_A_kernel_intra_sub_inter(
@@ -100,7 +101,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         triton.Config({}, num_warps=4),
         triton.Config({}, num_warps=8),
     ],
-    key=["BK", "BT"]
+    key=["BK", "BT"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_fwd_A_kernel_intra_sub_intra(
@@ -165,7 +167,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
         triton.Config({}, num_warps=4),
         triton.Config({}, num_warps=8),
     ],
-    key=['BC', 'BK']
+    key=['BC', 'BK'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
@@ -236,7 +239,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
         triton.Config({}, num_warps=4),
         triton.Config({}, num_warps=8),
     ],
-    key=['BC']
+    key=['BC'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
@@ -285,6 +289,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
         for num_warps in [2, 4, 8]
     ],
     key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_fwd_kernel_o(
@@ -361,6 +366,7 @@ def chunk_gla_fwd_kernel_o(
         for num_warps in [1, 2, 4, 8]
     ],
     key=['BK', 'NC', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_bwd_kernel_intra(
@@ -497,6 +503,7 @@ def chunk_gla_bwd_kernel_intra(
         triton.Config({}, num_warps=8),
     ],
     key=['BV', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_bwd_kernel_dA(
@@ -546,6 +553,7 @@ def chunk_gla_bwd_kernel_dA(
         for num_warps in [2, 4, 8]
     ],
     key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_bwd_kernel_dv(
@@ -620,6 +628,7 @@ def chunk_gla_bwd_kernel_dv(
         for num_warps in [2, 4, 8]
     ],
     key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gla_bwd_kernel_inter(

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -15,7 +15,7 @@ from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cumsum import chunk_local_cumsum
 from fla.ops.utils.op import exp
 from fla.ops.utils.softmax import softmax_bwd, softmax_fwd
-from fla.utils import input_guard
+from fla.utils import autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -29,7 +29,8 @@ from fla.utils import input_guard
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT']
+    key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gsa_fwd_k_kernel_inter(
@@ -190,7 +191,8 @@ def chunk_gsa_fwd_k_kernel_intra(
         triton.Config({}, num_warps=num_warps)
         for num_warps in [2, 4, 8]
     ],
-    key=["BT"]
+    key=["BT"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gsa_bwd_k_kernel_dA(
@@ -290,7 +292,8 @@ def chunk_gsa_bwd_k_kernel_dA(
         for num_warps in [2, 4]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT']
+    key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_gsa_bwd_k_kernel_dqkvg(

--- a/fla/ops/hgrn/chunk.py
+++ b/fla/ops/hgrn/chunk.py
@@ -25,7 +25,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import input_guard
+from fla.utils import autotune_cache_kwargs, input_guard
 
 
 @triton.autotune(
@@ -43,7 +43,8 @@ from fla.utils import input_guard
         triton.Config({'BD': 128}, num_warps=4),
         triton.Config({'BD': 128}, num_warps=8),
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_hgrn_fwd_kernel_h(
@@ -122,7 +123,8 @@ def chunk_hgrn_fwd_kernel_o(
         for BD in [32, 64, 128]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_hgrn_bwd_kernel_h(

--- a/fla/ops/hgrn/fused_recurrent.py
+++ b/fla/ops/hgrn/fused_recurrent.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import input_guard
+from fla.utils import autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -22,7 +22,8 @@ from fla.utils import input_guard
         for BD in [32, 64, 128]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_hgrn_fwd_kernel(
@@ -83,7 +84,8 @@ def fused_recurrent_hgrn_fwd_kernel(
         for BD in [32, 64, 128]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_hgrn_bwd_kernel(

--- a/fla/ops/log_linear_attn/chunk.py
+++ b/fla/ops/log_linear_attn/chunk.py
@@ -11,7 +11,7 @@ from einops import reduce
 
 from fla.ops.utils import chunk_local_cumsum
 from fla.ops.utils.op import safe_exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 BLOCK_K = 64
 
@@ -30,6 +30,7 @@ BLOCK_K = 64
         for num_stages in [2, 3, 4]
     ],
     key=["H", "K", "V"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=["T"])
 def chunkwise_fwd_kernel(
@@ -917,6 +918,7 @@ def copy_last_chunk_kernel(
     ],
     key=["H", "K", "V"],
     restore_value=["dh", "dg_last"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=["T"])
 def chunkwise_bwd_kernel_dhg(
@@ -1033,6 +1035,7 @@ def chunkwise_bwd_kernel_dhg(
     ],
     key=["H", "K", "V"],
     restore_value=["dq", "dg"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=["T"])
 def chunkwise_bwd_kernel_hdqgl(
@@ -1180,6 +1183,7 @@ def chunkwise_bwd_kernel_hdqgl(
     ],
     key=["H", "K", "V"],
     restore_value=["dk", "dg", "dg_last"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=["T"])
 def chunkwise_bwd_kernel_dkg(
@@ -1267,6 +1271,7 @@ def chunkwise_bwd_kernel_dkg(
     ],
     key=["H", "K", "V"],
     restore_value=["dv"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=["T"])
 def chunkwise_bwd_kernel_dv(
@@ -1329,6 +1334,7 @@ def chunkwise_bwd_kernel_dv(
     ],
     key=["H", "K", "V"],
     restore_value=["dl", "dq", "dk", "dv", "dg"],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=["T"])
 def chunkwise_bwd_kernel_diag(

--- a/fla/ops/mesa_net/chunk_h_fwd.py
+++ b/fla/ops/mesa_net/chunk_h_fwd.py
@@ -9,6 +9,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_offsets
 from fla.ops.utils.op import exp
+from fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics({
@@ -22,7 +23,8 @@ from fla.ops.utils.op import exp
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT']
+    key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_mesa_net_fwd_kernel_h(

--- a/fla/ops/mesa_net/chunk_h_kv_intra_bwd.py
+++ b/fla/ops/mesa_net/chunk_h_kv_intra_bwd.py
@@ -8,7 +8,7 @@ import triton.language as tl
 from fla.ops.mesa_net.chunk_h_kv_intra_bwd_separate import chunk_mesa_net_h_kv_bwd_intra_separate_fn
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
-from fla.utils import check_shared_mem, is_nvidia_hopper
+from fla.utils import autotune_cache_kwargs, check_shared_mem, is_nvidia_hopper
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
 
@@ -23,6 +23,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_mesa_net_h_kv_bwd_intra_kernel(

--- a/fla/ops/mesa_net/chunk_h_kv_intra_bwd_separate.py
+++ b/fla/ops/mesa_net/chunk_h_kv_intra_bwd_separate.py
@@ -7,7 +7,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp
-from fla.utils import is_nvidia_hopper
+from fla.utils import autotune_cache_kwargs, is_nvidia_hopper
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
 
@@ -22,6 +22,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_mesa_net_h_kv_bwd_intra_kernel_dkv(
@@ -140,6 +141,7 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dkv(
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'K', 'V', 'BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_mesa_net_h_kv_bwd_intra_kernel_dq(

--- a/fla/ops/nsa/compression.py
+++ b/fla/ops/nsa/compression.py
@@ -10,7 +10,7 @@ import triton.language as tl
 from fla.ops.attn.parallel import parallel_attn_bwd_preprocess
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets, prepare_token_indices
 from fla.ops.utils.op import exp, log
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, check_shared_mem, contiguous
 
 
 @triton.heuristics({
@@ -22,6 +22,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem
         for num_warps in [1, 2, 4]
     ],
     key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def parallel_nsa_compression_fwd_kernel(
@@ -124,6 +125,7 @@ def parallel_nsa_compression_fwd_kernel(
         for num_warps in [1, 2, 4]
     ],
     key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def parallel_nsa_compression_bwd_kernel_dq(
@@ -227,6 +229,7 @@ def parallel_nsa_compression_bwd_kernel_dq(
         for num_warps in [1, 2, 4]
     ],
     key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def parallel_nsa_compression_bwd_kernel_dkv(

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -14,7 +14,7 @@ from fla.ops.nsa.utils import _bitonic_merge
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets, prepare_lens, prepare_token_indices
 from fla.ops.utils.op import exp, log
 from fla.ops.utils.pooling import mean_pooling
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, check_shared_mem, contiguous
 
 try:
     from flash_attn import flash_attn_func, flash_attn_varlen_func
@@ -35,6 +35,7 @@ except ImportError:
         for num_warps in [1, 2, 4]
     ],
     key=['BS', 'BK'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def parallel_nsa_kernel_topk(
@@ -172,6 +173,7 @@ def parallel_nsa_kernel_topk(
         for num_warps in [1, 2, 4]
     ],
     key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def parallel_nsa_fwd_kernel(
@@ -298,6 +300,7 @@ def parallel_nsa_kernel_mask(
         for num_warps in [1, 2, 4]
     ],
     key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def parallel_nsa_bwd_kernel_dq(
@@ -406,6 +409,7 @@ def parallel_nsa_bwd_kernel_dq(
         for num_warps in [1, 2, 4]
     ],
     key=['BS', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def parallel_nsa_bwd_kernel_dkv(

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -12,7 +12,14 @@ from fla.ops.common.chunk_h import chunk_fwd_h
 from fla.ops.gla.chunk import chunk_gla_bwd_dA, chunk_gla_bwd_dv, chunk_gla_fwd_o_gk
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, input_guard, use_cuda_graph
+from fla.utils import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    autotune_cache_kwargs,
+    check_shared_mem,
+    input_guard,
+    use_cuda_graph
+)
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [32, 64] if check_shared_mem() else [16, 32]
@@ -30,6 +37,7 @@ BV_LIST = [32, 64] if check_shared_mem() else [16, 32]
     ],
     key=['S', 'BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_fwd_cumsum_kernel(
@@ -108,6 +116,7 @@ def chunk_rwkv6_fwd_cumsum(
     ],
     key=['BC'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
@@ -183,6 +192,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
     ],
     key=['BK', 'BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
@@ -257,6 +267,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
     ],
     key=['BC', 'BK'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
@@ -337,6 +348,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
     ],
     key=['BC'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge(
@@ -389,6 +401,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge(
     ],
     key=['BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_bwd_kernel_dh(
@@ -469,6 +482,7 @@ def chunk_rwkv6_bwd_kernel_dh(
     ],
     key=['BK', 'NC', 'BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_bwd_kernel_intra(
@@ -609,6 +623,7 @@ def chunk_rwkv6_bwd_kernel_intra(
     ],
     key=['BT'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_rwkv6_bwd_kernel_inter(

--- a/fla/ops/rwkv6/fused_recurrent.py
+++ b/fla/ops/rwkv6/fused_recurrent.py
@@ -9,7 +9,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -22,7 +22,8 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8, 16]
     ],
-    key=['BK', 'BV']
+    key=['BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_rwkv6_fwd_kernel(
@@ -108,7 +109,8 @@ def fused_recurrent_rwkv6_fwd_kernel(
         triton.Config({}, num_warps=2),
         triton.Config({}, num_warps=4),
     ],
-    key=['BK', 'BV']
+    key=['BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_rwkv6_bwd_kernel_dq(
@@ -197,7 +199,8 @@ def fused_recurrent_rwkv6_bwd_kernel_dq(
         triton.Config({}, num_warps=2),
         triton.Config({}, num_warps=4),
     ],
-    key=['BK', 'BV']
+    key=['BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_rwkv6_bwd_kernel_dkv(
@@ -294,7 +297,8 @@ def fused_recurrent_rwkv6_bwd_kernel_dkv(
         for BK in [32, 64]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['K']
+    key=['K'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_rwkv6_bwd_kernel_dw(

--- a/fla/ops/rwkv7/channel_mixing.py
+++ b/fla/ops/rwkv7/channel_mixing.py
@@ -4,7 +4,14 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_pytorch_version, input_guard, use_cuda_graph
+from fla.utils import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    autotune_cache_kwargs,
+    check_pytorch_version,
+    input_guard,
+    use_cuda_graph
+)
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +26,7 @@ if not check_pytorch_version('2.4'):
     ],
     key=['hidden_dim'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit
 def rwkv_seq_mix_kernel(
@@ -185,6 +193,7 @@ def relu_square_bwd_kernel(
     ],
     key=['hidden_dim'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit
 def rwkv_mix_bwd_kenel(

--- a/fla/ops/rwkv7/fused_addcmul.py
+++ b/fla/ops/rwkv7/fused_addcmul.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 from packaging.version import Version
 
-from fla.utils import check_pytorch_version, input_guard, is_amd, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, check_pytorch_version, input_guard, is_amd, use_cuda_graph
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,7 @@ NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
     ],
     key=['BD'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit
 def fused_addcmul_fwd_kernel(
@@ -103,6 +104,7 @@ def fused_addcmul_fwd_kernel(
     ],
     key=['BD'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit
 def addcmul_bwd_kernel1(

--- a/fla/ops/rwkv7/fused_k_update.py
+++ b/fla/ops/rwkv7/fused_k_update.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.utils import get_multiprocessor_count, input_guard, is_amd
+from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard, is_amd
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
 
@@ -24,7 +24,8 @@ def k_update_ref(k: torch.Tensor, a: torch.Tensor, ka: torch.Tensor) -> torch.Te
         for w in NUM_WARPS_AUTOTUNE
         for s in [1, 2, 3]
     ],
-    key=['BD']
+    key=['BD'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def k_update_fwd_kernel_short(
@@ -66,7 +67,8 @@ def k_update_fwd_kernel_short(
         for w in NUM_WARPS_AUTOTUNE
         for s in [1, 2, 3]
     ],
-    key=['BD', 'BT']
+    key=['BD', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def k_update_fwd_kernel_long(
@@ -112,7 +114,8 @@ def k_update_fwd_kernel_long(
         for s in [1, 2, 3]
         for BT in [2, 4, 8]
     ],
-    key=['BD']
+    key=['BD'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def k_update_bwd_kernel_short(
@@ -163,7 +166,8 @@ def k_update_bwd_kernel_short(
         for w in NUM_WARPS_AUTOTUNE
         for s in [1, 2, 3]
     ],
-    key=['BD', 'BT']
+    key=['BD', 'BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def k_update_bwd_kernel_long(

--- a/fla/ops/rwkv7/fused_recurrent.py
+++ b/fla/ops/rwkv7/fused_recurrent.py
@@ -10,7 +10,7 @@ import triton.language as tl
 
 from fla.ops.generalized_delta_rule import fused_recurrent_dplr_delta_rule
 from fla.ops.utils.op import exp
-from fla.utils import input_guard, use_cuda_graph
+from fla.utils import autotune_cache_kwargs, input_guard, use_cuda_graph
 
 
 @triton.heuristics({
@@ -27,6 +27,7 @@ from fla.utils import input_guard, use_cuda_graph
     ],
     key=['BK'],
     use_cuda_graph=use_cuda_graph,
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_rwkv7_fwd_kernel(

--- a/fla/ops/rwkv7/gate_output_correction.py
+++ b/fla/ops/rwkv7/gate_output_correction.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 
 def gate_output_correction_ref(
@@ -63,6 +63,7 @@ def gate_output_correction_backward_ref(grad_output, o, r, k, r_k, v, g):
         for BT in [2, 4, 8]
     ],
     key=['num_heads', 'head_dim', 'BLOCK_SIZE_D'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def gate_output_correction_fwd_kernel(
@@ -114,6 +115,7 @@ def gate_output_correction_fwd_kernel(
         for BT in [2, 4, 8]
     ],
     key=['num_heads', 'head_dim', 'BLOCK_SIZE_D'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def gate_output_correction_bwd_kernel(

--- a/fla/ops/simple_gla/parallel.py
+++ b/fla/ops/simple_gla/parallel.py
@@ -14,6 +14,7 @@ from fla.ops.utils.op import exp
 from fla.utils import (
     autocast_custom_bwd,
     autocast_custom_fwd,
+    autotune_cache_kwargs,
     check_shared_mem,
     input_guard,
     is_intel_alchemist,
@@ -38,6 +39,7 @@ NUM_WARPS = [2, 4, 8] if is_nvidia_hopper else [2, 4, 8, 16]
         for num_stages in [2, 3, 4]
     ],
     key=["BT", "BS", "BK", "BV", "USE_G"],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def parallel_simple_gla_fwd_kernel(
@@ -372,6 +374,7 @@ def parallel_simple_gla_bwd_kernel_dkv(
         for num_warps in NUM_WARPS
     ],
     key=['BT', 'BS', 'BK', 'BV', 'USE_G'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def parallel_simple_gla_bwd_kernel(

--- a/fla/ops/ttt/chunk.py
+++ b/fla/ops/ttt/chunk.py
@@ -11,7 +11,7 @@ import triton.language as tl
 
 from fla.modules.layernorm import group_norm
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -25,7 +25,8 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['BT', 'BK', 'BV']
+    key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_ttt_linear_fwd_kernel_h(
@@ -130,6 +131,7 @@ def chunk_ttt_linear_fwd_kernel_h(
         for num_stages in [2, 3]
     ],
     key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_ttt_linear_fwd_kernel_o(
@@ -222,6 +224,7 @@ def chunk_ttt_linear_fwd_kernel_o(
         for num_warps in [1, 2, 4, 8]
     ],
     key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_ttt_linear_bwd_kernel_h(
@@ -323,6 +326,7 @@ def chunk_ttt_linear_bwd_kernel_h(
         for num_warps in [4]
     ],
     key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_ttt_linear_bwd_kernel_dv_local(
@@ -397,6 +401,7 @@ def chunk_ttt_linear_bwd_kernel_dv_local(
         for num_warps in [2, 4, 8, 16]
     ],
     key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_ttt_linear_bwd_kernel_norm(
@@ -554,6 +559,7 @@ def chunk_ttt_linear_bwd_kernel_norm(
         for num_stages in [2, 3]
     ],
     key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_bwd_kernel_dqke(

--- a/fla/ops/ttt/fused_chunk.py
+++ b/fla/ops/ttt/fused_chunk.py
@@ -9,7 +9,7 @@ import triton
 import triton.language as tl
 
 from fla.modules.layernorm import group_norm
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, is_nvidia_hopper
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard, is_nvidia_hopper
 
 NUM_WARPS = [1, 2] if is_nvidia_hopper else [1, 2, 4, 8]
 
@@ -27,6 +27,7 @@ NUM_WARPS = [1, 2] if is_nvidia_hopper else [1, 2, 4, 8]
         triton.Config({}, num_warps=4)
     ],
     key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_chunk_ttt_linear_fwd_kernel(
@@ -149,6 +150,7 @@ def fused_chunk_ttt_linear_fwd_kernel(
         triton.Config({}, num_warps=4)
     ],
     key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_chunk_ttt_linear_bwd_kernel_h(
@@ -268,6 +270,7 @@ def fused_chunk_ttt_linear_bwd_kernel_h(
         for num_warps in NUM_WARPS
     ],
     key=['BT', 'BK', 'BV'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def fused_chunk_ttt_linear_bwd_kernel_dh(

--- a/fla/ops/utils/cumsum.py
+++ b/fla/ops/utils/cumsum.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.index import prepare_chunk_indices
-from fla.utils import check_shared_mem, input_guard
+from fla.utils import autotune_cache_kwargs, check_shared_mem, input_guard
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
@@ -22,7 +22,8 @@ BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['B', 'H', 'BT', 'IS_VARLEN', 'REVERSE']
+    key=['B', 'H', 'BT', 'IS_VARLEN', 'REVERSE'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_local_cumsum_scalar_kernel(
@@ -76,7 +77,8 @@ def chunk_local_cumsum_scalar_kernel(
         for BS in BS_LIST
         for num_warps in [2, 4, 8]
     ],
-    key=['B', 'H', 'S', 'BT', 'IS_VARLEN', 'REVERSE']
+    key=['B', 'H', 'S', 'BT', 'IS_VARLEN', 'REVERSE'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_local_cumsum_vector_kernel(
@@ -136,7 +138,8 @@ def chunk_local_cumsum_vector_kernel(
         for num_warps in [2, 4, 8]
         for num_stages in [1, 2, 3, 4]
     ],
-    key=['B', 'H', 'IS_VARLEN', 'REVERSE']
+    key=['B', 'H', 'IS_VARLEN', 'REVERSE'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_global_cumsum_scalar_kernel(
@@ -195,7 +198,8 @@ def chunk_global_cumsum_scalar_kernel(
         for num_warps in [2, 4, 8]
         for num_stages in [1, 2, 3, 4]
     ],
-    key=['B', 'H', 'S', 'IS_VARLEN', 'REVERSE']
+    key=['B', 'H', 'S', 'IS_VARLEN', 'REVERSE'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_global_cumsum_vector_kernel(

--- a/fla/ops/utils/index.py
+++ b/fla/ops/utils/index.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
-from fla.utils import tensor_cache
+from fla.utils import autotune_cache_kwargs, tensor_cache
 
 
 @triton.autotune(
@@ -17,6 +17,7 @@ from fla.utils import tensor_cache
         for num_warps in [4, 8, 16, 32]
     ],
     key=['B'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def prepare_position_ids_kernel(

--- a/fla/ops/utils/logcumsumexp.py
+++ b/fla/ops/utils/logcumsumexp.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp, log
+from fla.utils import autotune_cache_kwargs
 
 
 @triton.autotune(
@@ -13,7 +14,8 @@ from fla.ops.utils.op import exp, log
         for BT in [16, 32, 64]
         for num_warps in [2, 4, 8]
     ],
-    key=['S']
+    key=['S'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def logcumsumexp_fwd_kernel(

--- a/fla/ops/utils/logsumexp.py
+++ b/fla/ops/utils/logsumexp.py
@@ -8,6 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp, log
+from fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics({
@@ -18,7 +19,8 @@ from fla.ops.utils.op import exp, log
         triton.Config({}, num_warps=num_warps)
         for num_warps in [1, 2, 4, 8, 16, 32]
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def logsumexp_fwd_kernel(

--- a/fla/ops/utils/matmul.py
+++ b/fla/ops/utils/matmul.py
@@ -11,7 +11,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import input_guard
+from fla.utils import autotune_cache_kwargs, input_guard
 
 
 # `triton.jit`'ed functions can be auto-tuned by using the `triton.autotune` decorator, which consumes:
@@ -43,7 +43,8 @@ from fla.utils import input_guard
         # triton.Config({'BM': 64, 'BK': 64, 'BN': 128, 'G': 4}, num_stages=4, num_warps=4),
         # triton.Config({'BM': 128, 'BK': 64, 'BN': 32, 'G': 4}, num_stages=4, num_warps=4)
     ],
-    key=['M', 'N', 'K']
+    key=['M', 'N', 'K'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def matmul_kernel(

--- a/fla/ops/utils/pack.py
+++ b/fla/ops/utils/pack.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.index import prepare_lens
-from fla.utils import input_guard
+from fla.utils import autotune_cache_kwargs, input_guard
 
 
 @triton.autotune(
@@ -18,7 +18,8 @@ from fla.utils import input_guard
         triton.Config({}, num_warps=num_warps)
         for num_warps in [4, 8, 16, 32]
     ],
-    key=['D', 'PADDING_SIDE', 'PACK']
+    key=['D', 'PADDING_SIDE', 'PACK'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def packunpack_sequence_kernel(

--- a/fla/ops/utils/pooling.py
+++ b/fla/ops/utils/pooling.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.index import prepare_chunk_indices
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -20,7 +20,8 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
         for BD in [16, 32, 64, 128]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['BT']
+    key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def mean_pooling_fwd_kernel(
@@ -66,7 +67,8 @@ def mean_pooling_fwd_kernel(
         for BD in [16, 32, 64, 128]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=['BT']
+    key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def mean_pooling_bwd_kernel(

--- a/fla/ops/utils/softmax.py
+++ b/fla/ops/utils/softmax.py
@@ -8,7 +8,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import is_amd
+from fla.utils import autotune_cache_kwargs, is_amd
 
 NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
 
@@ -18,7 +18,8 @@ NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if is_amd else [1, 2, 4, 8, 16, 32]
         triton.Config({}, num_warps=num_warps)
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def softmax_fwd_kernel(
@@ -44,7 +45,8 @@ def softmax_fwd_kernel(
         triton.Config({}, num_warps=num_warps)
         for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D']
+    key=['D'],
+    **autotune_cache_kwargs
 )
 @triton.jit
 def softmax_bwd_kernel(

--- a/fla/ops/utils/solve_tril.py
+++ b/fla/ops/utils/solve_tril.py
@@ -10,7 +10,7 @@ import triton.language as tl
 
 from fla.ops.utils.index import prepare_chunk_indices
 from fla.ops.utils.op import make_tensor_descriptor
-from fla.utils import input_guard, is_amd, is_tma_supported
+from fla.utils import autotune_cache_kwargs, input_guard, is_amd, is_tma_supported
 
 FLA_TRIL_PRECISION = os.environ.get('FLA_TRIL_PRECISION', 'ieee')
 ALLOWED_TRIL_PRECISIONS = ['ieee', 'tf32'] if is_amd else ['ieee', 'tf32', 'tf32x3']
@@ -28,6 +28,7 @@ assert FLA_TRIL_PRECISION in ALLOWED_TRIL_PRECISIONS, \
         for num_stages in [2, 3, 4, 5]
     ],
     key=['BT'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def solve_tril_16x16_kernel(
@@ -91,6 +92,7 @@ def solve_tril_16x16_kernel(
         for num_stages in [2, 3, 4, 5]
     ],
     key=['H', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def merge_16x16_to_32x32_inverse_kernel(
@@ -178,6 +180,7 @@ def merge_16x16_to_32x32_inverse_kernel(
         for num_stages in [2, 3, 4, 5]
     ],
     key=['H', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs
 )
 @triton.jit(do_not_specialize=['T'])
 def merge_16x16_to_64x64_inverse_kernel(

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
     from fla import __version__
 
 FLA_CI_ENV = os.getenv("FLA_CI_ENV") == "1"
+FLA_CACHE_RESULTS = os.getenv('FLA_CACHE_RESULTS', '1') == '1'
+
+
+supports_autotune_cache = "cache_results" in inspect.signature(triton.autotune).parameters
+autotune_cache_kwargs = {"cache_results": FLA_CACHE_RESULTS} if supports_autotune_cache else {}
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added environment variable FLA_CACHE_RESULTS (default: on) to control caching of autotune results.

- Performance
  - Enabled reuse of cached autotuning across a wide set of kernels, reducing warm-up time and improving performance consistency on supported setups.

- Documentation
  - Updated ENVs.md with details on FLA_CACHE_RESULTS and its options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->