### PR TITLE
[Fix] Guard checkpoint weight re-initialization in RWKV-7, Mamba, Mamba2, and LogLinearMamba2

### DIFF
--- a/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
+++ b/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
@@ -112,16 +112,18 @@ class LogLinearMamba2PreTrainedModel(PreTrainedModel, FLAGenerationMixin):
         """Initialize the weights."""
         if isinstance(module, LogLinearMamba2):
             # --- A_log ---
-            A = torch.arange(1, module.num_heads + 1)
-            with torch.no_grad():
-                if not isinstance(module.A_log, torch.distributed.tensor.DTensor):
-                    module.A_log.copy_(torch.log(A))
-                else:
-                    logger.warning_once("`A_log` is a DTensor, skipping initialization")
+            if not getattr(module.A_log, '_is_hf_initialized', False):
+                A = torch.arange(1, module.num_heads + 1)
+                with torch.no_grad():
+                    if not isinstance(module.A_log, torch.distributed.tensor.DTensor):
+                        module.A_log.copy_(torch.log(A))
+                    else:
+                        logger.warning_once("`A_log` is a DTensor, skipping initialization")
             module.A_log._no_weight_decay = True
 
             # --- D ---
-            nn.init.ones_(module.D)
+            if not getattr(module.D, '_is_hf_initialized', False):
+                nn.init.ones_(module.D)
             module.D._no_weight_decay = True
 
             # --- conv1d ---
@@ -130,28 +132,30 @@ class LogLinearMamba2PreTrainedModel(PreTrainedModel, FLAGenerationMixin):
                 module.conv1d.weight._no_reinit = True
 
             # --- L ---
-            nn.init.ones_(module.L)
+            if not getattr(module.L, '_is_hf_initialized', False):
+                nn.init.ones_(module.L)
             module.L._no_weight_decay = True
 
             # --- dt_bias ---
-            dt = torch.exp(
-                torch.rand(self.config.num_heads)
-                * (
-                    math.log(self.config.dt_max)
-                    - math.log(self.config.dt_min)
-                )
-                + math.log(self.config.dt_min),
-            ).clamp(min=self.config.dt_init_floor)
-
-            # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-            inv_dt = dt + torch.log(-torch.expm1(-dt))
-            with torch.no_grad():
-                if not isinstance(module.dt_bias, torch.distributed.tensor.DTensor):
-                    module.dt_bias.copy_(inv_dt)
-                else:
-                    logger.warning_once(
-                        "`dt_bias` is a DTensor, skipping initialization",
+            if not getattr(module.dt_bias, '_is_hf_initialized', False):
+                dt = torch.exp(
+                    torch.rand(self.config.num_heads)
+                    * (
+                        math.log(self.config.dt_max)
+                        - math.log(self.config.dt_min)
                     )
+                    + math.log(self.config.dt_min),
+                ).clamp(min=self.config.dt_init_floor)
+
+                # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                inv_dt = dt + torch.log(-torch.expm1(-dt))
+                with torch.no_grad():
+                    if not isinstance(module.dt_bias, torch.distributed.tensor.DTensor):
+                        module.dt_bias.copy_(inv_dt)
+                    else:
+                        logger.warning_once(
+                            "`dt_bias` is a DTensor, skipping initialization",
+                        )
             module.dt_bias._no_reinit = True
 
         elif isinstance(module, (nn.Linear, nn.Conv1d)):
@@ -184,7 +188,7 @@ class LogLinearMamba2PreTrainedModel(PreTrainedModel, FLAGenerationMixin):
                 p = module.out_proj.weight
             elif hasattr(module, "down_proj"):
                 p = module.down_proj.weight
-            if p is not None:
+            if p is not None and not getattr(p, '_is_hf_initialized', False):
                 # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                 # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
                 # We need to reinit p since this code could be called multiple times

--- a/fla/models/mamba/modeling_mamba.py
+++ b/fla/models/mamba/modeling_mamba.py
@@ -116,13 +116,15 @@ class MambaPreTrainedModel(PreTrainedModel):
                     nn.init.zeros_(module.bias)
         elif isinstance(module, Mamba) and next(module.parameters()).device.type != 'meta':
             # S4D real initialization
-            A = torch.arange(1, module.ssm_state_size + 1, dtype=torch.float32)[None, :]
-            A = A.expand(module.intermediate_size, -1).contiguous()
-            with torch.no_grad():
-                module.A_log.copy_(torch.log(A))
+            if not getattr(module.A_log, '_is_hf_initialized', False):
+                A = torch.arange(1, module.ssm_state_size + 1, dtype=torch.float32)[None, :]
+                A = A.expand(module.intermediate_size, -1).contiguous()
+                with torch.no_grad():
+                    module.A_log.copy_(torch.log(A))
             module.A_log._no_weight_decay = True
 
-            nn.init.ones_(module.D)
+            if not getattr(module.D, '_is_hf_initialized', False):
+                nn.init.ones_(module.D)
             module.D._no_weight_decay = True
 
             dt_init_std = self.config.dt_rank**-0.5 * self.config.dt_scale
@@ -132,15 +134,16 @@ class MambaPreTrainedModel(PreTrainedModel):
                 nn.init.uniform_(module.dt_proj.weight, -dt_init_std, dt_init_std)
             module.dt_proj.weight._no_reinit = True
 
-            dt = torch.exp(
-                torch.rand(self.config.intermediate_size)
-                * (math.log(self.config.dt_max) - math.log(self.config.dt_min))
-                + math.log(self.config.dt_min),
-            ).clamp(min=self.config.dt_init_floor)
-            # # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-            inv_dt = dt + torch.log(-torch.expm1(-dt))
-            with torch.no_grad():
-                module.dt_proj.bias.data = nn.Parameter(inv_dt.to(module.dt_proj.bias.device))
+            if not getattr(module.dt_proj.bias, '_is_hf_initialized', False):
+                dt = torch.exp(
+                    torch.rand(self.config.intermediate_size)
+                    * (math.log(self.config.dt_max) - math.log(self.config.dt_min))
+                    + math.log(self.config.dt_min),
+                ).clamp(min=self.config.dt_init_floor)
+                # # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                inv_dt = dt + torch.log(-torch.expm1(-dt))
+                with torch.no_grad():
+                    module.dt_proj.bias.data = nn.Parameter(inv_dt.to(module.dt_proj.bias.device))
             module.dt_proj.bias._no_reinit = True
         elif isinstance(module, nn.Embedding):
             nn.init.normal_(module.weight, std=self.config.initializer_range)

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -152,24 +152,26 @@ class Mamba2PreTrainedModel(PreTrainedModel):
         if isinstance(module, Mamba2) and next(module.parameters()).device.type != 'meta':
 
             # --- A_log ---
-            A = torch.empty(module.num_heads, dtype=torch.float32).uniform_(*self.config.A_init_range)
-            with torch.no_grad():
-                A_log = torch.log(A)
-                if isinstance(module.A_log, DTensor):
-                    A_log = tensor_to_dtensor(
-                        tensor=A_log,
-                        device_mesh=module.A_log.device_mesh,
-                        current_placement=[Replicate()] * len(module.A_log.placements),
-                        desired_placement=module.A_log.placements,
-                        run_check=True,
-                    )
+            if not getattr(module.A_log, '_is_hf_initialized', False):
+                A = torch.empty(module.num_heads, dtype=torch.float32).uniform_(*self.config.A_init_range)
+                with torch.no_grad():
+                    A_log = torch.log(A)
+                    if isinstance(module.A_log, DTensor):
+                        A_log = tensor_to_dtensor(
+                            tensor=A_log,
+                            device_mesh=module.A_log.device_mesh,
+                            current_placement=[Replicate()] * len(module.A_log.placements),
+                            desired_placement=module.A_log.placements,
+                            run_check=True,
+                        )
 
-                module.A_log.copy_(A_log)
+                    module.A_log.copy_(A_log)
 
             module.A_log._no_weight_decay = True
 
             # --- D ---
-            nn.init.ones_(module.D)
+            if not getattr(module.D, '_is_hf_initialized', False):
+                nn.init.ones_(module.D)
             module.D._no_weight_decay = True
 
             # --- conv1d ---
@@ -178,25 +180,26 @@ class Mamba2PreTrainedModel(PreTrainedModel):
                 module.conv1d.weight._no_reinit = True
 
             # --- dt_bias ---
-            dt = torch.exp(
-                torch.rand(self.config.num_heads)
-                * (math.log(self.config.dt_max) - math.log(self.config.dt_min))
-                + math.log(self.config.dt_min),
-            ).clamp(min=self.config.dt_init_floor)
+            if not getattr(module.dt_bias, '_is_hf_initialized', False):
+                dt = torch.exp(
+                    torch.rand(self.config.num_heads)
+                    * (math.log(self.config.dt_max) - math.log(self.config.dt_min))
+                    + math.log(self.config.dt_min),
+                ).clamp(min=self.config.dt_init_floor)
 
-            # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-            inv_dt = dt + torch.log(-torch.expm1(-dt))
-            with torch.no_grad():
-                if isinstance(module.dt_bias, DTensor):
-                    inv_dt = tensor_to_dtensor(
-                        tensor=inv_dt,
-                        device_mesh=module.dt_bias.device_mesh,
-                        current_placement=[Replicate()] * len(module.dt_bias.placements),
-                        desired_placement=module.dt_bias.placements,
-                        run_check=True,
-                    )
+                # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                inv_dt = dt + torch.log(-torch.expm1(-dt))
+                with torch.no_grad():
+                    if isinstance(module.dt_bias, DTensor):
+                        inv_dt = tensor_to_dtensor(
+                            tensor=inv_dt,
+                            device_mesh=module.dt_bias.device_mesh,
+                            current_placement=[Replicate()] * len(module.dt_bias.placements),
+                            desired_placement=module.dt_bias.placements,
+                            run_check=True,
+                        )
 
-                module.dt_bias.copy_(inv_dt)
+                    module.dt_bias.copy_(inv_dt)
             module.dt_bias._no_reinit = True
             module.dt_bias._no_weight_decay = True
 
@@ -230,7 +233,7 @@ class Mamba2PreTrainedModel(PreTrainedModel):
                 p = module.out_proj.weight
             elif hasattr(module, 'down_proj'):
                 p = module.down_proj.weight
-            if p is not None:
+            if p is not None and not getattr(p, '_is_hf_initialized', False):
                 # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                 # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
                 # We need to reinit p since this code could be called multiple times

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -239,16 +239,18 @@ class RWKV7PreTrainedModel(PreTrainedModel):
     ):
         if isinstance(module, nn.Embedding):
             # https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v7/train_temp/src/model.py#L396C12-L399C58
-            scale = -1e-4
-            nn.init.uniform_(module.weight, a=scale, b=-scale)
+            if not getattr(module.weight, '_is_hf_initialized', False):
+                scale = -1e-4
+                nn.init.uniform_(module.weight, a=scale, b=-scale)
         elif isinstance(module, nn.Linear) and hasattr(self, 'lm_head') and module is self.lm_head:
             # https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v7/train_temp/src/model.py#L403
-            if self.config.vocab_size > self.config.hidden_size:
-                scale = 0.5 * math.sqrt(self.config.vocab_size / self.config.hidden_size)
-            else:
-                scale = 0.5
-            original_dtype = module.weight.dtype
-            module.weight.data = nn.init.orthogonal_(module.weight.data.to(torch.float32), gain=scale).to(original_dtype)
+            if not getattr(module.weight, '_is_hf_initialized', False):
+                if self.config.vocab_size > self.config.hidden_size:
+                    scale = 0.5 * math.sqrt(self.config.vocab_size / self.config.hidden_size)
+                else:
+                    scale = 0.5
+                original_dtype = module.weight.dtype
+                module.weight.data = nn.init.orthogonal_(module.weight.data.to(torch.float32), gain=scale).to(original_dtype)
         # Init Attention parameters
         elif isinstance(module, (nn.Linear, nn.Conv1d)) and getattr(module, '_in_rwkv_module', False) is False:
             # Slightly different from the TF version which uses truncated_normal for initialization


### PR DESCRIPTION
### Problem

Loading pretrained checkpoints with `transformers >= 5.0` silently **overwrites trained parameter values** in several FLA models. The model loads without errors, but produces degraded or broken outputs.

**Affected models and parameters** (confirmed via reproduction test):

| Model | Corrupted parameters | Mechanism |
|-------|---------------------|-----------|
| **RWKV-7** | `lm_head.weight` | `.data = ...to(float32)` strips `_is_hf_initialized` flag |
| **Mamba** | `A_log`, `dt_proj.bias` | `.copy_()` and `.data =` bypass `guard_torch_init_functions` |
| **Mamba2** | `A_log`, `dt_bias`, `out_proj.weight` | `.copy_()` bypasses guard; `rescale_prenorm_residual` divides loaded values |
| **LogLinearMamba2** | `A_log`, `dt_bias`, `out_proj.weight`, `down_proj.weight` | Same as Mamba2 plus no meta-device guard |

**Not affected:** GatedDeltaNet, Comba, KDA (fixed by #754), RWKV-6, and all standard-template models.

### Root cause

There are three distinct unsafe patterns in `_init_weights`, all triggered during the `_initialize_missing_keys` phase of `from_pretrained()`.

**Background:** transformers 5.x creates models on `meta` device, then loads checkpoint weights (stamping each with `_is_hf_initialized = True`), then calls `_initialize_missing_keys()` → `initialize_weights()` → `_initialize_weights(module)` → `_init_weights(module)` on every module that lacks a module-level `_is_hf_initialized` flag. The `@guard_torch_init_functions()` decorator patches `nn.init.*` functions to skip tensors that have `_is_hf_initialized = True`.

**Pattern 1: `.copy_()` bypasses the guard** (Mamba, Mamba2, LogLinearMamba2)

```python
# .copy_() is NOT an nn.init.* function, so guard_torch_init_functions does not intercept it
module.A_log.copy_(torch.log(A))     # overwrites loaded A_log with fresh random values
module.dt_bias.copy_(inv_dt)          # overwrites loaded dt_bias with fresh random values
```

The existing `meta`-device guard (`next(module.parameters()).device.type != 'meta'`) does not help: it was added by #793 to skip init during `__init__` on meta device, but during `_initialize_missing_keys` the params are already on CPU/CUDA, so the guard evaluates to `True` and init runs.

**Pattern 2: `.data = ...to(float32)` strips the flag** (RWKV-7)

```python
# .to(float32) creates a NEW tensor without _is_hf_initialized
module.weight.data = nn.init.orthogonal_(module.weight.data.to(torch.float32), gain=scale).to(original_dtype)
```

The guarded `orthogonal_` checks the flag on the tensor it receives. Since `.to(float32)` produced a fresh copy without the flag, the guard doesn't fire and the tensor is reinitialized.

**Pattern 3: `rescale_prenorm_residual` divides loaded values** (Mamba2, LogLinearMamba2)

```python
nn.init.kaiming_uniform_(p, a=math.sqrt(5))           # correctly guarded → no-op
with torch.no_grad():
    p /= math.sqrt(num_residuals_per_layer * ...)      # NOT guarded → divides loaded checkpoint values
```

The `kaiming_uniform_` is a no-op (flag respected), but the subsequent `p /= ...` runs unconditionally and divides the loaded `out_proj.weight` / `down_proj.weight` by a constant.

### Reproduction

Test script that simulates the full `from_pretrained` meta-device flow and detects corruption:

<details>
<summary>test_init_safety.py (click to expand)</summary>

```python
"""Simulates from_pretrained: meta-device init → checkpoint load → initialize_weights."""
import sys, math, torch, torch.nn as nn
from contextlib import ExitStack
sys.path.insert(0, "path/to/flash-linear-attention")
from transformers import initialization as hf_init

def test_model(model_cls, config, label):
    # Step 1: Create on meta device (as from_pretrained does)
    with ExitStack() as stack:
        stack.enter_context(hf_init.no_tie_weights())
        stack.enter_context(torch.device('meta'))
        model = model_cls(config)

    # Step 2: Move params off meta (simulating checkpoint load)
    for name, param in list(model.named_parameters()):
        if param.is_meta:
            new_param = nn.Parameter(torch.randn(param.shape, dtype=param.dtype, device='cpu'),
                                     requires_grad=param.requires_grad)
            new_param._is_hf_initialized = True
            parts = name.split('.')
            obj = model
            for p in parts[:-1]: obj = getattr(obj, p)
            setattr(obj, parts[-1], new_param)

    before = {n: p.data.clone() for n, p in model.named_parameters()}
    model.initialize_weights()  # Step 3: as _initialize_missing_keys does
    after = {n: p.data.clone() for n, p in model.named_parameters()}

    changed = [(n, (before[n].float()-after[n].float()).abs().max().item())
               for n in before if not torch.equal(before[n], after[n])]
    print(f"{'UNSAFE' if changed else 'SAFE':6s} {label}")
    for n, d in changed: print(f"         {n}: max_diff={d:.4f}")

# --- RWKV-7 ---
from fla.models.rwkv7.configuration_rwkv7 import RWKV7Config
from fla.models.rwkv7.modeling_rwkv7 import RWKV7ForCausalLM
test_model(RWKV7ForCausalLM, RWKV7Config(hidden_size=64, num_hidden_layers=2,
    num_heads=4, vocab_size=256, intermediate_size=128, tie_word_embeddings=False), "RWKV-7")

# --- Mamba ---
from fla.models.mamba.configuration_mamba import MambaConfig
from fla.models.mamba.modeling_mamba import MambaForCausalLM
test_model(MambaForCausalLM, MambaConfig(hidden_size=64, num_hidden_layers=2,
    intermediate_size=128, ssm_state_size=16, vocab_size=256), "Mamba")

# --- Mamba2 ---
from fla.models.mamba2.configuration_mamba2 import Mamba2Config
from fla.models.mamba2.modeling_mamba2 import Mamba2ForCausalLM
test_model(Mamba2ForCausalLM, Mamba2Config(hidden_size=64, num_hidden_layers=2,
    num_heads=4, vocab_size=256), "Mamba2")

# --- LogLinearMamba2 ---
from fla.models.log_linear_mamba2.configuration_log_linear_mamba2 import LogLinearMamba2Config
from fla.models.log_linear_mamba2.modeling_log_linear_mamba2 import LogLinearMamba2ForCausalLM
test_model(LogLinearMamba2ForCausalLM, LogLinearMamba2Config(hidden_size=64,
    num_hidden_layers=2, num_heads=4, vocab_size=256), "LogLinearMamba2")

# --- GatedDeltaNet (control, should be SAFE) ---
from fla.models.gated_deltanet.configuration_gated_deltanet import GatedDeltaNetConfig
from fla.models.gated_deltanet.modeling_gated_deltanet import GatedDeltaNetForCausalLM
test_model(GatedDeltaNetForCausalLM, GatedDeltaNetConfig(hidden_size=64,
    num_hidden_layers=2, num_heads=4, vocab_size=256), "GatedDeltaNet (control)")
```

</details>

Output before fix:
```
UNSAFE RWKV-7
         lm_head.weight: max_diff=4.2110
UNSAFE Mamba
         backbone.layers.0.mixer.A_log: max_diff=6.2057
         backbone.layers.0.mixer.dt_proj.bias: max_diff=8.3612
UNSAFE Mamba2
         backbone.layers.0.mixer.A_log: max_diff=3.2985
         backbone.layers.0.mixer.dt_bias: max_diff=5.8167
         backbone.layers.0.mixer.out_proj.weight: max_diff=1.1596
UNSAFE LogLinearMamba2
         backbone.layers.0.mixer.A_log: max_diff=2.5757
         backbone.layers.0.mixer.dt_bias: max_diff=7.1142
         backbone.layers.0.mixer.out_proj.weight: max_diff=2.0687
         backbone.layers.0.mlp.down_proj.weight: max_diff=2.0949
SAFE   GatedDeltaNet (control)
```

### Fix

Add `_is_hf_initialized` guards before every unsafe init block, matching the pattern from #754:

**Pattern 1 fix** — guard `.copy_()` calls (Mamba, Mamba2, LogLinearMamba2):
```python
# before
module.A_log.copy_(torch.log(A))

# after
if not getattr(module.A_log, '_is_hf_initialized', False):
    module.A_log.copy_(torch.log(A))
```

Same for `dt_bias` / `dt_proj.bias`.

**Pattern 2 fix** — guard `.data =` assignment (RWKV-7):
```python
# before (lm_head)
module.weight.data = nn.init.orthogonal_(module.weight.data.to(torch.float32), gain=scale).to(original_dtype)

# after
if not getattr(module.weight, '_is_hf_initialized', False):
    module.weight.data = nn.init.orthogonal_(module.weight.data.to(torch.float32), gain=scale).to(original_dtype)
```

Same guard added to the embedding branch for safety.

**Pattern 3 fix** — guard `rescale_prenorm_residual` division (Mamba2, LogLinearMamba2):
```python
# before
nn.init.kaiming_uniform_(p, a=math.sqrt(5))
with torch.no_grad():
    p /= math.sqrt(num_residuals_per_layer * self.config.num_hidden_layers)

# after
if not getattr(p, '_is_hf_initialized', False):
    nn.init.kaiming_uniform_(p, a=math.sqrt(5))
    with torch.no_grad():
        p /= math.sqrt(num_residuals_per_layer * self.config.num_hidden_layers)
```

### Files changed

| File | What changes |
|------|-------------|
| `fla/models/rwkv7/modeling_rwkv7.py` | Guard `lm_head` and embedding init |
| `fla/models/mamba/modeling_mamba.py` | Guard `A_log`, `D`, `dt_proj` init and `dt_proj.bias.data =` |
| `fla/models/mamba2/modeling_mamba2.py` | Guard `A_log`, `D`, `dt_bias` init and `rescale_prenorm_residual` |
| `fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py` | Guard `A_log`, `D`, `L`, `dt_bias` init and `rescale_prenorm_residual` |

### Why the existing guards are insufficient

PR #793 added `next(module.parameters()).device.type != 'meta'` to Mamba and Mamba2. This correctly prevents init during `__init__` on meta device, but does **not** protect during `_initialize_missing_keys`, which runs after params have been moved off meta onto CPU/CUDA. The `_is_hf_initialized` check is the correct guard because it is set on the tensor during checkpoint loading and persists regardless of device.

**Note on #754's claim that Mamba2/LogLinearMamba2 are "not affected":** #754 was specifically about the *double-transformation* bug where `guard_torch_init_functions` makes `nn.init.uniform_` a no-op but `.log()` still runs on the checkpoint value, producing `log(log(x))` → NaN. Mamba2 avoids that pattern by creating a fresh tensor (`torch.empty(...).uniform_()`). However, the subsequent `.copy_()` unconditionally overwrites the loaded checkpoint value with the fresh random one — a different failure mode that #754 did not consider.

### Checklist

- Follows the `_is_hf_initialized` guard pattern from #754
- No behavioral change for fresh model initialization (flag is `False` when not loading from checkpoint)
- Preserves BFloat16-safe `.to(float32)` cast in RWKV-7 (#393)
- Preserves DTensor handling in Mamba2 and LogLinearMamba2
- Preserves meta-device guards from #793 (kept as a secondary defense)

> **Verified against:** fla @ `3c6f70d`, transformers 5.5.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weight initialization to prevent redundant re-initialization across multiple model architectures (LogLinearMamba2, Mamba, Mamba2, and RWKV7). Initialization is now idempotent, ensuring parameters are initialized only once even if the initialization process is triggered multiple times. This improves model behavior stability in scenarios involving repeated initialization calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->