### PR TITLE
[Misc] Reduce recompile

### DIFF
--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -32,7 +32,6 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     cu_seqlens,
     scale,
     T,
-    B: tl.constexpr,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
@@ -85,7 +84,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
         p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
-    for _ in range(0, T):
+    for _ in tl.range(0, T):
         b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
         b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
         b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
@@ -174,7 +173,6 @@ def fused_recurrent_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens,
         scale=scale,
         T=T,
-        B=B,
         H=H,
         HV=HV,
         K=K,

--- a/fla/ops/kda/gate.py
+++ b/fla/ops/kda/gate.py
@@ -77,7 +77,7 @@ def naive_kda_lowerbound_gate(
     key=["H", "D"],
     **autotune_cache_kwargs,
 )
-@triton.jit
+@triton.jit(do_not_specialize=['T'])
 def kda_gate_fwd_kernel(
     g,
     A_log,
@@ -133,7 +133,7 @@ def kda_gate_fwd_kernel(
     key=["H", "D"],
     **autotune_cache_kwargs,
 )
-@triton.jit
+@triton.jit(do_not_specialize=['T'])
 def kda_gate_bwd_kernel(
     g,
     A_log,
@@ -349,7 +349,7 @@ def fused_kda_gate(
         for BS in BS_LIST
         for num_warps in [2, 4, 8]
     ],
-    key=['B', 'H', 'S', 'BT', 'IS_VARLEN', 'REVERSE'],
+    key=['H', 'S', 'BT', 'IS_VARLEN', 'REVERSE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -363,7 +363,6 @@ def kda_gate_chunk_cumsum_vector_kernel(
     chunk_indices,
     lower_bound,
     T,
-    B: tl.constexpr,
     H: tl.constexpr,
     S: tl.constexpr,
     BT: tl.constexpr,
@@ -447,7 +446,6 @@ def kda_gate_chunk_cumsum(
         chunk_indices=chunk_indices,
         lower_bound=lower_bound,
         T=T,
-        B=B,
         H=H,
         S=S,
         BT=BT,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and standardized low-level kernels to reduce unnecessary compile-time specialization and tightened JIT compilation settings for more consistent builds.
  * Replaced internal loop constructs with Triton-native ranges for cleaner, potentially faster kernel execution.
  * Updated kernel invocations to remove redundant arguments, improving compilation stability and runtime consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->