### PR TITLE
[PaTH] Prevent int32 index overflow for long sequences

### DIFF
--- a/fla/ops/path_attn/parallel_path_bwd_inter_dkv.py
+++ b/fla/ops/path_attn/parallel_path_bwd_inter_dkv.py
@@ -103,7 +103,7 @@ def parallel_path_bwd_dkv_kernel(
         b_delta = tl.load(p_delta, boundary_check=(0, ))
         b_l = tl.load(p_l, boundary_check=(0, ))
 
-        p_q = tl.make_block_ptr(q + ((bos * NUM_BLOCKS + idx_j) * HQ + i_hq) * K, (T, K),
+        p_q = tl.make_block_ptr(q + ((bos.to(tl.int64) * NUM_BLOCKS + idx_j) * HQ + i_hq) * K, (T, K),
                                 (HQ*K*NUM_BLOCKS, 1), (offset, 0), (BS, BK), (1, 0))
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_A = tl.dot(b_k, tl.trans(b_q).to(b_k.dtype))

--- a/fla/ops/path_attn/parallel_path_bwd_inter_dqh.py
+++ b/fla/ops/path_attn/parallel_path_bwd_inter_dqh.py
@@ -97,7 +97,7 @@ def parallel_path_bwd_dq_kernel(
 
     for offset_outer in range(0, curr_end, S):
         idx_j = offset_outer // S
-        p_q = tl.make_block_ptr(q + ((bos * NUM_BLOCKS + idx_j + 1) * HQ + i_hq) * K, (T, K),
+        p_q = tl.make_block_ptr(q + ((bos.to(tl.int64) * NUM_BLOCKS + idx_j + 1) * HQ + i_hq) * K, (T, K),
                                 (HQ*K*NUM_BLOCKS, 1), (i_t * BT, 0), (BT, BK), (1, 0))
         b_q = tl.load(p_q, boundary_check=(0, 1))
 

--- a/fla/ops/path_attn/transform_q.py
+++ b/fla/ops/path_attn/transform_q.py
@@ -48,7 +48,7 @@ def transform_q_fwd_kernel(
 
     if BS == BT:
         if (i_t * BT) % S == 0:
-            p_q_new = tl.make_block_ptr(q_new + ((bos * NUM_BLOCKS + (i_t * BT // S)) * HQ + i_hq) * K,
+            p_q_new = tl.make_block_ptr(q_new + ((bos.to(tl.int64) * NUM_BLOCKS + (i_t * BT // S)) * HQ + i_hq) * K,
                                         (T, K), (HQ*K*NUM_BLOCKS, 1), (i_t * BT, 0), (BT, BK), (1, 0))
             tl.store(p_q_new, b_q.to(q_new.dtype.element_ty), boundary_check=(0, 1))
 
@@ -63,7 +63,7 @@ def transform_q_fwd_kernel(
         b_q -= tl.dot(b_s2.to(b_w2.dtype), b_w2)
 
         if offset % S == 0:
-            p_q_new = tl.make_block_ptr(q_new + ((bos * NUM_BLOCKS + (offset // S)) * HQ + i_hq) * K,
+            p_q_new = tl.make_block_ptr(q_new + ((bos.to(tl.int64) * NUM_BLOCKS + (offset // S)) * HQ + i_hq) * K,
                                         (T, K), (HQ*K*NUM_BLOCKS, 1), (i_t * BT, 0), (BT, BK), (1, 0))
             tl.store(p_q_new, b_q.to(q_new.dtype.element_ty), boundary_check=(0, 1))
 


### PR DESCRIPTION
In PaTH backward pass, [q_new_large](https://github.com/fla-org/flash-linear-attention/blob/f24317a6a4f513748cd7eb05818534ce66029957/fla/ops/path_attn/transform_q.py#L87) is a large tensor of shape `(B, T, num_blocks, HQ, K)`. So for sufficiently long sequences and hence large `num_blocks`, `int32` offsets for this tensor within the Triton kernel will overflow (e.g., [here](https://github.com/fla-org/flash-linear-attention/blob/f24317a6a4f513748cd7eb05818534ce66029957/fla/ops/path_attn/transform_q.py#L66)). For example, the following example will fail with illegal memory access:

```python
from fla.ops import parallel_path_attn
import torch

if __name__ == "__main__":
    B = 4
    T = 16384
    H = 24
    D = 64
    dtype = torch.bfloat16
    device = "cuda"
    q = torch.randn((B, T, H, D), dtype=dtype, device=device, requires_grad=True)
    k = torch.randn((B, T, H, D), dtype=dtype, device=device, requires_grad=True)
    v = torch.randn((B, T, H, D), dtype=dtype, device=device, requires_grad=True)
    w = torch.randn((B, T, H, D), dtype=torch.float32, device=device, requires_grad=True)
    beta = torch.empty((B, T, H), dtype=torch.float32, device=device).uniform_(0, 1).requires_grad_()

    fwd = lambda: parallel_path_attn(q, k, v, w=w, beta=beta)[0]
    fwd().sum().backward()
```


To prevent this, we cast `bos` to `tl.int64` when creating the block pointers to prevent overflow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer arithmetic handling in backward pass attention operations for correct memory addressing across varying batch sizes.
  * Enhanced numerical precision in query transformation operations through more robust integer calculations.

These changes ensure more reliable memory access patterns in core attention operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->