### PR TITLE
Fix2: Correct K/V dimension mismatch in path_attn bwd kernels"changing K/BK to V/BV for v and dv operations

### DIFF
--- a/fla/ops/path_attn/parallel_path_bwd_inter_dqh.py
+++ b/fla/ops/path_attn/parallel_path_bwd_inter_dqh.py
@@ -118,9 +118,9 @@ def parallel_path_bwd_dq_kernel(
                 b_A = b_A + b_g_cumsum_q[:, None] - b_g_cumsum_k[None, :]
             b_A = exp2(b_A * sm_scale - b_l[:, None])
             b_A = tl.where(m_t[:, None], b_A, 0)
-            p_v = tl.make_block_ptr(v, (V, T), (1, V*H), (0, offset), (BK, BS), (0, 1))
+            p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (offset, 0), (BS, BV), (1, 0))
             b_v = tl.load(p_v, boundary_check=(0, 1))
-            b_dp = tl.dot(b_do, b_v.to(b_do.dtype))
+            b_dp = tl.dot(b_do, tl.trans(b_v).to(b_do.dtype))
             b_dA = (b_dp - b_delta[:, None]) * b_A * scale
             b_dq += tl.dot(b_dA.to(b_k.dtype), b_k)
             if USE_GATE:


### PR DESCRIPTION
This PR fixes a critical dimension mismatch bug found in the `path_attn` backward pass kernels, which occurs when `BK != BV`.

**Related Issue:**
Fixes #632

**Description:**
The backward kernels (`parallel_path_bwd_inter_dkv` and `parallel_path_bwd_inter_dqh`) incorrectly assumed that the key dimension (`K`) and value dimension (`V`)—and their corresponding block sizes (`BK`, `BV`)—were always equal. The code was incorrectly using `K`/`BK` constants for operations on `V`/`BV`-dimensioned tensors.

This bug was likely masked during validation where `BK == BV` was the default. My testing, which intentionally set `BK=64` and `BV=128`, exposed this bug, leading to a `triton.compiler.errors.CompilationError` (as detailed in the linked issue).

**Changes:**

2.  **`fla/ops/path_attn/parallel_path_bwd_inter_dqh.py`**:
    * Corrected the `tl.make_block_ptr` for `v` to load with the proper `(BS, BV)` block size.
    * Applied `tl.trans(b_v)` within the `tl.dot` operation to ensure correct matrix multiplication dimensions (`[BS, BV] @ [BV, BS]`) for calculating `b_dp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory access patterns and computation layout in the backward path algorithm to improve performance and efficiency during tensor operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->