### PR TITLE
Add head_dim parameter to NSA layer

### DIFF
--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -43,6 +43,7 @@ class NSABlock(GradientCheckpointingLayer):
             hidden_size=config.hidden_size,
             num_heads=config.num_heads,
             num_kv_heads=config.num_kv_heads,
+            head_dim=config.head_dim,
             qkv_bias=config.qkv_bias,
             block_size=config.block_size,
             block_counts=config.block_counts,


### PR DESCRIPTION
head_dim is part of the NSA model config but was actually not passed to the NSA layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved attention mechanism initialization through refined parameter configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->