### PR TITLE
[Deps] Make pytest an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ dependencies = [
     "transformers>=4.53.0",
     "datasets>=3.3.0",
     "einops",
-    "pytest",
 ]
 
 [project.optional-dependencies]
 conv1d = ["causal-conv1d>=1.4.0"]
 benchmark = ["matplotlib"]
+test = ["pytest"]
 
 [project.urls]
 Homepage = "https://github.com/fla-org/flash-linear-attention"

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,11 @@ setup(
         'torch>=2.5',
         'transformers>=4.53.0',
         'datasets>=3.3.0',
-        'einops',
-        'pytest'
+        'einops'
     ],
     extras_require={
         'conv1d': ['causal-conv1d>=1.4.0'],
         'benchmark': ['matplotlib'],
+        'test': ['pytest'],
     }
 )


### PR DESCRIPTION
Pytest is currently included in wheel dependencies, but it is needed only to run the unit tests. Move it to optional dependencies under the "test" group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced default install footprint by moving testing tools out of core requirements into an optional "test" extra.

* **Tests**
  * Enable testing via the optional "test" extra so tests remain easy to run without affecting standard installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->