### PR TITLE
[CI] Fix skip-test check failing on fork PRs

### DIFF
--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -58,8 +58,16 @@ jobs:
         id: check_skip
         run: |
           if [ -n "$GITHUB_HEAD_REF" ]; then
-            git fetch origin "$GITHUB_HEAD_REF" --depth=1
-            COMMIT_MSG=$(git log -1 --pretty=%s FETCH_HEAD)
+            # Extract PR number from GITHUB_REF (refs/pull/<number>/merge)
+            # and fetch the PR head ref which is always available on origin,
+            # regardless of whether the PR comes from a fork or the same repo.
+            PR_NUMBER=$(echo "$GITHUB_REF" | awk -F/ '{print $3}')
+            if [ -n "$PR_NUMBER" ] && git fetch origin "refs/pull/${PR_NUMBER}/head" --depth=1 2>/dev/null; then
+              COMMIT_MSG=$(git log -1 --pretty=%s FETCH_HEAD)
+            else
+              echo "Could not fetch PR head ref, falling back to merge commit"
+              COMMIT_MSG=$(git log -1 --pretty=%s HEAD)
+            fi
           else
             COMMIT_MSG=$(git log -1 --pretty=%s HEAD)
           fi
@@ -229,8 +237,16 @@ jobs:
         id: check_skip
         run: |
           if [ -n "$GITHUB_HEAD_REF" ]; then
-            git fetch origin "$GITHUB_HEAD_REF" --depth=1
-            COMMIT_MSG=$(git log -1 --pretty=%s FETCH_HEAD)
+            # Extract PR number from GITHUB_REF (refs/pull/<number>/merge)
+            # and fetch the PR head ref which is always available on origin,
+            # regardless of whether the PR comes from a fork or the same repo.
+            PR_NUMBER=$(echo "$GITHUB_REF" | awk -F/ '{print $3}')
+            if [ -n "$PR_NUMBER" ] && git fetch origin "refs/pull/${PR_NUMBER}/head" --depth=1 2>/dev/null; then
+              COMMIT_MSG=$(git log -1 --pretty=%s FETCH_HEAD)
+            else
+              echo "Could not fetch PR head ref, falling back to merge commit"
+              COMMIT_MSG=$(git log -1 --pretty=%s HEAD)
+            fi
           else
             COMMIT_MSG=$(git log -1 --pretty=%s HEAD)
           fi


### PR DESCRIPTION
## Problem

The `Check skip keyword in LATEST commit` step in `reusable-ci-tests.yml` runs:

```bash
git fetch origin $GITHUB_HEAD_REF --depth=1
```

For PRs from **forks**, `GITHUB_HEAD_REF` contains the branch name in the fork repo (e.g. `fix/guard-init-weights-from-pretrained`), which does not exist on `origin` (the base repo). This causes a `fatal: couldn't find remote ref` error and the entire CI job fails with exit code 128.

Example failure: https://github.com/fla-org/flash-linear-attention/actions/runs/24255856335/job/70827125096?pr=820

## Fix

Wrap the `git fetch` in a conditional: if it fails (fork PR case), gracefully fall back to reading the commit message from `HEAD` (the merge commit already checked out by `actions/checkout`).

This fix is applied to both occurrences of the pattern (`test-ops` and `test-models` jobs).

## Notes

- For same-repo PRs, the behavior is unchanged (`git fetch origin` succeeds as before).
- For fork PRs, the `[skip test]` feature now degrades gracefully: it checks the merge commit message instead of the PR head commit. Since `[skip test]` is typically in the PR commit message (not the auto-generated merge message), it won't trigger a false skip. A contributor who wants to skip tests can include `[skip test]` in the PR title or description and adjust the grep pattern if needed in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow robustness for pull request builds by adding safer detection and fetch fallback logic so commit messages are determined reliably whether PR refs can be fetched or not.
  * Ensures tests continue to run for forked and non-forked PRs by gracefully falling back to local commit data when remote fetches fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->