### PR TITLE
KDA - fix: don't force fused_recurrent when in training mode with small sequences

### DIFF
--- a/fla/layers/kda.py
+++ b/fla/layers/kda.py
@@ -172,7 +172,7 @@ class KimiDeltaAttention(nn.Module):
 
         batch_size, q_len, _ = hidden_states.shape
         # change to inference mode.
-        mode = 'fused_recurrent' if q_len <= 64 else self.mode
+        mode = 'fused_recurrent' if q_len <= 64 and not self.training else self.mode
         if self.training:
             assert mode == 'chunk', "Only chunk mode is supported in training."
 


### PR DESCRIPTION
When in training mode and with small sequences (< 64), this assert would trigger:

```
AssertionError: Only chunk mode is supported in training.
```

This PR adds a `not self.training` check in this:
```
mode = 'fused_recurrent' if q_len <= 64 else self.mode
if self.training:
            assert mode == 'chunk', "Only chunk mode is supported in training."
```
so to not trigger the assert erroneously.

I don't know the reason behind that mode override, but with this fix training and convergence seems fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attention mechanism mode handling to ensure proper behavior during training phases while maintaining inference optimizations for short sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->