### PR TITLE
Fix docstring for 'g' parameter shape

### DIFF
--- a/fla/ops/kda/fused_recurrent.py
+++ b/fla/ops/kda/fused_recurrent.py
@@ -29,7 +29,7 @@ def fused_recurrent_kda(
             values of shape `[B, T, HV, V]`.
             GVA is applied if `HV > H`.
         g (torch.Tensor):
-            g (decays) of shape `[B, T, HV]`.
+            g (decays) of shape `[B, T, HV, K]`.
         beta (torch.Tensor):
             betas of shape `[B, T, HV]`.
         scale (Optional[float]):


### PR DESCRIPTION
Updated the shape of the 'g' parameter in the docstring to reflect the new dimensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify tensor shape specifications for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->