### PR TITLE
[CP] Add cp for gdn and kda

### DIFF
--- a/benchmarks/cp/test_gdn_with_cp.py
+++ b/benchmarks/cp/test_gdn_with_cp.py
@@ -1,0 +1,917 @@
+'''shell
+
+GPUS=4
+ARGS=(
+    --ops
+    # --use-cp2hp
+    # --kda
+    --backward
+    --bench
+    # --profile
+    # --profile-path /home/user/gdn
+    --seqlen 32768
+    --mean 32768
+    --std 0
+)
+torchrun --nproc_per_node $GPUS test_gdn_with_cp.py ${ARGS[@]} $@
+
+'''
+import argparse
+import os
+import random
+import sys
+from functools import partial
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from einops import rearrange, repeat
+
+from fla.models.utils import Cache
+from fla.modules.convolution import causal_conv1d
+from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
+from fla.ops.kda import chunk_kda, fused_recurrent_kda
+
+sys.path.append("../../")
+
+
+try:
+    import fused_weight_gradient_mlp_cuda
+    apex_func = None
+    if hasattr(fused_weight_gradient_mlp_cuda, "wgrad_gemm_accum_fp32"):
+        apex_func = fused_weight_gradient_mlp_cuda.wgrad_gemm_accum_fp32
+    if hasattr(fused_weight_gradient_mlp_cuda, "fused_wgrad_gemm_accum_fp32"):
+        apex_func = fused_weight_gradient_mlp_cuda.fused_wgrad_gemm_accum_fp32
+    from functools import partial
+    if apex_func is None:
+        HAVE_APEX = False
+    else:
+        HAVE_APEX = True
+except Exception:
+    HAVE_APEX = False
+
+os.environ['TRITON_PRINT_AUTOTUNING'] = '1'
+os.environ['FLA_CONV_BACKEND'] = 'cuda'
+
+DTYPE = torch.bfloat16
+B = 1
+H = 64
+K = 128
+V = 128
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ops", action="store_true")
+    parser.add_argument("--kda", action="store_true")
+    parser.add_argument("--backward", action="store_true")
+    parser.add_argument("--bench", action="store_true")
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--profile-path", type=str, default="")
+    parser.add_argument("--seqlen", type=int, default=1024*32)
+    parser.add_argument("--mean", type=int, default=1024*32)
+    parser.add_argument("--std", type=int, default=0)
+    parser.add_argument("--use-cp2hp", action="store_true")
+    return parser.parse_args()
+
+# torchrun --nproc-per-node=4 test_cp.py
+
+
+def a2a(x, stage=1, group=None, async_op=False):
+    assert stage in [1, 2]
+    x = x.contiguous()
+    world_size = dist.get_world_size(group)
+    t, h, d = x.shape
+    if stage == 1:
+        x = x.reshape(t, world_size, h//world_size, d).transpose(0, 1).contiguous()
+    else:
+        x = x.reshape(world_size, t//world_size, h, d).contiguous()
+    out = torch.empty_like(x)
+    handle = dist.all_to_all_single(out, x, group=group, async_op=async_op)
+    if stage == 1:
+        out = out.flatten(0, 1)
+    else:
+        out = out.transpose(0, 1).contiguous().flatten(1, 2)
+    return out, handle
+
+
+class _All2All(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, stages, group, async_op):
+        fwd_stage, bwd_stage = stages
+        out, handle = a2a(x, fwd_stage, group, async_op=async_op)
+        ctx.bwd_stage = bwd_stage
+        ctx.group = group
+        return out, handle
+
+    @staticmethod
+    def backward(ctx, do, *args):
+        dx, handle = a2a(do, stage=ctx.bwd_stage, group=ctx.group)
+        return dx, None, None, None
+
+
+def qkvo_all2ll(x, is_qkv=True, group=None, async_op=False):
+    if is_qkv:
+        stages = [1, 2]
+    else:
+        stages = [2, 1]
+    out, handle = _All2All.apply(x, stages, group, async_op)
+    return out, handle
+
+
+def bench(fn, step=20, warm_up=10, grad_to_none=None):
+    # triton.testing.do_bench have bug if there are some comms in kernels
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    for i in range(warm_up):
+        fn()
+        if grad_to_none is not None:
+            for x in grad_to_none:
+                x.grad = None
+    start_event.record()
+    for i in range(step):
+        fn()
+    end_event.record()
+    torch.cuda.synchronize()
+    t1 = start_event.elapsed_time(end_event)
+    return t1 / step
+
+
+def print_rank0(*args, **kwargs):
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+        if torch.distributed.get_rank() == 0:
+            print(*args, **kwargs)
+        torch.distributed.barrier()
+    else:
+        print(*args, **kwargs)
+
+
+def compare(x, y, prefix=""):
+    if x is None or y is None:
+        return
+    if any([x.dtype == torch.float32, y.dtype == torch.float32]):
+        x, y = x.float(), y.float()
+    diff = (x-y).abs()
+    import torch.distributed as dist
+
+    def print_synchronized(*args, **kwargs):
+        dist.barrier()
+
+        for r in range(dist.get_world_size()):
+            if r == dist.get_rank():
+                print(*args, **kwargs)
+            dist.barrier()
+    print_synchronized(
+        prefix + f"max_diff: {diff.max().item()}, mean_diff: {diff.mean().item()}, absmax: {torch.maximum(x.abs().max(), y.abs().max()).item()}")
+
+
+def get_ref_grad(*tensors):
+    grads = []
+    for t in tensors:
+        grads.append(t.grad)
+        t.grad = None
+    if len(grads) == 1:
+        grads = grads[0]
+    return grads
+
+
+def broadcast(x, group=None):
+    dist.broadcast(x, src=0, group=group)
+
+
+def all_gather(x, group=None) -> torch.Tensor:
+    world_size = dist.get_world_size(group=group)
+    y = torch.empty(world_size * x.size(0), *x.shape[1:], device=x.device, dtype=x.dtype)
+    dist.all_gather_into_tensor(y, x, group=group)
+    return y
+
+
+def generate_cu_seqlens(end=8192, mean=2048, var=512):
+    random.seed(42)
+    r = [0]
+    while r[-1] < end:
+        a = random.randint(max(mean-var, 1), mean+var)
+        r.append(r[-1] + a)
+    r[-1] = end
+    cu_seqlens = torch.tensor(r, device=torch.cuda.current_device(), dtype=torch.int32)
+    return cu_seqlens
+
+
+class _LinearFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, inp, weight, bias):
+        inp_shape = inp.shape
+        out = torch.matmul(inp.view(-1, inp_shape[-1]), weight.t())
+        if bias is not None:
+            out += bias
+        ctx.save_for_backward(inp, weight, bias)
+        return out.view(*inp_shape[:-1], -1)
+
+    @staticmethod
+    def backward(ctx, dout):
+        inp, weight, bias = ctx.saved_tensors
+        inp_shape = inp.shape
+        inp = inp.view(-1, inp_shape[-1])
+        dout = dout.view(-1, dout.size(-1))
+        dgrad = torch.matmul(dout, weight).view(inp_shape)
+        main_grad = getattr(weight, "main_grad", None)
+        if main_grad is not None:
+            if HAVE_APEX:
+                wgrad = apex_func(inp, dout, main_grad)
+            else:
+                wgrad = torch.matmul(dout.t(), inp)
+                main_grad += wgrad
+            if hasattr(weight, 'grad_added_to_main_grad'):
+                # When overlap_grad_reduce is True, need to ensure that backward hooks
+                # are all run on the main backprop thread to prevent deadlocks. Setup
+                # dummy grad_weight tensor to prevent backward hooks from being run
+                # in a background thread.
+                wgrad = torch.empty(
+                    main_grad.shape,
+                    dtype=inp.dtype,
+                    device=torch.cuda.current_device(),
+                    requires_grad=False,
+                )
+                weight.grad_added_to_main_grad = True
+            else:
+                wgrad = None
+        else:
+            wgrad = torch.matmul(dout.t(), inp)
+        if bias is not None:
+            dbias = dout.sum(0)
+        else:
+            dbias = None
+        return dgrad, wgrad, dbias
+
+
+def fp32_grad_linear_forward(input, self):
+    out = _LinearFunction.apply(input, self.weight, self.bias)
+    return out
+
+
+def patch_fp32_grad_linear_forward(model: torch.nn.Module):
+    if HAVE_APEX:
+        for name, m in model.named_modules():
+            if isinstance(m, torch.nn.Linear):
+                # print(name)
+                m.forward = partial(fp32_grad_linear_forward, self=m)
+                m.weight.main_grad = torch.zeros_like(m.weight, dtype=torch.float32)
+
+
+def short_conv_forward(
+    x: torch.Tensor,
+    residual: torch.Tensor | None = None,
+    mask: torch.Tensor | None = None,
+    cache: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    cp_size=None,
+    cp_rank=None,
+    self=None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Args:
+        x (`torch.Tensor`):
+            Tensor of shape `[B, T, D]`. `B` must be 1 if `seq_idx` is provided.
+        residual (`Optional[torch.Tensor]`):
+            Residual tensor of shape `[B, T, D]`. Default: `None`.
+        mask (`Optional[torch.Tensor]`):
+            Attention mask dealing with padded positions.
+        cache (`Optional[torch.Tensor]`):
+            Previous cache tensor of shape `[N, D, W]`, where `W` is the kernel size.
+            If provided, the cache is updated **inplace**.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, D, W]`. Default: `False`.
+        cu_seqlens (Optional[torch.LongTensor]):
+            Cumulative sequence lengths for each batch. Used for varlen. Default: `None`.
+            Shape: [B+1]
+
+    Returns:
+        Tensor of shape `[B, T, D]`.
+    """
+
+    B, T, *_ = x.shape
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    if mask is not None:
+        if cu_seqlens is not None:
+            raise ValueError("`mask` and `cu_seqlens` cannot be provided at the same time")
+        x = x.mul_(mask.unsqueeze(-1))
+
+    # in decoding phase, the cache (if provided) is updated inplace
+    if B * T == N:
+        y, cache = self.step(
+            x=x,
+            residual=residual,
+            cache=cache,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens
+        )
+        return y, cache
+
+    # cuda backend do not support:
+    # 1. both `cu_seqlens` and `cache` being provided
+    # 2. both `cu_seqlens` and `output_final_state` being provided
+    if self.backend == 'cuda' and (
+        (cu_seqlens is not None and cache is not None) or
+        (cu_seqlens is not None and output_final_state)
+    ):
+        self.backend = 'triton'
+    # hidden_size, 1, kernel_size
+    weight = self.weight.chunk(cp_size, 0)[cp_rank].squeeze(1)
+
+    return causal_conv1d(
+        x=x,
+        weight=weight,
+        bias=self.bias,
+        residual=residual,
+        initial_state=cache,
+        output_final_state=output_final_state,
+        activation=self.activation,
+        backend=self.backend,
+        cu_seqlens=cu_seqlens,
+        **kwargs
+    )
+
+
+def maybe_wait(handle):
+    if handle is None:
+        return
+    handle.wait()
+
+
+def gdn_forward(
+    hidden_states: torch.Tensor,
+    attention_mask: torch.Tensor | None = None,
+    past_key_values: Cache | None = None,
+    use_cache: bool | None = False,
+    output_attentions: bool | None = False,
+    cp_group=None,
+    cp_size=None,
+    cp_rank=None,
+    self=None,
+    **kwargs
+) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+    if attention_mask is not None:
+        assert len(attention_mask.shape) == 2, (
+            "Expected attention_mask as a 0-1 matrix with shape [batch_size, seq_len] "
+            "for padding purposes (0 indicating padding). "
+            "Arbitrary attention masks of shape [batch_size, seq_len, seq_len] are not allowed."
+        )
+
+    batch_size, q_len, _ = hidden_states.shape
+    # change to inference mode.
+    mode = 'fused_recurrent' if q_len <= 64 else self.mode
+    if self.training:
+        assert mode == 'chunk', "Only chunk mode is supported in training."
+
+    last_state = None
+    if past_key_values is not None and len(past_key_values) > self.layer_idx:
+        last_state = past_key_values[self.layer_idx]
+
+    cu_seqlens = kwargs.get('cu_seqlens')
+    # assert cu_seqlens is not None
+
+    async_op = False
+    q = self.q_proj(hidden_states)
+    k = self.k_proj(hidden_states)
+    v = self.v_proj(hidden_states)
+    a = self.a_proj(hidden_states)
+    b = self.b_proj(hidden_states)
+    if self.use_gate:
+        gate = self.g_proj(hidden_states)
+    # set async_op=True and one proj one comm can overlap
+    q, handle_q = qkvo_all2ll(q.view(-1, self.num_heads, self.head_k_dim), is_qkv=True, group=cp_group, async_op=async_op)
+    k, handle_k = qkvo_all2ll(k.view(-1, self.num_heads, self.head_k_dim), is_qkv=True, group=cp_group, async_op=async_op)
+    v, handle_v = qkvo_all2ll(v.view(-1, self.num_v_heads, self.head_v_dim), is_qkv=True, group=cp_group, async_op=async_op)
+    a, handle_a = qkvo_all2ll(a.view(-1, self.num_v_heads, 1), is_qkv=True, group=cp_group, async_op=async_op)
+    b, handle_b = qkvo_all2ll(b.view(-1, self.num_v_heads, 1), is_qkv=True, group=cp_group, async_op=async_op)
+    if self.use_gate:
+        gate, handle_gate = qkvo_all2ll(gate.view(-1, self.num_v_heads, self.head_v_dim),
+                                        is_qkv=True, group=cp_group, async_op=async_op)
+    q, k, v, a, b = [t.flatten(-2, -1).unsqueeze(0) for t in [q, k, v, a, b]]
+
+    if self.use_short_conv:
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if last_state is not None:
+            conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
+        maybe_wait(handle_q)
+        q, conv_state_q = self.q_conv1d(
+            x=q,
+            cache=conv_state_q,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens
+        )
+        maybe_wait(handle_k)
+        k, conv_state_k = self.k_conv1d(
+            x=k,
+            cache=conv_state_k,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens
+        )
+        maybe_wait(handle_v)
+        v, conv_state_v = self.v_conv1d(
+            x=v,
+            cache=conv_state_v,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens
+        )
+    else:
+        maybe_wait(handle_q)
+        q = F.silu(q)
+        maybe_wait(handle_k)
+        k = F.silu(k)
+        maybe_wait(handle_v)
+        v = F.silu(v)
+
+    q, k = map(lambda x: rearrange(x, '... (h d) -> ... h d', d=self.head_k_dim), (q, k))
+    v = rearrange(v, '... (h d) -> ... h d', d=self.head_v_dim)
+
+    if self.num_v_heads > self.num_heads:
+        q, k = map(lambda x: repeat(x, '... h d -> ... (h g) d', g=self.num_v_heads // self.num_heads), (q, k))
+
+    maybe_wait(handle_b)
+    beta = b.sigmoid()
+    if self.allow_neg_eigval:
+        beta = beta * 2.
+
+    maybe_wait(handle_a)
+    A_log = self.A_log.chunk(cp_size)[cp_rank]
+    dt_bias = self.dt_bias.chunk(cp_size)[cp_rank]
+    g = -A_log.float().exp() * F.softplus(a.float() + dt_bias)
+
+    recurrent_state = last_state['recurrent_state'] if last_state is not None else None
+    if mode == 'chunk':
+        o, recurrent_state = chunk_gated_delta_rule(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=recurrent_state,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
+        )
+    elif mode == 'fused_recurrent':
+        o, recurrent_state = fused_recurrent_gated_delta_rule(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=recurrent_state,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
+        )
+    else:
+        raise NotImplementedError(f"Not supported mode `{mode}`.")
+
+    if past_key_values is not None:
+        past_key_values.update(
+            recurrent_state=recurrent_state,
+            conv_state=(conv_state_q, conv_state_k, conv_state_v) if self.use_short_conv else None,
+            layer_idx=self.layer_idx,
+            offset=q_len
+        )
+
+    if self.use_gate:
+        maybe_wait(handle_gate)
+        g = rearrange(gate.flatten(-2, -1).unsqueeze(0), '... (h d) -> ... h d', d=self.head_v_dim)
+        o = self.o_norm(o, g)
+    else:
+        o = self.o_norm(o)
+    # THD
+    o = o.flatten(0, 1)
+    o, _ = qkvo_all2ll(o, is_qkv=False, group=cp_group)
+
+    o = rearrange(o.unsqueeze(0), 'b t h d -> b t (h d)')
+    o = self.o_proj(o)
+
+    return o, None, past_key_values
+
+
+def kda_forward(
+    hidden_states: torch.Tensor,
+    attention_mask: torch.Tensor | None = None,
+    past_key_values: Cache | None = None,
+    use_cache: bool | None = False,
+    output_attentions: bool | None = False,
+    cp_group=None,
+    cp_size=None,
+    cp_rank=None,
+    self=None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+    if attention_mask is not None:
+        assert len(attention_mask.shape) == 2, (
+            "Expected attention_mask as a 0-1 matrix with shape [batch_size, seq_len] "
+            "for padding purposes (0 indicating padding). "
+            "Arbitrary attention masks of shape [batch_size, seq_len, seq_len] are not allowed."
+        )
+
+    batch_size, q_len, _ = hidden_states.shape
+    # change to inference mode.
+    mode = 'fused_recurrent' if q_len <= 64 else self.mode
+    if self.training:
+        assert mode == 'chunk', "Only chunk mode is supported in training."
+
+    last_state = None
+    if past_key_values is not None and len(past_key_values) > self.layer_idx:
+        last_state = past_key_values[self.layer_idx]
+
+    cu_seqlens = kwargs.get('cu_seqlens')
+
+    async_op = False
+    q = self.q_proj(hidden_states)
+    k = self.k_proj(hidden_states)
+    v = self.v_proj(hidden_states)
+    g = self.f_proj(hidden_states)
+    b = self.b_proj(hidden_states)
+    gate = self.g_proj(hidden_states)
+    q, handle_q = qkvo_all2ll(q.view(-1, self.num_heads, self.head_k_dim), is_qkv=True, group=cp_group, async_op=async_op)
+    k, handle_k = qkvo_all2ll(k.view(-1, self.num_heads, self.head_k_dim), is_qkv=True, group=cp_group, async_op=async_op)
+    v, handle_v = qkvo_all2ll(v.view(-1, self.num_v_heads, self.head_v_dim), is_qkv=True, group=cp_group, async_op=async_op)
+    g, handle_g = qkvo_all2ll(g.view(-1, self.num_heads, self.head_k_dim), is_qkv=True, group=cp_group, async_op=async_op)
+    b, handle_b = qkvo_all2ll(b.view(-1, self.num_heads, 1), is_qkv=True, group=cp_group, async_op=async_op)
+    gate, handle_gate = qkvo_all2ll(gate.view(-1, self.num_v_heads, self.head_v_dim),
+                                    is_qkv=True, group=cp_group, async_op=async_op)
+    q, k, v, g, b, gate = [t.flatten(-2, -1).unsqueeze(0) for t in [q, k, v, g, b, gate]]
+
+    if self.use_short_conv:
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if last_state is not None:
+            conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
+        maybe_wait(handle_q)
+        q, conv_state_q = self.q_conv1d(
+            x=q,
+            cache=conv_state_q,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens
+        )
+        maybe_wait(handle_k)
+        k, conv_state_k = self.k_conv1d(
+            x=k,
+            cache=conv_state_k,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens
+        )
+        maybe_wait(handle_v)
+        v, conv_state_v = self.v_conv1d(
+            x=v,
+            cache=conv_state_v,
+            output_final_state=use_cache,
+            cu_seqlens=cu_seqlens
+        )
+    else:
+        maybe_wait(handle_q)
+        q = F.silu(q)
+        maybe_wait(handle_k)
+        k = F.silu(k)
+        maybe_wait(handle_v)
+        v = F.silu(v)
+
+    A_log = self.A_log.chunk(cp_size, 0)[cp_rank]
+    dt_bias = self.dt_bias.chunk(cp_size, 0)[cp_rank]
+    maybe_wait(handle_g)
+    # g = fused_kda_gate(g, A_log, self.head_k_dim, g_bias=dt_bias)
+    maybe_wait(handle_b)
+    beta = b.sigmoid()
+
+    q, k, g = (rearrange(x, "... (h d) -> ... h d", d=self.head_k_dim) for x in (q, k, g))
+    v = rearrange(v, '... (h d) -> ... h d', d=self.head_v_dim)
+
+    if self.num_v_heads > self.num_heads:
+        q, k, g = (repeat(x, '... h d -> ... (h g) d', g=self.num_v_heads // self.num_heads) for x in (q, k, g))
+        beta = repeat(beta, '... h -> ... (h g)', g=self.num_v_heads // self.num_heads)
+
+    if self.allow_neg_eigval:
+        beta = beta * 2.
+    recurrent_state = last_state['recurrent_state'] if last_state is not None else None
+    if mode == 'chunk':
+        o, recurrent_state = chunk_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=recurrent_state,
+            output_final_state=use_cache,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=cu_seqlens,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            use_gate_in_kernel=True,
+        )
+    elif mode == 'fused_recurrent':
+        o, recurrent_state = fused_recurrent_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=recurrent_state,
+            output_final_state=use_cache,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=cu_seqlens,
+        )
+    else:
+        raise NotImplementedError(f"Not supported mode `{mode}`.")
+
+    if past_key_values is not None:
+        past_key_values.update(
+            recurrent_state=recurrent_state,
+            conv_state=(conv_state_q, conv_state_k, conv_state_v) if self.use_short_conv else None,
+            layer_idx=self.layer_idx,
+            offset=q_len,
+        )
+    maybe_wait(handle_gate)
+    o = self.o_norm(o, rearrange(gate, '... (h d) -> ... h d', d=self.head_v_dim))
+
+    # THD
+    o, _ = qkvo_all2ll(o.flatten(0, 1), is_qkv=False, group=cp_group)
+    o = rearrange(o.unsqueeze(0), 'b t h d -> b t (h d)')
+    o = self.o_proj(o)
+
+    return o, None, past_key_values
+
+
+def profile_func(fn, path):
+
+    with torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,  # 如果是GPU
+        ],
+            schedule=torch.profiler.schedule(wait=0, warmup=2, active=8),
+            with_stack=False,
+            record_shapes=True,
+            profile_memory=False,
+            # on_trace_ready=hook_fn,
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(path)
+
+    ) as prof:
+        for step in range(10):  # 总步数需覆盖schedule的wait+warmup+active
+            torch.cuda.synchronize()
+            fn()
+            torch.cuda.synchronize()
+            prof.step()  # 通知profiler一个步骤完成
+    return prof
+
+
+def test_ops(args):
+    from fla.ops.cp import build_cp_context
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+    from fla.ops.kda import chunk_kda
+
+    device = torch.cuda.current_device()
+    group = args.group
+    world_size = dist.get_world_size(group)
+    rank = dist.get_rank(group)
+    cu_seqlens = generate_cu_seqlens(args.seqlen, args.mean, args.std)
+    T = args.seqlen // world_size
+
+    q = torch.randn(B, T, H, K, dtype=DTYPE, device=device).requires_grad_(True)
+    k = F.normalize(torch.randn(B, T, H, K, dtype=DTYPE, device=device), p=2, dim=-1).requires_grad_(True)
+    v = torch.randn(B, T, H, V, dtype=DTYPE, device=device).requires_grad_(True)
+    beta = torch.rand(B, T, H, dtype=DTYPE, device=device).sigmoid().requires_grad_(True)
+    if not args.kda:
+        # if / 10000., the max diff is not 0
+        g = (F.logsigmoid(torch.rand(B, T, H, dtype=DTYPE, device=device)) / 1.).requires_grad_(True)
+    else:
+        g = (F.logsigmoid(torch.rand(B, T, H, K, dtype=DTYPE, device=device)) / 1.).requires_grad_(True)
+    do = torch.randn(B, T, H, V, dtype=DTYPE, device=device)
+
+    total_q = all_gather(q.squeeze(0), group=group).unsqueeze(0).detach().requires_grad_(True)
+    total_k = all_gather(k.squeeze(0), group=group).unsqueeze(0).detach().requires_grad_(True)
+    total_v = all_gather(v.squeeze(0), group=group).unsqueeze(0).detach().requires_grad_(True)
+    total_beta = all_gather(beta.squeeze(0), group=group).unsqueeze(0).detach().requires_grad_(True)
+    total_g = all_gather(g.squeeze(0), group=group).unsqueeze(0).detach().requires_grad_(True)
+    total_do = all_gather(do.squeeze(0), group=group).unsqueeze(0).detach().requires_grad_(True)
+
+    backward = args.backward
+    op = chunk_gated_delta_rule if not args.kda else chunk_kda
+
+    def gdn_no_cp():
+        total_out, total_ht = op(
+            total_q, total_k, total_v, total_g, total_beta,
+            cu_seqlens=cu_seqlens
+        )
+        dist.barrier()
+        if backward:
+            total_out.backward(total_do)
+        dist.barrier()
+        return total_out.chunk(world_size, 1)[rank]
+
+    def gdn_with_custom_cp():
+        cp_context = build_cp_context(cu_seqlens, group)
+        o, ht = op(
+            q, k, v, g, beta,
+            cu_seqlens=cp_context.cu_seqlens,
+            cp_context=cp_context,
+        )
+        dist.barrier()
+        if backward:
+            o.backward(do)
+            dist.barrier()
+        return o
+
+    def gdn_with_a2a():
+        q2, k2, v2 = [qkvo_all2ll(t.squeeze(0), is_qkv=True, group=group)[0].unsqueeze(0) for t in [q, k, v]]
+        if not args.kda:
+            g2 = qkvo_all2ll(g.squeeze(0).unsqueeze(-1), is_qkv=True, group=group)[0].unsqueeze(0).squeeze(-1)
+        else:
+            g2 = qkvo_all2ll(g.squeeze(0), is_qkv=True, group=group)[0].unsqueeze(0)
+        beta2 = qkvo_all2ll(beta.squeeze(0).unsqueeze(-1), is_qkv=True, group=group)[0].unsqueeze(0).squeeze(-1)
+        o, ht = op(
+            q2, k2, v2, g2, beta2,
+            cu_seqlens=cu_seqlens
+        )
+        o = qkvo_all2ll(o.squeeze(0), is_qkv=False, group=group)[0].unsqueeze(0)
+        dist.barrier()
+        if backward:
+            o.backward(do)
+            dist.barrier()
+        return o
+
+    o = gdn_with_custom_cp()
+    # o = gdn_no_cp()
+    dq, dk, dv, dg, dbeta = get_ref_grad(q, k, v, g, beta)
+    ref_o = gdn_with_a2a()
+    ref_dq, ref_dk, ref_dv, ref_dg, ref_dbeta = get_ref_grad(q, k, v, g, beta)
+
+    if rank == 0:
+        print(cu_seqlens)
+    dist.barrier()
+    compare(o, ref_o, f"rank:{rank}, out:")
+    dist.barrier()
+    if backward:
+        compare(dq, ref_dq, f"rank:{rank}, dq:")
+        dist.barrier()
+        compare(dk, ref_dk, f"rank:{rank}, dk:")
+        dist.barrier()
+        compare(dv, ref_dv, f"rank:{rank}, dv:")
+        dist.barrier()
+        compare(dg, ref_dg, f"rank:{rank}, dg:")
+        dist.barrier()
+        compare(dbeta, ref_dbeta, f"rank:{rank}, dbeta:")
+        dist.barrier()
+
+    if args.bench:
+        dist.barrier()
+        t1 = bench(gdn_no_cp)
+        dist.barrier()
+        t2 = bench(gdn_with_custom_cp)
+        dist.barrier()
+        t3 = bench(gdn_with_a2a)
+        if rank == world_size - 1:
+            print(f"custom cp, non-cp time: {t1:.3f} ms, cp time: {t2:.3f} ms, rate: {((t1/world_size) / t2 * 100):.2f} %")
+            print(f"all to all, non-cp time: {t1:.3f} ms, cp time: {t3:.3f} ms, rate: {((t1/world_size) / t3 * 100):.2f} %")
+
+    if args.profile:
+        def fn():
+            gdn_no_cp()
+            dist.barrier()
+            gdn_with_custom_cp()
+            dist.barrier()
+            gdn_with_a2a()
+            dist.barrier()
+        profile_func(fn, args.profile_path)
+
+
+def test_layer(args):
+    from fla.layers.gated_deltanet import GatedDeltaNet
+    from fla.layers.kda import KimiDeltaAttention
+
+    device = torch.cuda.current_device()
+    group = args.group
+    world_size = dist.get_world_size(group)
+    rank = dist.get_rank(group)
+    cu_seqlens = generate_cu_seqlens(args.seqlen, args.mean, args.std)
+    T = args.seqlen // world_size
+    hidden_size = 2304
+    n_head = 32
+    head_dim = 128
+    use_conv = True
+
+    x = torch.randn(B, T, hidden_size, dtype=DTYPE, device=device).requires_grad_(True)
+    do = torch.randn(B, T, hidden_size, dtype=DTYPE, device=device)
+    total_x = all_gather(x.squeeze(0), group=group).unsqueeze(0).detach().requires_grad_(True)
+    total_do = all_gather(do.squeeze(0), group=group).unsqueeze(0)
+    if not args.kda:
+        layer = GatedDeltaNet(hidden_size, expand_v=1, head_dim=head_dim, num_heads=n_head, use_short_conv=use_conv)
+        cp_layer = GatedDeltaNet(hidden_size, expand_v=1, head_dim=head_dim,
+                                 num_heads=n_head, use_short_conv=use_conv)
+        if args.use_cp2hp:
+            cp_layer.forward = partial(gdn_forward, self=cp_layer, cp_size=world_size, cp_rank=rank, cp_group=group)
+    else:
+        layer = KimiDeltaAttention(hidden_size, expand_v=1, head_dim=head_dim, num_heads=n_head, use_short_conv=use_conv)
+        cp_layer = KimiDeltaAttention(hidden_size, expand_v=1, head_dim=head_dim,
+                                      num_heads=n_head, use_short_conv=use_conv)
+        if args.use_cp2hp:
+            cp_layer.forward = partial(kda_forward, self=cp_layer, cp_size=world_size, cp_rank=rank, cp_group=group)
+    if args.use_cp2hp and use_conv:
+        cp_layer.q_conv1d.forward = partial(short_conv_forward, self=cp_layer.q_conv1d, cp_size=world_size, cp_rank=rank)
+        cp_layer.k_conv1d.forward = partial(short_conv_forward, self=cp_layer.k_conv1d, cp_size=world_size, cp_rank=rank)
+        cp_layer.v_conv1d.forward = partial(short_conv_forward, self=cp_layer.v_conv1d, cp_size=world_size, cp_rank=rank)
+
+    layer = layer.to(x)
+    cp_layer = cp_layer.to(x)
+    for p in layer.parameters():
+        broadcast(p, group)
+    cp_layer.load_state_dict(layer.state_dict())
+
+    patch_fp32_grad_linear_forward(layer)
+    patch_fp32_grad_linear_forward(cp_layer)
+    layer.dt_bias.to(torch.float)
+    layer.A_log.to(torch.float)
+    cp_layer.dt_bias.to(torch.float)
+    cp_layer.A_log.to(torch.float)
+
+    backward = args.backward
+
+    def gdn_no_cp():
+        total_o = layer(total_x, cu_seqlens=cu_seqlens)[0]
+        dist.barrier()
+        if backward:
+            total_o.backward(total_do)
+        dist.barrier()
+        return total_o.chunk(world_size, 1)[rank]
+
+    def gdn_with_custom_cp():
+        o = cp_layer(x, cu_seqlens=cu_seqlens)[0]
+        dist.barrier()
+        if backward:
+            o.backward(do)
+        dist.barrier()
+        return o
+
+    ref_o = gdn_no_cp()
+    if backward:
+        ref_dx = total_x.grad.chunk(world_size, 1)[rank]
+    else:
+        ref_dx = None
+    o = gdn_with_custom_cp()
+    dx = x.grad
+
+    if rank == 0:
+        print(cu_seqlens)
+    dist.barrier()
+    compare(o, ref_o, f"rank:{rank}, out:")
+    if backward:
+        compare(ref_dx, dx, f"rank:{rank}, input grad:")
+        dist.barrier()
+        for (name1, p1), (name2, p2) in zip(layer.named_parameters(), cp_layer.named_parameters()):
+            assert name1 == name2
+            if HAVE_APEX and hasattr(p1, "main_grad"):
+                grad1 = p1.main_grad
+                grad2 = p2.main_grad
+            else:
+                grad1 = p1.grad.float()
+                grad2 = p2.grad.float()
+            torch.distributed.all_reduce(grad2, group=group)
+            compare(grad1, grad2, f"rank:{rank}, {name1} grad:")
+            dist.barrier()
+
+    if args.bench:
+        dist.barrier()
+        t1 = bench(gdn_no_cp)
+        dist.barrier()
+        t2 = bench(gdn_with_custom_cp)
+        dist.barrier()
+        if rank == world_size - 1:
+            print(f"custom cp, non-cp time: {t1:.3f} ms, cp time: {t2:.3f} ms, rate: {((t1/world_size) / t2 * 100):.2f} %")
+
+    if args.profile:
+        def fn():
+            gdn_no_cp()
+            dist.barrier()
+            gdn_with_custom_cp()
+            dist.barrier()
+        profile_func(fn, args.profile_path)
+
+
+def main():
+    dist.init_process_group()
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    torch.manual_seed(rank + 42)
+    torch.cuda.manual_seed(rank + 42)
+    random.seed(42)
+    torch.cuda.set_device(rank)
+    group = dist.new_group(list(range(world_size)))
+    args = get_args()
+    args.group = group
+    if args.ops:
+        test_ops(args)
+    else:
+        test_layer(args)
+
+
+if __name__ == '__main__':
+    main()
+'''
+torchrun --nproc-per-node=4 test_gdn_with_cp.py
+'''

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -4,12 +4,14 @@ import math
 import warnings
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import triton
 import triton.language as tl
 from einops import rearrange
 
+from fla.ops.cp import FLACPContext, conv_cp_send_recv_bwd, conv_cp_send_recv_fwd
 from fla.ops.utils import prepare_chunk_indices, prepare_sequence_ids
 from fla.utils import IS_AMD, autotune_cache_kwargs, get_multiprocessor_count, input_guard
 
@@ -1101,6 +1103,7 @@ def causal_conv1d(
     cu_seqlens: torch.Tensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
     **kwargs,
 ):
     """
@@ -1139,6 +1142,21 @@ def causal_conv1d(
         Tuple of (output, final_state).
         If `output_final_state` is `False`, the final state is `None`.
     """
+    if cp_context is not None:
+        assert initial_state is None, "Initial state is not supported for CP"
+        assert output_final_state is False, "Output final state is not supported for CP"
+        assert cu_seqlens is not None, "cu_seqlens is required for CP"
+        output = causal_conv1d_cp(
+            x=x,
+            weight=weight,
+            bias=bias,
+            activation=activation,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_cpu=cu_seqlens_cpu,
+            chunk_indices=chunk_indices,
+            cp_context=cp_context,
+        )
+        return output, None
 
     if backend == 'triton':
         y, final_state = CausalConv1dFunction.apply(
@@ -1612,3 +1630,218 @@ class ImplicitLongConvolution(nn.Module):
 
         y = y.transpose(1, 2)
         return y.to(dtype=x.dtype)
+
+
+# CP Related Conv1d Functions
+
+class CausalConv1dFunctionCP(torch.autograd.Function):
+    """
+    Context Parallel version of CausalConv1dFunction.
+
+    Forward:
+        1. Get tails from previous rank to construct initial_state
+        2. Call causal_conv1d_fwd
+
+    Backward:
+        1. Call causal_conv1d_bwd to get dx
+        2. Sync communication: add next rank's first W-1 token gradients to current rank's last W-1 tokens
+    """
+
+    @staticmethod
+    def _prepare_initial_state_for_cp(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        context: FLACPContext,
+        group: dist.ProcessGroup | None,
+    ) -> torch.Tensor | None:
+        """Prepare initial_state for CP forward pass by communicating with previous rank.
+
+        Args:
+            x: Input tensor of shape [1, T, D]
+            weight: Weight tensor of shape [D, W]
+            cu_seqlens: Cumulative sequence lengths
+            context: CP context
+            group: Process group for communication
+
+        Returns:
+            initial_state: Initial state tensor of shape [N, D, W] or None
+        """
+        if group is None:
+            return None
+
+        W = weight.shape[-1]  # weight: [D, W]
+        D = weight.shape[0]
+        initial_state = None
+        if not context.is_first_rank:
+            # Non-first rank needs initial_state
+            assert x.dim() == 3 and x.shape[0] == 1, f"CP requires [1, T, D], got {x.shape}"
+            x_2d = x.squeeze(0)  # [T, D]
+            tails = x_2d[-(W-1):].contiguous()  # [W-1, D]
+            heads = conv_cp_send_recv_fwd(tails, group)  # [W-1, D]
+            # Construct initial_state: [N, D, W]
+            N = len(cu_seqlens) - 1
+            initial_state = torch.zeros(N, D, W, device=x.device, dtype=x.dtype)
+            valid_len = min(W - 1, context.pre_num_conv_tokens)
+            if valid_len > 0:
+                # heads[-valid_len:]: [valid_len, D] -> [D, valid_len]
+                initial_state[0, :, -valid_len:] = heads[-valid_len:].T
+        else:
+            # First rank also needs to participate in communication (send tails)
+            x_2d = x.squeeze(0)
+            tails = x_2d[-(W-1):].contiguous()
+            _ = conv_cp_send_recv_fwd(tails, group)  # Send but don't use
+
+        return initial_state
+
+    @staticmethod
+    def _correct_dx_for_cp(
+        dx: torch.Tensor,
+        dh0: torch.Tensor | None,
+        W: int,
+        group: dist.ProcessGroup | None,
+        is_first_rank: bool,
+    ) -> None:
+        """Correct dx gradients for CP backward pass by communicating with next rank.
+
+        Args:
+            dx: Gradient tensor to be corrected, shape [1, T, D]
+            dh0: Gradient w.r.t. initial_state, shape [N, D, W] or None
+            W: Kernel size
+            group: Process group for communication
+            is_first_rank: Whether this is the first rank in the sequence's processing chain
+        """
+        if group is None:
+            return
+
+        D = dx.shape[-1]
+        # dh0: [N, D, W] or None
+        # We only care about the first sequence's initial_state gradient
+        if dh0 is not None:
+            # Get first sequence's d_initial_state: [D, W] -> last W-1 cols -> [D, W-1] -> [W-1, D]
+            d_initial_state = dh0[0, :, -(W-1):].T.contiguous()  # [W-1, D]
+        else:
+            # dh0 is None only when this is the first rank (no initial_state needed)
+            assert is_first_rank, "dh0 should not be None when is_first_rank=False"
+            d_initial_state = torch.zeros(W-1, D, device=dx.device, dtype=dx.dtype)
+        # Sync communication: send d_initial_state to previous rank, receive from next rank
+        recv_d_init = conv_cp_send_recv_bwd(d_initial_state, group)  # [W-1, D]
+        # Add to current rank's last W-1 tokens (these tokens are used as initial_state by next rank)
+        dx[0, -(W-1):, :].add_(recv_d_init)
+
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+        activation: str | None,
+        cu_seqlens: torch.Tensor | None,
+        cu_seqlens_cpu: torch.Tensor | None,
+        chunk_indices: torch.Tensor | None,
+        cp_context: FLACPContext | None,
+    ):
+        if cp_context is None:
+            raise ValueError("cp_context must be provided for CausalConv1dFunctionCP")
+        group = cp_context.group
+
+        # Get kernel_size
+        W = weight.shape[-1]  # weight: [D, W]
+        # Prepare initial_state for CP
+        initial_state = CausalConv1dFunctionCP._prepare_initial_state_for_cp(
+            x=x,
+            weight=weight,
+            cu_seqlens=cu_seqlens,
+            context=cp_context,
+            group=group,
+        )
+
+        ctx.save_for_backward(x, weight, bias, initial_state)
+        ctx.activation = activation
+        ctx.cu_seqlens = cu_seqlens
+        ctx.cu_seqlens_cpu = cu_seqlens_cpu
+        ctx.chunk_indices = chunk_indices
+        ctx.group = group
+        ctx.W = W
+        ctx.is_first_rank = cp_context.is_first_rank
+
+        # Call original forward
+        y, _ = causal_conv1d_fwd(
+            x=x,
+            weight=weight,
+            bias=bias,
+            residual=None,
+            initial_state=initial_state,
+            output_final_state=False,
+            activation=activation,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_cpu=cu_seqlens_cpu,
+            chunk_indices=chunk_indices,
+        )
+
+        return y
+
+    @staticmethod
+    def backward(ctx, dy: torch.Tensor):
+        x, weight, bias, initial_state = ctx.saved_tensors
+        group = ctx.group
+        W = ctx.W
+
+        # Call original backward
+        dx, dw, db, _, dh0 = causal_conv1d_bwd(
+            x=x,
+            dy=dy,
+            dht=None,
+            weight=weight,
+            bias=bias,
+            residual=None,
+            initial_state=initial_state,
+            activation=ctx.activation,
+            cu_seqlens=ctx.cu_seqlens,
+            cu_seqlens_cpu=ctx.cu_seqlens_cpu,
+            chunk_indices=ctx.chunk_indices,
+        )
+
+        # Correct dx gradients for CP
+        CausalConv1dFunctionCP._correct_dx_for_cp(
+            dx=dx,
+            dh0=dh0,
+            W=W,
+            group=group,
+            is_first_rank=ctx.is_first_rank,
+        )
+
+        return dx, dw, db, None, None, None, None, None
+
+
+def causal_conv1d_cp(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    activation: str | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    cu_seqlens_cpu: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    cp_context: FLACPContext | None = None,
+):
+    """
+    Context Parallel version of causal_conv1d.
+
+    Automatically handles communication in CP environment:
+    - Forward: get initial_state from previous rank
+    - Backward: correct dx gradients
+
+    Args:
+        x: Input tensor of shape [1, T, D]
+        weight: Weight tensor of shape [D, W]
+        bias: Bias tensor of shape [D] or None
+        activation: Activation function name or None
+        cu_seqlens: Cumulative sequence lengths
+        cu_seqlens_cpu: Cumulative sequence lengths on CPU
+        chunk_indices: Chunk indices for variable-length sequences
+        cp_context: CP context (required for CP mode)
+    """
+    return CausalConv1dFunctionCP.apply(
+        x, weight, bias, activation,
+        cu_seqlens, cu_seqlens_cpu, chunk_indices, cp_context
+    )

--- a/fla/ops/cp/README.md
+++ b/fla/ops/cp/README.md
@@ -1,0 +1,2 @@
+# CP Related Features was first implemented by Duyue MA
+# And integrated by Zhiyuan Li

--- a/fla/ops/cp/__init__.py
+++ b/fla/ops/cp/__init__.py
@@ -1,0 +1,25 @@
+# Context Parallel operators and utilities
+
+from .comm import (
+    all_gather_into_tensor,
+    all_reduce_sum,
+    conv_cp_send_recv_bwd,
+    conv_cp_send_recv_fwd,
+    send_recv_bwd,
+    send_recv_fwd,
+)
+from .context import (
+    FLACPContext,
+    build_cp_context,
+)
+
+__all__ = [
+    "FLACPContext",
+    "all_gather_into_tensor",
+    "all_reduce_sum",
+    "build_cp_context",
+    "conv_cp_send_recv_bwd",
+    "conv_cp_send_recv_fwd",
+    "send_recv_bwd",
+    "send_recv_fwd",
+]

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -1,0 +1,764 @@
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+
+from fla.ops.cp.comm import all_gather_into_tensor
+from fla.ops.cp.context import FLACPContext
+from fla.ops.utils.op import exp, exp2
+from fla.utils import USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem, tensor_cache
+
+
+@tensor_cache
+def get_cp_cu_seqlens(
+    cu_seqlens: torch.LongTensor,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+    world_size: int | None = None,
+    rank: int | None = None,
+    group: dist.ProcessGroup | None = None,
+    kernel_size: int | None = None
+) -> FLACPContext:
+    # 1. Initialize environment info
+    if world_size is None:
+        assert group is not None
+        world_size = dist.get_world_size(group=group)
+        rank = dist.get_rank(group=group)
+
+    # 2. Operate on CPU to avoid D2H sync and leverage vectorization
+    if cu_seqlens_cpu is None:
+        cu_seqlens_cpu = cu_seqlens.cpu()
+
+    # Get total tokens and current rank's responsible range
+    # Assume cu_seqlens is [0, s1, s1+s2, ..., total]
+    total_tokens = cu_seqlens_cpu[-1].item()
+    part_len = total_tokens // world_size
+    rank_start = part_len * rank
+    rank_end = rank_start + part_len
+
+    # 3. Vectorized search: find sequences overlapping with current rank's interval [rank_start, rank_end)
+    # We need to find idx such that: global_ends[idx] > rank_start AND global_starts[idx] < rank_end
+
+    # Optimization: cu_seqlens is sorted, use searchsorted to quickly locate boundaries
+    # Find first sequence whose end > rank_start
+    # cu_seqlens_cpu[1:] contains all sequence end points
+    start_seq_idx = torch.searchsorted(cu_seqlens_cpu[1:], rank_start, side='right')
+
+    # Find first sequence whose start >= rank_end, sequences before this may overlap
+    # cu_seqlens_cpu[:-1] contains all sequence start points
+    end_seq_idx = torch.searchsorted(cu_seqlens_cpu[:-1], rank_end, side='left')
+
+    # Slice cu_seqlens_cpu[start_seq_idx : end_seq_idx + 1] to get relevant global cu_seqlens nodes
+    # +1 because end_seq_idx is an open boundary, and cu_seqlens length is num_seqs + 1
+    subset_cu_seqlens = cu_seqlens_cpu[start_seq_idx: end_seq_idx + 1]
+
+    # 4. Compute local cu_seqlens (CPU vectorized)
+    # Clamp global coordinates to [rank_start, rank_end], subtract rank_start to get local coordinates
+    # unique_consecutive removes duplicates from clamping (e.g., sequences entirely outside this rank)
+    local_cu_seqlens = (
+        subset_cu_seqlens.clamp(min=rank_start, max=rank_end) - rank_start
+    ).unique_consecutive()
+
+    # Transfer to GPU (small tensor, fast transfer)
+    # non_blocking=True can further hide latency in CUDA streams
+    cu_seqlens_gpu = local_cu_seqlens.to(device=cu_seqlens.device, dtype=torch.int32, non_blocking=True)
+
+    # 5. Compute Context Parallel metadata (first/last rank info)
+    # Use slice endpoints directly, avoiding loops
+
+    # Get global info for the first sequence that has data on current rank
+    first_seq_global_start = cu_seqlens_cpu[start_seq_idx].item()
+    # Get global info for the last sequence that has data on current rank
+    last_seq_global_end = cu_seqlens_cpu[end_seq_idx].item()
+
+    # Number of tokens current rank needs from previous ranks for conv
+    pre_num_conv_tokens = max(0, rank_start - first_seq_global_start)
+
+    # Compute first sequence's starting rank
+    first_rank_of_first_seq = first_seq_global_start // part_len
+    # Number of previous ranks current rank needs to receive state from
+    pre_num_ranks = rank - first_rank_of_first_seq
+    # Whether current rank is the first in the sequence's processing chain
+    is_first_rank = (rank == first_rank_of_first_seq)
+
+    # Compute last sequence's ending rank
+    # (last_seq_global_end - 1) is the index of the last token
+    last_rank_of_last_seq = (last_seq_global_end - 1) // part_len
+    # Number of subsequent ranks current rank needs to send state to
+    post_num_ranks = last_rank_of_last_seq - rank
+    # Whether current rank is the last in the sequence's processing chain
+    is_last_rank = (rank == last_rank_of_last_seq)
+
+    return FLACPContext(
+        group=group,
+        cu_seqlens=cu_seqlens_gpu,
+        is_last_rank=is_last_rank,
+        pre_num_ranks=pre_num_ranks,
+        is_first_rank=is_first_rank,
+        post_num_ranks=post_num_ranks,
+        kernel_size=kernel_size,
+        pre_num_conv_tokens=pre_num_conv_tokens
+    )
+
+
+@triton.heuristics({
+    'USE_G': lambda args: args['g'] is not None,
+    'USE_GK': lambda args: args['gk'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+        for BV in [32, 64]
+    ],
+    key=['H', 'K', 'V', 'BT', 'USE_EXP2', "STAGE"],
+    use_cuda_graph=USE_CUDA_GRAPH,
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def pre_process_fwd_kernel_stage1(
+    k,
+    v,
+    w,
+    g,
+    gk,
+    hm,
+    cu_seqlens,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_h = tl.program_id(0), tl.program_id(1)
+    i_n = 0
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+
+    # calculate offset
+    hm += i_h * K * (K + V)
+    v += ((bos * H + i_h) * V).to(tl.int64)
+    k += ((bos * H + i_h) * K).to(tl.int64)
+    w += ((bos * H + i_h) * K).to(tl.int64)
+    stride_v = H*V
+    stride_k = H*K
+
+    b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 64:
+        b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 128:
+        b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 192:
+        b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+    # main recurrence
+    for i_t in range(NT):
+        p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
+        if K > 64:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
+        if K > 128:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
+        if K > 192:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
+        p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+
+        last_idx = min((i_t + 1) * BT, T) - 1
+        if USE_G:
+            m_t = (i_t * BT + tl.arange(0, BT)) < T
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h).to(tl.float32)
+            p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+            if USE_EXP2:
+                b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp2(b_g_last)
+            else:
+                b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp(b_g_last)
+            b_h1 *= b_g_last
+            if K > 64:
+                b_h2 *= b_g_last
+            if K > 128:
+                b_h3 *= b_g_last
+            if K > 192:
+                b_h4 *= b_g_last
+
+        if USE_GK:
+            o_k1 = tl.arange(0, 64)
+            b_gk_last1 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
+            if USE_EXP2:
+                b_h1 *= exp2(b_gk_last1)[:, None]
+            else:
+                b_h1 *= exp(b_gk_last1)[:, None]
+            if K > 64:
+                o_k2 = 64 + o_k1
+                b_gk_last2 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
+                if USE_EXP2:
+                    b_h2 *= exp2(b_gk_last2)[:, None]
+                else:
+                    b_h2 *= exp(b_gk_last2)[:, None]
+            if K > 128:
+                o_k3 = 128 + o_k1
+                b_gk_last3 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
+                if USE_EXP2:
+                    b_h3 *= exp2(b_gk_last3)[:, None]
+                else:
+                    b_h3 *= exp(b_gk_last3)[:, None]
+            if K > 192:
+                o_k4 = 192 + o_k1
+                b_gk_last4 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
+                if USE_EXP2:
+                    b_h4 *= exp2(b_gk_last4)[:, None]
+                else:
+                    b_h4 *= exp(b_gk_last4)[:, None]
+
+        b_v = b_v.to(k.dtype.element_ty)
+
+        p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_h1 += tl.dot(b_k, b_v)
+        if K > 64:
+            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h2 += tl.dot(b_k, b_v)
+        if K > 128:
+            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h3 += tl.dot(b_k, b_v)
+        if K > 192:
+            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h4 += tl.dot(b_k, b_v)
+
+    p_h1 = tl.make_block_ptr(hm, (K, V), (K+V, 1), (0, i_v * BV), (64, BV), (1, 0))
+    tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+    if K > 64:
+        p_h2 = tl.make_block_ptr(hm, (K, V), (K+V, 1), (64, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+    if K > 128:
+        p_h3 = tl.make_block_ptr(hm, (K, V), (K+V, 1), (128, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+    if K > 192:
+        p_h4 = tl.make_block_ptr(hm, (K, V), (K+V, 1), (192, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'USE_G': lambda args: args['g'] is not None,
+    'USE_GK': lambda args: args['gk'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BK2': BK2}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+        for BK2 in [32]
+    ],
+    key=['H', 'BT', 'USE_EXP2', 'FORWARD'],
+    use_cuda_graph=USE_CUDA_GRAPH,
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def pre_process_fwd_bwd_kernel_stage2(
+    k,
+    w,
+    g,
+    gk,
+    hm,
+    cu_seqlens,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    BK1: tl.constexpr,
+    BK2: tl.constexpr,
+    FORWARD: tl.constexpr = True,
+):
+    i_k_col, i_h = tl.program_id(0), tl.program_id(1)
+    i_n = 0
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+
+    # calculate offset
+    hm += i_h * K * (K + V)
+    k += ((bos * H + i_h) * K).to(tl.int64)
+    w += ((bos * H + i_h) * K).to(tl.int64)
+    stride_k = H*K
+
+    row = tl.arange(0, BK1)
+    col = tl.arange(0, BK2) + i_k_col * BK2
+
+    b_m = tl.where(row[:, None] == col[None, :],  1.0,  0.0)
+    for _i_t in range(NT):
+        if FORWARD:
+            i_t = _i_t
+        else:
+            i_t = NT - 1 - _i_t
+        p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, BK1), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, BK1), (1, 0))
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        last_idx = min((i_t + 1) * BT, T) - 1
+        if USE_G:
+            m_t = (i_t * BT + tl.arange(0, BT)) < T
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h).to(tl.float32)
+            p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+            if USE_EXP2:
+                b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp2(b_g_last)
+            else:
+                b_k = b_k * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp(b_g_last)
+            b_diag = tl.where(row[:, None] == row[None, :], b_g_last,  0.0)
+        elif USE_GK:
+            b_gk_last = tl.load(gk + (bos + last_idx) * H*K + i_h * K + row, mask=(row < K), other=0.).to(tl.float32)
+            if USE_EXP2:
+                b_gk_last = exp2(b_gk_last)
+            else:
+                b_gk_last = exp(b_gk_last)
+            b_diag = tl.where(row[:, None] == row[None, :], b_gk_last[:, None], 0.0)
+        else:
+            b_diag = tl.where(row[:, None] == row[None, :], 1., 0.0)
+        if FORWARD:
+            b_kw = tl.dot(tl.trans(b_k.to(b_w.dtype)), b_w)
+        else:
+            b_kw = tl.dot(tl.trans(b_w), b_k.to(b_w.dtype))
+        b_m_i = b_diag - b_kw
+        b_m = tl.dot(b_m_i.to(b_w.dtype), b_m.to(b_w.dtype))
+    p_m = tl.make_block_ptr(hm + V, (K, K), (K+V, 1), (0, i_k_col * BK2), (BK1, BK2), (1, 0))
+    tl.store(p_m, b_m.to(p_m.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+        for BV in [32, 64]
+    ],
+    key=['H', 'K', 'V', 'BT', 'USE_EXP2'],
+    use_cuda_graph=USE_CUDA_GRAPH,
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['pre_or_post_num_ranks', 'rank'])
+def merge_fwd_bwd_kernel(
+    h,
+    ag_hm,
+    pre_or_post_num_ranks,
+    rank,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BV: tl.constexpr,
+    BK: tl.constexpr,
+    FORWARD: tl.constexpr = True
+):
+    i_v, i_h = tl.program_id(0), tl.program_id(1)
+    num_ranks = pre_or_post_num_ranks.to(tl.int32)
+    h += i_h * K * V
+    ag_hm += i_h * K * (K + V)
+    stride = H * K * (K + V)
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    for idx in range(num_ranks):
+        if FORWARD:
+            cur_rank = rank - num_ranks + idx
+        else:
+            cur_rank = rank + num_ranks - idx
+        p_ag_h = tl.make_block_ptr(ag_hm + cur_rank * stride, (K, V), (K + V, 1), (0, i_v * BV), (BK, BV), (1, 0))
+        b_ag_h = tl.load(p_ag_h, boundary_check=(0, 1))
+        p_ag_m = tl.make_block_ptr(ag_hm + cur_rank * stride + V, (K, K), (K + V, 1), (0, 0), (BK, BK), (1, 0))
+        b_ag_m = tl.load(p_ag_m, boundary_check=(0, 1))
+        b_h = tl.dot(b_ag_m, b_h.to(b_ag_m.dtype)) + b_ag_h
+    p_h = tl.make_block_ptr(h, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
+    tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'USE_G': lambda args: args['g'] is not None,
+    'USE_GK': lambda args: args['gk'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in ([4, 3, 2] if check_shared_mem('ampere') else [1])
+        for BV in [64, 32]
+    ],
+    key=['H', 'K', 'V', 'BT', 'BV', 'USE_G'],
+    use_cuda_graph=USE_CUDA_GRAPH,
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def pre_process_bwd_kernel_stage1(
+    q,
+    k,
+    w,
+    g,
+    gk,
+    do,
+    dhm,
+    dv,
+    cu_seqlens,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_h = tl.program_id(0), tl.program_id(1)
+    i_n = 0
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+
+    # [BK, BV]
+    b_dh1 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 64:
+        b_dh2 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 128:
+        b_dh3 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 192:
+        b_dh4 = tl.zeros([64, BV], dtype=tl.float32)
+
+    # calculate offset
+    q += ((bos * H + i_h) * K).to(tl.int64)
+    k += ((bos * H + i_h) * K).to(tl.int64)
+    w += ((bos * H + i_h) * K).to(tl.int64)
+    do += ((bos * H + i_h) * V).to(tl.int64)
+    dv += ((bos * H + i_h) * V).to(tl.int64)
+    dhm += i_h * K * (V + K)
+
+    stride_v = H*V
+    stride_k = H*K
+
+    for i_t in range(NT - 1, -1, -1):
+        last_idx = min((i_t + 1) * BT, T) - 1
+        if USE_G:
+            bg_last = tl.load(g + (bos + last_idx) * H + i_h)
+            bg_last_exp = exp(bg_last)
+            p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,))
+            b_g_exp = exp(b_g)
+
+        p_dv = tl.make_block_ptr(dv, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_do = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+
+        # Update dv
+        p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        if USE_GK:
+            o_k1 = tl.arange(0, 64)
+            b_gk_last1 = tl.load(gk + last_idx * H*K + o_k1, mask=(o_k1 < K), other=0.)
+        b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
+
+        if K > 64:
+            p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            if USE_GK:
+                o_k2 = 64 + o_k1
+                b_gk_last2 = tl.load(gk + last_idx * H*K + o_k2, mask=(o_k2 < K), other=0.)
+            b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
+
+        if K > 128:
+            p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            if USE_GK:
+                o_k3 = 128 + o_k1
+                b_gk_last3 = tl.load(gk + last_idx * H*K + o_k3, mask=(o_k3 < K), other=0.)
+            b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
+
+        if K > 192:
+            p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            if USE_GK:
+                o_k4 = 192 + o_k1
+                b_gk_last4 = tl.load(gk + last_idx * H*K + o_k4, mask=(o_k4 < K), other=0.)
+            b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
+
+        if USE_G:
+            m_t = (i_t * BT + tl.arange(0, BT)) < T
+            b_dv *= tl.where(m_t, exp(bg_last - b_g), 0)[:, None]
+        b_dv += tl.load(p_dv, boundary_check=(0, 1))
+
+        # Update dh
+        p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
+        p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        if USE_G:
+            b_dh1 *= bg_last_exp
+            b_q = b_q * b_g_exp[None, :]
+        if USE_GK:
+            b_dh1 *= exp(b_gk_last1[:, None])
+        b_dh1 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+        if K > 64:
+            p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
+            p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            if USE_G:
+                b_dh2 *= bg_last_exp
+                b_q = b_q * b_g_exp[None, :]
+            if USE_GK:
+                b_dh2 *= exp(b_gk_last2[:, None])
+            b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+        if K > 128:
+            p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
+            p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            if USE_G:
+                b_dh3 *= bg_last_exp
+                b_q = b_q * b_g_exp[None, :]
+            if USE_GK:
+                b_dh3 *= exp(b_gk_last3[:, None])
+            b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+        if K > 192:
+            p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
+            p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            if USE_G:
+                b_dh4 *= bg_last_exp
+                b_q = b_q * b_g_exp[None, :]
+            if USE_GK:
+                b_dh4 *= exp(b_gk_last4[:, None])
+            b_dh4 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+
+    p_dh1 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (0, i_v * BV), (64, BV), (1, 0))
+    tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+    if K > 64:
+        p_dh2 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (64, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+    if K > 128:
+        p_dh3 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (128, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+    if K > 192:
+        p_dh4 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (192, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+
+
+DTYPE = torch.float32
+
+
+def chunk_gated_delta_rule_fwd_h_pre_process(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
+    cu_seqlens: torch.LongTensor | None = None,
+    use_exp2: bool = False,
+    initial_state: torch.Tensor | None = None,
+    context: FLACPContext = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if context is None or context.group is None:
+        return initial_state
+    assert initial_state is None, "When enable CP, the provided initial_state must be None."
+    rank = dist.get_rank(group=context.group)
+
+    B, T, H, K, V = *k.shape, u.shape[-1]
+    BT = chunk_size
+    BK = triton.next_power_of_2(K)
+
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    if cu_seqlens is None:
+        N = B
+    else:
+        N = len(cu_seqlens) - 1
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    hm = k.new_zeros(H, K, (V + K), dtype=DTYPE)
+    initial_state = k.new_zeros(N, H, K, V, dtype=DTYPE)
+    if not context.is_last_rank:
+        # For HEAD_DIM=128, split into two kernels for better performance.
+        def grid(meta): return (triton.cdiv(V, meta['BV']), H)
+        pre_process_fwd_kernel_stage1[grid](
+            k=k,
+            v=u,
+            w=w,
+            g=g,
+            gk=gk,
+            hm=hm,
+            cu_seqlens=cu_seqlens[-2:],
+            T=T,
+            H=H,
+            K=K,
+            V=V,
+            BT=BT,
+            USE_EXP2=use_exp2,
+        )
+        def grid(meta): return (triton.cdiv(K, meta['BK2']), H)
+        pre_process_fwd_bwd_kernel_stage2[grid](
+            k=k,
+            w=w,
+            g=g,
+            gk=gk,
+            hm=hm,
+            cu_seqlens=cu_seqlens[-2:],
+            T=T,
+            H=H,
+            K=K,
+            V=V,
+            BT=BT,
+            BK1=BK,
+            USE_EXP2=use_exp2,
+        )
+    ag_hm, _ = all_gather_into_tensor(hm, group=context.group)
+    if not context.is_first_rank:
+        def grid(meta): return (triton.cdiv(V, meta['BV']), H)
+        merge_fwd_bwd_kernel[grid](
+            initial_state[0],
+            ag_hm,
+            context.pre_num_ranks,
+            rank,
+            H=H,
+            K=K,
+            V=V,
+            BK=BK,
+        )
+    return initial_state
+
+
+def chunk_gated_delta_rule_bwd_dhu_pre_process(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    do: torch.Tensor,
+    dv: torch.Tensor,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    use_exp2: bool = False,
+    dht: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    context: FLACPContext | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if context is None or context.group is None:
+        return dht, initial_state
+    assert dht is None, "When enable CP, the provided dht must be None."
+    rank = dist.get_rank(context.group)
+
+    B, T, H, K, V = *q.shape, do.shape[-1]
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    BT = 64
+    assert K <= 256, "current kernel does not support head dimension being larger than 256."
+    BK = triton.next_power_of_2(K)
+
+    if cu_seqlens is None:
+        N = B
+    else:
+        N = len(cu_seqlens) - 1
+
+    dhm = q.new_zeros(H, K, V + K, dtype=DTYPE)
+    dht = q.new_zeros(N, H, K, V, dtype=DTYPE)
+    if not context.is_first_rank:
+        def grid(meta): return (triton.cdiv(V, meta['BV']), H)
+        pre_process_bwd_kernel_stage1[grid](
+            q=q,
+            k=k,
+            w=w,
+            g=g,
+            gk=gk,
+            do=do,
+            dhm=dhm,
+            dv=dv,
+            cu_seqlens=cu_seqlens[:2],
+            scale=scale,
+            T=T,
+            H=H,
+            K=K,
+            V=V,
+            BT=BT,
+        )
+        def grid(meta): return (triton.cdiv(K, meta['BK2']), H)
+        pre_process_fwd_bwd_kernel_stage2[grid](
+            k=k,
+            w=w,
+            g=g,
+            gk=gk,
+            hm=dhm,
+            cu_seqlens=cu_seqlens[:2],
+            T=T,
+            H=H,
+            K=K,
+            V=V,
+            BT=BT,
+            BK1=BK,
+            USE_EXP2=use_exp2,
+            FORWARD=False
+        )
+    ag_dhm, _ = all_gather_into_tensor(dhm, group=context.group)
+    if not context.is_last_rank:
+        def grid(meta): return (triton.cdiv(V, meta['BV']), H)
+        merge_fwd_bwd_kernel[grid](
+            dht[-1],
+            ag_dhm,
+            context.post_num_ranks,
+            rank,
+            H=H,
+            K=K,
+            V=V,
+            BK=BK,
+            FORWARD=False
+        )
+    return dht, None
+
+
+def compress_h0(h0: torch.Tensor, context: FLACPContext):
+    if h0 is None or len(context.cu_seqlens) == 2:
+        return h0
+    # Here must use clone op or the full tensor will be saved for backward
+    return h0[:1].clone()
+
+
+def expand_h0(h0: torch.Tensor, context: FLACPContext):
+    if h0 is None or len(context.cu_seqlens) == 2:
+        return h0
+    B = len(context.cu_seqlens) - 1
+    expand_h0 = h0.new_zeros(B, *h0.shape[1:])
+    expand_h0[:1] = h0
+    return expand_h0

--- a/fla/ops/cp/comm.py
+++ b/fla/ops/cp/comm.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
+
+
+def all_gather_into_tensor(
+    inp: torch.Tensor,
+    out: torch.Tensor | None = None,
+    group: ProcessGroup | None = None,
+    async_op: bool = False
+) -> tuple[torch.Tensor, dist.Work | None]:
+    """
+    All-gather a tensor across ranks.
+
+    Args:
+        inp: Input tensor to gather
+        out: Optional output tensor of shape [world_size, *inp.shape]
+        group: Process group
+        async_op: Whether to perform async operation
+
+    Returns:
+        Tuple of (output tensor, handle if async_op else None)
+    """
+    world_size = dist.get_world_size(group=group)
+    if out is None:
+        out = torch.empty(world_size, *inp.shape, device=inp.device, dtype=inp.dtype)
+    handle = dist.all_gather_into_tensor(out, inp, group=group, async_op=async_op)
+    return out, handle
+
+
+def all_reduce_sum(
+    inp: torch.Tensor,
+    group: ProcessGroup | None = None,
+    async_op: bool = False
+) -> tuple[torch.Tensor, dist.Work | None]:
+    """
+    All-reduce sum a tensor across ranks.
+
+    Args:
+        inp: Input tensor to reduce (modified in-place)
+        group: Process group
+        async_op: Whether to perform async operation
+
+    Returns:
+        Tuple of (reduced tensor, handle if async_op else None)
+    """
+    handle = dist.all_reduce(inp, op=dist.ReduceOp.SUM, group=group, async_op=async_op)
+    return inp, handle
+
+
+def send_recv_fwd(
+    send_tensor: torch.Tensor,
+    group: ProcessGroup,
+    recv_from_prev: bool = True
+) -> torch.Tensor:
+    """
+    Forward pass communication: send tensor to next rank, receive from previous rank.
+
+    Uses all_gather for simplicity and to ensure all ranks participate.
+
+    Args:
+        send_tensor: Tensor to send (e.g., tails for conv1d)
+        group: Process group
+        recv_from_prev: If True, receive from previous rank; if False, receive from next rank
+
+    Returns:
+        Received tensor from the specified rank (zeros if no valid source)
+    """
+    rank = dist.get_rank(group)
+    world_size = dist.get_world_size(group)
+
+    # All-gather to ensure all ranks participate
+    gathered, _ = all_gather_into_tensor(send_tensor, group=group, async_op=False)
+
+    if recv_from_prev:
+        # Receive from previous rank
+        if rank == 0:
+            return torch.zeros_like(send_tensor)
+        else:
+            return gathered[rank - 1].clone()
+    else:
+        # Receive from next rank
+        if rank == world_size - 1:
+            return torch.zeros_like(send_tensor)
+        else:
+            return gathered[rank + 1].clone()
+
+
+def send_recv_bwd(
+    send_tensor: torch.Tensor,
+    group: ProcessGroup,
+    recv_from_next: bool = True
+) -> torch.Tensor:
+    """
+    Backward pass communication: send gradient to previous rank, receive from next rank.
+
+    Uses all_gather for simplicity and to ensure all ranks participate.
+
+    Args:
+        send_tensor: Gradient tensor to send
+        group: Process group
+        recv_from_next: If True, receive from next rank; if False, receive from previous rank
+
+    Returns:
+        Received gradient tensor from the specified rank (zeros if no valid source)
+    """
+    rank = dist.get_rank(group)
+    world_size = dist.get_world_size(group)
+
+    # All-gather to ensure all ranks participate
+    gathered, _ = all_gather_into_tensor(send_tensor, group=group, async_op=False)
+
+    if recv_from_next:
+        # Receive from next rank
+        if rank == world_size - 1:
+            return torch.zeros_like(send_tensor)
+        else:
+            return gathered[rank + 1].clone()
+    else:
+        # Receive from previous rank
+        if rank == 0:
+            return torch.zeros_like(send_tensor)
+        else:
+            return gathered[rank - 1].clone()
+
+
+# ============ Convenience aliases for conv1d CP ============
+
+def conv_cp_send_recv_fwd(tails: torch.Tensor, group: ProcessGroup) -> torch.Tensor:
+    """
+    Conv1d CP forward: each rank sends its tails, receives previous rank's tails as heads.
+
+    Args:
+        tails: [W-1, D] or [N, D, W-1] - tail tokens from current rank
+        group: Process group
+
+    Returns:
+        heads: Same shape as tails - head tokens from previous rank (zeros for rank 0)
+    """
+    return send_recv_fwd(tails, group, recv_from_prev=True)
+
+
+def conv_cp_send_recv_bwd(d_initial_state: torch.Tensor, group: ProcessGroup) -> torch.Tensor:
+    """
+    Conv1d CP backward: each rank sends d_initial_state, receives from next rank.
+
+    The received gradient should be added to the last W-1 tokens' gradient.
+
+    Args:
+        d_initial_state: [W-1, D] or [N, D, W-1] - gradient w.r.t. initial state
+        group: Process group
+
+    Returns:
+        recv_grad: Same shape - gradient from next rank (zeros for last rank)
+    """
+    return send_recv_bwd(d_initial_state, group, recv_from_next=True)

--- a/fla/ops/cp/context.py
+++ b/fla/ops/cp/context.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
+
+
+@dataclass
+class FLACPContext:
+    """FLA Context Parallel Context - Operator-level context management."""
+    group: ProcessGroup | None = None
+    cu_seqlens: torch.Tensor | None = None
+    is_last_rank: bool | None = None
+    pre_num_ranks: int | None = None
+    is_first_rank: bool | None = None
+    post_num_ranks: int | None = None
+    kernel_size: int | None = None
+    pre_num_conv_tokens: int | None = None
+
+    def copy_for_backward(self) -> FLACPContext:
+        """Create a copy for backward pass (useful when PP_SIZE > 1)."""
+        return FLACPContext(
+            group=self.group,
+            cu_seqlens=self.cu_seqlens.clone() if self.cu_seqlens is not None else None,
+            is_last_rank=self.is_last_rank,
+            pre_num_ranks=self.pre_num_ranks,
+            is_first_rank=self.is_first_rank,
+            post_num_ranks=self.post_num_ranks,
+            kernel_size=self.kernel_size,
+            pre_num_conv_tokens=self.pre_num_conv_tokens,
+        )
+
+    @property
+    def num_seqs(self) -> int:
+        """Number of sequences in this rank."""
+        return 0 if self.cu_seqlens is None else len(self.cu_seqlens) - 1
+
+    @property
+    def is_cp_enabled(self) -> bool:
+        """Whether context parallel is enabled."""
+        return self.group is not None
+
+
+def build_cp_context(
+    cu_seqlens: torch.Tensor,
+    group: ProcessGroup,
+    kernel_size: int | None = None,
+    cu_seqlens_cpu: torch.Tensor | None = None,
+) -> FLACPContext:
+    """Build a CP context for the given cu_seqlens and process group.
+
+    Args:
+        cu_seqlens: Cumulative sequence lengths tensor (before partition).
+        group: Process group for CP communication.
+        kernel_size: Kernel size for convolution (optional).
+        cu_seqlens_cpu: CPU version of cu_seqlens to avoid d2h transfer (optional).
+
+    Returns:
+        FLACPContext with computed cu_seqlens and rank information.
+    """
+    from fla.ops.cp.chunk_delta_h import get_cp_cu_seqlens
+    return get_cp_cu_seqlens(cu_seqlens, cu_seqlens_cpu=cu_seqlens_cpu, group=group, kernel_size=kernel_size)

--- a/tests/context_parallel/README.md
+++ b/tests/context_parallel/README.md
@@ -1,0 +1,7 @@
+# CP(Context Parallel)
+
+1. CP2TP refers to Context Parallelism with Tensor Parallelism on attention heads. When CP is mentioned in FLA kernels, it specifically denotes TP (head parallelism), which requires two all-to-all collective operations—one before and one after the attention computation.
+
+2. Ring CP introduces sequential dependencies between ranks. For example, in a CP2 configuration, Rank1 must wait for Rank0 to complete before it can compute; during backpropagation, Rank0 must conversely wait for Rank1.
+
+3. True CP resembles the CP implementation in FLA(KDA and GDN first), enabling genuinely parallel computation across all ranks with minimal communication overhead. However, this approach is more complex and requires sophisticated mathematical optimizations.

--- a/tests/context_parallel/test_cp_conv.py
+++ b/tests/context_parallel/test_cp_conv.py
@@ -1,0 +1,493 @@
+"""
+Test for Context Parallel (CP) Causal Convolution 1D
+
+Context Parallel Principle for Causal Conv1d:
+=============================================
+
+Causal convolution has a dependency on previous tokens due to the sliding window.
+In a standard implementation, each rank processes the full sequence sequentially.
+
+With Context Parallel:
+1. Sequence Partitioning: The input sequence is split across ranks along the sequence dimension.
+   - Rank 0: tokens [0, T/N)
+   - Rank 1: tokens [T/N, 2T/N)
+   - Rank 2: tokens [2T/N, 3T/N)
+   - ...
+
+2. Forward Pass:
+   - Each rank processes its local chunk independently
+   - Non-first ranks need the last (W-1) tokens from the previous rank as initial_state
+   - Communication: Previous rank sends its tail tokens (last W-1 tokens) to current rank
+   - Current rank receives and constructs initial_state from previous rank's tail
+   - This allows parallel computation while maintaining causal dependencies
+
+3. Backward Pass:
+   - Gradients need to be corrected because tokens used as initial_state by next rank
+     also contribute to gradients
+   - Communication: Current rank sends d_initial_state to previous rank
+   - Previous rank adds received gradients to its tail tokens (last W-1 tokens)
+   - This ensures gradient correctness across rank boundaries
+
+Key Insight:
+- The last (W-1) tokens of each rank are used as initial_state by the next rank
+- These tokens need gradient contributions from both local computation and next rank
+- Communication overhead is minimal: only (W-1) tokens per rank boundary
+
+Test Scenarios:
+===============
+1. CP2 with sequence cut in the middle (sequences span across rank boundary)
+2. CP2 with sequence boundary aligned (no sequence is cut)
+3. CP4 with one sequence spanning 3 ranks, another sequence also cut
+4. Single long sequence spanning all ranks
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from fla.modules.convolution import causal_conv1d
+from fla.ops.cp import build_cp_context
+
+
+def init_distributed(rank, world_size):
+    """Initialize distributed environment for a single process."""
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '29500'
+    os.environ['RANK'] = str(rank)
+    os.environ['WORLD_SIZE'] = str(world_size)
+    os.environ['LOCAL_RANK'] = str(rank)
+
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
+
+
+def cleanup_distributed():
+    """Clean up distributed environment."""
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def assert_close(name, ref, tri, atol=1e-3, rtol=1e-3):
+    """Helper function for assertion with detailed diff output."""
+    diff = (ref - tri).abs().max().item()
+    print(f"  Checking {name:<10} | Max Diff: {diff:.6f}")
+    assert diff < atol, f"{name} mismatch. Max diff: {diff}"
+
+
+def run_cp_conv_test_worker(
+    rank: int,
+    world_size: int,
+    test_name: str,
+    T: int,
+    D: int,
+    W: int,
+    lengths: list[int],
+    dtype,
+):
+    """
+    Worker function for CP convolution test.
+    Runs in a spawned process with the given rank.
+    """
+    try:
+        init_distributed(rank, world_size)
+        device = torch.device(f'cuda:{rank}')
+
+        assert T % world_size == 0, f"T={T} must be divisible by world_size={world_size}"
+        assert sum(lengths) == T, f"Sum of lengths {sum(lengths)} must equal T={T}"
+
+        if rank == 0:
+            print(f"\n{'='*60}")
+            print(f"Test: {test_name}")
+            print(f"Config: T={T}, D={D}, W={W}, world_size={world_size}")
+            print(f"Sequence lengths: {lengths}")
+            print(f"{'='*60}")
+
+        # Step 1: Prepare Global Data
+        torch.manual_seed(42)
+        B = 1
+
+        x_global = torch.randn(B, T, D, device=device, dtype=dtype)
+        dy_global = torch.randn(B, T, D, device=device, dtype=dtype)
+
+        weight = torch.randn(D, W, device=device, dtype=dtype)
+        bias = torch.randn(D, device=device, dtype=dtype)
+
+        dist.broadcast(weight, src=0)
+        dist.broadcast(bias, src=0)
+
+        cu_seqlens_list = [0] + torch.cumsum(torch.tensor(lengths), 0).tolist()
+        cu_seqlens_global = torch.tensor(cu_seqlens_list, device=device, dtype=torch.int32)
+
+        activation = 'swish'
+
+        # Step 2: Reference Run
+        ref_out, ref_dx, ref_dw, ref_db = None, None, None, None
+
+        if rank == 0:
+            x_ref = x_global.clone().detach().requires_grad_(True)
+            weight_ref = weight.clone().detach().requires_grad_(True)
+            bias_ref = bias.clone().detach().requires_grad_(True)
+
+            y_ref, _ = causal_conv1d(
+                x=x_ref,
+                weight=weight_ref,
+                bias=bias_ref,
+                activation=activation,
+                backend='triton',
+                cu_seqlens=cu_seqlens_global,
+            )
+
+            y_ref.backward(dy_global)
+
+            ref_out = y_ref.detach()
+            ref_dx = x_ref.grad.detach()
+            ref_dw = weight_ref.grad.detach()
+            ref_db = bias_ref.grad.detach()
+
+        # Step 3: Context Parallel Run
+        dist.barrier()
+
+        context = build_cp_context(cu_seqlens_global, group=dist.group.WORLD, kernel_size=W)
+
+        chunk_size = T // world_size
+        start_idx = rank * chunk_size
+        end_idx = (rank + 1) * chunk_size
+
+        x_local = x_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        dy_local = dy_global[:, start_idx:end_idx, :].clone()
+        weight_local = weight.clone().detach().requires_grad_(True)
+        bias_local = bias.clone().detach().requires_grad_(True)
+
+        print(f"[Rank {rank}] chunk: [{start_idx}, {end_idx}), "
+              f"cu_seqlens: {context.cu_seqlens.tolist()}, "
+              f"pre_num_ranks: {context.pre_num_ranks}, "
+              f"pre_num_conv_tokens: {context.pre_num_conv_tokens}")
+        dist.barrier()
+
+        # CP Forward
+        y_local, _ = causal_conv1d(
+            x=x_local,
+            weight=weight_local,
+            bias=bias_local,
+            activation=activation,
+            cu_seqlens=context.cu_seqlens,
+            cp_context=context,
+        )
+
+        # CP Backward
+        y_local.backward(dy_local)
+
+        # Step 4: Result Aggregation and Verification
+        y_gathered = [torch.zeros_like(y_local) for _ in range(world_size)]
+        dist.all_gather(y_gathered, y_local)
+        y_cp_global = torch.cat(y_gathered, dim=1)
+
+        dx_gathered = [torch.zeros_like(x_local.grad) for _ in range(world_size)]
+        dist.all_gather(dx_gathered, x_local.grad)
+        dx_cp_global = torch.cat(dx_gathered, dim=1)
+
+        dw_cp = weight_local.grad.clone()
+        db_cp = bias_local.grad.clone()
+        dist.all_reduce(dw_cp, op=dist.ReduceOp.SUM)
+        dist.all_reduce(db_cp, op=dist.ReduceOp.SUM)
+
+        test_passed = True
+        if rank == 0:
+            print(f"\n[{test_name}] Verification Results:")
+            try:
+                assert_close("Output", ref_out, y_cp_global, atol=1e-3)
+                assert_close("dx", ref_dx, dx_cp_global, atol=1e-3)
+                assert_close("dw", ref_dw, dw_cp, atol=1e-3)
+                assert_close("db", ref_db, db_cp, atol=1e-3)
+                print(f"✅ [{test_name}] Test Passed!\n")
+            except AssertionError as e:
+                print(f"❌ [{test_name}] Test Failed: {e}\n")
+                test_passed = False
+
+        dist.barrier()
+        cleanup_distributed()
+
+        if not test_passed:
+            raise AssertionError(f"Test {test_name} failed on rank {rank}")
+
+    except Exception as e:
+        cleanup_distributed()
+        raise e
+
+
+def run_cp_test_with_spawn(
+    world_size: int,
+    test_name: str,
+    T: int,
+    D: int,
+    W: int,
+    lengths: list[int],
+    dtype=torch.float32,
+):
+    """
+    Run CP test using torch.multiprocessing.spawn.
+    This allows running the test directly with pytest.
+    """
+    # Use start_processes with spawn to avoid fork/spawn conflicts
+    mp.start_processes(
+        run_cp_conv_test_worker,
+        args=(world_size, test_name, T, D, W, lengths, dtype),
+        nprocs=world_size,
+        join=True,
+        start_method='spawn',
+    )
+
+
+# ============================================================
+# Test Scenario Definitions
+# ============================================================
+
+def test_cp2_sequence_cut():
+    """
+    Test Case 1: CP2 with sequences cut in the middle.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[300, 400, 324] -> sequences span across rank boundary
+    - Rank 0: tokens [0, 512) contains seq0 (300) + part of seq1 (212)
+    - Rank 1: tokens [512, 1024) contains rest of seq1 (188) + seq2 (324)
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_SequenceCut",
+        T=1024,
+        D=128,
+        W=4,
+        lengths=[300, 400, 324],
+        dtype=torch.float32,
+    )
+
+
+def test_cp2_boundary_aligned():
+    """
+    Test Case 2: CP2 with sequence boundaries aligned with rank boundaries.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[512, 512] -> sequence boundary exactly at rank boundary
+    - Rank 0: tokens [0, 512) contains exactly seq0
+    - Rank 1: tokens [512, 1024) contains exactly seq1
+    - No sequence is split across ranks
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_BoundaryAligned",
+        T=1024,
+        D=128,
+        W=4,
+        lengths=[512, 512],
+        dtype=torch.float32,
+    )
+
+
+def test_cp4_complex():
+    """
+    Test Case 3: CP4 with complex sequence distribution.
+
+    Scenario:
+    - world_size=4, T=1024, chunk_size=256
+    - lengths=[700, 324] -> first sequence spans 3 ranks
+    - Rank 0: [0, 256) all seq0
+    - Rank 1: [256, 512) all seq0
+    - Rank 2: [512, 768) - 188 tokens of seq0 + 68 tokens of seq1
+    - Rank 3: [768, 1024) - 256 tokens of seq1
+    """
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_Complex",
+        T=1024,
+        D=128,
+        W=4,
+        lengths=[700, 324],
+        dtype=torch.float32,
+    )
+
+
+def test_cp4_single_sequence():
+    """
+    Test Case 4: CP4 with a single long sequence spanning all ranks.
+
+    Scenario:
+    - world_size=4, T=1024, chunk_size=256
+    - lengths=[1024] -> single sequence spans all 4 ranks
+    - Each rank processes 256 tokens of the same sequence
+    """
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_SingleSequence",
+        T=1024,
+        D=128,
+        W=4,
+        lengths=[1024],
+        dtype=torch.float32,
+    )
+
+
+def test_cp2_many_short_sequences():
+    """
+    Test Case 5: CP2 with many short sequences.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[100, 150, 200, 250, 124, 100, 100] -> many short sequences
+    - Some sequences are entirely in one rank, some span across
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_ManyShortSequences",
+        T=1024,
+        D=128,
+        W=4,
+        lengths=[100, 150, 200, 250, 124, 100, 100],
+        dtype=torch.float32,
+    )
+
+
+# ============================================================
+# Main Entry Point (for torchrun)
+# ============================================================
+
+def setup_distributed_torchrun():
+    """Initialize distributed environment for torchrun."""
+    if 'RANK' not in os.environ:
+        return False
+
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    return True
+
+
+if __name__ == "__main__":
+    # Check if running with torchrun
+    if 'RANK' in os.environ:
+        # Running with torchrun
+        if setup_distributed_torchrun():
+            from fla.utils import device as fla_device
+
+            world_size = dist.get_world_size()
+            rank = dist.get_rank()
+
+            try:
+                if rank == 0:
+                    print("=" * 60)
+                    print("Running CP Conv1d Tests (torchrun mode)")
+                    print("=" * 60)
+
+                # Define test configs based on world_size
+                if world_size == 2:
+                    test_configs = [
+                        ("CP2_SequenceCut", 1024, 128, 4, [300, 400, 324]),
+                        ("CP2_BoundaryAligned", 1024, 128, 4, [512, 512]),
+                        ("CP2_ManyShortSequences", 1024, 128, 4, [100, 150, 200, 250, 124, 100, 100]),
+                    ]
+                elif world_size == 4:
+                    test_configs = [
+                        ("CP4_Complex", 1024, 128, 4, [700, 324]),
+                        ("CP4_SingleSequence", 1024, 128, 4, [1024]),
+                    ]
+                else:
+                    test_configs = [
+                        (f"CP{world_size}_SingleSequence", 1024, 128, 4, [1024]),
+                    ]
+
+                for test_name, T, D, W, lengths in test_configs:
+                    # Run test inline (already in distributed context)
+                    torch.manual_seed(42)
+                    B = 1
+
+                    x_global = torch.randn(B, T, D, device=fla_device, dtype=torch.float32)
+                    dy_global = torch.randn(B, T, D, device=fla_device, dtype=torch.float32)
+                    weight = torch.randn(D, W, device=fla_device, dtype=torch.float32)
+                    bias = torch.randn(D, device=fla_device, dtype=torch.float32)
+
+                    dist.broadcast(weight, src=0)
+                    dist.broadcast(bias, src=0)
+
+                    cu_seqlens_list = [0] + torch.cumsum(torch.tensor(lengths), 0).tolist()
+                    cu_seqlens_global = torch.tensor(cu_seqlens_list, device=fla_device, dtype=torch.int32)
+
+                    # Reference
+                    ref_out, ref_dx, ref_dw, ref_db = None, None, None, None
+                    if rank == 0:
+                        x_ref = x_global.clone().detach().requires_grad_(True)
+                        weight_ref = weight.clone().detach().requires_grad_(True)
+                        bias_ref = bias.clone().detach().requires_grad_(True)
+                        y_ref, _ = causal_conv1d(x=x_ref, weight=weight_ref, bias=bias_ref,
+                                                 activation='swish', backend='triton', cu_seqlens=cu_seqlens_global)
+                        y_ref.backward(dy_global)
+                        ref_out, ref_dx = y_ref.detach(), x_ref.grad.detach()
+                        ref_dw, ref_db = weight_ref.grad.detach(), bias_ref.grad.detach()
+
+                    dist.barrier()
+                    context = build_cp_context(cu_seqlens_global, group=dist.group.WORLD, kernel_size=W)
+
+                    chunk_size = T // world_size
+                    start_idx, end_idx = rank * chunk_size, (rank + 1) * chunk_size
+                    x_local = x_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    dy_local = dy_global[:, start_idx:end_idx, :].clone()
+                    weight_local = weight.clone().detach().requires_grad_(True)
+                    bias_local = bias.clone().detach().requires_grad_(True)
+
+                    y_local, _ = causal_conv1d(x=x_local, weight=weight_local, bias=bias_local,
+                                               activation='swish', cu_seqlens=context.cu_seqlens, cp_context=context)
+                    y_local.backward(dy_local)
+
+                    y_gathered = [torch.zeros_like(y_local) for _ in range(world_size)]
+                    dist.all_gather(y_gathered, y_local)
+                    y_cp_global = torch.cat(y_gathered, dim=1)
+
+                    dx_gathered = [torch.zeros_like(x_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dx_gathered, x_local.grad)
+                    dx_cp_global = torch.cat(dx_gathered, dim=1)
+
+                    dw_cp, db_cp = weight_local.grad.clone(), bias_local.grad.clone()
+                    dist.all_reduce(dw_cp, op=dist.ReduceOp.SUM)
+                    dist.all_reduce(db_cp, op=dist.ReduceOp.SUM)
+
+                    if rank == 0:
+                        print(f"\n[{test_name}] Verification:")
+                        assert_close("Output", ref_out, y_cp_global, atol=1e-3)
+                        assert_close("dx", ref_dx, dx_cp_global, atol=1e-3)
+                        assert_close("dw", ref_dw, dw_cp, atol=1e-3)
+                        assert_close("db", ref_db, db_cp, atol=1e-3)
+                        print(f"✅ [{test_name}] Passed!")
+
+                    dist.barrier()
+
+                if rank == 0:
+                    print("\n" + "=" * 60)
+                    print("All tests passed!")
+                    print("=" * 60)
+
+            finally:
+                cleanup_distributed()
+    else:
+        # Not running with torchrun, show usage
+        print("Run tests with pytest or torchrun:")
+        print("  pytest tests/context_parallel/test_cp_conv.py -v")
+        print("  torchrun --nproc_per_node=2 tests/context_parallel/test_cp_conv.py")
+        print("  torchrun --nproc_per_node=4 tests/context_parallel/test_cp_conv.py")

--- a/tests/context_parallel/test_cp_gdn.py
+++ b/tests/context_parallel/test_cp_gdn.py
@@ -1,0 +1,555 @@
+"""
+Test for Context Parallel (CP) Gated Delta Rule (GDN)
+
+Context Parallel Principle for GDN:
+===================================
+
+GDN has a recurrent state dependency across tokens. The hidden state h evolves
+as tokens are processed, creating dependencies that span the sequence.
+
+With Context Parallel:
+1. Sequence Partitioning: The input sequence is split across ranks along the sequence dimension.
+   - Rank 0: tokens [0, T/N)
+   - Rank 1: tokens [T/N, 2T/N)
+   - ...
+
+2. Forward Pass:
+   - Each rank computes its local chunk
+   - Non-first ranks need the final state from previous rank as initial_state
+   - Communication: All-reduce style state passing between ranks
+
+3. Backward Pass:
+   - Gradients flow back through the recurrent state
+   - Communication: Gradient synchronization across ranks
+
+Test Scenarios:
+===============
+1. CP2 with sequence cut in the middle
+2. CP2 with sequence boundary aligned
+3. CP4 with complex sequence distribution
+4. CP4 with single long sequence
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+from fla.ops.cp import build_cp_context
+from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+
+
+def init_distributed(rank, world_size):
+    """Initialize distributed environment for a single process."""
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '29502'  # Different port from other tests
+    os.environ['RANK'] = str(rank)
+    os.environ['WORLD_SIZE'] = str(world_size)
+    os.environ['LOCAL_RANK'] = str(rank)
+
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
+
+
+def cleanup_distributed():
+    """Clean up distributed environment."""
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def assert_close(name, ref, tri, atol=1e-3, rtol=1e-3):
+    """Helper function for assertion with detailed diff output."""
+    diff = (ref - tri).abs().max().item()
+    print(f"  Checking {name:<10} | Max Diff: {diff:.6f}")
+    assert diff < atol, f"{name} mismatch. Max diff: {diff}"
+
+
+def run_cp_gdn_test_worker(
+    rank: int,
+    world_size: int,
+    test_name: str,
+    T: int,
+    H: int,
+    D: int,
+    lengths: list[int],
+    dtype,
+):
+    """
+    Worker function for CP GDN test.
+    Runs in a spawned process with the given rank.
+    """
+    try:
+        init_distributed(rank, world_size)
+        device = torch.device(f'cuda:{rank}')
+
+        assert T % world_size == 0, f"T={T} must be divisible by world_size={world_size}"
+        assert sum(lengths) == T, f"Sum of lengths {sum(lengths)} must equal T={T}"
+
+        if rank == 0:
+            print(f"\n{'='*60}")
+            print(f"Test: {test_name}")
+            print(f"Config: T={T}, H={H}, D={D}, world_size={world_size}")
+            print(f"Sequence lengths: {lengths}")
+            print(f"{'='*60}")
+
+        # Step 1: Prepare Global Data
+        torch.manual_seed(42)
+        B = 1
+
+        # Generate inputs - note: g is [B, T, H] for gated_delta_rule, not [B, T, H, D]
+        q_global = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        k_global = F.normalize(torch.randn(B, T, H, D, device=device, dtype=torch.float32), p=2, dim=-1).to(dtype)
+        v_global = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        g_global = F.logsigmoid(torch.randn(B, T, H, device=device, dtype=dtype))
+        beta_global = torch.randn(B, T, H, device=device, dtype=torch.float32).sigmoid()
+
+        # Broadcast to ensure all ranks have same data
+        dist.broadcast(q_global, src=0)
+        dist.broadcast(k_global, src=0)
+        dist.broadcast(v_global, src=0)
+        dist.broadcast(g_global, src=0)
+        dist.broadcast(beta_global, src=0)
+
+        # Prepare cu_seqlens
+        cu_seqlens_list = [0] + torch.cumsum(torch.tensor(lengths), 0).tolist()
+        cu_seqlens_global = torch.tensor(cu_seqlens_list, device=device, dtype=torch.long)
+
+        # Prepare gradients
+        do_global = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        dist.broadcast(do_global, src=0)
+
+        # Step 2: Reference Run (single GPU, varlen)
+        ref_out = None
+        ref_dq, ref_dk, ref_dv, ref_dg, ref_db = None, None, None, None, None
+
+        if rank == 0:
+            q_ref = q_global.clone().detach().requires_grad_(True)
+            k_ref = k_global.clone().detach().requires_grad_(True)
+            v_ref = v_global.clone().detach().requires_grad_(True)
+            g_ref = g_global.clone().detach().requires_grad_(True)
+            beta_ref = beta_global.clone().detach().requires_grad_(True)
+
+            # Use chunk_gated_delta_rule with varlen (no CP)
+            o_ref, _ = chunk_gated_delta_rule(
+                q=q_ref,
+                k=k_ref,
+                v=v_ref,
+                g=g_ref,
+                beta=beta_ref,
+                cu_seqlens=cu_seqlens_global,
+            )
+
+            o_ref.backward(do_global)
+
+            ref_out = o_ref.detach()
+            ref_dq = q_ref.grad.detach()
+            ref_dk = k_ref.grad.detach()
+            ref_dv = v_ref.grad.detach()
+            ref_dg = g_ref.grad.detach()
+            ref_db = beta_ref.grad.detach()
+
+        # Step 3: Context Parallel Run
+        dist.barrier()
+
+        # Build CP context
+        context = build_cp_context(cu_seqlens_global, group=dist.group.WORLD)
+
+        chunk_size = T // world_size
+        start_idx = rank * chunk_size
+        end_idx = (rank + 1) * chunk_size
+
+        # Get local slices - note: g is [B, T, H]
+        q_local = q_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        k_local = k_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        v_local = v_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        g_local = g_global[:, start_idx:end_idx].clone().detach().requires_grad_(True)
+        beta_local = beta_global[:, start_idx:end_idx].clone().detach().requires_grad_(True)
+        do_local = do_global[:, start_idx:end_idx, :].clone()
+
+        print(f"[Rank {rank}] chunk: [{start_idx}, {end_idx}), "
+              f"cu_seqlens: {context.cu_seqlens.tolist()}, "
+              f"pre_num_ranks: {context.pre_num_ranks}")
+        dist.barrier()
+
+        # CP Forward
+        o_local, _ = chunk_gated_delta_rule(
+            q=q_local,
+            k=k_local,
+            v=v_local,
+            g=g_local,
+            beta=beta_local,
+            cu_seqlens=context.cu_seqlens,
+            cp_context=context,
+        )
+
+        # CP Backward
+        o_local.backward(do_local)
+
+        # Step 4: Result Aggregation and Verification
+        o_gathered = [torch.zeros_like(o_local) for _ in range(world_size)]
+        dist.all_gather(o_gathered, o_local)
+        o_cp_global = torch.cat(o_gathered, dim=1)
+
+        dq_gathered = [torch.zeros_like(q_local.grad) for _ in range(world_size)]
+        dist.all_gather(dq_gathered, q_local.grad)
+        dq_cp_global = torch.cat(dq_gathered, dim=1)
+
+        dk_gathered = [torch.zeros_like(k_local.grad) for _ in range(world_size)]
+        dist.all_gather(dk_gathered, k_local.grad)
+        dk_cp_global = torch.cat(dk_gathered, dim=1)
+
+        dv_gathered = [torch.zeros_like(v_local.grad) for _ in range(world_size)]
+        dist.all_gather(dv_gathered, v_local.grad)
+        dv_cp_global = torch.cat(dv_gathered, dim=1)
+
+        dg_gathered = [torch.zeros_like(g_local.grad) for _ in range(world_size)]
+        dist.all_gather(dg_gathered, g_local.grad)
+        dg_cp_global = torch.cat(dg_gathered, dim=1)
+
+        db_gathered = [torch.zeros_like(beta_local.grad) for _ in range(world_size)]
+        dist.all_gather(db_gathered, beta_local.grad)
+        db_cp_global = torch.cat(db_gathered, dim=1)
+
+        test_passed = True
+        if rank == 0:
+            print(f"\n[{test_name}] Verification Results:")
+            try:
+                assert_close("Output", ref_out, o_cp_global, atol=5e-3)
+                assert_close("dq", ref_dq, dq_cp_global, atol=8e-3)
+                assert_close("dk", ref_dk, dk_cp_global, atol=8e-3)
+                assert_close("dv", ref_dv, dv_cp_global, atol=8e-3)
+                assert_close("dg", ref_dg, dg_cp_global, atol=2e-2)
+                assert_close("db", ref_db, db_cp_global, atol=2e-2)
+                print(f"✅ [{test_name}] Test Passed!\n")
+            except AssertionError as e:
+                print(f"❌ [{test_name}] Test Failed: {e}\n")
+                test_passed = False
+
+        dist.barrier()
+        cleanup_distributed()
+
+        if not test_passed:
+            raise AssertionError(f"Test {test_name} failed on rank {rank}")
+
+    except Exception as e:
+        cleanup_distributed()
+        raise e
+
+
+def run_cp_test_with_spawn(
+    world_size: int,
+    test_name: str,
+    T: int,
+    H: int,
+    D: int,
+    lengths: list[int],
+    dtype=torch.float16,
+):
+    """
+    Run CP test using torch.multiprocessing.spawn.
+    This allows running the test directly with pytest.
+    """
+    mp.start_processes(
+        run_cp_gdn_test_worker,
+        args=(world_size, test_name, T, H, D, lengths, dtype),
+        nprocs=world_size,
+        join=True,
+        start_method='spawn',
+    )
+
+
+# ============================================================
+# Test Scenario Definitions
+# ============================================================
+
+def test_cp2_sequence_cut():
+    """
+    Test Case 1: CP2 with sequences cut in the middle.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[300, 400, 324] -> sequences span across rank boundary
+    - Rank 0: tokens [0, 512) contains seq0 (300) + part of seq1 (212)
+    - Rank 1: tokens [512, 1024) contains rest of seq1 (188) + seq2 (324)
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_SequenceCut",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[300, 400, 324],
+        dtype=torch.float16,
+    )
+
+
+def test_cp2_boundary_aligned():
+    """
+    Test Case 2: CP2 with sequence boundaries aligned with rank boundaries.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[512, 512] -> sequence boundary exactly at rank boundary
+    - Rank 0: tokens [0, 512) contains exactly seq0
+    - Rank 1: tokens [512, 1024) contains exactly seq1
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_BoundaryAligned",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[512, 512],
+        dtype=torch.float16,
+    )
+
+
+def test_cp4_complex():
+    """
+    Test Case 3: CP4 with complex sequence distribution.
+
+    Scenario:
+    - world_size=4, T=1024, chunk_size=256
+    - lengths=[700, 324] -> first sequence spans 3 ranks
+    """
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_Complex",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[700, 324],
+        dtype=torch.float16,
+    )
+
+
+def test_cp4_single_sequence():
+    """
+    Test Case 4: CP4 with a single long sequence spanning all ranks.
+
+    Scenario:
+    - world_size=4, T=1024, chunk_size=256
+    - lengths=[1024] -> single sequence spans all 4 ranks
+    """
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_SingleSequence",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[1024],
+        dtype=torch.float16,
+    )
+
+
+def test_cp2_many_short_sequences():
+    """
+    Test Case 5: CP2 with many short sequences.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[100, 150, 200, 250, 124, 100, 100] -> many short sequences
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_ManyShortSequences",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[100, 150, 200, 250, 124, 100, 100],
+        dtype=torch.float16,
+    )
+
+
+# ============================================================
+# Main Entry Point (for torchrun)
+# ============================================================
+
+def setup_distributed_torchrun():
+    """Initialize distributed environment for torchrun."""
+    if 'RANK' not in os.environ:
+        return False
+
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    return True
+
+
+if __name__ == "__main__":
+    # Check if running with torchrun
+    if 'RANK' in os.environ:
+        # Running with torchrun
+        if setup_distributed_torchrun():
+            from fla.utils import device as fla_device
+
+            world_size = dist.get_world_size()
+            rank = dist.get_rank()
+
+            try:
+                if rank == 0:
+                    print("=" * 60)
+                    print("Running CP GDN Tests (torchrun mode)")
+                    print("=" * 60)
+
+                # Define test configs based on world_size
+                if world_size == 2:
+                    test_configs = [
+                        ("CP2_SequenceCut", 1024, 4, 64, [300, 400, 324]),
+                        ("CP2_BoundaryAligned", 1024, 4, 64, [512, 512]),
+                        ("CP2_ManyShortSequences", 1024, 4, 64, [100, 150, 200, 250, 124, 100, 100]),
+                    ]
+                elif world_size == 4:
+                    test_configs = [
+                        ("CP4_Complex", 1024, 4, 64, [700, 324]),
+                        ("CP4_SingleSequence", 1024, 4, 64, [1024]),
+                    ]
+                else:
+                    test_configs = [
+                        (f"CP{world_size}_SingleSequence", 1024, 4, 64, [1024]),
+                    ]
+
+                for test_name, T, H, D, lengths in test_configs:
+                    torch.manual_seed(42)
+                    B = 1
+
+                    # Generate global data - note: g is [B, T, H] for gated_delta_rule
+                    q_global = torch.randn(B, T, H, D, device=fla_device, dtype=torch.float16)
+                    k_global = F.normalize(torch.randn(B, T, H, D, device=fla_device,
+                                           dtype=torch.float32), p=2, dim=-1).to(torch.float16)
+                    v_global = torch.randn(B, T, H, D, device=fla_device, dtype=torch.float16)
+                    g_global = F.logsigmoid(torch.randn(B, T, H, device=fla_device, dtype=torch.float16))
+                    beta_global = torch.randn(B, T, H, device=fla_device, dtype=torch.float32).sigmoid()
+                    do_global = torch.randn(B, T, H, D, device=fla_device, dtype=torch.float16)
+
+                    # Broadcast
+                    dist.broadcast(q_global, src=0)
+                    dist.broadcast(k_global, src=0)
+                    dist.broadcast(v_global, src=0)
+                    dist.broadcast(g_global, src=0)
+                    dist.broadcast(beta_global, src=0)
+                    dist.broadcast(do_global, src=0)
+
+                    cu_seqlens_list = [0] + torch.cumsum(torch.tensor(lengths), 0).tolist()
+                    cu_seqlens_global = torch.tensor(cu_seqlens_list, device=fla_device, dtype=torch.long)
+
+                    # Reference
+                    ref_out, ref_dq, ref_dk, ref_dv, ref_dg, ref_db = None, None, None, None, None, None
+                    if rank == 0:
+                        q_ref = q_global.clone().detach().requires_grad_(True)
+                        k_ref = k_global.clone().detach().requires_grad_(True)
+                        v_ref = v_global.clone().detach().requires_grad_(True)
+                        g_ref = g_global.clone().detach().requires_grad_(True)
+                        beta_ref = beta_global.clone().detach().requires_grad_(True)
+
+                        o_ref, _ = chunk_gated_delta_rule(
+                            q=q_ref,
+                            k=k_ref,
+                            v=v_ref,
+                            g=g_ref,
+                            beta=beta_ref,
+                            cu_seqlens=cu_seqlens_global,
+                        )
+                        o_ref.backward(do_global)
+                        ref_out = o_ref.detach()
+                        ref_dq = q_ref.grad.detach()
+                        ref_dk = k_ref.grad.detach()
+                        ref_dv = v_ref.grad.detach()
+                        ref_dg = g_ref.grad.detach()
+                        ref_db = beta_ref.grad.detach()
+
+                    dist.barrier()
+
+                    # CP run
+                    context = build_cp_context(cu_seqlens_global, group=dist.group.WORLD)
+
+                    chunk_size = T // world_size
+                    start_idx, end_idx = rank * chunk_size, (rank + 1) * chunk_size
+
+                    # note: g is [B, T, H]
+                    q_local = q_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    k_local = k_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    v_local = v_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    g_local = g_global[:, start_idx:end_idx].clone().detach().requires_grad_(True)
+                    beta_local = beta_global[:, start_idx:end_idx].clone().detach().requires_grad_(True)
+                    do_local = do_global[:, start_idx:end_idx, :].clone()
+
+                    o_local, _ = chunk_gated_delta_rule(
+                        q=q_local,
+                        k=k_local,
+                        v=v_local,
+                        g=g_local,
+                        beta=beta_local,
+                        cu_seqlens=context.cu_seqlens,
+                        cp_context=context,
+                    )
+                    o_local.backward(do_local)
+
+                    # Gather output and gradients
+                    o_gathered = [torch.zeros_like(o_local) for _ in range(world_size)]
+                    dist.all_gather(o_gathered, o_local)
+                    o_cp_global = torch.cat(o_gathered, dim=1)
+
+                    dq_gathered = [torch.zeros_like(q_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dq_gathered, q_local.grad)
+                    dq_cp_global = torch.cat(dq_gathered, dim=1)
+
+                    dk_gathered = [torch.zeros_like(k_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dk_gathered, k_local.grad)
+                    dk_cp_global = torch.cat(dk_gathered, dim=1)
+
+                    dv_gathered = [torch.zeros_like(v_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dv_gathered, v_local.grad)
+                    dv_cp_global = torch.cat(dv_gathered, dim=1)
+
+                    dg_gathered = [torch.zeros_like(g_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dg_gathered, g_local.grad)
+                    dg_cp_global = torch.cat(dg_gathered, dim=1)
+
+                    db_gathered = [torch.zeros_like(beta_local.grad) for _ in range(world_size)]
+                    dist.all_gather(db_gathered, beta_local.grad)
+                    db_cp_global = torch.cat(db_gathered, dim=1)
+
+                    if rank == 0:
+                        print(f"\n[{test_name}] Verification:")
+                        assert_close("Output", ref_out, o_cp_global, atol=5e-3)
+                        assert_close("dq", ref_dq, dq_cp_global, atol=8e-3)
+                        assert_close("dk", ref_dk, dk_cp_global, atol=8e-3)
+                        assert_close("dv", ref_dv, dv_cp_global, atol=8e-3)
+                        assert_close("dg", ref_dg, dg_cp_global, atol=2e-2)
+                        assert_close("db", ref_db, db_cp_global, atol=2e-2)
+                        print(f"✅ [{test_name}] Passed!")
+
+                    dist.barrier()
+
+                if rank == 0:
+                    print("\n" + "=" * 60)
+                    print("All tests passed!")
+                    print("=" * 60)
+
+            finally:
+                cleanup_distributed()
+    else:
+        # Not running with torchrun, show usage
+        print("Run tests with pytest or torchrun:")
+        print("  pytest tests/context_parallel/test_cp_gdn.py -v")
+        print("  torchrun --nproc_per_node=2 tests/context_parallel/test_cp_gdn.py")
+        print("  torchrun --nproc_per_node=4 tests/context_parallel/test_cp_gdn.py")

--- a/tests/context_parallel/test_cp_kda.py
+++ b/tests/context_parallel/test_cp_kda.py
@@ -1,0 +1,553 @@
+"""
+Test for Context Parallel (CP) KDA (Kimi Delta Attention)
+
+Context Parallel Principle for KDA:
+===================================
+
+KDA has a recurrent state dependency across tokens. The hidden state h evolves
+as tokens are processed, creating dependencies that span the sequence.
+
+With Context Parallel:
+1. Sequence Partitioning: The input sequence is split across ranks along the sequence dimension.
+   - Rank 0: tokens [0, T/N)
+   - Rank 1: tokens [T/N, 2T/N)
+   - ...
+
+2. Forward Pass:
+   - Each rank computes its local chunk
+   - Non-first ranks need the final state from previous rank as initial_state
+   - Communication: All-reduce style state passing between ranks
+
+3. Backward Pass:
+   - Gradients flow back through the recurrent state
+   - Communication: Gradient synchronization across ranks
+
+Test Scenarios:
+===============
+1. CP2 with sequence cut in the middle
+2. CP2 with sequence boundary aligned
+3. CP4 with complex sequence distribution
+4. CP4 with single long sequence
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+from fla.ops.cp import build_cp_context
+from fla.ops.kda import chunk_kda
+
+
+def init_distributed(rank, world_size):
+    """Initialize distributed environment for a single process."""
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '29501'  # Different port from conv test
+    os.environ['RANK'] = str(rank)
+    os.environ['WORLD_SIZE'] = str(world_size)
+    os.environ['LOCAL_RANK'] = str(rank)
+
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
+
+
+def cleanup_distributed():
+    """Clean up distributed environment."""
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def assert_close(name, ref, tri, atol=1e-3, rtol=1e-3):
+    """Helper function for assertion with detailed diff output."""
+    diff = (ref - tri).abs().max().item()
+    print(f"  Checking {name:<10} | Max Diff: {diff:.6f}")
+    assert diff < atol, f"{name} mismatch. Max diff: {diff}"
+
+
+def run_cp_kda_test_worker(
+    rank: int,
+    world_size: int,
+    test_name: str,
+    T: int,
+    H: int,
+    D: int,
+    lengths: list[int],
+    dtype,
+):
+    """
+    Worker function for CP KDA test.
+    Runs in a spawned process with the given rank.
+    """
+    try:
+        init_distributed(rank, world_size)
+        device = torch.device(f'cuda:{rank}')
+
+        assert T % world_size == 0, f"T={T} must be divisible by world_size={world_size}"
+        assert sum(lengths) == T, f"Sum of lengths {sum(lengths)} must equal T={T}"
+
+        if rank == 0:
+            print(f"\n{'='*60}")
+            print(f"Test: {test_name}")
+            print(f"Config: T={T}, H={H}, D={D}, world_size={world_size}")
+            print(f"Sequence lengths: {lengths}")
+            print(f"{'='*60}")
+
+        # Step 1: Prepare Global Data
+        torch.manual_seed(42)
+        B = 1
+
+        # Generate inputs
+        q_global = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        k_global = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        v_global = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        g_global = F.logsigmoid(torch.randn(B, T, H, D, device=device, dtype=torch.float))
+        beta_global = torch.randn(B, T, H, device=device, dtype=dtype).sigmoid()
+
+        # Broadcast to ensure all ranks have same data
+        dist.broadcast(q_global, src=0)
+        dist.broadcast(k_global, src=0)
+        dist.broadcast(v_global, src=0)
+        dist.broadcast(g_global, src=0)
+        dist.broadcast(beta_global, src=0)
+
+        # Prepare cu_seqlens
+        cu_seqlens_list = [0] + torch.cumsum(torch.tensor(lengths), 0).tolist()
+        cu_seqlens_global = torch.tensor(cu_seqlens_list, device=device, dtype=torch.long)
+
+        # Prepare gradients
+        do_global = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        dist.broadcast(do_global, src=0)
+
+        # Step 2: Reference Run (single GPU, varlen)
+        ref_out = None
+        ref_dq, ref_dk, ref_dv, ref_dg, ref_db = None, None, None, None, None
+
+        if rank == 0:
+            q_ref = q_global.clone().detach().requires_grad_(True)
+            k_ref = k_global.clone().detach().requires_grad_(True)
+            v_ref = v_global.clone().detach().requires_grad_(True)
+            g_ref = g_global.clone().detach().requires_grad_(True)
+            beta_ref = beta_global.clone().detach().requires_grad_(True)
+
+            # Use chunk_kda with varlen (no CP)
+            o_ref, _ = chunk_kda(
+                q=F.normalize(q_ref, p=2, dim=-1),
+                k=F.normalize(k_ref, p=2, dim=-1),
+                v=v_ref,
+                g=g_ref,
+                beta=beta_ref,
+                cu_seqlens=cu_seqlens_global,
+            )
+
+            o_ref.backward(do_global)
+
+            ref_out = o_ref.detach()
+            ref_dq = q_ref.grad.detach()
+            ref_dk = k_ref.grad.detach()
+            ref_dv = v_ref.grad.detach()
+            ref_dg = g_ref.grad.detach()
+            ref_db = beta_ref.grad.detach()
+
+        # Step 3: Context Parallel Run
+        dist.barrier()
+
+        # Build CP context
+        context = build_cp_context(cu_seqlens_global, group=dist.group.WORLD)
+
+        chunk_size = T // world_size
+        start_idx = rank * chunk_size
+        end_idx = (rank + 1) * chunk_size
+
+        # Get local slices
+        q_local = q_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        k_local = k_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        v_local = v_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        g_local = g_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+        beta_local = beta_global[:, start_idx:end_idx].clone().detach().requires_grad_(True)
+        do_local = do_global[:, start_idx:end_idx, :].clone()
+
+        print(f"[Rank {rank}] chunk: [{start_idx}, {end_idx}), "
+              f"cu_seqlens: {context.cu_seqlens.tolist()}, "
+              f"pre_num_ranks: {context.pre_num_ranks}")
+        dist.barrier()
+
+        # CP Forward
+        o_local, _ = chunk_kda(
+            q=F.normalize(q_local, p=2, dim=-1),
+            k=F.normalize(k_local, p=2, dim=-1),
+            v=v_local,
+            g=g_local,
+            beta=beta_local,
+            cu_seqlens=context.cu_seqlens,
+            cp_context=context,
+        )
+
+        # CP Backward
+        o_local.backward(do_local)
+
+        # Step 4: Result Aggregation and Verification
+        o_gathered = [torch.zeros_like(o_local) for _ in range(world_size)]
+        dist.all_gather(o_gathered, o_local)
+        o_cp_global = torch.cat(o_gathered, dim=1)
+
+        dq_gathered = [torch.zeros_like(q_local.grad) for _ in range(world_size)]
+        dist.all_gather(dq_gathered, q_local.grad)
+        dq_cp_global = torch.cat(dq_gathered, dim=1)
+
+        dk_gathered = [torch.zeros_like(k_local.grad) for _ in range(world_size)]
+        dist.all_gather(dk_gathered, k_local.grad)
+        dk_cp_global = torch.cat(dk_gathered, dim=1)
+
+        dv_gathered = [torch.zeros_like(v_local.grad) for _ in range(world_size)]
+        dist.all_gather(dv_gathered, v_local.grad)
+        dv_cp_global = torch.cat(dv_gathered, dim=1)
+
+        dg_gathered = [torch.zeros_like(g_local.grad) for _ in range(world_size)]
+        dist.all_gather(dg_gathered, g_local.grad)
+        dg_cp_global = torch.cat(dg_gathered, dim=1)
+
+        db_gathered = [torch.zeros_like(beta_local.grad) for _ in range(world_size)]
+        dist.all_gather(db_gathered, beta_local.grad)
+        db_cp_global = torch.cat(db_gathered, dim=1)
+
+        test_passed = True
+        if rank == 0:
+            print(f"\n[{test_name}] Verification Results:")
+            try:
+                assert_close("Output", ref_out, o_cp_global, atol=5e-3)
+                assert_close("dq", ref_dq, dq_cp_global, atol=8e-3)
+                assert_close("dk", ref_dk, dk_cp_global, atol=8e-3)
+                assert_close("dv", ref_dv, dv_cp_global, atol=8e-3)
+                assert_close("dg", ref_dg, dg_cp_global, atol=2e-2)
+                assert_close("db", ref_db, db_cp_global, atol=2e-2)
+                print(f"✅ [{test_name}] Test Passed!\n")
+            except AssertionError as e:
+                print(f"❌ [{test_name}] Test Failed: {e}\n")
+                test_passed = False
+
+        dist.barrier()
+        cleanup_distributed()
+
+        if not test_passed:
+            raise AssertionError(f"Test {test_name} failed on rank {rank}")
+
+    except Exception as e:
+        cleanup_distributed()
+        raise e
+
+
+def run_cp_test_with_spawn(
+    world_size: int,
+    test_name: str,
+    T: int,
+    H: int,
+    D: int,
+    lengths: list[int],
+    dtype=torch.float16,
+):
+    """
+    Run CP test using torch.multiprocessing.spawn.
+    This allows running the test directly with pytest.
+    """
+    mp.start_processes(
+        run_cp_kda_test_worker,
+        args=(world_size, test_name, T, H, D, lengths, dtype),
+        nprocs=world_size,
+        join=True,
+        start_method='spawn',
+    )
+
+
+# ============================================================
+# Test Scenario Definitions
+# ============================================================
+
+def test_cp2_sequence_cut():
+    """
+    Test Case 1: CP2 with sequences cut in the middle.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[300, 400, 324] -> sequences span across rank boundary
+    - Rank 0: tokens [0, 512) contains seq0 (300) + part of seq1 (212)
+    - Rank 1: tokens [512, 1024) contains rest of seq1 (188) + seq2 (324)
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_SequenceCut",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[300, 400, 324],
+        dtype=torch.float16,
+    )
+
+
+def test_cp2_boundary_aligned():
+    """
+    Test Case 2: CP2 with sequence boundaries aligned with rank boundaries.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[512, 512] -> sequence boundary exactly at rank boundary
+    - Rank 0: tokens [0, 512) contains exactly seq0
+    - Rank 1: tokens [512, 1024) contains exactly seq1
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_BoundaryAligned",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[512, 512],
+        dtype=torch.float16,
+    )
+
+
+def test_cp4_complex():
+    """
+    Test Case 3: CP4 with complex sequence distribution.
+
+    Scenario:
+    - world_size=4, T=1024, chunk_size=256
+    - lengths=[700, 324] -> first sequence spans 3 ranks
+    """
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_Complex",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[700, 324],
+        dtype=torch.float16,
+    )
+
+
+def test_cp4_single_sequence():
+    """
+    Test Case 4: CP4 with a single long sequence spanning all ranks.
+
+    Scenario:
+    - world_size=4, T=1024, chunk_size=256
+    - lengths=[1024] -> single sequence spans all 4 ranks
+    """
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_SingleSequence",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[1024],
+        dtype=torch.float16,
+    )
+
+
+def test_cp2_many_short_sequences():
+    """
+    Test Case 5: CP2 with many short sequences.
+
+    Scenario:
+    - world_size=2, T=1024, chunk_size=512
+    - lengths=[100, 150, 200, 250, 124, 100, 100] -> many short sequences
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_ManyShortSequences",
+        T=1024,
+        H=4,
+        D=64,
+        lengths=[100, 150, 200, 250, 124, 100, 100],
+        dtype=torch.float16,
+    )
+
+
+# ============================================================
+# Main Entry Point (for torchrun)
+# ============================================================
+
+def setup_distributed_torchrun():
+    """Initialize distributed environment for torchrun."""
+    if 'RANK' not in os.environ:
+        return False
+
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    return True
+
+
+if __name__ == "__main__":
+    # Check if running with torchrun
+    if 'RANK' in os.environ:
+        # Running with torchrun
+        if setup_distributed_torchrun():
+            from fla.utils import device as fla_device
+
+            world_size = dist.get_world_size()
+            rank = dist.get_rank()
+
+            try:
+                if rank == 0:
+                    print("=" * 60)
+                    print("Running CP KDA Tests (torchrun mode)")
+                    print("=" * 60)
+
+                # Define test configs based on world_size
+                if world_size == 2:
+                    test_configs = [
+                        ("CP2_SequenceCut", 1024, 4, 64, [300, 400, 324]),
+                        ("CP2_BoundaryAligned", 1024, 4, 64, [512, 512]),
+                        ("CP2_ManyShortSequences", 1024, 4, 64, [100, 150, 200, 250, 124, 100, 100]),
+                    ]
+                elif world_size == 4:
+                    test_configs = [
+                        ("CP4_Complex", 1024, 4, 64, [700, 324]),
+                        ("CP4_SingleSequence", 1024, 4, 64, [1024]),
+                    ]
+                else:
+                    test_configs = [
+                        (f"CP{world_size}_SingleSequence", 1024, 4, 64, [1024]),
+                    ]
+
+                for test_name, T, H, D, lengths in test_configs:
+                    torch.manual_seed(42)
+                    B = 1
+
+                    # Generate global data
+                    q_global = torch.randn(B, T, H, D, device=fla_device, dtype=torch.float16)
+                    k_global = torch.randn(B, T, H, D, device=fla_device, dtype=torch.float16)
+                    v_global = torch.randn(B, T, H, D, device=fla_device, dtype=torch.float16)
+                    g_global = F.logsigmoid(torch.randn(B, T, H, D, device=fla_device, dtype=torch.float))
+                    beta_global = torch.randn(B, T, H, device=fla_device, dtype=torch.float16).sigmoid()
+                    do_global = torch.randn(B, T, H, D, device=fla_device, dtype=torch.float16)
+
+                    # Broadcast
+                    dist.broadcast(q_global, src=0)
+                    dist.broadcast(k_global, src=0)
+                    dist.broadcast(v_global, src=0)
+                    dist.broadcast(g_global, src=0)
+                    dist.broadcast(beta_global, src=0)
+                    dist.broadcast(do_global, src=0)
+
+                    cu_seqlens_list = [0] + torch.cumsum(torch.tensor(lengths), 0).tolist()
+                    cu_seqlens_global = torch.tensor(cu_seqlens_list, device=fla_device, dtype=torch.long)
+
+                    # Reference
+                    ref_out, ref_dq, ref_dk, ref_dv, ref_dg, ref_db = None, None, None, None, None, None
+                    if rank == 0:
+                        q_ref = q_global.clone().detach().requires_grad_(True)
+                        k_ref = k_global.clone().detach().requires_grad_(True)
+                        v_ref = v_global.clone().detach().requires_grad_(True)
+                        g_ref = g_global.clone().detach().requires_grad_(True)
+                        beta_ref = beta_global.clone().detach().requires_grad_(True)
+
+                        o_ref, _ = chunk_kda(
+                            q=F.normalize(q_ref, p=2, dim=-1),
+                            k=F.normalize(k_ref, p=2, dim=-1),
+                            v=v_ref,
+                            g=g_ref,
+                            beta=beta_ref,
+                            cu_seqlens=cu_seqlens_global,
+                        )
+                        o_ref.backward(do_global)
+                        ref_out = o_ref.detach()
+                        ref_dq = q_ref.grad.detach()
+                        ref_dk = k_ref.grad.detach()
+                        ref_dv = v_ref.grad.detach()
+                        ref_dg = g_ref.grad.detach()
+                        ref_db = beta_ref.grad.detach()
+
+                    dist.barrier()
+
+                    # CP run
+                    context = build_cp_context(cu_seqlens_global, group=dist.group.WORLD)
+
+                    chunk_size = T // world_size
+                    start_idx, end_idx = rank * chunk_size, (rank + 1) * chunk_size
+
+                    q_local = q_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    k_local = k_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    v_local = v_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    g_local = g_global[:, start_idx:end_idx, :].clone().detach().requires_grad_(True)
+                    beta_local = beta_global[:, start_idx:end_idx].clone().detach().requires_grad_(True)
+                    do_local = do_global[:, start_idx:end_idx, :].clone()
+
+                    o_local, _ = chunk_kda(
+                        q=F.normalize(q_local, p=2, dim=-1),
+                        k=F.normalize(k_local, p=2, dim=-1),
+                        v=v_local,
+                        g=g_local,
+                        beta=beta_local,
+                        cu_seqlens=context.cu_seqlens,
+                        cp_context=context,
+                    )
+                    o_local.backward(do_local)
+
+                    # Gather output and gradients
+                    o_gathered = [torch.zeros_like(o_local) for _ in range(world_size)]
+                    dist.all_gather(o_gathered, o_local)
+                    o_cp_global = torch.cat(o_gathered, dim=1)
+
+                    dq_gathered = [torch.zeros_like(q_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dq_gathered, q_local.grad)
+                    dq_cp_global = torch.cat(dq_gathered, dim=1)
+
+                    dk_gathered = [torch.zeros_like(k_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dk_gathered, k_local.grad)
+                    dk_cp_global = torch.cat(dk_gathered, dim=1)
+
+                    dv_gathered = [torch.zeros_like(v_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dv_gathered, v_local.grad)
+                    dv_cp_global = torch.cat(dv_gathered, dim=1)
+
+                    dg_gathered = [torch.zeros_like(g_local.grad) for _ in range(world_size)]
+                    dist.all_gather(dg_gathered, g_local.grad)
+                    dg_cp_global = torch.cat(dg_gathered, dim=1)
+
+                    db_gathered = [torch.zeros_like(beta_local.grad) for _ in range(world_size)]
+                    dist.all_gather(db_gathered, beta_local.grad)
+                    db_cp_global = torch.cat(db_gathered, dim=1)
+
+                    if rank == 0:
+                        print(f"\n[{test_name}] Verification:")
+                        assert_close("Output", ref_out, o_cp_global, atol=5e-3)
+                        assert_close("dq", ref_dq, dq_cp_global, atol=8e-3)
+                        assert_close("dk", ref_dk, dk_cp_global, atol=8e-3)
+                        assert_close("dv", ref_dv, dv_cp_global, atol=8e-3)
+                        assert_close("dg", ref_dg, dg_cp_global, atol=2e-2)
+                        assert_close("db", ref_db, db_cp_global, atol=2e-2)
+                        print(f"✅ [{test_name}] Passed!")
+
+                    dist.barrier()
+
+                if rank == 0:
+                    print("\n" + "=" * 60)
+                    print("All tests passed!")
+                    print("=" * 60)
+
+            finally:
+                cleanup_distributed()
+    else:
+        # Not running with torchrun, show usage
+        print("Run tests with pytest or torchrun:")
+        print("  pytest tests/context_parallel/test_cp_kda.py -v")
+        print("  torchrun --nproc_per_node=2 tests/context_parallel/test_cp_kda.py")
+        print("  torchrun --nproc_per_node=4 tests/context_parallel/test_cp_kda.py")


### PR DESCRIPTION
Based on the blog [DeltaNet如何做序列并行](https://yywangcs.notion.site/DeltaNet-2a9fc9f5d8058013a498f34e0b25bd52) and my own understanding, I implemented context parallel(CP) for KDA and GDN. The performance is better than the all-to-all CP approach, and the number of CP splits is not limited by the number of heads. Integrating it into FLA minimally disrupts the original code structure—it's essentially plug-and-play.

## Performance
32K, CP=4, num_head=64, head_dim=128, GPU=h800, triton=3.4, torch=2.8, cuda=12.8
### GDN
```python
forward
custom cp, non-cp time: 4.808 ms, cp time: 2.001 ms, rate: 60.08 %
all to all, non-cp time: 4.808 ms, cp time: 4.114 ms, rate: 29.22 %

forward + backward
custom cp, non-cp time: 15.560 ms, cp time: 5.730 ms, rate: 67.89 %
all to all, non-cp time: 15.560 ms, cp time: 10.591 ms, rate: 36.73 %
```
Performance is significantly better than the cp-all-to-all approach.
<img width="2805" height="498" alt="image" src="https://github.com/user-attachments/assets/020d45b6-ad9d-4871-81d7-8b5464e465cf" />

The additional operations include three extra operators and one all-gather communication, with a communication volume of CP×H×K×(K+V). Generally, this communication volume is much smaller than that of all-to-all, and since there is no head splitting, the operator parallelism is higher.
<img width="2990" height="468" alt="image" src="https://github.com/user-attachments/assets/35bd29dc-8efb-455f-80d1-0665babb8a45" />
### KDA
```python
forward
custom cp, non-cp time: 7.839 ms, cp time: 2.591 ms, rate: 75.65 %
all to all, non-cp time: 7.839 ms, cp time: 5.276 ms, rate: 37.15 %

forward + backward
custom cp, non-cp time: 36.193 ms, cp time: 10.490 ms, rate: 86.26 %
all to all, non-cp time: 36.193 ms, cp time: 16.415 ms, rate: 55.12 %
```
The diagrams below are similar to those for GDN.
<img width="2964" height="669" alt="image" src="https://github.com/user-attachments/assets/63de5f7b-4d27-4651-857c-ae73705cf8f3" />
<img width="2493" height="558" alt="image" src="https://github.com/user-attachments/assets/bd05e20e-562e-4872-97ae-3fb63de4c38e" />

## conv1d
Since conv1d is used in both KDA and GDN, the all-to-all approach can handle incomplete sequences on a single rank. If using the CP method described here, additional processing in conv1d is required—specifically, gathering tail tokens from the previous rank and concatenating them with the current rank’s sequence.

## Drawbacks
Compared to the all-to-all CP approach, the output and gradient information is lossy.
Communication volume is proportional to the size of CP. If CP is large, communication latency becomes more noticeable.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Context Parallel (CP) support across causal 1D convolution, gated delta rule, and KDA, including public CP context and communication surfaces for cross-rank state/gradient exchange.
* **Testing**
  * Added extensive distributed test suites validating CP forward/backward correctness for convolution, gated delta rule, GDN, and KDA.
* **Documentation**
  * New CP-focused READMEs describing concepts and usage.
* **Benchmarking**
  * New CP-enabled benchmarking harness for profiling and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->