### PR TITLE
[MAMBA-2] fix mamba-2 init for FSDP-2 with DTensors

### DIFF
--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -17,6 +17,9 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
+from torch.distributed._tensor.placement_types import Placement, Replicate
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput, logging
 from transformers.utils.deprecation import deprecate_kwarg
@@ -26,9 +29,6 @@ from fla.models.mamba2.configuration_mamba2 import Mamba2Config
 from fla.models.utils import FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules.l2warp import l2_warp
-from torch.distributed._tensor.placement_types import Placement, Replicate
-from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor import DTensor
 
 try:
     from transformers.modeling_layers import GradientCheckpointingLayer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to convert local tensors into distributed tensors and optionally redistribute them across device meshes with flexible placement options.

* **Bug Fixes**
  * Improved initialization for distributed tensor-backed modules so tensor data is properly materialized and copied during setup, avoiding skipped or incorrect initializations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->