### PR TITLE
Fix overflow in prepare_qg_kg leading to NaNs in dv

### DIFF
--- a/fla/ops/gla/fused_chunk.py
+++ b/fla/ops/gla/fused_chunk.py
@@ -43,7 +43,7 @@ def prepare_qg_kg(
         b_k = tl.load(p_k, mask=mask, other=0)
         b_g = tl.load(p_g, mask=mask, other=0).to(tl.float32)
         b_q *= exp(b_g) * scale
-        b_k *= exp(last_decay - b_g)
+        b_k *= safe_exp(last_decay - b_g)
         tl.store(p_kg, b_k.to(p_kg.dtype.element_ty), mask=mask)
         tl.store(p_qg, b_q.to(p_qg.dtype.element_ty), mask=mask)
         p_q += K


### PR DESCRIPTION
This PR fixes a numerical overflow in the `prepare_qg_kg` kernel, which caused isolated NaN values in dv during training. The issue appears when the cumulative decay term produces a large positive exponent in:

`b_k *= exp(last_decay - b_g)`

which can overflow to inf in float32, causing `k_g` to contain ±inf for a single (batch, head, time) position. This then propagates through the inter-chunk forward/backward paths and leads to NaN in the corresponding slice of `dv`.


**Root Cause**

`g` is transformed via `chunk_local_cumsum`, so within a chunk `last_decay - b_g` can become large and positive. In those cases:

```
exp(last_decay - b_g) → +inf   (fp32 overflow)
b_k * +inf → ±inf
```

producing `k_g[b,h,t,:] = [-inf, ..., -inf]`.
This corrupts the corresponding forward state and produces NaNs during backward.

**Minimal Fix**

Replace the overflow-prone exp with `safe_exp` only for the `b_k` update, which is the sole source of the observed NaNs:

```
-        b_k *= exp(last_decay - b_g)
+        b_k *= safe_exp(last_decay - b_g)
```

This is sufficient to prevent `k_g` from ever becoming ±inf, and it fully resolves the NaN issue.

**Optional :**

The line

`b_q *= exp(b_g) * scale`

can also overflow in principle if g becomes large and positive.
In practice, this was not the source of the NaNs observed here, so this PR keeps the change minimal. However, using `safe_exp(b_g)` there as well could be considered in a follow-up for additional numerical robustness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in decay factor computations to reduce overflow and NaN errors during processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->