### PR TITLE
[Attn] Add sliding window attention support

### DIFF
--- a/fla/ops/attn/naive.py
+++ b/fla/ops/attn/naive.py
@@ -14,6 +14,7 @@ def naive_parallel_attn(
     k: torch.Tensor,
     v: torch.Tensor,
     scale: float | None = None,
+    window_size: int | None = None,
     causal: bool = True,
 ):
     """
@@ -24,6 +25,8 @@ def naive_parallel_attn(
         k: [B, T, H, D]
         v: [B, T, H, D]
         scale: float, optional. If None, defaults to 1 / sqrt(D)
+        window_size: int, optional. If provided, each query at position i only attends to
+            keys in [i - window_size + 1, i]. If None, full causal attention is used.
         causal: bool, default True
 
     Returns:
@@ -54,8 +57,14 @@ def naive_parallel_attn(
 
     # Apply causal mask
     if causal:
-        causal_mask = torch.triu(torch.ones(T, T, dtype=torch.bool, device=q.device), diagonal=1)
-        scores = scores.masked_fill(causal_mask.unsqueeze(0), float('-inf'))
+        row_idx = torch.arange(T, device=q.device).unsqueeze(1)
+        col_idx = torch.arange(T, device=q.device).unsqueeze(0)
+        # Causal: mask out future positions
+        mask = col_idx > row_idx
+        # Sliding window: additionally mask out positions outside the window
+        if window_size is not None:
+            mask = mask | (row_idx - col_idx >= window_size)
+        scores = scores.masked_fill(mask.unsqueeze(0), float('-inf'))
 
     # Compute max_logits (max over key dimension): [B*H*G, T]
     max_logits_flat = scores.max(dim=-1).values

--- a/fla/ops/attn/naive.py
+++ b/fla/ops/attn/naive.py
@@ -40,39 +40,27 @@ def naive_parallel_attn(
     if scale is None:
         scale = D ** -0.5
 
-    # Reshape q to separate heads and groups
-    q = q.reshape(B, T, H, G, D)  # [B, T, H, G, D]
+    # reshape q to separate groups: [B, T, HQ, D] -> [B, T, H, G, D]
+    q = q.reshape(B, T, H, G, D)
 
-    # Repeat k and v to match groups: [B, T, H, D] -> [B, T, H, G, D]
-    k = k.unsqueeze(3).expand(B, T, H, G, D)  # Expand along group dimension
-    v = v.unsqueeze(3).expand(B, T, H, G, D)
+    # compute attention scores via einsum: [B, H, G, T, T]
+    # k is [B, T, H, D] — no group dim, so each group shares the same k
+    scores = torch.einsum('bqhgd,bkhd->bhgqk', q, k) * scale
 
-    # Reshape to treat each (B, H, G,) as a separate head
-    q_flat = q.reshape(B * H * G, T, D)  # [B*H*G, T, D]
-    k_flat = k.reshape(B * H * G, T, D)  # [B*H*G, T, D]
-    v_flat = v.reshape(B * H * G, T, D)  # [B*H*G, T, D]
-
-    # Compute attention scores: [B*H*G, T, T]
-    scores = torch.bmm(q_flat, k_flat.transpose(1, 2)) * scale
-
-    # Apply causal mask
+    # apply causal mask
     if causal:
         row_idx = torch.arange(T, device=q.device).unsqueeze(1)
         col_idx = torch.arange(T, device=q.device).unsqueeze(0)
-        # Causal: mask out future positions
         mask = col_idx > row_idx
-        # Sliding window: additionally mask out positions outside the window
         if window_size is not None:
             mask = mask | (row_idx - col_idx >= window_size)
-        scores = scores.masked_fill(mask.unsqueeze(0), float('-inf'))
+        scores = scores.masked_fill(mask, float('-inf'))
 
-    # Compute max_logits (max over key dimension): [B*H*G, T]
-    max_logits_flat = scores.max(dim=-1).values
-    max_logits = max_logits_flat.reshape(B, T, HQ)  # [B, T, HQ]
+    # max_logits: [B, H, G, T] -> [B, T, HQ]
+    max_logits = scores.max(dim=-1).values.permute(0, 3, 1, 2).reshape(B, T, HQ)
 
-    # Compute attention weights and output
-    attn_weights = F.softmax(scores, dim=-1)  # [B*H*G, T, T]
-    output_flat = torch.bmm(attn_weights, v_flat)  # [B*H*G, T, D]
-    output = output_flat.reshape(B, T, HQ, D)  # [B, T, HQ, D]
+    # compute output via einsum: [B, H, G, T, T] x [B, T, H, D] -> [B, T, H, G, D]
+    attn_weights = F.softmax(scores, dim=-1)
+    output = torch.einsum('bhgqk,bkhd->bqhgd', attn_weights, v).reshape(B, T, HQ, D)
 
     return output, max_logits

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -5,8 +5,6 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-import warnings
-
 import torch
 import triton
 import triton.language as tl
@@ -20,6 +18,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem
 
 @triton.heuristics({
     'USE_G': lambda args: args['g_cumsum'] is not None,
+    'USE_WINDOW': lambda args: args['W'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.jit
@@ -34,6 +33,7 @@ def parallel_attn_fwd_kernel(
     cu_seqlens,
     chunk_indices,
     T,
+    W: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
     HQ: tl.constexpr,
@@ -45,6 +45,7 @@ def parallel_attn_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_WINDOW: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -79,7 +80,14 @@ def parallel_attn_fwd_kernel(
     else:
         b_gq = None
 
-    for i_s in range(0, i_t * BT, BS):
+    # [BT]
+    o_q = i_t * BT + tl.arange(0, BT)
+
+    # for sliding window, skip key blocks that are entirely outside the window.
+    # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
+    i_start = max(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
+
+    for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
         p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
         # [BK, BS]
@@ -89,11 +97,14 @@ def parallel_attn_fwd_kernel(
         # [BT, BS]
         b_s = tl.dot(b_q, b_k) * scale * RCP_LN2
 
+        o_k = i_s + tl.arange(0, BS)
+        m_k = o_k < T
         if USE_G:
-            o_k = i_s + tl.arange(0, BS)
-            m_k = o_k < T
             b_gk = tl.load(g_cumsum + (bos + o_k) * HQ + i_hq, mask=m_k, other=0).to(tl.float32)
             b_s += b_gq[:, None] - b_gk[None, :]
+
+        if USE_WINDOW:
+            b_s = tl.where((o_q[:, None] - o_k[None, :] < W) & m_k[None, :], b_s, float('-inf'))
 
         # [BT, BS]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
@@ -107,8 +118,6 @@ def parallel_attn_fwd_kernel(
 
         b_mp = b_m
 
-    # [BT]
-    o_q = i_t * BT + tl.arange(0, BT)
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
         p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
@@ -127,7 +136,10 @@ def parallel_attn_fwd_kernel(
             b_gk = tl.load(g_cumsum + (bos + o_k) * HQ + i_hq, mask=m_k, other=0).to(tl.float32)
             b_s += b_gq[:, None] - b_gk[None, :]
 
-        b_s = tl.where((o_q[:, None] >= o_k[None, :]) & m_k[None, :], b_s, float('-inf'))
+        m_s = (o_q[:, None] >= o_k[None, :]) & m_k[None, :]
+        if USE_WINDOW:
+            m_s = m_s & (o_q[:, None] - o_k[None, :] < W)
+        b_s = tl.where(m_s, b_s, float('-inf'))
 
         # [BT]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
@@ -167,6 +179,7 @@ def parallel_attn_bwd_kernel_preprocess(
 
 @triton.heuristics({
     'USE_G': lambda args: args['g_cumsum'] is not None,
+    'USE_WINDOW': lambda args: args['W'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.jit(do_not_specialize=['T'])
@@ -184,6 +197,7 @@ def parallel_attn_bwd_kernel_dq(
     cu_seqlens,
     chunk_indices,
     T,
+    W: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
     HQ: tl.constexpr,
@@ -196,6 +210,7 @@ def parallel_attn_bwd_kernel_dq(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_WINDOW: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
@@ -236,7 +251,10 @@ def parallel_attn_bwd_kernel_dq(
         b_dg = None
 
     o_q = i_t * BT + tl.arange(0, BT)
-    for i_s in range(0, i_t * BT, BS):
+
+    i_start = max(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
+
+    for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
         p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
 
@@ -252,7 +270,8 @@ def parallel_attn_bwd_kernel_dq(
             b_gk = tl.load(g_cumsum + (bos + o_k) * HQ + i_hq, mask=m_k, other=0).to(tl.float32)
             b_s += b_gq[:, None] - b_gk[None, :]
 
-        b_s = tl.where((o_q[:, None] >= o_k[None, :]) & m_k[None, :], b_s, float('-inf'))
+        if USE_WINDOW:
+            b_s = tl.where((o_q[:, None] - o_k[None, :] < W) & m_k[None, :], b_s, float('-inf'))
         b_p = exp2(b_s - b_lse[:, None])
         # [BT, BV] @ [BV, BS] -> [BT, BS]
         b_dp = tl.dot(b_do, b_v)
@@ -262,8 +281,6 @@ def parallel_attn_bwd_kernel_dq(
         if USE_G:
             b_dg += tl.sum(b_ds, 1)
 
-    # [BT]
-    o_q = i_t * BT + tl.arange(0, BT)
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
         p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
@@ -282,7 +299,13 @@ def parallel_attn_bwd_kernel_dq(
             p_gk = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
             b_gk = tl.load(p_gk, boundary_check=(0,)).to(tl.float32)
             b_s += b_gq[:, None] - b_gk[None, :]
-        b_p = tl.where((o_q[:, None] >= o_k[None, :]) & m_k[None, :], exp2(b_s - b_lse[:, None]), 0)
+        if USE_WINDOW:
+            b_p = tl.where(
+                (o_q[:, None] >= o_k[None, :]) & (o_q[:, None] - o_k[None, :] < W) & m_k[None, :],
+                exp2(b_s - b_lse[:, None]), 0
+            )
+        else:
+            b_p = tl.where((o_q[:, None] >= o_k[None, :]) & m_k[None, :], exp2(b_s - b_lse[:, None]), 0)
 
         # [BT, BV] @ [BV, BS] -> [BT, BS]
         b_dp = tl.dot(b_do, b_v)
@@ -301,6 +324,7 @@ def parallel_attn_bwd_kernel_dq(
 
 @triton.heuristics({
     'USE_G': lambda args: args['g_cumsum'] is not None,
+    'USE_WINDOW': lambda args: args['W'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.jit(do_not_specialize=['T'])
@@ -319,6 +343,7 @@ def parallel_attn_bwd_kernel_dkv(
     chunk_indices,
     scale,
     T,
+    W: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
     HQ: tl.constexpr,
@@ -330,6 +355,7 @@ def parallel_attn_bwd_kernel_dkv(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_WINDOW: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -389,7 +415,13 @@ def parallel_attn_bwd_kernel_dkv(
             p_gq = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
             b_gq = tl.load(p_gq, boundary_check=(0,)).to(tl.float32)
             b_s += b_gq[None, :] - b_gk[:, None]
-        b_p = tl.where((o_k[:, None] <= o_q[None, :]) & m_q[None, :], exp2(b_s - b_lse[None, :]), 0)
+        if USE_WINDOW:
+            b_p = tl.where(
+                (o_k[:, None] <= o_q[None, :]) & (o_q[None, :] - o_k[:, None] < W) & m_q[None, :],
+                exp2(b_s - b_lse[None, :]), 0
+            )
+        else:
+            b_p = tl.where((o_k[:, None] <= o_q[None, :]) & m_q[None, :], exp2(b_s - b_lse[None, :]), 0)
         # [BT, BS] @ [BS, BV] -> [BT, BV]
         b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
         # [BT, BV] @ [BV, BS] -> [BT, BS]
@@ -401,7 +433,12 @@ def parallel_attn_bwd_kernel_dkv(
         if USE_G:
             b_dg -= tl.sum(b_ds, 1)
 
-    for i_s in range((i_t + 1) * BT, tl.cdiv(T, BS) * BS, BS):
+    # for sliding window, limit the range of future query blocks to process.
+    # a key at position k_pos can only be attended to by queries at positions [k_pos, k_pos + W - 1].
+    # so we only need queries up to (i_t + 1) * BT - 1 + W - 1.
+    i_end = min(tl.cdiv(T, BS) * BS, (i_t + 1) * BT + W - 1) if USE_WINDOW else tl.cdiv(T, BS) * BS
+
+    for i_s in range((i_t + 1) * BT, i_end, BS):
         p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (BS, BK), (1, 0))
         p_do = tl.make_block_ptr(do + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
         p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
@@ -423,7 +460,10 @@ def parallel_attn_bwd_kernel_dkv(
             p_gq = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
             b_gq = tl.load(p_gq, boundary_check=(0,)).to(tl.float32)
             b_s += b_gq[None, :] - b_gk[:, None]
-        b_p = tl.where(m_q[None, :], exp2(b_s - b_lse[None, :]), 0)
+        if USE_WINDOW:
+            b_p = tl.where((o_q[None, :] - o_k[:, None] < W) & m_q[None, :], exp2(b_s - b_lse[None, :]), 0)
+        else:
+            b_p = tl.where(m_q[None, :], exp2(b_s - b_lse[None, :]), 0)
         # [BT, BS] @ [BS, BV] -> [BT, BV]
         b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
         # [BT, BV] @ [BV, BS] -> [BT, BS]
@@ -449,6 +489,7 @@ def parallel_attn_fwd(
     v: torch.Tensor,
     g_cumsum: torch.Tensor,
     scale: float,
+    window_size: int | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
 ):
@@ -494,6 +535,7 @@ def parallel_attn_fwd(
         chunk_indices=chunk_indices,
         B=B,
         T=T,
+        W=window_size,
         H=H,
         HQ=HQ,
         G=G,
@@ -533,6 +575,7 @@ def parallel_attn_bwd(
     lse: torch.Tensor,
     do: torch.Tensor,
     scale: float = None,
+    window_size: int | None = None,
     chunk_size: int = 128,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
@@ -590,6 +633,7 @@ def parallel_attn_bwd(
         chunk_indices=chunk_indices,
         scale=scale,
         T=T,
+        W=window_size,
         B=B,
         H=H,
         HQ=HQ,
@@ -617,6 +661,7 @@ def parallel_attn_bwd(
         chunk_indices=chunk_indices,
         scale=scale,
         T=T,
+        W=window_size,
         B=B,
         H=H,
         HQ=HQ,
@@ -642,7 +687,7 @@ class ParallelAttentionFunction(torch.autograd.Function):
     @staticmethod
     @contiguous
     @autocast_custom_fwd
-    def forward(ctx, q, k, v, g, scale, cu_seqlens, chunk_indices=None):
+    def forward(ctx, q, k, v, g, scale, window_size, cu_seqlens, chunk_indices=None):
         ctx.dtype = q.dtype
 
         RCP_LN2: float = 1.4426950216
@@ -653,12 +698,14 @@ class ParallelAttentionFunction(torch.autograd.Function):
             v=v,
             g_cumsum=g_cumsum,
             scale=scale,
+            window_size=window_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
         )
         ctx.save_for_backward(q, k, v, o, g_cumsum, lse)
-        ctx.cu_seqlens = cu_seqlens
         ctx.scale = scale
+        ctx.window_size = window_size
+        ctx.cu_seqlens = cu_seqlens
         return o.to(q.dtype)
 
     @staticmethod
@@ -675,12 +722,13 @@ class ParallelAttentionFunction(torch.autograd.Function):
             lse=lse,
             do=do,
             scale=ctx.scale,
+            window_size=ctx.window_size,
             cu_seqlens=ctx.cu_seqlens,
         )
         if dg is not None:
             dg = chunk_global_cumsum(dg, cu_seqlens=ctx.cu_seqlens, reverse=True)
 
-        return dq.to(q), dk.to(k), dv.to(v), dg, None, None, None
+        return dq.to(q), dk.to(k), dv.to(v), dg, None, None, None, None
 
 
 def parallel_attn(
@@ -689,9 +737,10 @@ def parallel_attn(
     v: torch.Tensor,
     g: torch.Tensor | None = None,
     scale: float | None = None,
+    window_size: int | None = None,
     cu_seqlens: torch.LongTensor | None = None,
-    head_first: bool = False,
     chunk_indices: torch.LongTensor | None = None,
+    **kwargs
 ) -> torch.Tensor:
     r"""
     Args:
@@ -707,33 +756,27 @@ def parallel_attn(
         scale (Optional[float]):
             Scale factor for attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        window_size (Optional[int]):
+            Sliding window size. If provided, each query at position i only attends to
+            keys in `[i - window_size + 1, i]`. If `None`, full causal attention is used.
+            Default: `None`.
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
-        head_first (Optional[bool]):
-            Whether the inputs are in the head-first format. Default: `False`.
-            This argument has been deprecated.
 
     Returns:
         o (torch.Tensor):
             Outputs of shape `[B, T, HQ, V]`.
     """
-    if head_first:
+    if kwargs.get('head_first', False):
         raise DeprecationWarning(
             "head_first is deprecated and will be removed in a future version. "
             "Please use head_first=False for now instead.",
-        )
-    if not head_first and q.shape[1] < q.shape[2]:
-        warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
-            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
-            "when head_first=False was specified. "
-            "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
         )
     if scale is None:
         scale = k.shape[-1] ** -0.5
     if cu_seqlens is not None:
         assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
 
-    o = ParallelAttentionFunction.apply(q, k, v, g, scale, cu_seqlens, chunk_indices)
+    o = ParallelAttentionFunction.apply(q, k, v, g, scale, window_size, cu_seqlens, chunk_indices)
     return o

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -216,9 +216,9 @@ def parallel_attn_bwd_kernel_dq(
     BS: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
     USE_WINDOW: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -85,13 +85,15 @@ def parallel_attn_fwd_kernel(
 
     # for sliding window, skip key blocks that are entirely outside the window.
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
-    i_start = tl.maximum(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
+    i_start = 0
+    if USE_WINDOW:
+        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0)
 
     # per-query window start: the earliest key position within its sliding window.
     # used to detect when a query has not yet encountered any valid key,
     # avoiding -inf - (-inf) = NaN in the online softmax rescaling.
     if USE_WINDOW:
-        o_w = tl.maximum(o_q - W + 1, 0)
+        o_w = tl.where(o_q - W + 1 > 0, o_q - W + 1, 0)
 
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
@@ -260,7 +262,9 @@ def parallel_attn_bwd_kernel_dq(
 
     o_q = i_t * BT + tl.arange(0, BT)
 
-    i_start = tl.maximum(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
+    i_start = 0
+    if USE_WINDOW:
+        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0)
 
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -85,9 +85,10 @@ def parallel_attn_fwd_kernel(
 
     # for sliding window, skip key blocks that are entirely outside the window.
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
-    i_start: tl.int32 = 0
+    i_start = 0
     if USE_WINDOW:
-        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, i_start)
+        i_start = (i_t * BT - W + 1) // BS * BS
+        i_start = i_start * (i_start > 0)
 
     # per-query window start: the earliest key position within its sliding window.
     # used to detect when a query has not yet encountered any valid key,
@@ -262,9 +263,10 @@ def parallel_attn_bwd_kernel_dq(
 
     o_q = i_t * BT + tl.arange(0, BT)
 
-    i_start: tl.int32 = 0
+    i_start = 0
     if USE_WINDOW:
-        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, i_start)
+        i_start = (i_t * BT - W + 1) // BS * BS
+        i_start = i_start * (i_start > 0)
 
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -85,10 +85,7 @@ def parallel_attn_fwd_kernel(
 
     # for sliding window, skip key blocks that are entirely outside the window.
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
-    i_start = 0
-    if USE_WINDOW:
-        i_start = (i_t * BT - W + 1) // BS * BS
-        i_start = i_start * (i_start > 0)
+    i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0) if USE_WINDOW else 0
 
     # per-query window start: the earliest key position within its sliding window.
     # used to detect when a query has not yet encountered any valid key,
@@ -263,10 +260,7 @@ def parallel_attn_bwd_kernel_dq(
 
     o_q = i_t * BT + tl.arange(0, BT)
 
-    i_start = 0
-    if USE_WINDOW:
-        i_start = (i_t * BT - W + 1) // BS * BS
-        i_start = i_start * (i_start > 0)
+    i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0) if USE_WINDOW else 0
 
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -87,6 +87,12 @@ def parallel_attn_fwd_kernel(
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
     i_start = max(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
 
+    # per-query window start: the earliest key position within its sliding window.
+    # used to detect when a query has not yet encountered any valid key,
+    # avoiding -inf - (-inf) = NaN in the online softmax rescaling.
+    if USE_WINDOW:
+        o_w = tl.maximum(o_q - W + 1, 0)
+
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
         p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
@@ -108,9 +114,11 @@ def parallel_attn_fwd_kernel(
 
         # [BT, BS]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
-        b_r = exp2(b_mp - b_m)
-        # [BT, BS]
-        b_p = exp2(b_s - b_m[:, None])
+        # when the key block is entirely before a query's window, b_m is still -inf.
+        # replace with 0 so that exp2(-inf - 0) = 0 instead of exp2(-inf - (-inf)) = NaN
+        b_mw = tl.where((i_s + BS - 1) < o_w, 0., b_m) if USE_WINDOW else b_m
+        b_r = exp2(b_mp - b_mw)
+        b_p = exp2(b_s - b_mw[:, None])
         # [BT]
         b_acc = b_acc * b_r + tl.sum(b_p, 1)
         # [BT, BV]
@@ -143,9 +151,9 @@ def parallel_attn_fwd_kernel(
 
         # [BT]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
-        b_r = exp2(b_mp - b_m)
-        # [BT, BS]
-        b_p = exp2(b_s - b_m[:, None])
+        b_mw = tl.where((i_s + BS - 1) < o_w, 0., b_m) if USE_WINDOW else b_m
+        b_r = exp2(b_mp - b_mw)
+        b_p = exp2(b_s - b_mw[:, None])
         # [BT]
         b_acc = b_acc * b_r + tl.sum(b_p, 1)
         # [BT, BV]

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -85,9 +85,9 @@ def parallel_attn_fwd_kernel(
 
     # for sliding window, skip key blocks that are entirely outside the window.
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
-    i_start = 0
+    i_start: tl.int32 = 0
     if USE_WINDOW:
-        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0)
+        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, i_start)
 
     # per-query window start: the earliest key position within its sliding window.
     # used to detect when a query has not yet encountered any valid key,
@@ -262,9 +262,9 @@ def parallel_attn_bwd_kernel_dq(
 
     o_q = i_t * BT + tl.arange(0, BT)
 
-    i_start = 0
+    i_start: tl.int32 = 0
     if USE_WINDOW:
-        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0)
+        i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, i_start)
 
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -85,7 +85,7 @@ def parallel_attn_fwd_kernel(
 
     # for sliding window, skip key blocks that are entirely outside the window.
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
-    i_start = max(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
+    i_start = tl.maximum(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
 
     # per-query window start: the earliest key position within its sliding window.
     # used to detect when a query has not yet encountered any valid key,
@@ -260,7 +260,7 @@ def parallel_attn_bwd_kernel_dq(
 
     o_q = i_t * BT + tl.arange(0, BT)
 
-    i_start = max(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
+    i_start = tl.maximum(0, (i_t * BT - W + 1) // BS * BS) if USE_WINDOW else 0
 
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))

--- a/fla/ops/forgetting_attn/naive.py
+++ b/fla/ops/forgetting_attn/naive.py
@@ -16,6 +16,7 @@ def naive_forgetting_attn(
     v: torch.Tensor,
     g: torch.Tensor,
     scale: float | None = None,
+    window_size: int | None = None,
 ):
     """
     Reference PyTorch implementation of forgetting attention.
@@ -26,6 +27,8 @@ def naive_forgetting_attn(
         v: [B, T, H, D]
         g: [B, T, HQ]
         scale: float, optional. If None, defaults to 1 / sqrt(D)
+        window_size: int, optional. If provided, each query only attends to keys
+            in [i - window_size + 1, i]. If None, full causal attention is used.
 
     Returns:
         output: [B, T, HQ, D]
@@ -39,6 +42,8 @@ def naive_forgetting_attn(
 
     gc = g.float().cumsum(1)
     mask = torch.tril(torch.ones((T, T), dtype=torch.bool, device=q.device))
+    if window_size is not None:
+        mask = mask & torch.triu(torch.ones((T, T), dtype=torch.bool, device=q.device), diagonal=-(window_size - 1))
 
     ref = torch.einsum("bqhd,bkhd->bhqk", q.float() * scale, repeat(k, "b t h d -> b t (h g) d", g=G).float())
     ref = ref + rearrange(gc, "b t h -> b h t 1") - rearrange(gc, "b t h -> b h 1 t")

--- a/fla/ops/forgetting_attn/parallel.py
+++ b/fla/ops/forgetting_attn/parallel.py
@@ -16,6 +16,7 @@ def parallel_forgetting_attn(
     v: torch.Tensor,
     g: torch.Tensor,
     scale: float | None = None,
+    window_size: int | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     **kwargs
 ) -> torch.Tensor:
@@ -33,6 +34,10 @@ def parallel_forgetting_attn(
         scale (Optional[float]):
             Scale factor for attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        window_size (Optional[int]):
+            Sliding window size. If provided, each query at position i only attends to
+            keys in `[i - window_size + 1, i]`. If `None`, full causal attention is used.
+            Default: `None`.
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
@@ -51,5 +56,5 @@ def parallel_forgetting_attn(
     if cu_seqlens is not None:
         assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
 
-    o = parallel_attn(q, k, v, g, scale, cu_seqlens=cu_seqlens)
+    o = parallel_attn(q, k, v, g, scale, window_size=window_size, cu_seqlens=cu_seqlens)
     return o

--- a/fla/ops/forgetting_attn/parallel.py
+++ b/fla/ops/forgetting_attn/parallel.py
@@ -5,8 +5,6 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-import warnings
-
 import torch
 
 from fla.ops.attn.parallel import parallel_attn
@@ -19,7 +17,7 @@ def parallel_forgetting_attn(
     g: torch.Tensor,
     scale: float | None = None,
     cu_seqlens: torch.LongTensor | None = None,
-    head_first: bool = False,
+    **kwargs
 ) -> torch.Tensor:
     r"""
     Args:
@@ -31,37 +29,27 @@ def parallel_forgetting_attn(
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         g (torch.Tensor):
-            Log decay at rach time step (in **log space**) of shape `[B, T, HQ]` if `head_first=False` else `[B, HQ, T]`.
+            log decay factors of shape `[B, T, HQ]`.
         scale (Optional[float]):
             Scale factor for attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
-        head_first (Optional[bool]):
-            Whether the inputs are in the head-first format. Default: `False`.
-            This argument has been deprecated.
 
     Returns:
         o (torch.Tensor):
             Outputs of shape `[B, T, HQ, V]`.
     """
-
-    if scale is None:
-        scale = k.shape[-1] ** -0.5
-    if cu_seqlens is not None:
-        assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
-    if head_first:
+    if kwargs.get('head_first', False):
         raise DeprecationWarning(
             "head_first is deprecated and will be removed in a future version. "
             "Please use head_first=False for now instead.",
         )
-    if not head_first and q.shape[1] < q.shape[2]:
-        warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
-            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
-            "when head_first=False was specified. "
-            "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
-        )
-    o = parallel_attn(q, k, v, g, scale, cu_seqlens)
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    if cu_seqlens is not None:
+        assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
+
+    o = parallel_attn(q, k, v, g, scale, cu_seqlens=cu_seqlens)
     return o

--- a/tests/ops/test_attn.py
+++ b/tests/ops/test_attn.py
@@ -12,14 +12,7 @@ import torch
 
 from fla.ops.attn.naive import naive_parallel_attn
 from fla.ops.attn.parallel import parallel_attn
-from fla.ops.utils import prepare_lens
 from fla.utils import assert_close, check_shared_mem, device
-
-try:
-    from flash_attn import flash_attn_func, flash_attn_varlen_func
-    HAS_FLASH = True
-except Exception:
-    HAS_FLASH = False
 
 
 @pytest.mark.parametrize(
@@ -45,8 +38,6 @@ def test_parallel(
 ):
     if not check_shared_mem('hopper') and D > 128:
         pytest.skip(reason="Skip test, do not have enough shard mem")
-    if not HAS_FLASH:
-        pytest.skip(reason="Skipping test because flash-attn is not installed")
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
     q = torch.randn((B, T, HQ, D), dtype=torch.float16, device=device).requires_grad_(True)
@@ -54,7 +45,8 @@ def test_parallel(
     v = torch.randn((B, T, H, D), dtype=torch.float16, device=device).requires_grad_(True)
     do = torch.randn((B, T, HQ, D), dtype=torch.float16, device=device)
 
-    ref = flash_attn_func(q=q, k=k, v=v, softmax_scale=scale, causal=True)
+    ref, _ = naive_parallel_attn(q=q.float(), k=k.float(), v=v.float(), scale=scale)
+    ref = ref.to(q.dtype)
     ref.backward(do)
     ref_dq, q.grad = q.grad.clone(), None
     ref_dk, k.grad = k.grad.clone(), None
@@ -89,10 +81,9 @@ def test_parallel_varlen(
     D: int,
     cu_seqlens: list[int],
 ):
-    if not HAS_FLASH:
-        pytest.skip(reason="Skipping test because flash-attn is not installed")
+    torch.manual_seed(42)
     T = cu_seqlens[-1]
-    cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+    cu_seqlens_th = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
     dtype = torch.float16
 
     q = torch.randn((1, T, HQ, D), dtype=dtype, device=device).requires_grad_()
@@ -100,17 +91,15 @@ def test_parallel_varlen(
     v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_()
     do = torch.randn((1, T, HQ, D), dtype=dtype, device=device)
 
-    ref = flash_attn_varlen_func(
-        q=q.squeeze(0),
-        k=k.squeeze(0),
-        v=v.squeeze(0),
-        cu_seqlens_q=cu_seqlens,
-        cu_seqlens_k=cu_seqlens,
-        max_seqlen_q=prepare_lens(cu_seqlens).max(),
-        max_seqlen_k=prepare_lens(cu_seqlens).max(),
-        causal=True,
-    )
-    ref.backward(do.squeeze(0))
+    ref = q.new_empty(1, T, HQ, D)
+    for bos, eos in zip(cu_seqlens[:-1], cu_seqlens[1:], strict=False):
+        ref[:, bos:eos], _ = naive_parallel_attn(
+            q=q[:, bos:eos].float(),
+            k=k[:, bos:eos].float(),
+            v=v[:, bos:eos].float(),
+        )
+    ref = ref.to(dtype)
+    ref.backward(do)
     ref_dq, q.grad = q.grad.clone(), None
     ref_dk, k.grad = k.grad.clone(), None
     ref_dv, v.grad = v.grad.clone(), None
@@ -119,14 +108,14 @@ def test_parallel_varlen(
         q=q,
         k=k,
         v=v,
-        cu_seqlens=cu_seqlens,
+        cu_seqlens=cu_seqlens_th,
     )
     tri.backward(do)
     tri_dq, q.grad = q.grad.clone(), None
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close(" o", ref, tri, 0.004)
+    assert_close(" o", ref, tri, 0.005)
     assert_close("dq", ref_dq.squeeze(), tri_dq.squeeze(), 0.005)
     assert_close("dk", ref_dk.squeeze(), tri_dk.squeeze(), 0.005)
     assert_close("dv", ref_dv.squeeze(), tri_dv.squeeze(), 0.005)
@@ -160,10 +149,7 @@ def test_parallel_swa(
     v = torch.randn((B, T, H, D), dtype=torch.float16, device=device).requires_grad_(True)
     do = torch.randn((B, T, HQ, D), dtype=torch.float16, device=device)
 
-    ref, _ = naive_parallel_attn(
-        q=q.float(), k=k.float(), v=v.float(),
-        window_size=W,
-    )
+    ref, _ = naive_parallel_attn(q=q.float(), k=k.float(), v=v.float(), window_size=W)
     ref = ref.to(q.dtype)
     ref.backward(do)
     ref_dq, q.grad = q.grad.clone(), None

--- a/tests/ops/test_attn.py
+++ b/tests/ops/test_attn.py
@@ -139,10 +139,7 @@ def test_parallel_varlen(
         for test in [
             (1, 63, 1, 1, 64, 16),
             (3, 111, 2, 2, 100, 32),
-            (3, 1024, 2, 8, 60, 64),
-            (3, 1024, 2, 8, 128, 128),
-            (4, 2048, 2, 8, 64, 256),
-            (2, 512, 2, 4, 64, 512),
+            (3, 1024, 2, 8, 128, 64),
         ]
     ],
 )
@@ -174,6 +171,65 @@ def test_parallel_swa(
     ref_dv, v.grad = v.grad.clone(), None
 
     tri = parallel_attn(q=q, k=k, v=v, window_size=W)
+    tri.backward(do)
+    tri_dq, q.grad = q.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dv, v.grad = v.grad.clone(), None
+
+    assert_close(" o", ref, tri, 0.005)
+    assert_close("dq", ref_dq, tri_dq, 0.005)
+    assert_close("dk", ref_dk, tri_dk, 0.005)
+    assert_close("dv", ref_dv, tri_dv, 0.005)
+
+
+@pytest.mark.parametrize(
+    ('H', 'HQ', 'D', 'W', 'cu_seqlens'),
+    [
+        pytest.param(*test, id="H{}-HQ{}-D{}-W{}-cu_seqlens{}".format(*test))
+        for test in [
+            (2, 2, 64, 16, [0, 111]),
+            (2, 8, 100, 32, [0, 256, 500, 1000]),
+        ]
+    ],
+)
+def test_parallel_swa_varlen(
+    H: int,
+    HQ: int,
+    D: int,
+    W: int,
+    cu_seqlens: list[int],
+):
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    T = cu_seqlens[-1]
+    cu_seqlens_th = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+    dtype = torch.float16
+
+    q = torch.randn((1, T, HQ, D), dtype=dtype, device=device).requires_grad_(True)
+    k = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    v = torch.randn((1, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    do = torch.randn((1, T, HQ, D), dtype=dtype, device=device)
+
+    # per-sequence naive reference
+    refs_o, refs_dq, refs_dk, refs_dv = [], [], [], []
+    for i in range(len(cu_seqlens) - 1):
+        s, e = cu_seqlens[i], cu_seqlens[i + 1]
+        qi = q[:, s:e].detach().float().requires_grad_(True)
+        ki = k[:, s:e].detach().float().requires_grad_(True)
+        vi = v[:, s:e].detach().float().requires_grad_(True)
+        oi, _ = naive_parallel_attn(q=qi, k=ki, v=vi, window_size=W)
+        oi = oi.to(dtype)
+        oi.backward(do[:, s:e])
+        refs_o.append(oi)
+        refs_dq.append(qi.grad.to(dtype))
+        refs_dk.append(ki.grad.to(dtype))
+        refs_dv.append(vi.grad.to(dtype))
+    ref = torch.cat(refs_o, dim=1)
+    ref_dq = torch.cat(refs_dq, dim=1)
+    ref_dk = torch.cat(refs_dk, dim=1)
+    ref_dv = torch.cat(refs_dv, dim=1)
+
+    tri = parallel_attn(q=q, k=k, v=v, window_size=W, cu_seqlens=cu_seqlens_th)
     tri.backward(do)
     tri_dq, q.grad = q.grad.clone(), None
     tri_dk, k.grad = k.grad.clone(), None

--- a/tests/ops/test_attn.py
+++ b/tests/ops/test_attn.py
@@ -10,6 +10,7 @@ import os
 import pytest
 import torch
 
+from fla.ops.attn.naive import naive_parallel_attn
 from fla.ops.attn.parallel import parallel_attn
 from fla.ops.utils import prepare_lens
 from fla.utils import assert_close, check_shared_mem, device
@@ -129,3 +130,56 @@ def test_parallel_varlen(
     assert_close("dq", ref_dq.squeeze(), tri_dq.squeeze(), 0.005)
     assert_close("dk", ref_dk.squeeze(), tri_dk.squeeze(), 0.005)
     assert_close("dv", ref_dv.squeeze(), tri_dv.squeeze(), 0.005)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HQ', 'D', 'W'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HQ{}-D{}-W{}".format(*test))
+        for test in [
+            (1, 63, 1, 1, 64, 16),
+            (3, 111, 2, 2, 100, 32),
+            (3, 1024, 2, 8, 60, 64),
+            (3, 1024, 2, 8, 128, 128),
+            (4, 2048, 2, 8, 64, 256),
+            (2, 512, 2, 4, 64, 512),
+        ]
+    ],
+)
+def test_parallel_swa(
+    B: int,
+    T: int,
+    H: int,
+    HQ: int,
+    D: int,
+    W: int,
+):
+    if not check_shared_mem('hopper') and D > 128:
+        pytest.skip(reason="Skip test, do not have enough shard mem")
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    q = torch.randn((B, T, HQ, D), dtype=torch.float16, device=device).requires_grad_(True)
+    k = torch.randn((B, T, H, D), dtype=torch.float16, device=device).requires_grad_(True)
+    v = torch.randn((B, T, H, D), dtype=torch.float16, device=device).requires_grad_(True)
+    do = torch.randn((B, T, HQ, D), dtype=torch.float16, device=device)
+
+    ref, _ = naive_parallel_attn(
+        q=q.float(), k=k.float(), v=v.float(),
+        window_size=W,
+    )
+    ref = ref.to(q.dtype)
+    ref.backward(do)
+    ref_dq, q.grad = q.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dv, v.grad = v.grad.clone(), None
+
+    tri = parallel_attn(q=q, k=k, v=v, window_size=W)
+    tri.backward(do)
+    tri_dq, q.grad = q.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dv, v.grad = v.grad.clone(), None
+
+    assert_close(" o", ref, tri, 0.005)
+    assert_close("dq", ref_dq, tri_dq, 0.005)
+    assert_close("dk", ref_dk, tri_dk, 0.005)
+    assert_close("dv", ref_dv, tri_dv, 0.005)

--- a/tests/ops/test_forgetting_attn.py
+++ b/tests/ops/test_forgetting_attn.py
@@ -132,3 +132,54 @@ def test_parallel_varlen(
     assert_close(" dk", ref_dk.squeeze(), tri_dk.squeeze(), 0.005)
     assert_close(" dv", ref_dv.squeeze(), tri_dv.squeeze(), 0.005)
     assert_close(" dg", ref_dg.squeeze(), tri_dg.squeeze(), 0.005)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HQ', 'D', 'W'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HQ{}-D{}-W{}".format(*test))
+        for test in [
+            (1, 63, 1, 1, 64, 16),
+            (3, 111, 2, 2, 100, 32),
+            (3, 1024, 2, 8, 128, 64),
+        ]
+    ],
+)
+def test_parallel_swa(
+    B: int,
+    T: int,
+    H: int,
+    HQ: int,
+    D: int,
+    W: int,
+):
+    torch.manual_seed(42)
+    if not check_shared_mem('hopper') and D > 128:
+        pytest.skip("Skipping test because global shared memory is not available")
+
+    dtype = torch.float16
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device).requires_grad_(True)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    g = torch.randn((B, T, HQ), dtype=dtype, device=device).uniform_(-0.1, -0.01).requires_grad_(True)
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+
+    ref = naive_forgetting_attn(q, k, v, g, window_size=W)
+    ref.backward(do)
+    ref_dq, q.grad = q.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dv, v.grad = v.grad.clone(), None
+    ref_dg, g.grad = g.grad.clone(), None
+
+    tri = parallel_forgetting_attn(q=q, k=k, v=v, g=g, window_size=W)
+    tri.backward(do)
+    tri_dq, q.grad = q.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dv, v.grad = v.grad.clone(), None
+    tri_dg, g.grad = g.grad.clone(), None
+
+    assert_close(" o", ref, tri, 0.005)
+    assert_close("dq", ref_dq, tri_dq, 0.005)
+    assert_close("dk", ref_dk, tri_dk, 0.005)
+    assert_close("dv", ref_dv, tri_dv, 0.005)
+    assert_close("dg", ref_dg, tri_dg, 0.005)


### PR DESCRIPTION
## Summary
- Add `window_size` parameter to `parallel_attn` and `naive_parallel_attn` for sliding window attention
- When `window_size=None` (default), behavior is identical to before (full causal attention)
- When `window_size=W`, each query at position `i` only attends to keys in `[i - W + 1, i]`
- Forward and backward Triton kernels skip blocks outside the window for efficiency
- Supports GQA, variable-length sequences (`cu_seqlens`), and gating (`g`)

## Test plan
- [ ] `test_parallel_swa`: verifies Triton kernel output and gradients against naive PyTorch reference across various `(B, T, H, HQ, D, W)` configurations
- [ ] Existing `test_parallel` and `test_parallel_varlen` should remain unaffected (`window_size=None` by default)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional sliding-window attention (configurable window size) and exposed a window-size parameter in public attention APIs.

* **Bug Fixes / Stability**
  * Improved numerical stability for cases where queries have no in-window keys to avoid invalid softmax/rescaling.

* **Tests**
  * Added deterministic tests comparing reference and optimized attention implementations (fixed-length and variable-length) for outputs and gradients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->