### PR TITLE
[L2Norm] Fix bf16 numerical stability by calculating norm in f32 then normalising in input dtype

### DIFF
--- a/fla/modules/l2norm.py
+++ b/fla/modules/l2norm.py
@@ -32,9 +32,11 @@ def l2norm_fwd_kernel1(
     cols = tl.arange(0, BD)
     mask = cols < D
 
-    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
-    b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x) + eps)
-    b_y = b_x * b_rstd
+    # compute norm in f32 for stability
+    b_x = tl.load(x + cols, mask=mask, other=0.0)
+    b_x_f32 = b_x.to(tl.float32)
+    b_rstd = tl.rsqrt(tl.sum(b_x_f32 * b_x_f32) + eps)
+    b_y = b_x * b_rstd.to(b_x.dtype)
     tl.store(y + cols, b_y, mask=mask)
     tl.store(rstd + i_t, b_rstd)
 
@@ -90,9 +92,11 @@ def l2norm_fwd_kernel(
     p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
     p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
 
-    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
-    b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x, 1) + eps)
-    b_y = b_x * b_rstd[:, None]
+    # compute norm in f32 for stability
+    b_x = tl.load(p_x, boundary_check=(0, 1))
+    b_x_f32 = b_x.to(tl.float32)
+    b_rstd = tl.rsqrt(tl.sum(b_x_f32 * b_x_f32, 1) + eps)
+    b_y = b_x * b_rstd[:, None].to(b_x.dtype)
 
     tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))


### PR DESCRIPTION
We were witnessing numerical instability in downstream operations like the matrix inversion in gated delta rule - the output tensor didn't have norm close enough to 1 bf16.... This change removed that instability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numerical stability in L2 normalization computations to deliver more accurate and consistent results across different input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->