### PR TITLE
Fix shared memory guards for AMD RDNA GPUs (64KB shared mem)

### DIFF
--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -24,8 +24,8 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
     configs=[
         triton.Config({'BV': BV}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4]
-        for num_stages in [2, 3, 4]
-        for BV in [32, 64]
+        for num_stages in ([4, 3, 2] if check_shared_mem('ampere') else [2, 1])
+        for BV in ([32, 64] if check_shared_mem('ada') else [32])
     ],
     key=['H', 'K', 'V', 'BT', 'USE_EXP2'],
     use_cuda_graph=USE_CUDA_GRAPH,
@@ -236,7 +236,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         triton.Config({'BV': BV}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4]
         for num_stages in ([4, 3, 2] if check_shared_mem('ampere') else [1])
-        for BV in [64, 32]
+        for BV in ([64, 32] if check_shared_mem('ada') else [32])
     ],
     key=['H', 'K', 'V', 'BT', 'BV', 'USE_G', 'USE_EXP2'],
     use_cuda_graph=USE_CUDA_GRAPH,


### PR DESCRIPTION
## Summary

AMD RDNA GPUs (RDNA1-4) have 64KB shared memory per CU — significantly less than NVIDIA ADA (~101KB) or Ampere (~167KB). Three issues cause Triton compilation failures and runtime crashes on these devices.

## Symptoms on RDNA

Without these fixes, FLA on AMD RDNA GPUs produces:

```
OutOfResources: shared memory, Required: 73728, Hardware limit: 65536
```

- **Triton autotune tries BV=64 configs** that require 72KB+ shared memory but only 64KB is available
- **`chunk_bwd_dv` always uses CONST_TILING=64** due to missing parentheses bug (issue #3 below), forcing 64-wide tiles even on 64KB devices

## Fixes

### 1. Unguarded BV/num_stages in `chunk_delta_h.py` FWD autotune

The forward kernel offers `BV in [32, 64]` and `num_stages in [2, 3, 4]` unconditionally, while the backward kernel already guards both. BV=64 requires ~72KB shared memory on RDNA — exceeds the 64KB hardware limit.

**Fix:** Added `check_shared_mem('ada')` guard for BV and `check_shared_mem('ampere')` guard for num_stages, consistent with the BWD kernel.

### 2. Missing tier in `chunk_o.py` BKV_LIST

```python
# Before: ADA (101KB) and RDNA (64KB) share the same else branch
BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]

# After: Three tiers — RDNA gets safe [32] only
BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
```

The `[32, 64]` else branch is an intentional ADA fallback (`Backend.DEFAULT > Backend.ADA`), but RDNA GPUs with far less shared memory also land here and cannot handle BKV=64.

### 3. Bug: Missing parentheses in `chunk_o.py`

```python
# Before — evaluates function object as truthy (always True)
elif check_shared_mem:
    CONST_TILING = 64

# After — actually calls the function
elif check_shared_mem():
    CONST_TILING = 64
```

This affects `chunk_bwd_dv` and `chunk_bwd_dv_local`. The missing `()` means `CONST_TILING=64` is forced on ALL devices, bypassing the `else: CONST_TILING=32` branch that RDNA needs.

## Shared memory tier summary

| Shared Mem | Guard | BV/BKV tiles |
|---|---|---|
| >= 102KB (Ampere/Hopper) | `check_shared_mem()` | Large: [64, 128] |
| >= 101KB (ADA/RTX 4090) | `check_shared_mem('ada')` | Medium: [32, 64] |
| < 101KB (RDNA = 64KB) | else | Safe: [32] |

## Testing

Tested on **AMD Radeon AI Pro 9700** (RDNA4, gfx1201, 64KB shared mem) training **Qwen3-Next-80B-A3B-Instruct** (GatedDeltaNet + full attention layers) with FLA — stable forward and backward passes across 3 GPUs, 30+ training steps, loss converging normally.

## Note for maintainers

`Backend.DEFAULT` (102400) is intentionally above `Backend.ADA` (101376), creating the ADA fallback tier. However, no explicit lower tier existed for devices with substantially less shared memory (all AMD RDNA = 64KB). This PR adds that missing tier using the existing `check_shared_mem('ada')` infrastructure — no changes to `utils.py` needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional logic that determines memory-based tiling choices for backward operations, ensuring correct tiling on different GPUs.

* **Performance**
  * Autotuning now adapts block tiling and stage selections based on GPU architecture and shared-memory availability (e.g., Ampere/Ada/Hopper), yielding better runtime performance and more efficient resource use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->