### PR TITLE
[Misc] centralize reference implementations in naive.py

### DIFF
--- a/fla/ops/attn/__init__.py
+++ b/fla/ops/attn/__init__.py
@@ -1,6 +1,8 @@
 
+from .naive import naive_parallel_attn
 from .parallel import parallel_attn
 
 __all__ = [
+    'naive_parallel_attn',
     'parallel_attn',
 ]

--- a/fla/ops/attn/naive.py
+++ b/fla/ops/attn/naive.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+import torch.nn.functional as F
+
+
+def naive_parallel_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+    causal: bool = True,
+):
+    """
+    Reference PyTorch implementation of parallel attention that returns both output and max_logits.
+
+    Args:
+        q: [B, T, HQ, D]
+        k: [B, T, H, D]
+        v: [B, T, H, D]
+        scale: float, optional. If None, defaults to 1 / sqrt(D)
+        causal: bool, default True
+
+    Returns:
+        output: [B, T, HQ, D]
+        max_logits: [B, T, HQ]
+    """
+    B, T, HQ, D = q.shape
+    H = k.shape[2]
+    G = HQ // H
+
+    if scale is None:
+        scale = D ** -0.5
+
+    # Reshape q to separate heads and groups
+    q = q.reshape(B, T, H, G, D)  # [B, T, H, G, D]
+
+    # Repeat k and v to match groups: [B, T, H, D] -> [B, T, H, G, D]
+    k = k.unsqueeze(3).expand(B, T, H, G, D)  # Expand along group dimension
+    v = v.unsqueeze(3).expand(B, T, H, G, D)
+
+    # Reshape to treat each (B, H, G,) as a separate head
+    q_flat = q.reshape(B * H * G, T, D)  # [B*H*G, T, D]
+    k_flat = k.reshape(B * H * G, T, D)  # [B*H*G, T, D]
+    v_flat = v.reshape(B * H * G, T, D)  # [B*H*G, T, D]
+
+    # Compute attention scores: [B*H*G, T, T]
+    scores = torch.bmm(q_flat, k_flat.transpose(1, 2)) * scale
+
+    # Apply causal mask
+    if causal:
+        causal_mask = torch.triu(torch.ones(T, T, dtype=torch.bool, device=q.device), diagonal=1)
+        scores = scores.masked_fill(causal_mask.unsqueeze(0), float('-inf'))
+
+    # Compute max_logits (max over key dimension): [B*H*G, T]
+    max_logits_flat = scores.max(dim=-1).values
+    max_logits = max_logits_flat.reshape(B, T, HQ)  # [B, T, HQ]
+
+    # Compute attention weights and output
+    attn_weights = F.softmax(scores, dim=-1)  # [B*H*G, T, T]
+    output_flat = torch.bmm(attn_weights, v_flat)  # [B*H*G, T, D]
+    output = output_flat.reshape(B, T, HQ, D)  # [B, T, HQ, D]
+
+    return output, max_logits

--- a/fla/ops/comba/__init__.py
+++ b/fla/ops/comba/__init__.py
@@ -1,7 +1,10 @@
 from .chunk import chunk_comba
 from .fused_recurrent import fused_recurrent_comba
+from .naive import naive_chunk_comba, naive_recurrent_comba
 
 __all__ = [
     "chunk_comba",
     "fused_recurrent_comba",
+    "naive_chunk_comba",
+    "naive_recurrent_comba",
 ]

--- a/fla/ops/comba/naive.py
+++ b/fla/ops/comba/naive.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+
+def naive_recurrent_comba(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    p: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+):
+    """
+    Reference PyTorch implementation of recurrent COMBA.
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        v: [B, T, H, V]
+        p: [B, T, H, K]
+        beta: [B, T, H]
+        g: [B, T, H]
+        scale: float, optional
+        initial_state: [B, H, K, V], optional
+        output_final_state: bool
+
+    Returns:
+        o: [B, T, H, V]
+        final_state: [B, H, K, V] if output_final_state else None
+    """
+    q, k, v, p, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, p, beta, g])
+    B, H, T, K, V = *k.shape, v.shape[-1]
+    o = torch.zeros(B, H, T, V).to(v)
+    h = torch.zeros(B, H, K, V).to(v)
+    if initial_state is not None:
+        h = initial_state.to(torch.float32)
+    if scale is None:
+        scale = 1 / (q.shape[-1] ** 0.5)
+    q = q * scale
+
+    for i in range(T):
+        b_q = q[:, :, i]
+        b_k = k[:, :, i]
+        b_v = v[:, :, i].clone()
+        b_p = p[:, :, i]
+        h = h.clone() * g[:, :, i].exp()[..., None, None]
+        b_beta = beta[:, :, i]
+        b_v = b_v - (h.clone() * b_p[..., None]).sum(-2)
+        b_v = b_v * b_beta[..., None]
+        h = h.clone() + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
+        o[:, :, i] = torch.einsum('bhd,bhdm->bhm', b_q, h)
+
+    if not output_final_state:
+        h = None
+    o = o.transpose(1, 2).contiguous()
+    return o, h
+
+
+def naive_chunk_comba(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    p: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int = 64,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+):
+    """
+    Reference PyTorch implementation of chunk COMBA.
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        v: [B, T, H, V]
+        p: [B, T, H, K]
+        g: [B, T, H]
+        beta: [B, T, H]
+        chunk_size: int
+        scale: float, optional
+        initial_state: [B, H, K, V], optional
+        output_final_state: bool
+
+    Returns:
+        o: [B, T, H, V]
+        final_state: [B, H, K, V] if output_final_state else None
+    """
+    BT = chunk_size
+    if scale is None:
+        scale = 1 / (q.shape[-1] ** 0.5)
+
+    q, k, v, p, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, p, beta, g])
+
+    T = q.shape[-2]
+    pad_len = (BT - (T % BT)) % BT
+    if pad_len > 0:
+        q = F.pad(q, (0, 0, 0, pad_len))
+        k = F.pad(k, (0, 0, 0, pad_len))
+        v = F.pad(v, (0, 0, 0, pad_len))
+        p = F.pad(p, (0, 0, 0, pad_len))
+        beta = F.pad(beta, (0, pad_len))
+        g = F.pad(g, (0, pad_len))
+
+    decay = g
+    chunk_size = BT
+    b, h, l, d_k = q.shape
+    d_v = v.shape[-1]
+    q = q * scale
+    v = v * beta[..., None]
+    p_beta = p * beta[..., None]
+    assert l % chunk_size == 0
+
+    # note that diagonal is masked.
+    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=0)
+    q, k, v, p_beta, decay, g = map(
+        lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=chunk_size),
+        [q, k, v, p_beta, decay.unsqueeze(-1), g.unsqueeze(-1)],
+    )
+    decay = decay.squeeze(-1).cumsum(-1)  # [B, H, n, c]
+    decay_0 = decay - g.squeeze(-1)  # [B, H, n, c]
+    L_mask = ((decay.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().float()).tril()
+    L_mask_0 = ((decay_0.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().float()).tril()
+
+    # [B, H, n, c, d] @ [B, H, n, d, c] -> [B, H, n, c, c]
+    attn = -((p_beta @ k.transpose(-1, -2)) * L_mask_0).masked_fill(mask, 0)
+    for i in range(1, chunk_size):
+        attn[..., i, :i] = attn[..., i, :i].clone() + (attn[..., i, :i, None].clone() * attn[..., :i, :i].clone()).sum(-2)
+    attn = attn + torch.eye(chunk_size, dtype=torch.float, device=q.device)
+
+    # for U
+    k_cumsum = attn @ v
+    # for W
+    k_cumdecay = attn @ (p_beta * decay_0[..., None].exp())
+    v = k_cumsum
+
+    S = k.new_zeros(b, h, d_k, d_v)
+    if initial_state is not None:
+        S = initial_state.to(torch.float32)
+
+    o = torch.zeros_like(v)
+    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=1)
+    for i in range(0, l // chunk_size):
+        q_i, k_i, v_i = q[:, :, i], k[:, :, i], v[:, :, i]
+        attn = (q_i @ k_i.transpose(-1, -2) * L_mask[:, :, i]).masked_fill_(mask, 0)
+        v_prime = k_cumdecay[:, :, i] @ S
+        v_new = v_i - v_prime
+        o_inter = (q_i * decay[:, :, i, :, None].exp()) @ S
+        o[:, :, i] = o_inter + attn @ v_new
+        S = S * decay[:, :, i, -1, None, None].exp() + (k_i * (decay[:, :, i, -1, None] - decay[:, :, i]).exp()
+                                                        [..., None]).transpose(-1, -2) @ v_new
+    if not output_final_state:
+        S = None
+
+    # unpad
+    o = rearrange(o, 'b h n c d -> b h (n c) d')
+    o = o[:, :, :T]
+    o = o.transpose(1, 2)
+    return o, S

--- a/fla/ops/forgetting_attn/__init__.py
+++ b/fla/ops/forgetting_attn/__init__.py
@@ -1,6 +1,8 @@
 
+from .naive import naive_forgetting_attn
 from .parallel import parallel_forgetting_attn
 
 __all__ = [
+    'naive_forgetting_attn',
     'parallel_forgetting_attn',
 ]

--- a/fla/ops/forgetting_attn/naive.py
+++ b/fla/ops/forgetting_attn/naive.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange, repeat
+
+
+def naive_forgetting_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    scale: float | None = None,
+):
+    """
+    Reference PyTorch implementation of forgetting attention.
+
+    Args:
+        q: [B, T, HQ, D]
+        k: [B, T, H, D]
+        v: [B, T, H, D]
+        g: [B, T, HQ]
+        scale: float, optional. If None, defaults to 1 / sqrt(D)
+
+    Returns:
+        output: [B, T, HQ, D]
+    """
+    _, T, HQ, D = q.shape
+    H = k.shape[2]
+    G = HQ // H
+
+    if scale is None:
+        scale = D ** -0.5
+
+    gc = g.float().cumsum(1)
+    mask = torch.tril(torch.ones((T, T), dtype=torch.bool, device=q.device))
+
+    ref = torch.einsum("bqhd,bkhd->bhqk", q.float() * scale, repeat(k, "b t h d -> b t (h g) d", g=G).float())
+    ref = ref + rearrange(gc, "b t h -> b h t 1") - rearrange(gc, "b t h -> b h 1 t")
+    ref = ref.masked_fill(~mask.unsqueeze(0).unsqueeze(0), -float('inf'))
+    ref = torch.einsum("bhqk,bkhd->bqhd", F.softmax(ref, dim=-1), repeat(v, "b t h d -> b t (h g) d", g=G).float())
+
+    return ref

--- a/fla/ops/gated_delta_rule/__init__.py
+++ b/fla/ops/gated_delta_rule/__init__.py
@@ -1,7 +1,10 @@
 from .chunk import chunk_gated_delta_rule
 from .fused_recurrent import fused_recurrent_gated_delta_rule
+from .naive import naive_chunk_gated_delta_rule, naive_recurrent_gated_delta_rule
 
 __all__ = [
     "chunk_gated_delta_rule",
     "fused_recurrent_gated_delta_rule",
+    "naive_chunk_gated_delta_rule",
+    "naive_recurrent_gated_delta_rule",
 ]

--- a/fla/ops/gated_delta_rule/naive.py
+++ b/fla/ops/gated_delta_rule/naive.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+
+def naive_recurrent_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+):
+    """
+    Reference PyTorch implementation of recurrent gated delta rule.
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        v: [B, T, H, V]
+        beta: [B, T, H]
+        g: [B, T, H]
+        scale: float, optional
+        initial_state: [B, H, K, V], optional
+        output_final_state: bool
+
+    Returns:
+        o: [B, T, H, V]
+        final_state: [B, H, K, V] if output_final_state else None
+    """
+    q, k, v, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, beta, g])
+    B, H, T, K, V = *k.shape, v.shape[-1]
+    o = torch.zeros(B, H, T, V).to(v)
+    h = torch.zeros(B, H, K, V).to(v)
+    if initial_state is not None:
+        h = initial_state.to(torch.float32)
+    if scale is None:
+        scale = 1 / (q.shape[-1] ** 0.5)
+    q = q * scale
+
+    for i in range(T):
+        b_q = q[:, :, i]
+        b_k = k[:, :, i]
+        b_v = v[:, :, i].clone()
+        h = h.clone() * g[:, :, i].exp()[..., None, None]
+        b_beta = beta[:, :, i]
+        b_v = b_v - (h.clone() * b_k[..., None]).sum(-2)
+        b_v = b_v * b_beta[..., None]
+        h = h.clone() + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
+        o[:, :, i] = torch.einsum('bhd,bhdm->bhm', b_q, h)
+
+    if not output_final_state:
+        h = None
+    o = o.transpose(1, 2).contiguous()
+    return o, h
+
+
+def naive_chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int = 64,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+):
+    """
+    Reference PyTorch implementation of chunk gated delta rule.
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        v: [B, T, H, V]
+        g: [B, T, H]
+        beta: [B, T, H]
+        chunk_size: int
+        scale: float, optional
+        initial_state: [B, H, K, V], optional
+        output_final_state: bool
+
+    Returns:
+        o: [B, T, H, V]
+        final_state: [B, H, K, V] if output_final_state else None
+    """
+    BT = chunk_size
+    if scale is None:
+        scale = 1 / (q.shape[-1] ** 0.5)
+
+    q, k, v, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, beta, g])
+
+    T = q.shape[-2]
+    pad_len = (BT - (T % BT)) % BT
+    if pad_len > 0:
+        q = F.pad(q, (0, 0, 0, pad_len))
+        k = F.pad(k, (0, 0, 0, pad_len))
+        v = F.pad(v, (0, 0, 0, pad_len))
+        beta = F.pad(beta, (0, pad_len))
+        g = F.pad(g, (0, pad_len))
+
+    q, k, v, beta, g = map(lambda x: x.to(torch.float32), [q, k, v, beta, g])
+    decay = g
+    chunk_size = BT
+    b, h, l, d_k = q.shape
+    d_v = v.shape[-1]
+    q = q * scale
+    v = v * beta[..., None]
+    k_beta = k * beta[..., None]
+    assert l % chunk_size == 0
+
+    # note that diagonal is masked.
+    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=0)
+    q, k, v, k_beta, decay = map(
+        lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=chunk_size),
+        [q, k, v, k_beta, decay.unsqueeze(-1)],
+    )
+    decay = decay.squeeze(-1).cumsum(-1)
+    decay_exp = decay.exp()[..., None]
+    L_mask = ((decay.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().float()).tril()
+    attn = -((k_beta @ k.transpose(-1, -2)) * L_mask).masked_fill(mask, 0)
+    for i in range(1, chunk_size):
+        attn[..., i, :i] = attn[..., i, :i].clone() + (attn[..., i, :i, None].clone() * attn[..., :i, :i].clone()).sum(-2)
+    attn = attn + torch.eye(chunk_size, dtype=torch.float, device=q.device)
+    attn = attn
+    k_cumsum = attn @ v
+    k_cumdecay = attn @ (k_beta * decay_exp)
+    v = k_cumsum
+
+    S = k.new_zeros(b, h, d_k, d_v)
+    if initial_state is not None:
+        S = initial_state.to(torch.float32)
+
+    o = torch.zeros_like(v)
+    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=1)
+    for i in range(0, l // chunk_size):
+        q_i, k_i, v_i = q[:, :, i], k[:, :, i], v[:, :, i]
+        attn = (q_i @ k_i.transpose(-1, -2) * L_mask[:, :, i]).masked_fill_(mask, 0)
+        v_prime = (k_cumdecay[:, :, i]) @ S
+        v_new = v_i - v_prime
+        o_inter = (q_i * decay[:, :, i, :, None].exp()) @ S
+        o[:, :, i] = o_inter + attn @ v_new
+        S = S * decay[:, :, i, -1, None, None].exp() + (k_i * (decay[:, :, i, -1, None] - decay[:, :, i]).exp()
+                                                        [..., None]).transpose(-1, -2) @ v_new
+    if not output_final_state:
+        S = None
+
+    # unpad
+    o = rearrange(o, 'b h n c d -> b h (n c) d')
+    o = o[:, :, :T]
+    o = o.transpose(1, 2)
+    return o, S

--- a/fla/ops/path_attn/__init__.py
+++ b/fla/ops/path_attn/__init__.py
@@ -1,6 +1,8 @@
 
+from .naive import naive_path_attn
 from .parallel import parallel_path_attn
 
 __all__ = [
+    'naive_path_attn',
     'parallel_path_attn',
 ]

--- a/fla/ops/path_attn/naive.py
+++ b/fla/ops/path_attn/naive.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+
+def naive_path_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    w: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    scale: float,
+    chunk_size: int = 64,
+):
+    """
+    Reference PyTorch implementation of path attention.
+
+    Args:
+        q: [B, T, HQ, D]
+        k: [B, T, H, D]
+        v: [B, T, H, D]
+        w: [B, T, H, D]
+        beta: [B, T, H]
+        g: [B, T, HQ]
+        scale: float
+        chunk_size: int, default 64
+
+    Returns:
+        output: [B, T, HQ, D]
+    """
+    original_dtype = q.dtype
+    HQ = q.shape[2]
+    H = k.shape[2]
+    BT = chunk_size
+
+    q, k, v, w, beta, g = map(lambda x: x.to(torch.float).transpose(1, 2), [q, k, v, w, beta, g])
+    g_cumsum = g.cumsum(-1)
+
+    q = q.unsqueeze(2).expand(-1, -1, HQ // HQ, -1, -1).flatten(1, 2)
+    k = k.unsqueeze(2).expand(-1, -1, HQ // H, -1, -1).flatten(1, 2)
+    v = v.unsqueeze(2).expand(-1, -1, HQ // H, -1, -1).flatten(1, 2)
+    w = w.unsqueeze(2).expand(-1, -1, HQ // H, -1, -1).flatten(1, 2)
+    beta = beta.unsqueeze(2).expand(-1, -1, HQ // H, -1).flatten(1, 2)
+
+    b, h, l, _ = q.shape
+    if l % BT != 0:
+        padding_size = BT - l % BT
+        q, k, w = map(lambda x: F.pad(x, (0, 0, 0, padding_size)), [q, k, w])
+        beta = F.pad(beta, (0, padding_size))
+
+    seq_len = q.shape[2]
+    w_beta = w * beta[..., None]
+    q, k, w, w_beta = map(lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=BT), [q, k, w, w_beta])
+
+    mask = torch.triu(torch.ones(BT, BT, dtype=torch.bool, device=q.device), diagonal=0)
+    T_mat = -(w_beta @ w.transpose(-1, -2)).masked_fill(mask, 0)
+
+    for i in range(1, BT):
+        T_mat[..., i, :i] = T_mat[..., i, :i].clone() + (T_mat[..., i, :, None].clone() * T_mat[..., :, :i].clone()).sum(-2)
+
+    T_mat = T_mat + torch.eye(BT, dtype=q.dtype, device=q.device)
+    Twbk = T_mat @ (w_beta @ k.transpose(-1, -2)).masked_fill(mask, 0)
+    qw = (q @ w.transpose(-1, -2)).tril()
+    Twb = T_mat @ w_beta
+    A_local = (q @ k.transpose(-1, -2)).tril() - qw @ Twbk
+    q = q - qw @ Twb
+    k = k - Twbk.transpose(-1, -2) @ w
+    H_mat = w.transpose(-1, -2) @ Twb
+
+    A = torch.zeros(b, h, seq_len, seq_len, device=q.device)
+    q, k, w, w_beta = map(lambda x: rearrange(x, 'b h n c d -> b h (n c) d'), [q, k, w, w_beta])
+
+    for i in range(0, seq_len, BT):
+        q_i = q[:, :, i:i+BT].clone()
+        for j in range(i - BT, -BT, -BT):
+            k_j = k[:, :, j:j+BT]
+            A_ij = q_i @ k_j.transpose(-1, -2)
+            A[:, :, i:i+BT, j:j+BT] = A_ij
+            q_i = q_i - q_i @ H_mat[:, :, j // BT]
+
+    for i in range(0, seq_len // BT):
+        A[:, :, i*BT:i*BT+BT, i*BT:i*BT+BT] = A_local[:, :, i]
+
+    A = A.masked_fill_(~torch.tril(torch.ones(seq_len, seq_len, device=q.device, dtype=torch.bool)), float("-inf"))
+    A = A[:, :, :l, :l]
+    A = A + g_cumsum[..., None] - g_cumsum[..., None, :]
+    ref_o = (A * scale).softmax(-1).to(v) @ v
+
+    return ref_o.to(original_dtype).transpose(1, 2)

--- a/tests/ops/test_comba.py
+++ b/tests/ops/test_comba.py
@@ -5,9 +5,9 @@ import os
 import pytest
 import torch
 import torch.nn.functional as F
-from einops import rearrange
 
 from fla.ops.comba import chunk_comba, fused_recurrent_comba
+from fla.ops.comba.naive import naive_chunk_comba
 from fla.ops.comba.utils import chunk_comba_cumsum_scalar_fwd
 from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
 
@@ -50,85 +50,6 @@ def test_cumsum_local_scalar_fwd(
     assert_close("local cumsum scalar", ref_1, tri_1, 0.001 if dtype == torch.float else 0.003)
 
 
-def chunk_comba_ref(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    p: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
-    chunk_size: int = 64,
-    scale: float = None,
-    initial_state: torch.Tensor = None,
-    output_final_state: bool = False,
-):
-    BT = chunk_size
-    if scale is None:
-        scale = 1 / (q.shape[-1] ** 0.5)
-    # Calculate padding needed to make T a multiple of BT
-    q, k, v, p, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, p, beta, g])
-
-    T = q.shape[-2]
-    pad_len = (BT - (T % BT)) % BT
-    if pad_len > 0:
-        # Pad all tensors
-        q = F.pad(q, (0, 0, 0, pad_len))
-        k = F.pad(k, (0, 0, 0, pad_len))
-        v = F.pad(v, (0, 0, 0, pad_len))
-        p = F.pad(p, (0, 0, 0, pad_len))
-        beta = F.pad(beta, (0, pad_len))
-        g = F.pad(g, (0, pad_len))
-    decay = g
-    chunk_size = BT
-    b, h, l, d_k = q.shape
-    d_v = v.shape[-1]
-    q = q * scale
-    v = v * beta[..., None]
-    p_beta = p * beta[..., None]
-    assert l % chunk_size == 0
-    # note that diagonal is masked.
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=0)
-    q, k, v, p_beta, decay, g = map(
-        lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=chunk_size),
-        [q, k, v, p_beta, decay.unsqueeze(-1), g.unsqueeze(-1)],
-    )
-    decay = decay.squeeze(-1).cumsum(-1)  # [B, H, n, c]
-    decay_0 = decay - g.squeeze(-1)  # [B, H, n, c]
-    L_mask = ((decay.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().float()).tril()
-    L_mask_0 = ((decay_0.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().float()).tril()
-    # [B, H, n, c, d] @ [B, H, n, d, c] -> [B, H, n, c, c]
-    attn = -((p_beta @ k.transpose(-1, -2)) * L_mask_0).masked_fill(mask, 0)
-    for i in range(1, chunk_size):
-        attn[..., i, :i] = attn[..., i, :i].clone() + (attn[..., i, :i, None].clone() * attn[..., :i, :i].clone()).sum(-2)
-    attn = attn + torch.eye(chunk_size, dtype=torch.float, device=q.device)
-    # for U
-    k_cumsum = attn @ v
-    # for W
-    k_cumdecay = attn @ (p_beta * decay_0[..., None].exp())
-    v = k_cumsum
-    S = k.new_zeros(b, h, d_k, d_v)
-    if initial_state is not None:
-        S += initial_state
-    o = torch.zeros_like(v)
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=1)
-    for i in range(0, l // chunk_size):
-        q_i, k_i, v_i = q[:, :, i], k[:, :, i], v[:, :, i]
-        attn = (q_i @ k_i.transpose(-1, -2) * L_mask[:, :, i]).masked_fill_(mask, 0)
-        v_prime = k_cumdecay[:, :, i] @ S
-        v_new = v_i - v_prime
-        o_inter = (q_i * decay[:, :, i, :, None].exp()) @ S
-        o[:, :, i] = o_inter + attn @ v_new
-        S = S * decay[:, :, i, -1, None, None].exp() + (k_i * (decay[:, :, i, -1, None] - decay[:, :, i]).exp()
-                                                        [..., None]).transpose(-1, -2) @ v_new
-    if not output_final_state:
-        S = None
-    # unpad
-    o = rearrange(o, 'b h n c d -> b h (n c) d')
-    o = o[:, :, :T]
-    o = o.transpose(1, 2)
-    return o, S
-
-
 @pytest.mark.parametrize(
     ('B', 'T', 'H', 'D', 'scale', 'gate_logit_normalizer', 'dtype'),
     [
@@ -164,7 +85,7 @@ def test_fused_recurrent(
     g = g / gate_logit_normalizer
     h0 = torch.randn(B, H, D, D, dtype=torch.float32)
     q, k, v, p, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, p, beta, g, h0))
-    ref, ref_ht = chunk_comba_ref(
+    ref, ref_ht = naive_chunk_comba(
         q=q.clone(),
         k=k.clone(),
         v=v.clone(),
@@ -252,7 +173,7 @@ def test_chunk(
     tri_dq, tri_dk, tri_dv, tri_dp, tri_dbeta, tri_dg, tri_dh0 = q.grad, k.grad, v.grad, p.grad, beta.grad, g.grad, h0.grad
     q.grad = k.grad = v.grad = p.grad = beta.grad = g.grad = h0.grad = None
 
-    ref, ref_ht = chunk_comba_ref(
+    ref, ref_ht = naive_chunk_comba(
         q=F.normalize(q.clone(), p=2, dim=-1),
         k=F.normalize(k.clone(), p=2, dim=-1),
         p=F.normalize(p.clone(), p=2, dim=-1),
@@ -341,7 +262,7 @@ def test_chunk_varlen(
     ref = []
     ref_ht = []
     for i in range(N):
-        ref_i, ref_ht_i = chunk_comba_ref(
+        ref_i, ref_ht_i = naive_chunk_comba(
             q=q[:, cu_seqlens[i]:cu_seqlens[i+1]],
             k=k[:, cu_seqlens[i]:cu_seqlens[i+1]],
             v=v[:, cu_seqlens[i]:cu_seqlens[i+1]],

--- a/tests/ops/test_gated_delta.py
+++ b/tests/ops/test_gated_delta.py
@@ -5,120 +5,11 @@ import os
 import pytest
 import torch
 import torch.nn.functional as F
-from einops import rearrange, repeat
+from einops import repeat
 
 from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
+from fla.ops.gated_delta_rule.naive import naive_recurrent_gated_delta_rule
 from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
-
-
-def recurrent_gated_delta_rule_ref(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    beta: torch.Tensor,
-    g: torch.Tensor,
-    scale: float = None,
-    initial_state: torch.Tensor = None,
-    output_final_state: bool = False,
-):
-    q, k, v, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, beta, g])
-    B, H, T, K, V = *k.shape, v.shape[-1]
-    o = torch.zeros(B, H, T, V).to(v)
-    h = torch.zeros(B, H, K, V).to(v)
-    if initial_state is not None:
-        h = initial_state
-    if scale is None:
-        scale = 1 / (q.shape[-1] ** 0.5)
-    q = q * scale
-    for i in range(T):
-        b_q = q[:, :, i]
-        b_k = k[:, :, i]
-        b_v = v[:, :, i].clone()
-        h = h.clone() * g[:, :, i].exp()[..., None, None]
-        b_beta = beta[:, :, i]
-        b_v = b_v - (h.clone() * b_k[..., None]).sum(-2)
-        b_v = b_v * b_beta[..., None]
-        h = h.clone() + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
-        o[:, :, i] = torch.einsum('bhd,bhdm->bhm', b_q, h)
-    if not output_final_state:
-        h = None
-    o = o.transpose(1, 2).contiguous()
-    return o, h
-
-
-def chunk_gated_delta_rule_ref(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
-    chunk_size: int = 64,
-    scale: float = None,
-    initial_state: torch.Tensor = None,
-    output_final_state: bool = False,
-):
-    BT = chunk_size
-    if scale is None:
-        scale = 1 / (q.shape[-1] ** 0.5)
-    # Calculate padding needed to make T a multiple of BT
-    q, k, v, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, beta, g])
-
-    T = q.shape[-2]
-    pad_len = (BT - (T % BT)) % BT
-    if pad_len > 0:
-        # Pad all tensors
-        q = F.pad(q, (0, 0, 0, pad_len))
-        k = F.pad(k, (0, 0, 0, pad_len))
-        v = F.pad(v, (0, 0, 0, pad_len))
-        beta = F.pad(beta, (0, pad_len))
-        g = F.pad(g, (0, pad_len))
-    q, k, v, beta, g = map(lambda x: x.to(torch.float32), [q, k, v, beta, g])
-    decay = g
-    chunk_size = BT
-    b, h, l, d_k = q.shape
-    d_v = v.shape[-1]
-    q = q * scale
-    v = v * beta[..., None]
-    k_beta = k * beta[..., None]
-    assert l % chunk_size == 0
-    # note that diagonal is masked.
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=0)
-    q, k, v, k_beta, decay = map(
-        lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=chunk_size),
-        [q, k, v, k_beta, decay.unsqueeze(-1)],
-    )
-    decay = decay.squeeze(-1).cumsum(-1)
-    decay_exp = decay.exp()[..., None]
-    L_mask = ((decay.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().float()).tril()
-    attn = -((k_beta @ k.transpose(-1, -2)) * L_mask).masked_fill(mask, 0)
-    for i in range(1, chunk_size):
-        attn[..., i, :i] = attn[..., i, :i].clone() + (attn[..., i, :i, None].clone() * attn[..., :i, :i].clone()).sum(-2)
-    attn = attn + torch.eye(chunk_size, dtype=torch.float, device=q.device)
-    attn = attn
-    k_cumsum = attn @ v
-    k_cumdecay = attn @ (k_beta * decay_exp)
-    v = k_cumsum
-    S = k.new_zeros(b, h, d_k, d_v)
-    if initial_state is not None:
-        S = initial_state
-    o = torch.zeros_like(v)
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), diagonal=1)
-    for i in range(0, l // chunk_size):
-        q_i, k_i, v_i = q[:, :, i], k[:, :, i], v[:, :, i]
-        attn = (q_i @ k_i.transpose(-1, -2) * L_mask[:, :, i]).masked_fill_(mask, 0)
-        v_prime = (k_cumdecay[:, :, i]) @ S
-        v_new = v_i - v_prime
-        o_inter = (q_i * decay[:, :, i, :, None].exp()) @ S
-        o[:, :, i] = o_inter + attn @ v_new
-        S = S * decay[:, :, i, -1, None, None].exp() + (k_i * (decay[:, :, i, -1, None] - decay[:, :, i]).exp()
-                                                        [..., None]).transpose(-1, -2) @ v_new
-    if not output_final_state:
-        S = None
-    # unpad
-    o = rearrange(o, 'b h n c d -> b h (n c) d')
-    o = o[:, :, :T]
-    o = o.transpose(1, 2)
-    return o, S
 
 
 @pytest.mark.parametrize(
@@ -156,7 +47,7 @@ def test_fused_recurrent(
     g = g / gate_logit_normalizer
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     q, k, v, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, beta, g, h0))
-    ref, ref_ht = recurrent_gated_delta_rule_ref(
+    ref, ref_ht = naive_recurrent_gated_delta_rule(
         q=F.normalize(repeat(q.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1).to(dtype),
         k=F.normalize(repeat(k.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1).to(dtype),
         v=v.clone(),
@@ -242,7 +133,7 @@ def test_chunk(
     tri_dq, tri_dk, tri_dv, tri_dbeta, tri_dg, tri_dh0 = q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad
     q.grad = k.grad = v.grad = beta.grad = g.grad = h0.grad = None
 
-    ref, ref_ht = recurrent_gated_delta_rule_ref(
+    ref, ref_ht = naive_recurrent_gated_delta_rule(
         q=F.normalize(q.clone(), p=2, dim=-1),
         k=F.normalize(k.clone(), p=2, dim=-1),
         v=v.clone(),
@@ -327,7 +218,7 @@ def test_chunk_varlen(
     ref = []
     ref_ht = []
     for i in range(N):
-        ref_i, ref_ht_i = recurrent_gated_delta_rule_ref(
+        ref_i, ref_ht_i = naive_recurrent_gated_delta_rule(
             q=q[:, cu_seqlens[i]:cu_seqlens[i+1]],
             k=k[:, cu_seqlens[i]:cu_seqlens[i+1]],
             v=v[:, cu_seqlens[i]:cu_seqlens[i+1]],
@@ -411,7 +302,7 @@ def test_chunk_varlen_prefill(
     ref = []
     ref_ht = []
     for i in range(N):
-        ref_i, ref_ht_i = recurrent_gated_delta_rule_ref(
+        ref_i, ref_ht_i = naive_recurrent_gated_delta_rule(
             q=q[:, cu_seqlens[i]:cu_seqlens[i+1]],
             k=k[:, cu_seqlens[i]:cu_seqlens[i+1]],
             v=v[:, cu_seqlens[i]:cu_seqlens[i+1]],

--- a/tests/ops/test_path_attn.py
+++ b/tests/ops/test_path_attn.py
@@ -5,60 +5,10 @@ import os
 import pytest
 import torch
 import torch.nn.functional as F
-from einops import rearrange
 
+from fla.ops.path_attn import naive_path_attn
 from fla.ops.path_attn.parallel import parallel_path_attention
 from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
-
-
-def naive_path_attn(q, k, v, w, beta, g, scale, BT=64):
-    original_dtype = q.dtype
-    HQ = q.shape[2]
-    H = k.shape[2]
-    q, k, v, w, beta, g = map(lambda x: x.to(torch.float).transpose(1, 2), [q, k, v, w, beta, g])
-    g_cumsum = g.cumsum(-1)
-    q = q.unsqueeze(2).expand(-1, -1, HQ//HQ, -1, -1).flatten(1, 2)
-    k = k.unsqueeze(2).expand(-1, -1, HQ//H, -1, -1).flatten(1, 2)
-    v = v.unsqueeze(2).expand(-1, -1, HQ//H, -1, -1).flatten(1, 2)
-    w = w.unsqueeze(2).expand(-1, -1, HQ//H, -1, -1).flatten(1, 2)
-    beta = beta.unsqueeze(2).expand(-1, -1, HQ//H, -1).flatten(1, 2)
-
-    b, h, l, _ = q.shape
-    if l % BT != 0:
-        padding_size = BT - l % BT
-        q, k, w = map(lambda x: F.pad(x, (0, 0, 0, padding_size)), [q, k, w])
-        beta = F.pad(beta, (0, padding_size))
-    seq_len = q.shape[2]
-    w_beta = w * beta[..., None]
-    q, k, w, w_beta = map(lambda x: rearrange(x, 'b h (n c) d -> b h n c d', c=BT), [q, k, w, w_beta])
-    mask = torch.triu(torch.ones(BT, BT, dtype=torch.bool, device=q.device), diagonal=0)
-    T = -(w_beta @ w.transpose(-1, -2)).masked_fill(mask, 0)
-    for i in range(1, BT):
-        T[..., i, :i] = T[..., i, :i].clone() + (T[..., i, :, None].clone() * T[..., :, :i].clone()).sum(-2)
-    T = T + torch.eye(BT, dtype=q.dtype, device=q.device)
-    Twbk = T @ (w_beta @ k.transpose(-1, -2)).masked_fill(mask, 0)
-    qw = (q @ w.transpose(-1, -2)).tril()
-    Twb = T @ w_beta
-    A_local = (q @ k.transpose(-1, -2)).tril() - qw @ Twbk
-    q = q - qw @ Twb
-    k = k - Twbk.transpose(-1, -2) @ w
-    H = w.transpose(-1, -2) @ Twb
-    A = torch.zeros(b, h, seq_len, seq_len, device=q.device)
-    q, k, w, w_beta = map(lambda x: rearrange(x, 'b h n c d -> b h (n c) d'), [q, k, w, w_beta])
-    for i in range(0, seq_len, BT):
-        q_i = q[:, :, i:i+BT].clone()
-        for j in range(i - BT, -BT, -BT):
-            k_j = k[:, :, j:j+BT]
-            A_ij = q_i @ k_j.transpose(-1, -2)
-            A[:, :, i:i+BT, j:j+BT] = A_ij
-            q_i = q_i - q_i @ H[:, :, j // BT]
-    for i in range(0, seq_len//BT):
-        A[:, :, i*BT:i*BT+BT, i*BT:i*BT+BT] = A_local[:, :, i]
-    A = A.masked_fill_(~torch.tril(torch.ones(seq_len, seq_len, device=q.device, dtype=torch.bool)), float("-inf"))
-    A = A[:, :, :l, :l]
-    A = A + g_cumsum[..., None] - g_cumsum[..., None, :]
-    ref_o = (A * scale).softmax(-1).to(v) @ v
-    return ref_o.to(original_dtype).transpose(1, 2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reference implementations for multiple attention mechanisms: parallel attention, forgetting attention, COMBA (recurrent and chunked variants), gated delta rule (recurrent and chunked variants), and path attention.
  * All new implementations are now available as part of the public API for use in custom workflows.

* **Tests**
  * Updated tests to use the new reference implementations, improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->