### PR TITLE
fix issue 640

### DIFF
--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -11,15 +11,15 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp, exp2
-from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, TRITON_AT_MOST_3_6_0, autotune_cache_kwargs, check_shared_mem
+from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
 
 # On Hopper (SM90) with Triton 3.4.0–3.6.0, ttg.local_alloc for a #linear tensor (from
-# tt.trans #mma) incorrectly emits stmatrix instead of st.shared.b32. Triton 3.3.x is
-# unaffected; behavior above 3.6.0 is unknown.
-HOPPER_TRANS_PATCH = IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and TRITON_AT_MOST_3_6_0
+# tt.trans #mma) incorrectly emits stmatrix instead of st.shared.b32.
+# TODO: remove once fixed in a future Triton release.
+HOPPER_TRANS_PATCH = IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0
 HOPPER_TRANS_PATCH_CONSTEXPR = tl.constexpr(HOPPER_TRANS_PATCH)
 
 

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -16,6 +16,11 @@ from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
 
+# On Hopper (SM90) with Triton 3.4+, ttg.local_alloc for a #linear tensor (from
+# tt.trans #mma) incorrectly emits stmatrix instead of st.shared.b32
+# (Triton JIT disallows plain Python globals; constexpr-wrapped values are allowed)
+IS_NVIDIA_HOPPER_CONSTEXPR = tl.constexpr(IS_NVIDIA_HOPPER)
+
 
 @triton.heuristics({
     'USE_G': lambda args: args['g'] is not None,
@@ -168,6 +173,7 @@ def chunk_bwd_kernel_dqkwg(
     dw,
     dv,
     dg,
+    scratch,
     cu_seqlens,
     chunk_indices,
     scale,
@@ -189,6 +195,9 @@ def chunk_bwd_kernel_dqkwg(
 ):
     i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // HV, i_bh % HV
+
+    if IS_NVIDIA_HOPPER_CONSTEXPR:
+        i_prog_t = i_t
 
     all = B * T
     if IS_VARLEN:
@@ -273,6 +282,11 @@ def chunk_bwd_kernel_dqkwg(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+
+    if IS_NVIDIA_HOPPER_CONSTEXPR:
+        scratch_off = (i_k.to(tl.int64) * tl.num_programs(1) * (B * HV) +
+                       i_prog_t.to(tl.int64) * (B * HV) + i_bh.to(tl.int64)) * (BT * BT)
+
     if USE_G:
         b_dg = tl.zeros([BT], dtype=tl.float32)
         g += bos * HV + i_h
@@ -306,7 +320,13 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
-        b_dk += tl.dot(tl.trans(b_ds), b_q)
+        if IS_NVIDIA_HOPPER_CONSTEXPR:
+            p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
+            tl.store(p_scr, b_ds)
+            b_ds_r = tl.load(p_scr)
+            b_dk += tl.dot(tl.trans(b_ds_r), b_q)
+        else:
+            b_dk += tl.dot(tl.trans(b_ds), b_q)
         p_dg = tl.make_block_ptr(dg, (T,), (HV,), (i_t * BT,), (BT,), (0,))
         # (SY 09/21) revcumsum in a separate kernel due to strange triton compiler issue
         # b_dg = tl.dot(tl.where(o_t[:, None] <= o_t[None, :], 1., 0.), b_dg, allow_tf32=False) + b_dg_last)
@@ -327,7 +347,13 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
-        b_dk += tl.dot(tl.trans(b_ds), b_q)
+        if IS_NVIDIA_HOPPER_CONSTEXPR:
+            p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
+            tl.store(p_scr, b_ds)
+            b_ds_r = tl.load(p_scr)
+            b_dk += tl.dot(tl.trans(b_ds_r), b_q)
+        else:
+            b_dk += tl.dot(tl.trans(b_ds), b_q)
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 
@@ -335,7 +361,13 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = tl.where(m_A, b_ds, 0)
         b_ds = b_ds.to(b_k.dtype)
         b_dq += tl.dot(b_ds, b_k)
-        b_dk += tl.dot(tl.trans(b_ds), b_q) * scale
+        if IS_NVIDIA_HOPPER_CONSTEXPR:
+            p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
+            tl.store(p_scr, b_ds)
+            b_ds_r = tl.load(p_scr)
+            b_dk += tl.dot(tl.trans(b_ds_r), b_q) * scale
+        else:
+            b_dk += tl.dot(tl.trans(b_ds), b_q) * scale
         b_dq *= scale
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
@@ -734,6 +766,11 @@ def chunk_bwd_dqkwg(
     dg = torch.empty(NK, *g.shape, dtype=torch.float32, device=g.device) if g is not None else None
     dw = torch.empty_like(w) if w is not None else None
 
+    scratch = (
+        torch.empty(NK * NT * B * HV * BT * BT, dtype=torch.float16, device=q.device)
+        if IS_NVIDIA_HOPPER else None
+    )
+
     grid = (NK, NT, B * HV)
     chunk_bwd_kernel_dqkwg[grid](
         q=q,
@@ -749,6 +786,7 @@ def chunk_bwd_dqkwg(
         dk=dk,
         dv=dv,
         dg=dg,
+        scratch=scratch,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         scale=scale,

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -11,15 +11,16 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp, exp2
-from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
+from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, TRITON_AT_MOST_3_6_0, autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
 
-# On Hopper (SM90) with Triton 3.4+, ttg.local_alloc for a #linear tensor (from
-# tt.trans #mma) incorrectly emits stmatrix instead of st.shared.b32
-# (Triton JIT disallows plain Python globals; constexpr-wrapped values are allowed)
-IS_NVIDIA_HOPPER_CONSTEXPR = tl.constexpr(IS_NVIDIA_HOPPER)
+# On Hopper (SM90) with Triton 3.4.0–3.6.0, ttg.local_alloc for a #linear tensor (from
+# tt.trans #mma) incorrectly emits stmatrix instead of st.shared.b32. Triton 3.3.x is
+# unaffected; behavior above 3.6.0 is unknown.
+HOPPER_TRANS_PATCH = IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and TRITON_AT_MOST_3_6_0
+HOPPER_TRANS_PATCH_CONSTEXPR = tl.constexpr(HOPPER_TRANS_PATCH)
 
 
 @triton.heuristics({
@@ -196,7 +197,7 @@ def chunk_bwd_kernel_dqkwg(
     i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // HV, i_bh % HV
 
-    if IS_NVIDIA_HOPPER_CONSTEXPR:
+    if HOPPER_TRANS_PATCH_CONSTEXPR:
         i_prog_t = i_t
 
     all = B * T
@@ -283,7 +284,7 @@ def chunk_bwd_kernel_dqkwg(
     m_t = o_t < T
     m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
 
-    if IS_NVIDIA_HOPPER_CONSTEXPR:
+    if HOPPER_TRANS_PATCH_CONSTEXPR:
         scratch_off = (i_k.to(tl.int64) * tl.num_programs(1) * (B * HV) +
                        i_prog_t.to(tl.int64) * (B * HV) + i_bh.to(tl.int64)) * (BT * BT)
         p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
@@ -321,7 +322,7 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
-        if IS_NVIDIA_HOPPER_CONSTEXPR:
+        if HOPPER_TRANS_PATCH_CONSTEXPR:
             tl.store(p_scr, b_ds)
             b_ds = tl.load(p_scr)
         b_dk += tl.dot(tl.trans(b_ds), b_q)
@@ -345,7 +346,7 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
-        if IS_NVIDIA_HOPPER_CONSTEXPR:
+        if HOPPER_TRANS_PATCH_CONSTEXPR:
             tl.store(p_scr, b_ds)
             b_ds = tl.load(p_scr)
         b_dk += tl.dot(tl.trans(b_ds), b_q)
@@ -356,7 +357,7 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = tl.where(m_A, b_ds, 0)
         b_ds = b_ds.to(b_k.dtype)
         b_dq += tl.dot(b_ds, b_k)
-        if IS_NVIDIA_HOPPER_CONSTEXPR:
+        if HOPPER_TRANS_PATCH_CONSTEXPR:
             tl.store(p_scr, b_ds)
             b_ds = tl.load(p_scr)
         b_dk += tl.dot(tl.trans(b_ds), b_q) * scale
@@ -760,7 +761,7 @@ def chunk_bwd_dqkwg(
 
     scratch = (
         torch.empty(NK * NT * B * HV * BT * BT, dtype=q.dtype, device=q.device)
-        if IS_NVIDIA_HOPPER else None
+        if HOPPER_TRANS_PATCH else None
     )
 
     grid = (NK, NT, B * HV)

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -286,6 +286,7 @@ def chunk_bwd_kernel_dqkwg(
     if IS_NVIDIA_HOPPER_CONSTEXPR:
         scratch_off = (i_k.to(tl.int64) * tl.num_programs(1) * (B * HV) +
                        i_prog_t.to(tl.int64) * (B * HV) + i_bh.to(tl.int64)) * (BT * BT)
+        p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
 
     if USE_G:
         b_dg = tl.zeros([BT], dtype=tl.float32)
@@ -321,12 +322,9 @@ def chunk_bwd_kernel_dqkwg(
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
         if IS_NVIDIA_HOPPER_CONSTEXPR:
-            p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
             tl.store(p_scr, b_ds)
-            b_ds_r = tl.load(p_scr)
-            b_dk += tl.dot(tl.trans(b_ds_r), b_q)
-        else:
-            b_dk += tl.dot(tl.trans(b_ds), b_q)
+            b_ds = tl.load(p_scr)
+        b_dk += tl.dot(tl.trans(b_ds), b_q)
         p_dg = tl.make_block_ptr(dg, (T,), (HV,), (i_t * BT,), (BT,), (0,))
         # (SY 09/21) revcumsum in a separate kernel due to strange triton compiler issue
         # b_dg = tl.dot(tl.where(o_t[:, None] <= o_t[None, :], 1., 0.), b_dg, allow_tf32=False) + b_dg_last)
@@ -348,12 +346,9 @@ def chunk_bwd_kernel_dqkwg(
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
         if IS_NVIDIA_HOPPER_CONSTEXPR:
-            p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
             tl.store(p_scr, b_ds)
-            b_ds_r = tl.load(p_scr)
-            b_dk += tl.dot(tl.trans(b_ds_r), b_q)
-        else:
-            b_dk += tl.dot(tl.trans(b_ds), b_q)
+            b_ds = tl.load(p_scr)
+        b_dk += tl.dot(tl.trans(b_ds), b_q)
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 
@@ -362,12 +357,9 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = b_ds.to(b_k.dtype)
         b_dq += tl.dot(b_ds, b_k)
         if IS_NVIDIA_HOPPER_CONSTEXPR:
-            p_scr = tl.make_block_ptr(scratch + scratch_off, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
             tl.store(p_scr, b_ds)
-            b_ds_r = tl.load(p_scr)
-            b_dk += tl.dot(tl.trans(b_ds_r), b_q) * scale
-        else:
-            b_dk += tl.dot(tl.trans(b_ds), b_q) * scale
+            b_ds = tl.load(p_scr)
+        b_dk += tl.dot(tl.trans(b_ds), b_q) * scale
         b_dq *= scale
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
@@ -767,7 +759,7 @@ def chunk_bwd_dqkwg(
     dw = torch.empty_like(w) if w is not None else None
 
     scratch = (
-        torch.empty(NK * NT * B * HV * BT * BT, dtype=torch.float16, device=q.device)
+        torch.empty(NK * NT * B * HV * BT * BT, dtype=q.dtype, device=q.device)
         if IS_NVIDIA_HOPPER else None
     )
 

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -31,6 +31,7 @@ FLA_CACHE_RESULTS = os.getenv('FLA_CACHE_RESULTS', '1') == '1'
 FLA_DISABLE_TENSOR_CACHE = os.getenv('FLA_DISABLE_TENSOR_CACHE', '0') == '1'
 TRITON_ABOVE_3_4_0 = version.parse(triton.__version__) >= version.parse("3.4.0")
 TRITON_ABOVE_3_5_1 = version.parse(triton.__version__) >= version.parse("3.5.1")
+TRITON_AT_MOST_3_6_0 = version.parse(triton.__version__) <= version.parse("3.6.0")
 
 
 SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -31,7 +31,6 @@ FLA_CACHE_RESULTS = os.getenv('FLA_CACHE_RESULTS', '1') == '1'
 FLA_DISABLE_TENSOR_CACHE = os.getenv('FLA_DISABLE_TENSOR_CACHE', '0') == '1'
 TRITON_ABOVE_3_4_0 = version.parse(triton.__version__) >= version.parse("3.4.0")
 TRITON_ABOVE_3_5_1 = version.parse(triton.__version__) >= version.parse("3.5.1")
-TRITON_AT_MOST_3_6_0 = version.parse(triton.__version__) <= version.parse("3.6.0")
 
 
 SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters


### PR DESCRIPTION
Fixes https://github.com/fla-org/flash-linear-attention/issues/640

## Symptom

On H20/H100 (Hopper SM90) + Triton 3.4+, `chunk_gated_delta_rule` backward produces
wrong `db` and `dg` gradients (error > `atol=0.02`). Forward pass is unaffected.

Affected kernel: `chunk_bwd_kernel_dqkwg` in `fla/ops/common/chunk_o.py`.

### The problematic line

```python
b_ds = b_ds.to(b_k.dtype)           # f32 MMA layout → f16 MMA layout
b_dk += tl.dot(tl.trans(b_ds), b_q) # ← BUG on Triton 3.4+ / Hopper
```

`b_ds` is the result of accumulated `tl.dot` calls, so it lives in **wgmma output
register layout** (`#mma`). Calling `tl.trans` on it produces a `#linear` layout tensor.

## Performance

Benchmarked on H20 (`triton.testing.do_bench(warmup=25, rep=100)`).
The scratch round-trip is one 8 KB global memory store+load per CTA
(`BT×BT × sizeof(f16) = 64×64×2 = 8192 bytes`), negligible against the matrix
multiplications over K and V dimensions.

| B | T | H | K | latency (ms) |
|---|---|---|---|-------------|
| 1 | 1024 | 4 | 100 | 0.040 |
| 4 | 2048 | 8 | 64 | 0.072 |
| 1 | 4096 | 16 | 64 | 0.074 |

**No performance regression observed.**

If Triton fixes the PTX emitter for `#linear` tensors in a future release, the
`if IS_NVIDIA_HOPPER_CONSTEXPR:` guard and scratch buffer can be removed.

<details>
<summary>Verification script</summary>

```python
"""
Minimal reproduction for https://github.com/fla-org/flash-linear-attention/issues/640
[Bug] GDN precision issue on H20 + Triton 3.4+

bug in: https://github.com/fla-org/flash-linear-attention/commit/4926edd

Fix: chunk_bwd_kernel_dqkwg routes b_ds through a global scratch buffer on Hopper to
avoid the Triton 3.4+ stmatrix PTX codegen bug for #linear (tt.trans #mma) tensors.
This file also benchmarks the overhead of that fix on the current GPU.
"""

import torch
import torch.nn.functional as F
import triton

from fla.ops.gated_delta_rule import chunk_gated_delta_rule
from fla.ops.common.chunk_o import chunk_bwd_dqkwg
from fla.utils import IS_NVIDIA_HOPPER


def recurrent_gated_delta_rule_ref(
    q: torch.Tensor,
    k: torch.Tensor,
    v: torch.Tensor,
    beta: torch.Tensor,
    g: torch.Tensor,
    scale: float = None,
    initial_state: torch.Tensor = None,
    output_final_state: bool = False,
):
    q, k, v, beta, g = map(lambda x: x.transpose(1, 2).contiguous().to(torch.float32), [q, k, v, beta, g])
    B, H, T, K, V = *k.shape, v.shape[-1]
    o = torch.zeros(B, H, T, V).to(v)
    h = torch.zeros(B, H, K, V).to(v)
    if initial_state is not None:
        h = initial_state
    if scale is None:
        scale = 1 / (q.shape[-1] ** 0.5)
    q = q * scale
    for i in range(T):
        b_q = q[:, :, i]
        b_k = k[:, :, i]
        b_v = v[:, :, i].clone()
        h = h.clone() * g[:, :, i].exp()[..., None, None]
        b_beta = beta[:, :, i]
        b_v = b_v - (h.clone() * b_k[..., None]).sum(-2)
        b_v = b_v * b_beta[..., None]
        h = h.clone() + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
        o[:, :, i] = torch.einsum('bhd,bhdm->bhm', b_q, h)
    if not output_final_state:
        h = None
    o = o.transpose(1, 2).contiguous()
    return o, h


# Parameters matching the failing test case in the original issue
B, T, H, D = 1, 1024, 4, 100
scale = 1.0
gate_logit_normalizer = 0.1
mask_p = 0.0
use_qk_l2norm_in_kernel = False
dtype = torch.float16
device = 'cuda'

torch.manual_seed(42)

# Build inputs
q = torch.rand(B, T, H, D, dtype=dtype)
k = torch.rand(B, T, H, D, dtype=dtype)
v = torch.rand(B, T, H, D, dtype=dtype)
beta = torch.rand(B, T, H, dtype=dtype).sigmoid()
g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
g = g / gate_logit_normalizer
g = g * (torch.rand_like(g) > mask_p)
h0 = torch.zeros(B, H, D, D, dtype=torch.float32)

q, k, v, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, beta, g, h0))

do = torch.randn(B, T, H, D, dtype=dtype, device=device)
dht = torch.randn(B, H, D, D, dtype=torch.float32, device=device)

# Triton kernel forward + backward
tri, tri_ht = chunk_gated_delta_rule(
    q=F.normalize(q.clone(), p=2, dim=-1),
    k=F.normalize(k.clone(), p=2, dim=-1),
    v=v.clone(),
    g=g.clone(),
    beta=beta.clone(),
    scale=scale,
    initial_state=h0.clone(),
    output_final_state=True,
    use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
)
((tri * do).sum() + (tri_ht * dht).sum()).backward()
tri_dq, tri_dk, tri_dv, tri_dbeta, tri_dg, tri_dh0 = \
    q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad
q.grad = k.grad = v.grad = beta.grad = g.grad = h0.grad = None

# Reference forward + backward
ref, ref_ht = recurrent_gated_delta_rule_ref(
    q=F.normalize(q.clone(), p=2, dim=-1),
    k=F.normalize(k.clone(), p=2, dim=-1),
    v=v.clone(),
    beta=beta.clone(),
    g=g.clone(),
    scale=scale,
    output_final_state=True,
    initial_state=h0.clone(),
)
((ref * do).sum() + (ref_ht * dht).sum()).backward()
ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dg, ref_dh0 = \
    q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad


def assert_close(name, ref, tri, atol):
    diff = (ref.float() - tri.float()).abs()
    print(f"{name:6s}  max={diff.max():.6f}  mean={diff.mean():.6f}  atol={atol}  {'✓' if diff.max() < atol else '✗ FAIL'}")


assert_close('o',    ref,       tri,       0.005)
assert_close('ht',   ref_ht,    tri_ht,    0.005)
assert_close('dq',   ref_dq,    tri_dq,    0.008)
assert_close('dk',   ref_dk,    tri_dk,    0.008)
assert_close('dv',   ref_dv,    tri_dv,    0.008)
assert_close('db',   ref_dbeta, tri_dbeta, 0.02)   # fails on H20/H100 + Triton 3.4 without fix
assert_close('dg',   ref_dg,    tri_dg,    0.02)   # fails on H20/H100 + Triton 3.4 without fix
assert_close('dh0',  ref_dh0,   tri_dh0,   0.02)

# ---------------------------------------------------------------------------
# Performance regression: chunk_bwd_kernel_dqkwg
#
# On Hopper the fix adds a BT×BT f16 global memory store+load per program to
# work around the stmatrix PTX bug.  Benchmark this overhead vs. a baseline
# run that exercises the full backward call.
# ---------------------------------------------------------------------------
print()
print("=" * 60)
print(f"chunk_bwd_kernel_dqkwg  perf regression  (Hopper={IS_NVIDIA_HOPPER})")
print("=" * 60)

BT = 64
configs = [
    # (B,  T,    H,   K)
    (1,  1024,  4,   100),   # issue_640 repro size
    (4,  2048,  8,   64),    # medium
    (1,  4096,  16,  64),    # long sequence
]

for B_p, T_p, H_p, K_p in configs:
    V_p = K_p
    NT = triton.cdiv(T_p, BT)

    q_p  = torch.randn(B_p, T_p, H_p, K_p, dtype=torch.float16, device=device)
    k_p  = torch.randn(B_p, T_p, H_p, K_p, dtype=torch.float16, device=device)
    v_p  = torch.randn(B_p, T_p, H_p, V_p, dtype=torch.float16, device=device)
    do_p = torch.randn(B_p, T_p, H_p, V_p, dtype=torch.float16, device=device)
    h_p  = torch.randn(B_p * NT, H_p, V_p, K_p, dtype=torch.float16, device=device)
    dh_p = torch.randn_like(h_p)
    g_p  = torch.randn(B_p, T_p, H_p, dtype=torch.float32, device=device)

    ms = triton.testing.do_bench(
        lambda: chunk_bwd_dqkwg(
            q=q_p, k=k_p, v=v_p, do=do_p,
            h=h_p, dh=dh_p, g=g_p, scale=1.0, chunk_size=BT,
        ),
        warmup=25, rep=100,
    )
    bandwidth_gb = (
        # reads: q, k, v, do, h, dh, g  |  writes: dq, dk, dg
        (q_p.nbytes + k_p.nbytes + v_p.nbytes + do_p.nbytes +
         h_p.nbytes + dh_p.nbytes + g_p.nbytes +
         q_p.nbytes + k_p.nbytes + g_p.nbytes * 4)  # dg is fp32
        / ms * 1e-6
    )
    print(f"  B={B_p:2d} T={T_p:5d} H={H_p:3d} K={K_p:3d}  "
          f"{ms:6.3f} ms   ~{bandwidth_gb:6.1f} GB/s")
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized memory operations for Hopper architecture with Triton 3.4.0 and later versions to improve system compatibility and performance on affected hardware configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->