### PR TITLE
fix: register default global_scratch allocator on Blackwell GPUs

### DIFF
--- a/fla/utils.py
+++ b/fla/utils.py
@@ -487,7 +487,7 @@ def _default_alloc_fn(size: int, alignment: int, stream: int | None):
 if IS_TMA_SUPPORTED:
     logger.info('TMA is supported, using TMA by default.')
     triton.set_allocator(_default_alloc_fn)
-elif IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 10:
+elif IS_NVIDIA and torch.cuda.get_device_capability()[0] >= 10:
     # Blackwell (SM 10.0+): Triton compiler may emit global_scratch for
     # autotuned kernels even without TMA. Register a default allocator to
     # prevent NullAllocator crashes. See triton-lang/triton#10002.

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -479,8 +479,10 @@ if IS_NVIDIA and not IS_TF32_SUPPORTED:
     # This is a workaround for old nvidia card.
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
+
 def _default_alloc_fn(size: int, alignment: int, stream: int | None):
     return torch.empty(size, device=torch.device(device_name, device_torch_lib.current_device()), dtype=torch.int8)
+
 
 if IS_TMA_SUPPORTED:
     logger.info('TMA is supported, using TMA by default.')

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -479,13 +479,18 @@ if IS_NVIDIA and not IS_TF32_SUPPORTED:
     # This is a workaround for old nvidia card.
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'
 
+def _default_alloc_fn(size: int, alignment: int, stream: int | None):
+    return torch.empty(size, device=torch.device(device_name, device_torch_lib.current_device()), dtype=torch.int8)
+
 if IS_TMA_SUPPORTED:
     logger.info('TMA is supported, using TMA by default.')
-
-    def alloc_fn(size: int, alignment: int, stream: int | None):
-        return torch.empty(size, device=torch.device(device_name, device_torch_lib.current_device()), dtype=torch.int8)
-
-    triton.set_allocator(alloc_fn)
+    triton.set_allocator(_default_alloc_fn)
+elif IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 10:
+    # Blackwell (SM 10.0+): Triton compiler may emit global_scratch for
+    # autotuned kernels even without TMA. Register a default allocator to
+    # prevent NullAllocator crashes. See triton-lang/triton#10002.
+    logger.info('Blackwell detected: registering default global_scratch allocator.')
+    triton.set_allocator(_default_alloc_fn)
 
 
 def get_all_max_shared_mem():

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -464,7 +464,7 @@ IS_INTEL = (device_platform == 'xpu')
 IS_NVIDIA = (device_platform == 'cuda')
 IS_INTEL_ALCHEMIST = (IS_INTEL and 'Intel(R) Arc(TM) A' in torch.xpu.get_device_name(0))
 IS_NVIDIA_HOPPER = (IS_NVIDIA and ('NVIDIA H' in torch.cuda.get_device_name(0) or torch.cuda.get_device_capability()[0] >= 9))
-IS_NVIDIA_BLACKWELL = (IS_NVIDIA and torch.cuda.get_device_capability()[0] == 10)
+IS_NVIDIA_BLACKWELL = (IS_NVIDIA and torch.cuda.get_device_capability()[0] >= 10)
 USE_CUDA_GRAPH = (IS_NVIDIA and os.environ.get('FLA_USE_CUDA_GRAPH', '0') == '1')
 
 # Nvidia Ampere or newer, haven't check AMD and intel yet.
@@ -487,7 +487,7 @@ def _default_alloc_fn(size: int, alignment: int, stream: int | None):
 if IS_TMA_SUPPORTED:
     logger.info('TMA is supported, using TMA by default.')
     triton.set_allocator(_default_alloc_fn)
-elif IS_NVIDIA and torch.cuda.get_device_capability()[0] >= 10:
+elif IS_NVIDIA_BLACKWELL:
     # Blackwell (SM 10.0+): Triton compiler may emit global_scratch for
     # autotuned kernels even without TMA. Register a default allocator to
     # prevent NullAllocator crashes. See triton-lang/triton#10002.


### PR DESCRIPTION
## Problem

On Blackwell GPUs (SM 10.0+), the Triton compiler emits `global_scratch` memory for autotuned kernels even when TMA is not used (`FLA_USE_TMA=0`, the default). Without an allocator registered, this causes `NullAllocator` crashes during kernel autotuning:

```
RuntimeError: Kernel requires a runtime memory allocation, but no allocator was set.
```

The exception is caught by the autotuner's `_bench()`, but this corrupts CUDA synchronization state, leading to process deadlocks on `futex_wait_queue`. This affects all MoE+Mamba models (Qwen3-Coder-Next, Qwen3.5) running on Blackwell via vLLM.

The standard workaround (`--enforce-eager`) disables CUDA graphs and `torch.compile`, costing **12x performance** (13 tok/s vs 156 tok/s on RTX PRO 6000).

## Root cause

The existing allocator registration in `fla/utils.py` only runs when `IS_TMA_SUPPORTED` is True, which requires `FLA_USE_TMA=1`. On Blackwell with the default `FLA_USE_TMA=0`, no allocator is registered, but the Triton compiler still needs `global_scratch` for inter-CTA workspace in autotuned kernel configurations.

## Fix

Register the default `torch.empty`-based allocator on Blackwell (capability >= 10) regardless of `FLA_USE_TMA`. This is a 5-line change in `fla/utils.py`.

## Testing

Tested on RTX PRO 6000 Blackwell (SM 12.0, CUDA 13.1, Triton 3.6.0) with vLLM serving Qwen3-Coder-Next 80B:

| Configuration | tok/s |
|---|---|
| Without fix (`--enforce-eager`) | 13.3 |
| **With this fix** | **156.4** |

Reproduce script: https://gist.github.com/ssubbotin/2cfa8ac4f3904df66872a882e44eeb86

## Related

- triton-lang/triton#10002 — Triton maintainers confirmed this is expected to be handled by the user/library, not Triton itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved GPU memory allocation for more consistent behavior across device families.
  * Expanded allocator registration to cover newer NVIDIA GPU classes and added logging for global scratch allocations.
  * Centralized allocation logic and reduced conditional divergence for more predictable performance.
  * Improved reliability across varying TMA support configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->