### PR TITLE
[Misc] remove redundant dot precision param in KDA recompute_w_u

### DIFF
--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -6,7 +6,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
-from fla.utils import IS_TF32_SUPPORTED, autotune_cache_kwargs, check_shared_mem
+from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 
 @triton.heuristics({


### PR DESCRIPTION
Thanks for the wonderful work about linear attention algorithm and implementation, which has been widely used in frontier models.

In KDA's `recompute_w_u_fwd_kda_kernel`, it is a little confusing about the DOT_PRECISION input parameter because the input Akk and V are both always fp16 or bf16.
https://github.com/fla-org/flash-linear-attention/blob/7ef6685c08e91400d222f10f9e16cf0187a52933/fla/ops/kda/wy_fast.py#L72
In Triton, if inputs are not in dtype f32, this option is ignored. So we can safely remove it.
https://github.com/triton-lang/triton/blob/5ce5c68c2a3122a61c282058d652769254637b27/python/triton/language/core.py#L2120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified numerical-precision handling inside performance-critical kernels by removing explicit precision toggles and streamlining autotuning configuration; maintains existing behavior while reducing internal complexity and potential configuration overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->