### PR TITLE
Add autotune for causal conv update

### DIFF
--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -619,7 +619,6 @@ def causal_conv1d_update(
     D = x.shape[-1]
     N = x.numel() // D
     W = weight.shape[1] if weight is not None else None
-    BD = 8
     BW = triton.next_power_of_2(W)
 
     if x.dim() == 2:

--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -322,6 +322,14 @@ def causal_conv1d_bwd_kernel(
     'HAS_BIAS': lambda args: args['bias'] is not None,
     'HAS_RESIDUAL': lambda args: args['residual'] is not None,
 })
+@triton.autotune(
+    configs=[
+        triton.Config({'BD': BD}, num_warps=num_warps)
+        for BD in [16, 32, 64, 128, 256]
+        for num_warps in [8, 16, 32]
+    ],
+    key=['D'],
+)
 @triton.jit
 def causal_conv1d_update_kernel(
     x,
@@ -656,9 +664,7 @@ def causal_conv1d_update(
         stride_y_d=stride_y_d,
         D=D,
         W=W,
-        BD=BD,
         BW=BW,
         ACTIVATION=activation,
-        num_warps=STATIC_WARPS,
     )
     return y.view(shape), cache

--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -325,10 +325,11 @@ def causal_conv1d_bwd_kernel(
 @triton.autotune(
     configs=[
         triton.Config({'BD': BD}, num_warps=num_warps)
-        for BD in [16, 32, 64, 128, 256]
-        for num_warps in [8, 16, 32]
+        for BD in [8, 16, 32, 64, 128, 256]
+        for num_warps in NUM_WARPS_AUTOTUNE
     ],
-    key=['D'],
+    key=['D', 'W'],
+    **autotune_cache_kwargs,
 )
 @triton.jit
 def causal_conv1d_update_kernel(

--- a/fla/modules/conv/triton/ops.py
+++ b/fla/modules/conv/triton/ops.py
@@ -289,7 +289,6 @@ def causal_conv1d_update(
     D = x.shape[-1]
     N = x.numel() // D
     W = weight.shape[1] if weight is not None else None
-    BD = 8
     BW = triton.next_power_of_2(W)
 
     if x.dim() == 2:

--- a/fla/modules/conv/triton/ops.py
+++ b/fla/modules/conv/triton/ops.py
@@ -334,10 +334,8 @@ def causal_conv1d_update(
         stride_y_d=stride_y_d,
         D=D,
         W=W,
-        BD=BD,
         BW=BW,
         ACTIVATION=activation,
-        num_warps=STATIC_WARPS,
     )
     return y.view(shape), cache
 

--- a/fla/modules/conv/triton/ops.py
+++ b/fla/modules/conv/triton/ops.py
@@ -13,7 +13,6 @@ from fla.ops.utils import prepare_chunk_indices
 from fla.utils import input_guard
 
 from .kernels import (
-    STATIC_WARPS,
     causal_conv1d_bwd_kernel,
     causal_conv1d_fwd_kernel,
     causal_conv1d_states_fwd_kernel,


### PR DESCRIPTION
origin BD=8 too small, it hurt performance when numtokens increase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enabled automatic kernel autotuning for causal 1D convolution so the runtime selects optimal compute parameters instead of relying on fixed settings. This yields more consistent and often improved performance across varied input sizes and hardware, with no changes to public APIs or observable behavior beyond faster and more stable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->