### PR TITLE
[KDA][GDN] Support transpose_state_layout for [V,K] state memory layout

### DIFF
--- a/fla/ops/common/backends/intracard.py
+++ b/fla/ops/common/backends/intracard.py
@@ -45,6 +45,7 @@ class IntraCardCPBackend(BaseBackend):
         cu_seqlens_cpu: torch.LongTensor | None = None,
         chunk_indices: torch.LongTensor | None = None,
         use_exp2: bool = False,
+        transpose_state_layout: bool = False,
     ) -> tuple[bool, str | None]:
         """Check if intracard CP should handle this call."""
         # Only in inference mode
@@ -72,6 +73,7 @@ class IntraCardCPBackend(BaseBackend):
         cu_seqlens_cpu: torch.LongTensor | None = None,
         chunk_indices: torch.LongTensor | None = None,
         use_exp2: bool = False,
+        transpose_state_layout: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         """Intra-card CP implementation of chunk_gated_delta_rule_fwd_h."""
         from fla.ops.common.intracard_cp import intracard_fwd_h
@@ -87,4 +89,5 @@ class IntraCardCPBackend(BaseBackend):
             chunk_indices=chunk_indices,
             use_exp2=use_exp2,
             max_splits=MAX_SUBSEQS,
+            transpose_state_layout=transpose_state_layout,
         )

--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -27,7 +27,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
         for num_stages in ([4, 3, 2] if check_shared_mem('ampere') else [2, 1])
         for BV in ([32, 64] if check_shared_mem('ada') else [32])
     ],
-    key=['H', 'K', 'V', 'BT', 'USE_EXP2'],
+    key=['H', 'K', 'V', 'BT', 'USE_EXP2', 'TRANSPOSE_STATE'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -56,6 +56,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     STORE_FINAL_STATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     USE_EXP2: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
@@ -70,14 +71,22 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         NT = tl.cdiv(T, BT)
         boh = i_n * NT
 
-    # [BK, BV]
-    b_h1 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 64:
-        b_h2 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 128:
-        b_h3 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 192:
-        b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+    if TRANSPOSE_STATE:
+        b_h1 = tl.zeros([BV, 64], dtype=tl.float32)
+        if K > 64:
+            b_h2 = tl.zeros([BV, 64], dtype=tl.float32)
+        if K > 128:
+            b_h3 = tl.zeros([BV, 64], dtype=tl.float32)
+        if K > 192:
+            b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
+    else:
+        b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 64:
+            b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 128:
+            b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 192:
+            b_h4 = tl.zeros([64, BV], dtype=tl.float32)
 
     # calculate offset
     h += (boh * H + i_h).to(tl.int64) * K*V
@@ -94,48 +103,84 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     # load initial state
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        else:
+            p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
         b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
         if K > 64:
-            p_h0_2 = tl.make_block_ptr(h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h0_2 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            else:
+                p_h0_2 = tl.make_block_ptr(h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
             b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
         if K > 128:
-            p_h0_3 = tl.make_block_ptr(h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h0_3 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            else:
+                p_h0_3 = tl.make_block_ptr(h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
             b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
         if K > 192:
-            p_h0_4 = tl.make_block_ptr(h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h0_4 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            else:
+                p_h0_4 = tl.make_block_ptr(h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
             b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
         i_t_int64 = i_t.to(tl.int64)
-        p_h1 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_h1 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        else:
+            p_h1 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
         tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
-            p_h2 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h2 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            else:
+                p_h2 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
             tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
         if K > 128:
-            p_h3 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h3 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            else:
+                p_h3 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
             tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
         if K > 192:
-            p_h4 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h4 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            else:
+                p_h4 = tl.make_block_ptr(h + i_t_int64 * H*K*V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
             tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
 
         p_w = tl.make_block_ptr(w, (T, K), (H*K, 1), (i_t * BT, 0), (BT, 64), (1, 0))
         b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
+        if TRANSPOSE_STATE:
+            b_v = tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))
+        else:
+            b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
         if K > 64:
             p_w = tl.make_block_ptr(w, (T, K), (H*K, 1), (i_t * BT, 64), (BT, 64), (1, 0))
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
+            if TRANSPOSE_STATE:
+                b_v += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
+            else:
+                b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
         if K > 128:
             p_w = tl.make_block_ptr(w, (T, K), (H*K, 1), (i_t * BT, 128), (BT, 64), (1, 0))
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
+            if TRANSPOSE_STATE:
+                b_v += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
+            else:
+                b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
         if K > 192:
             p_w = tl.make_block_ptr(w, (T, K), (H*K, 1), (i_t * BT, 192), (BT, 64), (1, 0))
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
+            if TRANSPOSE_STATE:
+                b_v += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
+            else:
+                b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
         p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
 
@@ -166,61 +211,109 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         if USE_GK:
             o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
-            if USE_EXP2:
-                b_h1 *= exp2(b_gk_last1)[:, None]
+            if TRANSPOSE_STATE:
+                if USE_EXP2:
+                    b_h1 *= exp2(b_gk_last1)[None, :]
+                else:
+                    b_h1 *= exp(b_gk_last1)[None, :]
             else:
-                b_h1 *= exp(b_gk_last1)[:, None]
+                if USE_EXP2:
+                    b_h1 *= exp2(b_gk_last1)[:, None]
+                else:
+                    b_h1 *= exp(b_gk_last1)[:, None]
             if K > 64:
                 o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
-                if USE_EXP2:
-                    b_h2 *= exp2(b_gk_last2)[:, None]
+                if TRANSPOSE_STATE:
+                    if USE_EXP2:
+                        b_h2 *= exp2(b_gk_last2)[None, :]
+                    else:
+                        b_h2 *= exp(b_gk_last2)[None, :]
                 else:
-                    b_h2 *= exp(b_gk_last2)[:, None]
+                    if USE_EXP2:
+                        b_h2 *= exp2(b_gk_last2)[:, None]
+                    else:
+                        b_h2 *= exp(b_gk_last2)[:, None]
             if K > 128:
                 o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
-                if USE_EXP2:
-                    b_h3 *= exp2(b_gk_last3)[:, None]
+                if TRANSPOSE_STATE:
+                    if USE_EXP2:
+                        b_h3 *= exp2(b_gk_last3)[None, :]
+                    else:
+                        b_h3 *= exp(b_gk_last3)[None, :]
                 else:
-                    b_h3 *= exp(b_gk_last3)[:, None]
+                    if USE_EXP2:
+                        b_h3 *= exp2(b_gk_last3)[:, None]
+                    else:
+                        b_h3 *= exp(b_gk_last3)[:, None]
             if K > 192:
                 o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
-                if USE_EXP2:
-                    b_h4 *= exp2(b_gk_last4)[:, None]
+                if TRANSPOSE_STATE:
+                    if USE_EXP2:
+                        b_h4 *= exp2(b_gk_last4)[None, :]
+                    else:
+                        b_h4 *= exp(b_gk_last4)[None, :]
                 else:
-                    b_h4 *= exp(b_gk_last4)[:, None]
+                    if USE_EXP2:
+                        b_h4 *= exp2(b_gk_last4)[:, None]
+                    else:
+                        b_h4 *= exp(b_gk_last4)[:, None]
 
         b_v = b_v.to(k.dtype.element_ty)
 
         p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (0, i_t * BT), (64, BT), (0, 1))
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_h1 += tl.dot(b_k, b_v)
+        if TRANSPOSE_STATE:
+            b_h1 += tl.trans(tl.dot(b_k, b_v))
+        else:
+            b_h1 += tl.dot(b_k, b_v)
         if K > 64:
             p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (64, i_t * BT), (64, BT), (0, 1))
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h2 += tl.dot(b_k, b_v)
+            if TRANSPOSE_STATE:
+                b_h2 += tl.trans(tl.dot(b_k, b_v))
+            else:
+                b_h2 += tl.dot(b_k, b_v)
         if K > 128:
             p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (128, i_t * BT), (64, BT), (0, 1))
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h3 += tl.dot(b_k, b_v)
+            if TRANSPOSE_STATE:
+                b_h3 += tl.trans(tl.dot(b_k, b_v))
+            else:
+                b_h3 += tl.dot(b_k, b_v)
         if K > 192:
             p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (192, i_t * BT), (64, BT), (0, 1))
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h4 += tl.dot(b_k, b_v)
+            if TRANSPOSE_STATE:
+                b_h4 += tl.trans(tl.dot(b_k, b_v))
+            else:
+                b_h4 += tl.dot(b_k, b_v)
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        else:
+            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
         tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            else:
+                p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
             tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 128:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            else:
+                p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
             tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 192:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            else:
+                p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
             tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -238,7 +331,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         for num_stages in ([4, 3, 2] if check_shared_mem('ampere') else [1])
         for BV in ([64, 32] if check_shared_mem('ada') else [32])
     ],
-    key=['H', 'K', 'V', 'BT', 'BV', 'USE_G', 'USE_EXP2'],
+    key=['H', 'K', 'V', 'BT', 'BV', 'USE_G', 'USE_EXP2', 'TRANSPOSE_STATE'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -269,6 +362,7 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
     USE_INITIAL_STATE: tl.constexpr,
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
     USE_EXP2: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
@@ -283,14 +377,22 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
         NT = tl.cdiv(T, BT)
         boh = i_n * NT
 
-    # [BK, BV]
-    b_dh1 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 64:
-        b_dh2 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 128:
-        b_dh3 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 192:
-        b_dh4 = tl.zeros([64, BV], dtype=tl.float32)
+    if TRANSPOSE_STATE:
+        b_dh1 = tl.zeros([BV, 64], dtype=tl.float32)
+        if K > 64:
+            b_dh2 = tl.zeros([BV, 64], dtype=tl.float32)
+        if K > 128:
+            b_dh3 = tl.zeros([BV, 64], dtype=tl.float32)
+        if K > 192:
+            b_dh4 = tl.zeros([BV, 64], dtype=tl.float32)
+    else:
+        b_dh1 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 64:
+            b_dh2 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 128:
+            b_dh3 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 192:
+            b_dh4 = tl.zeros([64, BV], dtype=tl.float32)
 
     # calculate offset
     q += (bos * H + i_h).to(tl.int64) * K
@@ -309,30 +411,54 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
         dht += i_nh * K*V
 
     if USE_FINAL_STATE_GRADIENT:
-        p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_dht1 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        else:
+            p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
         b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
         if K > 64:
-            p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dht2 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            else:
+                p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
             b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
         if K > 128:
-            p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dht3 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            else:
+                p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
             b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
         if K > 192:
-            p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dht4 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            else:
+                p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
             b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
 
     for i_t in range(NT - 1, -1, -1):
         i_t_int64 = i_t.to(tl.int64)
-        p_dh1 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_dh1 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        else:
+            p_dh1 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
         tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
-            p_dh2 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dh2 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            else:
+                p_dh2 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
             tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
         if K > 128:
-            p_dh3 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dh3 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            else:
+                p_dh3 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
             tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
         if K > 192:
-            p_dh4 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dh4 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            else:
+                p_dh4 = tl.make_block_ptr(dh + i_t_int64*H*K*V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
             tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
 
         last_idx = min((i_t + 1) * BT, T) - 1
@@ -359,7 +485,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
         if USE_GK:
             o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(gk + last_idx * H*K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
-        b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
+        if TRANSPOSE_STATE:
+            b_dv = tl.dot(b_k, tl.trans(b_dh1).to(b_k.dtype))
+        else:
+            b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
 
         if K > 64:
             p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 64), (BT, 64), (1, 0))
@@ -367,7 +496,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             if USE_GK:
                 o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(gk + last_idx * H*K + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
-            b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
+            if TRANSPOSE_STATE:
+                b_dv += tl.dot(b_k, tl.trans(b_dh2).to(b_k.dtype))
+            else:
+                b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
 
         if K > 128:
             p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 128), (BT, 64), (1, 0))
@@ -375,7 +507,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             if USE_GK:
                 o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(gk + last_idx * H*K + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
-            b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
+            if TRANSPOSE_STATE:
+                b_dv += tl.dot(b_k, tl.trans(b_dh3).to(b_k.dtype))
+            else:
+                b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
 
         if K > 192:
             p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 192), (BT, 64), (1, 0))
@@ -383,7 +518,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             if USE_GK:
                 o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(gk + last_idx * H*K + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
-            b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
+            if TRANSPOSE_STATE:
+                b_dv += tl.dot(b_k, tl.trans(b_dh4).to(b_k.dtype))
+            else:
+                b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
 
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
@@ -403,11 +541,20 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             b_dh1 *= bg_last_exp
             b_q = b_q * b_g_exp[None, :]
         if USE_GK:
-            if USE_EXP2:
-                b_dh1 *= exp2(b_gk_last1[:, None])
+            if TRANSPOSE_STATE:
+                if USE_EXP2:
+                    b_dh1 *= exp2(b_gk_last1)[None, :]
+                else:
+                    b_dh1 *= exp(b_gk_last1)[None, :]
             else:
-                b_dh1 *= exp(b_gk_last1[:, None])
-        b_dh1 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+                if USE_EXP2:
+                    b_dh1 *= exp2(b_gk_last1[:, None])
+                else:
+                    b_dh1 *= exp(b_gk_last1[:, None])
+        if TRANSPOSE_STATE:
+            b_dh1 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
+        else:
+            b_dh1 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 64:
             p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (64, i_t * BT), (64, BT), (0, 1))
             p_w = tl.make_block_ptr(w, (K, T), (1, H*K), (64, i_t * BT), (64, BT), (0, 1))
@@ -417,11 +564,20 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_dh2 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
             if USE_GK:
-                if USE_EXP2:
-                    b_dh2 *= exp2(b_gk_last2[:, None])
+                if TRANSPOSE_STATE:
+                    if USE_EXP2:
+                        b_dh2 *= exp2(b_gk_last2)[None, :]
+                    else:
+                        b_dh2 *= exp(b_gk_last2)[None, :]
                 else:
-                    b_dh2 *= exp(b_gk_last2[:, None])
-            b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+                    if USE_EXP2:
+                        b_dh2 *= exp2(b_gk_last2[:, None])
+                    else:
+                        b_dh2 *= exp(b_gk_last2[:, None])
+            if TRANSPOSE_STATE:
+                b_dh2 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
+            else:
+                b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 128:
             p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (128, i_t * BT), (64, BT), (0, 1))
             p_w = tl.make_block_ptr(w, (K, T), (1, H*K), (128, i_t * BT), (64, BT), (0, 1))
@@ -431,11 +587,20 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_dh3 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
             if USE_GK:
-                if USE_EXP2:
-                    b_dh3 *= exp2(b_gk_last3[:, None])
+                if TRANSPOSE_STATE:
+                    if USE_EXP2:
+                        b_dh3 *= exp2(b_gk_last3)[None, :]
+                    else:
+                        b_dh3 *= exp(b_gk_last3)[None, :]
                 else:
-                    b_dh3 *= exp(b_gk_last3[:, None])
-            b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+                    if USE_EXP2:
+                        b_dh3 *= exp2(b_gk_last3[:, None])
+                    else:
+                        b_dh3 *= exp(b_gk_last3[:, None])
+            if TRANSPOSE_STATE:
+                b_dh3 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
+            else:
+                b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 192:
             p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (192, i_t * BT), (64, BT), (0, 1))
             p_w = tl.make_block_ptr(w, (K, T), (1, H*K), (192, i_t * BT), (64, BT), (0, 1))
@@ -445,23 +610,44 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_dh4 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
             if USE_GK:
-                if USE_EXP2:
-                    b_dh4 *= exp2(b_gk_last4[:, None])
+                if TRANSPOSE_STATE:
+                    if USE_EXP2:
+                        b_dh4 *= exp2(b_gk_last4)[None, :]
+                    else:
+                        b_dh4 *= exp(b_gk_last4)[None, :]
                 else:
-                    b_dh4 *= exp(b_gk_last4[:, None])
-            b_dh4 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
+                    if USE_EXP2:
+                        b_dh4 *= exp2(b_gk_last4[:, None])
+                    else:
+                        b_dh4 *= exp(b_gk_last4[:, None])
+            if TRANSPOSE_STATE:
+                b_dh4 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
+            else:
+                b_dh4 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_dh0 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        else:
+            p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
         tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
-            p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dh1 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            else:
+                p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
             tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
         if K > 128:
-            p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dh2 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            else:
+                p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
             tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
         if K > 192:
-            p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_dh3 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            else:
+                p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
             tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -474,12 +660,13 @@ def chunk_gated_delta_rule_fwd_h(
     gk: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     output_final_state: bool = False,
-    chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
+    chunk_size: int = 64,
     save_new_value: bool = True,
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
     use_exp2: bool = False,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     B, T, H, K, V = *k.shape, u.shape[-1]
     BT = chunk_size
@@ -493,10 +680,12 @@ def chunk_gated_delta_rule_fwd_h(
         N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
-    h = k.new_empty(B, NT, H, K, V)
-    # Ensure final output is zeros
-    # vLLM will use padding for CUDA Graph
-    final_state = k.new_zeros(N, H, K, V, dtype=torch.float32) if output_final_state else None
+    if transpose_state_layout:
+        h = k.new_empty(B, NT, H, V, K)
+        final_state = k.new_zeros(N, H, V, K, dtype=torch.float32) if output_final_state else None
+    else:
+        h = k.new_empty(B, NT, H, K, V)
+        final_state = k.new_zeros(N, H, K, V, dtype=torch.float32) if output_final_state else None
 
     v_new = torch.empty_like(u) if save_new_value else None
     def grid(meta): return (triton.cdiv(V, meta['BV']), N*H)
@@ -518,6 +707,7 @@ def chunk_gated_delta_rule_fwd_h(
         V=V,
         BT=BT,
         USE_EXP2=use_exp2,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     return h, v_new, final_state
 
@@ -534,9 +724,10 @@ def chunk_gated_delta_rule_bwd_dhu(
     dht: torch.Tensor | None = None,
     scale: float | None = None,
     cu_seqlens: torch.LongTensor | None = None,
-    chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
+    chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
     use_exp2: bool = False,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *q.shape, do.shape[-1]
     # N: the actual number of sequences in the batch with either equal or variable lengths
@@ -550,7 +741,10 @@ def chunk_gated_delta_rule_bwd_dhu(
     else:
         N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
 
-    dh = q.new_empty(B, NT, H, K, V)
+    if transpose_state_layout:
+        dh = q.new_empty(B, NT, H, V, K)
+    else:
+        dh = q.new_empty(B, NT, H, K, V)
     dh0 = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
     dv2 = torch.empty_like(dv)
 
@@ -576,5 +770,6 @@ def chunk_gated_delta_rule_bwd_dhu(
         V=V,
         BT=BT,
         USE_EXP2=use_exp2,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     return dh, dh0, dv2

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -23,7 +23,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
         triton.Config({'BK': 64, 'BV': 64}, num_warps=4, num_stages=3),
         triton.Config({'BK': 32, 'BV': 32}, num_warps=2, num_stages=3),
     ],
-    key=['H', 'K', 'V', 'BT'],
+    key=['H', 'K', 'V', 'BT', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -47,6 +47,7 @@ def chunk_fwd_kernel_o(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -76,16 +77,21 @@ def chunk_fwd_kernel_o(
     for i_k in range(tl.cdiv(K, BK)):
         p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        else:
+            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
         # [BT, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         # [BK, BT]
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        # [BK, BV]
         b_h = tl.load(p_h, boundary_check=(0, 1))
 
         # [BT, BK] @ [BK, BV] -> [BT, BV]
-        b_o += tl.dot(b_q, b_h)
+        if TRANSPOSE_STATE:
+            b_o += tl.dot(b_q, tl.trans(b_h))
+        else:
+            b_o += tl.dot(b_q, b_h)
         # [BT, BK] @ [BK, BT] -> [BT, BT]
         b_A += tl.dot(b_q, b_k)
 
@@ -129,7 +135,7 @@ def chunk_fwd_kernel_o(
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_DW'],
+    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_DW', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -161,6 +167,7 @@ def chunk_bwd_kernel_dqkwg(
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
     USE_DW: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -208,8 +215,12 @@ def chunk_bwd_kernel_dqkwg(
     for i_v in range(tl.cdiv(V, BV)):
         p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+        if TRANSPOSE_STATE:
+            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        else:
+            p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
         # [BT, BV]
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_do = tl.load(p_do, boundary_check=(0, 1))
@@ -495,6 +506,7 @@ def chunk_fwd_o(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> torch.Tensor:
     B, T, H, K, V = *q.shape, v.shape[-1]
     BT = chunk_size
@@ -522,6 +534,7 @@ def chunk_fwd_o(
         K=K,
         V=V,
         BT=BT,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     return o
 
@@ -646,6 +659,7 @@ def chunk_bwd_dqkwg(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
     B, T, H, K, V = *k.shape, v.shape[-1]
@@ -694,6 +708,7 @@ def chunk_bwd_dqkwg(
         BT=BT,
         BK=BK,
         BV=BV,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
 
     if dg is not None:

--- a/fla/ops/common/intracard_cp.py
+++ b/fla/ops/common/intracard_cp.py
@@ -84,6 +84,7 @@ def _raw_chunk_gated_delta_rule_fwd_h(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
     use_exp2: bool = False,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     B, T, H, K, V = *k.shape, u.shape[-1]
     BT = chunk_size
@@ -95,8 +96,12 @@ def _raw_chunk_gated_delta_rule_fwd_h(
     else:
         N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
 
-    h = k.new_empty(B, NT, H, K, V)
-    final_state = k.new_zeros(N, H, K, V, dtype=torch.float32) if output_final_state else None
+    if transpose_state_layout:
+        h = k.new_empty(B, NT, H, V, K)
+        final_state = k.new_zeros(N, H, V, K, dtype=torch.float32) if output_final_state else None
+    else:
+        h = k.new_empty(B, NT, H, K, V)
+        final_state = k.new_zeros(N, H, K, V, dtype=torch.float32) if output_final_state else None
     v_new = torch.empty_like(u) if save_new_value else None
 
     def grid(meta):
@@ -107,6 +112,7 @@ def _raw_chunk_gated_delta_rule_fwd_h(
         g=g, gk=gk, h=h, h0=initial_state, ht=final_state,
         cu_seqlens=cu_seqlens, chunk_offsets=chunk_offsets,
         T=T, H=H, K=K, V=V, BT=BT, USE_EXP2=use_exp2,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     return h, v_new, final_state
 
@@ -272,6 +278,7 @@ def intracard_merge(
     merge_init_offsets: list[int],
     device: torch.device,
     initial_state: torch.Tensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor | None, int]:
     """Merge sub-sequence states using pre-computed parameters.
 
@@ -301,7 +308,10 @@ def intracard_merge(
     init_offsets = all_tensor[n_so:n_so + n_io]
     h0_seq_ids = all_tensor[n_so + n_io:]
 
-    initial_states_merge = hm.new_empty(num_non_first, H, K, V, dtype=torch.float32)
+    if transpose_state_layout:
+        initial_states_merge = hm.new_empty(num_non_first, H, V, K, dtype=torch.float32)
+    else:
+        initial_states_merge = hm.new_empty(num_non_first, H, K, V, dtype=torch.float32)
 
     def grid(meta):
         return (triton.cdiv(V, meta['BV']), num_split_seqs, H)
@@ -322,6 +332,7 @@ def intracard_merge(
         FORWARD=True,
         INTRACARD_MODE=True,
         NUM_SEQ_ENTRIES=num_split_seqs,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
 
     return initial_states_merge, num_non_first
@@ -415,6 +426,7 @@ def intracard_fwd_h(
     chunk_indices: torch.LongTensor | None = None,
     use_exp2: bool = False,
     max_splits: int = 32,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     assert cu_seqlens is not None, "intracard_fwd_h requires cu_seqlens"
 
@@ -485,6 +497,7 @@ def intracard_fwd_h(
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             use_exp2=use_exp2,
+            transpose_state_layout=transpose_state_layout,
         )
 
     N_orig = len(cu_seqlens_cpu) - 1
@@ -544,9 +557,13 @@ def intracard_fwd_h(
         merge_init_offsets=merge_init_offsets,
         device=device,
         initial_state=initial_state,
+        transpose_state_layout=transpose_state_layout,
     )
 
-    initial_state_expanded = k.new_zeros(total_subseqs, H, K, V, dtype=torch.float32)
+    if transpose_state_layout:
+        initial_state_expanded = k.new_zeros(total_subseqs, H, V, K, dtype=torch.float32)
+    else:
+        initial_state_expanded = k.new_zeros(total_subseqs, H, K, V, dtype=torch.float32)
 
     if initial_state is not None:
         initial_state_expanded[first_subseq_indices] = initial_state
@@ -569,6 +586,7 @@ def intracard_fwd_h(
         cu_seqlens=cu_seqlens_subseq_gpu,
         chunk_indices=chunk_indices_subseq,
         use_exp2=use_exp2,
+        transpose_state_layout=transpose_state_layout,
     )
 
     if output_final_state and final_state_subseq is not None:

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -534,14 +534,14 @@ def pre_process_fwd_kernel_merged(
 )
 @triton.jit(do_not_specialize=['pre_or_post_num_ranks', 'rank', 'NUM_SEQ_ENTRIES'])
 def merge_fwd_bwd_kernel(
-    h,                   # [H, K, V] or [num_non_first, H, K, V] for intracard
-    ag_hm,               # [H, K, K+V] or [S_split, H, K, K+V] for intracard
+    h,                   # [H, K, V] or [num_non_first, H, K, V] for intracard (or [V, K] when transposed)
+    ag_hm,               # [H, K, K+V] or [S_split, H, K, K+V] for intracard (always [K, V+K])
     pre_or_post_num_ranks,  # num_ranks for CP, NUM_SPLIT_SEQS for intracard
     rank,                # rank for CP, not used for intracard
     seq_offsets,         # None for CP, [num_split_seqs+1] for intracard
     init_offsets,        # None for CP, [num_split_seqs+1] for intracard
     h0_seq_ids,          # None for CP, [num_split_seqs] for intracard
-    h0,                  # None or [N_orig, H, K, V] for intracard
+    h0,                  # None or [N_orig, H, K, V] for intracard (or [V, K] when transposed)
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -551,6 +551,7 @@ def merge_fwd_bwd_kernel(
     INTRACARD_MODE: tl.constexpr,          # True: intracard mode, False: CP mode
     NUM_SEQ_ENTRIES,         # num_split_seqs for intracard
     HAS_H0: tl.constexpr,                  # Heuristic: whether h0 is provided
+    TRANSPOSE_STATE: tl.constexpr = False,  # When True, h0/h use [V, K] layout; ag_hm always [K, V+K]
 ):
     """
     Unified merge kernel for both CP and Intra-card modes.
@@ -562,6 +563,10 @@ def merge_fwd_bwd_kernel(
     Intra-card mode (INTRACARD_MODE=True):
         Grid: (V/BV, NUM_SEQ_ENTRIES, H)
         Merges across subseqs within card for intra-card context parallel.
+
+    When TRANSPOSE_STATE=True, h0 and output h use [V, K] layout.
+    ag_hm always uses [K, V+K] layout (from pre_scan).
+    The recurrence h' = M @ h + he becomes h_T' = h_T @ M^T + he^T.
     """
     i_v = tl.program_id(0)
     if INTRACARD_MODE:
@@ -583,19 +588,30 @@ def merge_fwd_bwd_kernel(
         # Initialize from h0 if provided
         if HAS_H0:
             orig_seq_id = tl.load(h0_seq_ids + i_seq).to(tl.int32)
-            p_h0 = tl.make_block_ptr(
-                h0 + (orig_seq_id * H + i_h) * K * V,
-                (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0)
-            )
-            b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+            if TRANSPOSE_STATE:
+                p_h0 = tl.make_block_ptr(
+                    h0 + (orig_seq_id * H + i_h) * V * K,
+                    (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0)
+                )
+                b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+            else:
+                p_h0 = tl.make_block_ptr(
+                    h0 + (orig_seq_id * H + i_h) * K * V,
+                    (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0)
+                )
+                b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
         else:
-            b_h = tl.zeros([BK, BV], dtype=tl.float32)
+            if TRANSPOSE_STATE:
+                b_h = tl.zeros([BV, BK], dtype=tl.float32)
+            else:
+                b_h = tl.zeros([BK, BV], dtype=tl.float32)
 
         # Merge loop over subseqs
         for idx in range(num_subseqs):
             i_ss = ss_start + idx
             base = i_ss * stride_hm_s + i_h * stride_hm_h
 
+            # he and m are always in [K, V+K] layout from pre_scan
             p_he = tl.make_block_ptr(
                 ag_hm + base, (K, V), (V + K, 1), (0, i_v * BV), (BK, BV), (1, 0)
             )
@@ -604,16 +620,26 @@ def merge_fwd_bwd_kernel(
                 ag_hm + base + V, (K, K), (V + K, 1), (0, 0), (BK, BK), (1, 0)
             )
             b_m = tl.load(p_m, boundary_check=(0, 1)).to(tl.float32)
-            b_h = tl.dot(b_m.to(tl.float32), b_h.to(tl.float32)) + b_he.to(tl.float32)
+            if TRANSPOSE_STATE:
+                # h_T' = h_T @ M^T + he^T
+                b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_m)) + tl.trans(b_he)
+            else:
+                b_h = tl.dot(b_m.to(tl.float32), b_h.to(tl.float32)) + b_he.to(tl.float32)
 
             # Store for non-first subseqs
             if idx < num_subseqs - 1:
                 init_idx = init_base + idx
                 stride_init = H * K * V
-                p_out = tl.make_block_ptr(
-                    h + init_idx * stride_init + i_h * K * V,
-                    (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0)
-                )
+                if TRANSPOSE_STATE:
+                    p_out = tl.make_block_ptr(
+                        h + init_idx * stride_init + i_h * V * K,
+                        (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0)
+                    )
+                else:
+                    p_out = tl.make_block_ptr(
+                        h + init_idx * stride_init + i_h * K * V,
+                        (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0)
+                    )
                 tl.store(p_out, b_h.to(p_out.dtype.element_ty), boundary_check=(0, 1))
     else:
         # CP mode
@@ -622,7 +648,10 @@ def merge_fwd_bwd_kernel(
         h += i_h * K * V
         ag_hm += i_h * K * (K + V)
         stride = H * K * (K + V)
-        b_h = tl.zeros([BK, BV], dtype=tl.float32)
+        if TRANSPOSE_STATE:
+            b_h = tl.zeros([BV, BK], dtype=tl.float32)
+        else:
+            b_h = tl.zeros([BK, BV], dtype=tl.float32)
         for idx in range(num_ranks):
             if FORWARD:
                 cur_rank = rank - num_ranks + idx
@@ -632,8 +661,14 @@ def merge_fwd_bwd_kernel(
             b_ag_h = tl.load(p_ag_h, boundary_check=(0, 1))
             p_ag_m = tl.make_block_ptr(ag_hm + cur_rank * stride + V, (K, K), (K + V, 1), (0, 0), (BK, BK), (1, 0))
             b_ag_m = tl.load(p_ag_m, boundary_check=(0, 1))
-            b_h = tl.dot(b_ag_m.to(tl.float32), b_h.to(tl.float32)) + b_ag_h.to(tl.float32)
-        p_h = tl.make_block_ptr(h, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_ag_m).to(tl.float32)) + tl.trans(b_ag_h).to(tl.float32)
+            else:
+                b_h = tl.dot(b_ag_m.to(tl.float32), b_h.to(tl.float32)) + b_ag_h.to(tl.float32)
+        if TRANSPOSE_STATE:
+            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
+        else:
+            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
         tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -1105,6 +1140,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
     use_exp2: bool = False,
     initial_state: torch.Tensor | None = None,
     context: FLACPContext = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if context is None or context.group is None:
         return initial_state
@@ -1123,7 +1159,10 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
     hm = k.new_zeros(H, K, (V + K), dtype=torch.float32)
-    initial_state = k.new_zeros(N, H, K, V, dtype=torch.float32)
+    if transpose_state_layout:
+        initial_state = k.new_zeros(N, H, V, K, dtype=torch.float32)
+    else:
+        initial_state = k.new_zeros(N, H, K, V, dtype=torch.float32)
     if not context.is_last_rank:
         BLOCK_SIZE = 32 if K <= 64 else 64
         grid = (triton.cdiv(V, BLOCK_SIZE) + triton.cdiv(K, BLOCK_SIZE), H)
@@ -1164,6 +1203,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
             FORWARD=True,
             INTRACARD_MODE=False,
             NUM_SEQ_ENTRIES=0,
+            TRANSPOSE_STATE=transpose_state_layout,
         )
     return initial_state
 
@@ -1182,6 +1222,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
     dht: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     context: FLACPContext | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if context is None or context.group is None:
         return dht, initial_state
@@ -1200,7 +1241,10 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
         N = len(cu_seqlens) - 1
 
     dhm = q.new_zeros(H, K, V + K, dtype=torch.float32)
-    dht = q.new_zeros(N, H, K, V, dtype=torch.float32)
+    if transpose_state_layout:
+        dht = q.new_zeros(N, H, V, K, dtype=torch.float32)
+    else:
+        dht = q.new_zeros(N, H, K, V, dtype=torch.float32)
 
     if not context.is_first_rank:
         BLOCK_SIZE = 32 if K <= 64 else 64
@@ -1246,6 +1290,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
             FORWARD=False,
             INTRACARD_MODE=False,
             NUM_SEQ_ENTRIES=0,
+            TRANSPOSE_STATE=transpose_state_layout,
         )
 
     # initial_state is None in the CP mode

--- a/fla/ops/gated_delta_rule/chunk.py
+++ b/fla/ops/gated_delta_rule/chunk.py
@@ -33,6 +33,7 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ):
     g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
     # obtain WY representation. u is actually the new v.
@@ -69,6 +70,7 @@ def chunk_gated_delta_rule_fwd(
             cu_seqlens=cu_seqlens,
             initial_state=initial_state,
             context=cp_context,
+            transpose_state_layout=transpose_state_layout,
         )
 
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
@@ -80,6 +82,7 @@ def chunk_gated_delta_rule_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
     )
 
     if cp_context is not None:
@@ -94,6 +97,7 @@ def chunk_gated_delta_rule_fwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
     )
     return g, o, A, final_state, initial_state
 
@@ -112,6 +116,7 @@ def chunk_gated_delta_rule_bwd(
     cu_seqlens: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ):
     w, u = recompute_w_u_fwd(
         k=k,
@@ -135,6 +140,7 @@ def chunk_gated_delta_rule_bwd(
         output_final_state=False,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
     )
     dv = chunk_bwd_dv_local(
         q=q,
@@ -161,6 +167,7 @@ def chunk_gated_delta_rule_bwd(
             dht=dht,
             initial_state=initial_state,
             context=cp_context,
+            transpose_state_layout=transpose_state_layout,
         )
 
     dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
@@ -175,6 +182,7 @@ def chunk_gated_delta_rule_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
     )
     dq, dk, dw, dg = chunk_bwd_dqkwg(
         q=q,
@@ -189,6 +197,7 @@ def chunk_gated_delta_rule_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
     )
     dk2, dv, db, dg2 = prepare_wy_repr_bwd(
         k=k,
@@ -226,6 +235,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         cu_seqlens_cpu: torch.LongTensor | None = None,
         use_qk_l2norm_in_kernel: bool = False,
         cp_context: FLACPContext | None = None,
+        transpose_state_layout: bool = False,
     ):
         q_rstd, k_rstd = None, None
         if use_qk_l2norm_in_kernel:
@@ -246,11 +256,13 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             cp_context=cp_context,
             chunk_indices=chunk_indices,
+            transpose_state_layout=transpose_state_layout,
         )
         ctx.save_for_backward(q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens, chunk_indices)
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
         ctx.cp_context = cp_context
+        ctx.transpose_state_layout = transpose_state_layout
         return o.to(q.dtype), final_state
 
     @staticmethod
@@ -276,11 +288,12 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             cp_context=ctx.cp_context,
             chunk_indices=chunk_indices,
+            transpose_state_layout=ctx.transpose_state_layout,
         )
         if ctx.use_qk_l2norm_in_kernel:
             dq = l2norm_bwd(q, q_rstd, dq)
             dk = l2norm_bwd(k, k_rstd, dk)
-        return dq.to(q), dk.to(k), dv.to(v), dg.to(g), db.to(beta), None, dh0, None, None, None, None, None
+        return dq.to(q), dk.to(k), dv.to(v), dg.to(g), db.to(beta), None, dh0, None, None, None, None, None, None
 
 
 @torch.compiler.disable
@@ -297,6 +310,7 @@ def chunk_gated_delta_rule(
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
+    transpose_state_layout: bool = False,
     **kwargs,
 ):
     r"""
@@ -401,5 +415,6 @@ def chunk_gated_delta_rule(
         cu_seqlens_cpu,
         use_qk_l2norm_in_kernel,
         cp_context,
+        transpose_state_layout,
     )
     return o, final_state

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -45,6 +45,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     IS_BETA_HEADWISE: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
@@ -77,11 +78,20 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
 
     mask_k = o_k < K
     mask_v = o_v < V
-    mask_h = mask_k[:, None] & mask_v[None, :]
+    if TRANSPOSE_STATE:
+        mask_h = mask_v[:, None] & mask_k[None, :]
+    else:
+        mask_h = mask_k[:, None] & mask_v[None, :]
 
-    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if TRANSPOSE_STATE:
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        if TRANSPOSE_STATE:
+            p_h0 = h0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
     for _ in tl.range(0, T):
@@ -97,24 +107,32 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
         else:
             b_beta = tl.load(p_beta, mask=mask_v, other=0).to(tl.float32)
 
-        # [BK, BV]
         if USE_G:
             b_g = tl.load(p_g).to(tl.float32)
             b_h *= exp(b_g)
 
         if USE_GK:
             b_gk = tl.load(p_gk).to(tl.float32)
-            b_h *= exp(b_gk[:, None])
+            if TRANSPOSE_STATE:
+                b_h *= exp(b_gk[None, :])
+            else:
+                b_h *= exp(b_gk[:, None])
 
         if USE_GV:
             b_gv = tl.load(p_gv).to(tl.float32)
-            b_h *= exp(b_gv[None, :])
+            if TRANSPOSE_STATE:
+                b_h *= exp(b_gv[:, None])
+            else:
+                b_h *= exp(b_gv[None, :])
 
-        b_v = b_beta * (b_v - tl.sum(b_h * b_k[:, None], 0))
-        b_h += b_k[:, None] * b_v
-
-        # [BV]
-        b_o = tl.sum(b_h * b_q[:, None], 0)
+        if TRANSPOSE_STATE:
+            b_v = b_beta * (b_v - tl.sum(b_h * b_k[None, :], 1))
+            b_h += b_v[:, None] * b_k[None, :]
+            b_o = tl.sum(b_h * b_q[None, :], 1)
+        else:
+            b_v = b_beta * (b_v - tl.sum(b_h * b_k[:, None], 0))
+            b_h += b_k[:, None] * b_v
+            b_o = tl.sum(b_h * b_q[:, None], 0)
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
 
         p_q += H*K
@@ -130,7 +148,10 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
         p_o += HV*V
 
     if STORE_FINAL_STATE:
-        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        if TRANSPOSE_STATE:
+            p_ht = ht + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
 
@@ -147,6 +168,7 @@ def fused_recurrent_gated_delta_rule_fwd(
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     HV = v.shape[2]
@@ -156,7 +178,13 @@ def fused_recurrent_gated_delta_rule_fwd(
     NV = triton.cdiv(V, BV)
 
     o = torch.empty_like(v)
-    final_state = q.new_empty(N, HV, K, V, dtype=torch.float32) if output_final_state else None
+    if output_final_state:
+        if transpose_state_layout:
+            final_state = q.new_empty(N, HV, V, K, dtype=torch.float32)
+        else:
+            final_state = q.new_empty(N, HV, K, V, dtype=torch.float32)
+    else:
+        final_state = None
 
     grid = (NV, N * HV)
     fused_recurrent_gated_delta_rule_fwd_kernel[grid](
@@ -181,6 +209,7 @@ def fused_recurrent_gated_delta_rule_fwd(
         BV=BV,
         IS_BETA_HEADWISE=beta.ndim != v.ndim,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        TRANSPOSE_STATE=transpose_state_layout,
         num_warps=1,
         num_stages=3,
     )
@@ -205,6 +234,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
         output_final_state: bool = False,
         use_qk_l2norm_in_kernel: bool = False,
         cu_seqlens: torch.LongTensor | None = None,
+        transpose_state_layout: bool = False,
     ):
         o, final_state = fused_recurrent_gated_delta_rule_fwd(
             q=q,
@@ -219,6 +249,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
             cu_seqlens=cu_seqlens,
+            transpose_state_layout=transpose_state_layout,
         )
 
         return o, final_state
@@ -246,6 +277,7 @@ def fused_recurrent_gated_delta_rule(
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""
     Args:
@@ -278,6 +310,8 @@ def fused_recurrent_gated_delta_rule(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
+        transpose_state_layout (bool):
+            Whether to use transposed state layout `[V, K]` instead of `[K, V]`. Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -343,5 +377,6 @@ def fused_recurrent_gated_delta_rule(
         output_final_state,
         use_qk_l2norm_in_kernel,
         cu_seqlens,
+        transpose_state_layout,
     )
     return o, final_state

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -301,7 +301,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT'],
+    key=['BT', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -323,6 +323,7 @@ def chunk_gla_fwd_kernel_o(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_EXP2: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -344,7 +345,10 @@ def chunk_gla_fwd_kernel_o(
     for i_k in range(tl.cdiv(K, BK)):
         p_q = tl.make_block_ptr(q + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         p_g = tl.make_block_ptr(g + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        if TRANSPOSE_STATE:
+            p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        else:
+            p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
 
         # [BT, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -355,12 +359,12 @@ def chunk_gla_fwd_kernel_o(
             b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
         else:
             b_qg = (b_q * exp(b_g)).to(b_q.dtype)
-        # [BK, BV]
         b_h = tl.load(p_h, boundary_check=(0, 1))
-        # works but dkw, owing to divine benevolence
-        # [BT, BV]
         if i_k >= 0:
-            b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+            if TRANSPOSE_STATE:
+                b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+            else:
+                b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
     b_o *= scale
     p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
     p_o = tl.make_block_ptr(o + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
@@ -867,6 +871,7 @@ def chunk_gla_fwd_o_gk(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
     use_exp2: bool = False,
+    transpose_state_layout: bool = False,
 ):
     B, T, H, K, V = *q.shape, v.shape[-1]
     BT = chunk_size
@@ -894,6 +899,7 @@ def chunk_gla_fwd_o_gk(
         V=V,
         BT=BT,
         USE_EXP2=use_exp2,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     return o
 

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -36,6 +36,7 @@ class ChunkKDAFunction(torch.autograd.Function):
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         cp_context: FLACPContext | None = None,
+        transpose_state_layout: bool = False,
     ):
         chunk_size = 64
 
@@ -70,6 +71,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             disable_recompute=disable_recompute,
             return_intermediate_states=return_intermediate_states,
             cp_context=cp_context,
+            transpose_state_layout=transpose_state_layout,
         )
 
         if return_intermediate_states:
@@ -90,6 +92,7 @@ class ChunkKDAFunction(torch.autograd.Function):
         ctx.use_gate_in_kernel = use_gate_in_kernel
         ctx.disable_recompute = disable_recompute
         ctx.cp_context = cp_context
+        ctx.transpose_state_layout = transpose_state_layout
         return o.type_as(q), final_state
 
     @staticmethod
@@ -128,13 +131,14 @@ class ChunkKDAFunction(torch.autograd.Function):
             disable_recompute=ctx.disable_recompute,
             w=w, u=u, qg=qg, kg=kg, v_new=v_new, h=h,
             cp_context=ctx.cp_context,
+            transpose_state_layout=ctx.transpose_state_layout,
         )
         if ctx.use_qk_l2norm_in_kernel:
             dq = l2norm_bwd(q, q_rstd, dq)
             dk = l2norm_bwd(k, k_rstd, dk)
 
         return (dq.to(q), dk.to(k), dv.to(v), dg.to(g), db.to(beta), dA, dbias, None, dh0,
-                None, None, None, None, None, None, None, None, None, None)
+                None, None, None, None, None, None, None, None, None, None, None)
 
 
 @torch.compiler.disable
@@ -156,6 +160,7 @@ def chunk_kda(
     disable_recompute: bool = False,
     return_intermediate_states: bool = False,
     cp_context: FLACPContext = None,
+    transpose_state_layout: bool = False,
     **kwargs,
 ):
     r"""
@@ -329,4 +334,5 @@ def chunk_kda(
         disable_recompute,
         return_intermediate_states,
         cp_context,
+        transpose_state_layout,
     )

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -116,7 +116,7 @@ def chunk_kda_bwd_kernel_dAv(
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['BT'],
+    key=['BT', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -148,6 +148,7 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     BT: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
@@ -215,8 +216,12 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         for i_v in range(tl.cdiv(V, BV)):
             p_v_new = tl.make_block_ptr(v_new, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            if TRANSPOSE_STATE:
+                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            else:
+                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
             p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             # [BT, BV]
             b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
@@ -353,6 +358,7 @@ def chunk_kda_bwd_wy_dqkg_fused(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = chunk_size
@@ -395,6 +401,7 @@ def chunk_kda_bwd_wy_dqkg_fused(
         K=K,
         V=V,
         BT=BT,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     dv = dv2
     return dq, dk, dv, db, dg, dA
@@ -423,6 +430,7 @@ def chunk_kda_bwd(
     dt_bias: torch.Tensor | None = None,
     disable_recompute: bool = False,
     cp_context: FLACPContext | None = None,
+    transpose_state_layout: bool = False,
     **kwargs,
 ):
     if disable_recompute is False:
@@ -461,6 +469,7 @@ def chunk_kda_bwd(
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             use_exp2=True,
+            transpose_state_layout=transpose_state_layout,
         )
     else:
         w, u, qg, kg, v_new, h = kwargs["w"], kwargs["u"], kwargs["qg"], kwargs["kg"], kwargs["v_new"], kwargs["h"]
@@ -499,6 +508,7 @@ def chunk_kda_bwd(
             initial_state=initial_state,
             use_exp2=True,
             context=cp_context,
+            transpose_state_layout=transpose_state_layout,
         )
 
     dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
@@ -514,6 +524,7 @@ def chunk_kda_bwd(
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         use_exp2=True,
+        transpose_state_layout=transpose_state_layout,
     )
 
     dq, dk, dv, db, dg, dAkk = chunk_kda_bwd_wy_dqkg_fused(
@@ -532,6 +543,7 @@ def chunk_kda_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
     )
 
     dq, dk, db, dg = chunk_kda_bwd_intra(

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -34,6 +34,7 @@ def chunk_kda_fwd(
     disable_recompute: bool = False,
     return_intermediate_states: bool = False,
     cp_context: FLACPContext | None = None,
+    transpose_state_layout: bool = False,
 ):
     # Apply gate activation
     g_org = None
@@ -83,6 +84,7 @@ def chunk_kda_fwd(
             initial_state=initial_state,
             context=cp_context,
             use_exp2=True,
+            transpose_state_layout=transpose_state_layout,
         )
 
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
@@ -96,6 +98,7 @@ def chunk_kda_fwd(
         cu_seqlens_cpu=cu_seqlens_cpu,
         chunk_indices=chunk_indices,
         use_exp2=True,
+        transpose_state_layout=transpose_state_layout,
     )
 
     if cp_context is not None:
@@ -116,6 +119,7 @@ def chunk_kda_fwd(
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         use_exp2=True,
+        transpose_state_layout=transpose_state_layout,
     )
     if disable_recompute is False:
         # Delete to save memory

--- a/fla/ops/kda/fused_recurrent.py
+++ b/fla/ops/kda/fused_recurrent.py
@@ -61,6 +61,7 @@ def fused_recurrent_kda_fwd_kernel(
     HAS_DT_BIAS: tl.constexpr,
     USE_GATE_IN_KERNEL: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
     num_stages: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -102,9 +103,15 @@ def fused_recurrent_kda_fwd_kernel(
 
     mask_k = o_k < K
     mask_v = o_v < V
-    mask_h = mask_k[:, None] & mask_v[None, :]
+    if TRANSPOSE_STATE:
+        mask_h = mask_v[:, None] & mask_k[None, :]
+    else:
+        mask_h = mask_k[:, None] & mask_v[None, :]
 
-    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if TRANSPOSE_STATE:
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
             if IS_SPEC_DECODING:
@@ -118,11 +125,15 @@ def fused_recurrent_kda_fwd_kernel(
                 )
                 * stride_init_state_token
             )
-            p_h0 = p_h0 + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+            if TRANSPOSE_STATE:
+                p_h0 = p_h0 + i_hv * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_h0 = p_h0 + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
         else:
-            # For non-continuous batching: h0 has shape [N, HV, K, V]
-            # where N = B (batch size) for equal-length sequences
-            p_h0 = h0 + (i_n * HV + i_hv) * K * V + o_k[:, None] * V + o_v[None, :]
+            if TRANSPOSE_STATE:
+                p_h0 = h0 + (i_n * HV + i_hv) * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_h0 = h0 + (i_n * HV + i_hv) * K * V + o_k[:, None] * V + o_v[None, :]
         b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
     for i_t in tl.range(0, T, num_stages=num_stages):
@@ -134,48 +145,45 @@ def fused_recurrent_kda_fwd_kernel(
             b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
             b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
         b_q = b_q * scale
-        # [BK, BV]
         b_g = tl.load(p_g, eviction_policy='evict_last').to(tl.float32)
 
-        # Compute gate if USE_GATE_IN_KERNEL is True
         if USE_GATE_IN_KERNEL:
-            # Load A_log for this head
             b_A = tl.load(A_log + i_h).to(tl.float32)
 
-            # Apply dt_bias if exists
             if HAS_DT_BIAS:
                 b_bias = tl.load(dt_bias + i_h * K + o_k, mask=mask_k, other=0).to(tl.float32)
                 b_g = b_g + b_bias
 
-            # Compute gate based on lower_bound
             if USE_LOWER_BOUND:
-                # lower_bound * sigmoid(exp(A_log) * g)
                 b_gk = lower_bound * tl.sigmoid(exp(b_A) * b_g)
             else:
-                # -exp(A_log) * softplus(g)
                 b_gk = -exp(b_A) * softplus(b_g)
         else:
-            # Use g directly as gate
             b_gk = b_g
 
-        b_h *= exp(b_gk[:, None])
+        if TRANSPOSE_STATE:
+            b_h *= exp(b_gk[None, :])
+        else:
+            b_h *= exp(b_gk[:, None])
 
-        # [BV]
-        b_v -= tl.sum(b_h * b_k[:, None], 0)
+        if TRANSPOSE_STATE:
+            b_v -= tl.sum(b_h * b_k[None, :], 1)
+        else:
+            b_v -= tl.sum(b_h * b_k[:, None], 0)
         if IS_BETA_HEADWISE:
             b_beta = tl.load(p_beta, mask=mask_v, other=0, eviction_policy='evict_first').to(tl.float32)
         else:
             b_beta = tl.load(p_beta, eviction_policy='evict_last').to(tl.float32)
         b_v *= b_beta
-        # [BK, BV]
-        b_h += b_k[:, None] * b_v[None, :]
-        # [BV]
-        b_o = tl.sum(b_h * b_q[:, None], 0)
+        if TRANSPOSE_STATE:
+            b_h += b_v[:, None] * b_k[None, :]
+            b_o = tl.sum(b_h * b_q[None, :], 1)
+        else:
+            b_h += b_k[:, None] * b_v[None, :]
+            b_o = tl.sum(b_h * b_q[:, None], 0)
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v, eviction_policy='evict_first')
 
         if IS_CONTINUOUS_BATCHING:
-            # keep the states for multi-query tokens
-            # only save per step in vllm
             if INPLACE_FINAL_STATE:
                 p_ht = (
                     ht
@@ -186,7 +194,10 @@ def fused_recurrent_kda_fwd_kernel(
                 )
             else:
                 p_ht = ht + (bos + i_t) * stride_final_state_token
-            p_ht = p_ht + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+            if TRANSPOSE_STATE:
+                p_ht = p_ht + i_hv * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_ht = p_ht + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
             tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
         p_q += H * K
@@ -197,11 +208,11 @@ def fused_recurrent_kda_fwd_kernel(
         p_beta += HV * (V if IS_BETA_HEADWISE else 1)
 
     if not IS_CONTINUOUS_BATCHING:
-        # Non-vLLM mode: only save final state at the end of loop (standard behavior)
         if STORE_FINAL_STATE:
-            # Use unified indexing: (i_n * HV + i_hv) for [N, HV, K, V] layout
-            # Both initial_state and final_state use this formula for consistency
-            p_ht = ht + (i_n * HV + i_hv) * K * V + o_k[:, None] * V + o_v[None, :]
+            if TRANSPOSE_STATE:
+                p_ht = ht + (i_n * HV + i_hv) * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_ht = ht + (i_n * HV + i_hv) * K * V + o_k[:, None] * V + o_v[None, :]
             tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
 
@@ -225,6 +236,7 @@ def fused_recurrent_kda_fwd(
     use_gate_in_kernel: bool = False,
     lower_bound: float | None = None,
     out: torch.Tensor | None = None,
+    transpose_state_layout: bool = False,
     **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if scale is None:
@@ -244,7 +256,10 @@ def fused_recurrent_kda_fwd(
         assert initial_state is not None
         final_state = initial_state
     elif output_final_state:
-        final_state = q.new_empty(N, HV, K, V, dtype=torch.float32)
+        if transpose_state_layout:
+            final_state = q.new_empty(N, HV, V, K, dtype=torch.float32)
+        else:
+            final_state = q.new_empty(N, HV, K, V, dtype=torch.float32)
     else:
         final_state = None
 
@@ -291,6 +306,7 @@ def fused_recurrent_kda_fwd(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         INPLACE_FINAL_STATE=inplace_final_state,
         USE_GATE_IN_KERNEL=use_gate_in_kernel,
+        TRANSPOSE_STATE=transpose_state_layout,
         num_warps=4,
         num_stages=2,
     )
@@ -314,6 +330,7 @@ def fused_recurrent_kda(
     use_gate_in_kernel: bool = False,
     lower_bound: float | None = None,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
     **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""
@@ -343,6 +360,8 @@ def fused_recurrent_kda(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
+        transpose_state_layout (bool):
+            Whether to use transposed state layout `[V, K]` instead of `[K, V]`. Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -410,5 +429,6 @@ def fused_recurrent_kda(
         use_gate_in_kernel=use_gate_in_kernel,
         lower_bound=lower_bound,
         cu_seqlens=cu_seqlens,
+        transpose_state_layout=transpose_state_layout,
     )
     return o, final_state

--- a/tests/context_parallel/test_cp_gdn.py
+++ b/tests/context_parallel/test_cp_gdn.py
@@ -99,6 +99,7 @@ def run_cp_gdn_test_worker(
     D: int,
     lengths: list[int],
     dtype,
+    transpose_state_layout: bool = False,
 ):
     """
     Worker function for CP GDN test.
@@ -166,6 +167,7 @@ def run_cp_gdn_test_worker(
                 g=g_ref,
                 beta=beta_ref,
                 cu_seqlens=cu_seqlens_global,
+                transpose_state_layout=transpose_state_layout,
             )
 
             o_ref.backward(do_global)
@@ -207,6 +209,7 @@ def run_cp_gdn_test_worker(
             g=g_local,
             beta=beta_local,
             cp_context=context,
+            transpose_state_layout=transpose_state_layout,
         )
 
         # CP Backward
@@ -277,6 +280,7 @@ def run_cp_test_with_spawn(
     D: int,
     lengths: list[int],
     dtype=torch.bfloat16,
+    transpose_state_layout: bool = False,
 ):
     """
     Run CP test using torch.multiprocessing.spawn.
@@ -284,7 +288,7 @@ def run_cp_test_with_spawn(
     """
     mp.start_processes(
         run_cp_gdn_test_worker,
-        args=(world_size, test_name, T, H, D, lengths, dtype),
+        args=(world_size, test_name, T, H, D, lengths, dtype, transpose_state_layout),
         nprocs=world_size,
         join=True,
         start_method='spawn',
@@ -376,6 +380,40 @@ def test_cp2_many_short_sequences():
         T=10240, H=4, D=128,
         lengths=[1000, 1500, 2000, 2500, 1240, 1000, 1000],
         dtype=torch.bfloat16,
+    )
+
+
+# ============================================================
+# Transpose State Layout Tests
+# ============================================================
+
+def test_cp2_transpose_state():
+    """CP2: transpose_state_layout=True with sequence cut."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_TransposeState",
+        T=10240, H=4, D=128,
+        lengths=[3000, 4000, 3240],
+        dtype=torch.bfloat16,
+        transpose_state_layout=True,
+    )
+
+
+def test_cp4_transpose_state():
+    """CP4: transpose_state_layout=True with single long sequence."""
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_TransposeState",
+        T=10240, H=4, D=128,
+        lengths=[10240],
+        dtype=torch.bfloat16,
+        transpose_state_layout=True,
     )
 
 

--- a/tests/context_parallel/test_cp_kda.py
+++ b/tests/context_parallel/test_cp_kda.py
@@ -157,6 +157,7 @@ def run_cp_kda_test_worker(
     use_gate_in_kernel: bool = False,
     safe_gate: bool = False,
     lower_bound: float | None = None,
+    transpose_state_layout: bool = False,
 ):
     """
     Worker function for CP KDA test.
@@ -390,6 +391,7 @@ def run_cp_kda_test_worker(
             lower_bound=lower_bound,
             A_log=A_log_global[:H].contiguous() if use_gate_in_kernel else None,
             dt_bias=dt_bias_global if use_gate_in_kernel else None,
+            transpose_state_layout=transpose_state_layout,
         )
 
         # CP Backward
@@ -464,6 +466,7 @@ def run_cp_test_with_spawn(
     use_gate_in_kernel: bool = False,
     safe_gate: bool = False,
     lower_bound: float | None = None,
+    transpose_state_layout: bool = False,
 ):
     """
     Run CP test using torch.multiprocessing.spawn.
@@ -471,7 +474,8 @@ def run_cp_test_with_spawn(
     """
     mp.start_processes(
         run_cp_kda_test_worker,
-        args=(world_size, test_name, T, H, D, lengths, dtype, disable_recompute, use_gate_in_kernel, safe_gate, lower_bound),
+        args=(world_size, test_name, T, H, D, lengths, dtype, disable_recompute,
+              use_gate_in_kernel, safe_gate, lower_bound, transpose_state_layout),
         nprocs=world_size,
         join=True,
         start_method='spawn',
@@ -588,6 +592,42 @@ def test_cp2_disable_recompute():
         lengths=[3000, 4000, 3240],
         dtype=torch.bfloat16,
         disable_recompute=True,
+        **GATE_KWARGS,
+    )
+
+
+# ============================================================
+# Transpose State Layout Tests
+# ============================================================
+
+def test_cp2_transpose_state():
+    """CP2: transpose_state_layout=True with sequence cut."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_TransposeState",
+        T=10240, H=4, D=128,
+        lengths=[3000, 4000, 3240],
+        dtype=torch.bfloat16,
+        transpose_state_layout=True,
+        **GATE_KWARGS,
+    )
+
+
+def test_cp4_transpose_state():
+    """CP4: transpose_state_layout=True with single long sequence."""
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_TransposeState",
+        T=10240, H=4, D=128,
+        lengths=[10240],
+        dtype=torch.bfloat16,
+        transpose_state_layout=True,
         **GATE_KWARGS,
     )
 

--- a/tests/ops/test_gated_delta.py
+++ b/tests/ops/test_gated_delta.py
@@ -157,6 +157,146 @@ def test_chunk(
 
 
 @pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'scale', 'gate_logit_normalizer', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test))
+        for test in [
+            (1, 63, 1, 64, 1, 1, torch.float16),
+            (2, 500, 3, 60, 1, 1, torch.float16),
+            (3, 1024, 4, 128, 0.1, 1, torch.float16),
+            (4, 2048, 8, 64, 0.1, 1, torch.float16),
+        ]
+    ],
+)
+def test_chunk_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    if IS_INTEL_ALCHEMIST and D > 128:
+        pytest.skip(reason='chunk_gated_delta_rule is not supported on alchemist for D>128')
+
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, H, D, dtype=dtype)
+    beta = torch.rand(B, T, H, dtype=dtype).sigmoid()
+    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    g = g / gate_logit_normalizer
+    # Non-zero initial state so transpose load path is actually exercised
+    h0_kv = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+    q, k, v, beta, g, h0_kv, h0_vk = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, beta, g, h0_kv, h0_vk))
+
+    tri, tri_ht = chunk_gated_delta_rule(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_vk.clone(),
+        output_final_state=True,
+        transpose_state_layout=True,
+    )
+    do = torch.randn_like(v)
+    dht_vk = torch.randn(B, H, D, D, dtype=torch.float32, device=device)
+    dht_kv = dht_vk.transpose(-1, -2).contiguous()
+    ((tri * do).sum() + (tri_ht * dht_vk).sum()).backward(retain_graph=True)
+    tri_dq, tri_dk, tri_dv, tri_dbeta, tri_dg, tri_dh0 = q.grad, k.grad, v.grad, beta.grad, g.grad, h0_vk.grad
+    q.grad = k.grad = v.grad = beta.grad = g.grad = h0_vk.grad = None
+
+    ref, ref_ht = chunk_gated_delta_rule(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_kv.clone(),
+        output_final_state=True,
+        transpose_state_layout=False,
+    )
+    ((ref * do).sum() + (ref_ht * dht_kv).sum()).backward(retain_graph=True)
+    ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dg, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, g.grad, h0_kv.grad
+
+    assert_close('o', ref, tri, 1e-4)
+    assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 1e-4)
+    assert_close('dq', ref_dq, tri_dq, 1e-4)
+    assert_close('dk', ref_dk, tri_dk, 1e-4)
+    assert_close('dv', ref_dv, tri_dv, 1e-4)
+    assert_close('db', ref_dbeta, tri_dbeta, 1e-4)
+    assert_close('dg', ref_dg, tri_dg, 1e-4)
+    assert_close('dh0', ref_dh0, tri_dh0.transpose(-1, -2), 1e-4)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HV', 'D', 'scale', 'gate_logit_normalizer', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test))
+        for test in [
+            (1, 63, 1, 1, 64, 1, 1, torch.float),
+            (2, 500, 4, 4, 60, 1, 1, torch.float),
+            (2, 1000, 2, 8, 128, 1, 0.1, torch.float),
+            (3, 1024, 2, 2, 128, 0.1, 1, torch.float),
+            (4, 2048, 4, 4, 64, 0.1, 1, torch.float),
+        ]
+    ],
+)
+def test_fused_recurrent_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    q = torch.randn(B, T, H, D, dtype=torch.float32)
+    k = torch.randn(B, T, H, D, dtype=torch.float32)
+    v = torch.randn(B, T, HV, D, dtype=dtype)
+    beta = torch.rand(B, T, HV, dtype=dtype).sigmoid()
+    g = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32))
+    g = g / gate_logit_normalizer
+    h0_kv = torch.randn(B, HV, D, D, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+    q, k, v, beta, g, h0_kv, h0_vk = map(lambda x: x.to(device), (q, k, v, beta, g, h0_kv, h0_vk))
+
+    ref, ref_ht = fused_recurrent_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        beta=beta.clone(),
+        g=g.clone(),
+        scale=scale,
+        initial_state=h0_kv.clone(),
+        use_qk_l2norm_in_kernel=True,
+        output_final_state=True,
+        transpose_state_layout=False,
+    )
+    tri, tri_ht = fused_recurrent_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        beta=beta.clone(),
+        g=g.clone(),
+        scale=scale,
+        initial_state=h0_vk.clone(),
+        use_qk_l2norm_in_kernel=True,
+        output_final_state=True,
+        transpose_state_layout=True,
+    )
+    assert_close('o', ref, tri, 1e-4)
+    assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 1e-4)
+
+
+@pytest.mark.parametrize(
     ('H', 'D', 'mask_p', 'cu_seqlens', 'dtype'),
     [
         pytest.param(*test, id="H{}-D{}-mask_p{}-cu_seqlens{}-{}".format(*test))

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -137,6 +137,68 @@ def test_fused_recurrent(
 
 
 @pytest.mark.parametrize(
+    ("B", "T", "H", "D", "scale", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
+        )
+        for test in [
+            (1, 64, 1, 64, 1, 1, torch.float),
+            (2, 512, 3, 60, 1, 1, torch.float),
+            (3, 1000, 4, 100, 0.1, 1, torch.float),
+            (4, 1024, 4, 128, 0.1, 1, torch.float),
+        ]
+    ],
+)
+def test_fused_recurrent_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, H, D, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float)) / gate_logit_normalizer
+    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    h0_kv = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+    q, k, v, g, beta, h0_kv, h0_vk = map(lambda x: x.to(device), (q, k, v, g, beta, h0_kv, h0_vk))
+
+    ref, ref_ht = fused_recurrent_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_kv.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        transpose_state_layout=False,
+    )
+    tri, tri_ht = fused_recurrent_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_vk.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        transpose_state_layout=True,
+    )
+    assert_close("o", ref, tri, 1e-4)
+    assert_close("ht", ref_ht, tri_ht.transpose(-1, -2), 1e-4)
+
+
+@pytest.mark.parametrize(
     ("B", "H", "D", "scale", "gate_logit_normalizer", "use_qk_l2norm_in_kernel", "use_gate_in_kernel", "safe_gate", "dtype"),
     [
         pytest.param(
@@ -398,6 +460,85 @@ def test_chunk(
         assert_close("dA", ref_dA, tri_dA, 0.003, warning=True)
         assert_close("dbias", ref_dbias, tri_dbias, 0.008)
     assert_close("dh0", ref_dh0, tri_dh0, 0.008)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "scale", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
+        )
+        for test in [
+            (1, 63, 1, 64, 1, 1, torch.float16),
+            (2, 500, 3, 60, 1, 1, torch.float16),
+            (3, 1024, 4, 128, 0.1, 1, torch.float16),
+            (4, 2048, 8, 64, 0.1, 1, torch.float16),
+        ]
+    ],
+)
+def test_chunk_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, H, D, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float)) / gate_logit_normalizer
+    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    h0_kv = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+    q, k, v, g, beta, h0_kv, h0_vk = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0_kv, h0_vk))
+
+    do = torch.randn_like(v)
+    dht_vk = torch.randn(B, H, D, D, dtype=torch.float32, device=device)
+    dht_kv = dht_vk.transpose(-1, -2).contiguous()
+
+    tri, tri_ht = chunk_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_vk.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        transpose_state_layout=True,
+    )
+    ((tri * do).sum() + (tri_ht * dht_vk).sum()).backward(retain_graph=True)
+    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0_vk.grad
+    q.grad = k.grad = v.grad = g.grad = beta.grad = h0_vk.grad = None
+
+    ref, ref_ht = chunk_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_kv.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        transpose_state_layout=False,
+    )
+    ((ref * do).sum() + (ref_ht * dht_kv).sum()).backward(retain_graph=True)
+    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0_kv.grad
+
+    assert_close("o", ref, tri, 1e-4)
+    assert_close("ht", ref_ht, tri_ht.transpose(-1, -2), 1e-4)
+    assert_close("dq", ref_dq, tri_dq, 1e-4)
+    assert_close("dk", ref_dk, tri_dk, 1e-4)
+    assert_close("dv", ref_dv, tri_dv, 1e-4)
+    assert_close("dg", ref_dg, tri_dg, 1e-4)
+    assert_close("db", ref_db, tri_db, 1e-4)
+    assert_close("dh0", ref_dh0, tri_dh0.transpose(-1, -2), 1e-4)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add transpose_state_layout parameter to chunk, fused_recurrent, and context parallel paths for both KDA and GDN. When enabled, all state tensors use [V,K] layout instead of [K,V] to improve memory access patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional transpose_state_layout flag (default False) across multiple ops and fused/chunk workflows to select an alternate state tensor layout for forward/backward paths and final-state outputs. Preserves existing behavior when disabled and is threaded through kernel invocations and public APIs.

* **Tests**
  * Added unit and multi-GPU context-parallel tests covering outputs, gradients, and final-state layouts with transpose_state_layout enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->