### PR TITLE
Update Windows warning to detect triton-windows

### DIFF
--- a/fla/utils.py
+++ b/fla/utils.py
@@ -44,7 +44,7 @@ def check_environments():
     if sys.platform == 'win32':
         # Check if triton-windows is installed
         try:
-            from importlib.metadata import metadata, PackageNotFoundError
+            from importlib.metadata import PackageNotFoundError, metadata
             metadata('triton-windows')
             # triton-windows is installed, no warning needed
         except PackageNotFoundError:


### PR DESCRIPTION
Triton now has official Windows support via https://github.com/triton-lang/triton-windows
This PR updates the Windows warning to skip if triton-windows is installed, since FLA works correctly with it.
Tested with triton-windows 3.6.0, PyTorch 2.10, Python 3.12 on Windows 11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows environment checks: the app now detects whether the optional Triton Windows package is installed and only shows a setup warning when it’s missing, offering clearer guidance for better compatibility while preserving existing Triton and Python version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->