### PR TITLE
[Fix] Guard A_log and dt_bias re-initialization against loaded checkpoint values in GatedDeltaNet, Comba, and KDA

### DIFF
--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -126,14 +126,16 @@ class CombaPreTrainedModel(PreTrainedModel):
     ):
         if isinstance(module, Comba) and next(module.parameters()).device.type != 'meta':
             with torch.no_grad():
-                module.A_log.copy_(nn.init.uniform_(module.A_log, a=0, b=16).log())
+                if not getattr(module.A_log, '_is_hf_initialized', False):
+                    module.A_log.copy_(nn.init.uniform_(module.A_log, a=0, b=16).log())
                 module.A_log._no_weight_decay = True
-                dt = torch.exp(
-                    nn.init.uniform_(module.dt_bias) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
-                ).clamp(min=1e-4)
-                # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-                inv_dt = dt + torch.log(-torch.expm1(-dt))
-                module.dt_bias.copy_(inv_dt)
+                if not getattr(module.dt_bias, '_is_hf_initialized', False):
+                    dt = torch.exp(
+                        nn.init.uniform_(module.dt_bias) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
+                    ).clamp(min=1e-4)
+                    # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                    inv_dt = dt + torch.log(-torch.expm1(-dt))
+                    module.dt_bias.copy_(inv_dt)
                 module.dt_bias._no_weight_decay = True
 
         elif isinstance(module, (nn.Linear, nn.Conv1d)):

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -127,14 +127,16 @@ class GatedDeltaNetPreTrainedModel(PreTrainedModel):
     ):
         if isinstance(module, GatedDeltaNet) and next(module.parameters()).device.type != 'meta':
             with torch.no_grad():
-                module.A_log.copy_(nn.init.uniform_(module.A_log, a=0, b=16).log())
+                if not getattr(module.A_log, '_is_hf_initialized', False):
+                    module.A_log.copy_(nn.init.uniform_(module.A_log, a=0, b=16).log())
                 module.A_log._no_weight_decay = True
-                dt = torch.exp(
-                    nn.init.uniform_(module.dt_bias) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
-                ).clamp(min=1e-4)
-                # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-                inv_dt = dt + torch.log(-torch.expm1(-dt))
-                module.dt_bias.copy_(inv_dt)
+                if not getattr(module.dt_bias, '_is_hf_initialized', False):
+                    dt = torch.exp(
+                        nn.init.uniform_(module.dt_bias) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
+                    ).clamp(min=1e-4)
+                    # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                    inv_dt = dt + torch.log(-torch.expm1(-dt))
+                    module.dt_bias.copy_(inv_dt)
                 module.dt_bias._no_weight_decay = True
 
         elif isinstance(module, (nn.Linear, nn.Conv1d)):


### PR DESCRIPTION
### Problem

Loading any of `GatedDeltaNet`, `Comba`, or `KimiDeltaAttention` checkpoints with `transformers >= 5.0` produces **NaN outputs**, causing the model to generate only padding/EOS tokens.

**Cause:**

1. **transformers 5.x loads models on `meta` device first.** During `__init__`, the `post_init()` call reaches `_init_weights`, but the guard `next(module.parameters()).device.type != 'meta'` evaluates to `False`, so `A_log` and `dt_bias` are *not* randomly initialized at this stage.

2. **After weights are loaded from the checkpoint**, `_finalize_model_loading` calls `_initialize_missing_keys()` → `initialize_weights()` (decorated with `@guard_torch_init_functions()`). This re-enters `_init_weights` for every module that lacks a module-level `_is_hf_initialized` flag — including every `GatedDeltaNet`/`Comba`/`KimiDeltaAttention` layer.

3. **`guard_torch_init_functions` patches `nn.init.uniform_` to be a no-op** on tensors that already have `_is_hf_initialized = True` (i.e., parameters loaded from the checkpoint). So in:

```python
module.A_log.copy_(nn.init.uniform_(module.A_log, a=0, b=16).log())
```

the `uniform_` call returns `module.A_log` unchanged, and `.log()` is applied directly to the already-correct checkpoint values. If any trained `A_log` entry is negative (which is valid — it means the corresponding eigenvalue decay factor is < 1), `log(negative) = NaN`, which propagates through all downstream layers.

For `dt_bias`, the loaded (large negative) values are exponentiated via `exp(dt_bias × log_range + log_dt_min)`, producing near-zero results that are always clamped to `1e-4`, then mapped through `inv_softplus` — giving every layer the same wrong value (≈ `−9.19` in bfloat16).

> **Verified against:** fla 0.4.2, transformers 5.2.0

**Models not affected:** `mamba2` and `log_linear_mamba2` — they generate fresh tensors via `torch.empty(...).uniform_()` (a tensor method, not patched by `guard_torch_init_functions`) rather than calling `nn.init.uniform_` directly on the parameter, so the double-transformation does not occur.

***

### Fix

Add `_is_hf_initialized` guards before the `A_log` and `dt_bias` blocks in `_init_weights`, matching the pattern that transformers 5.x expects for checkpoint-safe initialization:

```python
# before
module.A_log.copy_(nn.init.uniform_(module.A_log, a=0, b=16).log())

# after
if not getattr(module.A_log, '_is_hf_initialized', False):
    module.A_log.copy_(nn.init.uniform_(module.A_log, a=0, b=16).log())
```

Same guard applied to `dt_bias` in all three files.

***

### PS

A simple script that converts the huggingface hub GatedDeltaNet safetensors (saved under the old fla + transformers version, e.g. `linear-moe-hub/Gated-Deltanet-340M`) to the currently compatible weights:

```python
import fla
import os
import torch
from transformers import AutoConfig, AutoTokenizer
from huggingface_hub import hf_hub_download
from safetensors.torch import load_file, save_file

model_name = "linear-moe-hub/Gated-Deltanet-340M"
save_path = "./Gated-Deltanet-340M-Fixed"
os.makedirs(save_path, exist_ok=True)

model_file = hf_hub_download(repo_id=model_name, filename="model.safetensors")
state_dict = load_file(model_file)

new_state_dict = {}
for k, v in state_dict.items():
    # Drop the unexpected attention parameter
    if "attn.D" in k:
        continue 
    
    # Split the fused MLP layer into gate_proj and up_proj
    if "mlp.gate_proj.weight" in k and v.shape[0] == 5632:
        gate_weight, up_weight = torch.chunk(v, 2, dim=0)
        new_state_dict[k] = gate_weight
        new_state_dict[k.replace("gate_proj", "up_proj")] = up_weight
    else:
        new_state_dict[k] = v

save_file(new_state_dict, os.path.join(save_path, "model.safetensors"))

config = AutoConfig.from_pretrained(model_name)
config.tie_word_embeddings = False  # Tells transformers not to tie the embedding and lm_head
config.save_pretrained(save_path)

tokenizer = AutoTokenizer.from_pretrained(model_name)
tokenizer.save_pretrained(save_path)

print(f"\nThe model is saved in: {save_path}")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed unintended parameter reinitialization in model initialization routines across multiple model architectures (Comba, GatedDeltaNet, KDA). Parameters now remain stable on subsequent initializations, preventing inadvertent override of prior configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->