### PR TITLE
[Attn] Add GPT-OSS-style attention sink support

### DIFF
--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -24,7 +24,7 @@ from fla.utils import autotune_cache_kwargs, check_shared_mem
         for num_warps in [1, 2, 4] + ([] if check_shared_mem('hopper') else [8])
         for num_stages in [2, 3, 4, 5]
     ],
-    key=['H', 'G', 'K', 'V', 'BK', 'BV', 'USE_G'],
+    key=['H', 'G', 'K', 'V', 'BK', 'BV', 'USE_G', 'USE_SINK'],
     **autotune_cache_kwargs,
 )
 @triton.jit

--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -16,7 +16,7 @@ from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 @triton.heuristics({
     'USE_G': lambda args: args['g_cumsum'] is not None,
-    'USE_SINK': lambda args: args['sinks'] is not None,
+    'USE_SINK_BIAS': lambda args: args['sink_bias'] is not None,
 })
 @triton.autotune(
     configs=[
@@ -24,7 +24,7 @@ from fla.utils import autotune_cache_kwargs, check_shared_mem
         for num_warps in [1, 2, 4] + ([] if check_shared_mem('hopper') else [8])
         for num_stages in [2, 3, 4, 5]
     ],
-    key=['H', 'G', 'K', 'V', 'BK', 'BV', 'USE_G', 'USE_SINK'],
+    key=['H', 'G', 'K', 'V', 'BK', 'BV', 'USE_G', 'USE_SINK_BIAS'],
     **autotune_cache_kwargs,
 )
 @triton.jit
@@ -34,9 +34,8 @@ def naive_attn_decoding_kernel(
     v,
     o,
     g_cumsum,
-    sinks,
+    sink_bias,
     scale,
-    gate_scale,
     cu_seqlens,
     T,
     B: tl.constexpr,
@@ -49,7 +48,7 @@ def naive_attn_decoding_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_SINK: tl.constexpr,
+    USE_SINK_BIAS: tl.constexpr,
 ):
     i_v, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
@@ -75,10 +74,10 @@ def naive_attn_decoding_kernel(
     else:
         b_gq = None
 
-    if USE_SINK:
-        b_sink = tl.load(sinks + i_hq).to(tl.float32)
+    if USE_SINK_BIAS:
+        b_sink_bias = tl.load(sink_bias + i_hq).to(tl.float32)
     else:
-        b_sink = None
+        b_sink_bias = None
 
     for i_s in range(0, T, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_s, 0), (BS, BK), (1, 0))
@@ -96,7 +95,7 @@ def naive_attn_decoding_kernel(
         if USE_G:
             p_gk = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
             b_gk = tl.load(p_gk, boundary_check=(0,)).to(tl.float32)
-            b_s += (b_gq - b_gk) * gate_scale
+            b_s += b_gq - b_gk
         # [BT, BS]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s)), b_m
         b_r = exp(b_mp - b_m)
@@ -109,10 +108,10 @@ def naive_attn_decoding_kernel(
         b_o = b_o * b_r + tl.sum(b_p[:, None] * b_v, 0)
         b_mp = b_m
 
-    if USE_SINK:
-        # Keep the sink merge finite when masking leaves a row with no valid key.
+    if USE_SINK_BIAS:
+        # keep the sink-bias merge finite when masking leaves a row with no valid key.
         b_m = tl.where(b_m == float('-inf'), 0., b_m)
-        b_acc += exp(b_sink - b_m)
+        b_acc += exp(b_sink_bias - b_m)
     b_o = b_o / b_acc
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, ))
 
@@ -126,7 +125,7 @@ def attn_decoding_one_step(
     cu_seqlens: torch.LongTensor = None,
     do_gate_scale: bool = False,
     *,
-    sinks: torch.Tensor | None = None,
+    sink_bias: torch.Tensor | None = None,
 ):
     r"""
     Args:
@@ -148,8 +147,10 @@ def attn_decoding_one_step(
         do_gate_scale (bool):
             Whether to apply gate scale. Default: `False`. If `True`, the attention scale will also be applied
             to the gating bias term in Forgetting Transformer or PaTH-FoX.
-        sinks (Optional[torch.Tensor]):
-            Per-query-head sink logits of shape `[HQ]`.
+        sink_bias (Optional[torch.Tensor]):
+            Per-query-head attention-sink bias logits of shape `[HQ]` — one
+            learnable scalar per query head, as introduced by GPT-OSS.
+            Augments the softmax denominator without contributing to the output.
 
     Returns:
         o (torch.Tensor):
@@ -162,8 +163,8 @@ def attn_decoding_one_step(
     G = HQ // H
     if scale is None:
         scale = K ** -0.5
-    if sinks is not None:
-        assert sinks.shape == (HQ,), "sinks must have shape [HQ]"
+    if sink_bias is not None:
+        assert sink_bias.shape == (HQ,), "sink_bias must have shape [HQ]"
 
     BK = max(triton.next_power_of_2(K), 16)
     if check_shared_mem('hopper', q.device.index):
@@ -175,10 +176,14 @@ def attn_decoding_one_step(
     else:
         BS = min(32, max(16, triton.next_power_of_2(T)))
         BV = min(64, max(16, triton.next_power_of_2(V)))
-    g_cumsum = chunk_global_cumsum(g, cu_seqlens=cu_seqlens, output_dtype=torch.float32) if g is not None else None
+    g_cumsum = chunk_global_cumsum(
+        g,
+        cu_seqlens=cu_seqlens,
+        scale=scale if do_gate_scale else None,
+        output_dtype=torch.float32,
+    ) if g is not None else None
     NV = triton.cdiv(V, BV)
     o = torch.empty(*q.shape[:-1], V, dtype=v.dtype, device=q.device)
-    gate_scale = 1.0 if not do_gate_scale else scale
 
     grid = (NV, N * HQ)
     naive_attn_decoding_kernel[grid](
@@ -187,9 +192,8 @@ def attn_decoding_one_step(
         v=v,
         o=o,
         g_cumsum=g_cumsum,
-        sinks=sinks,
+        sink_bias=sink_bias,
         scale=scale,
-        gate_scale=gate_scale,
         cu_seqlens=cu_seqlens,
         B=B,
         T=T,

--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -136,7 +136,7 @@ def attn_decoding_one_step(
         v (torch.Tensor):
             values of shape `[1, T, H, V]`.
         g (Optional[torch.Tensor]):
-            log decay factors of shape `[1, T, H]`. Default: `None`.
+            log decay factors of shape `[1, T, HQ]`. Default: `None`.
         scale (Optional[float]):
             Scale factor for attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
@@ -151,7 +151,7 @@ def attn_decoding_one_step(
 
     Returns:
         o (torch.Tensor):
-            Outputs of shape `[B, 1, HQ, V]`.
+            Outputs of shape `[1, B, HQ, V]`.
     """
     assert cu_seqlens is not None, "The cu_seqlens must be provided for varlen decoding"
     B, T, H, K, V = *k.shape, v.shape[-1]

--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -16,6 +16,7 @@ from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 @triton.heuristics({
     'USE_G': lambda args: args['g_cumsum'] is not None,
+    'USE_SINK': lambda args: args['sinks'] is not None,
 })
 @triton.autotune(
     configs=[
@@ -33,6 +34,7 @@ def naive_attn_decoding_kernel(
     v,
     o,
     g_cumsum,
+    sinks,
     scale,
     gate_scale,
     cu_seqlens,
@@ -47,6 +49,7 @@ def naive_attn_decoding_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_SINK: tl.constexpr,
 ):
     i_v, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
@@ -71,6 +74,11 @@ def naive_attn_decoding_kernel(
         b_gq = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
     else:
         b_gq = None
+
+    if USE_SINK:
+        b_sink = tl.load(sinks + i_hq).to(tl.float32)
+    else:
+        b_sink = None
 
     for i_s in range(0, T, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_s, 0), (BS, BK), (1, 0))
@@ -100,6 +108,9 @@ def naive_attn_decoding_kernel(
         # [BT, BV]
         b_o = b_o * b_r + tl.sum(b_p[:, None] * b_v, 0)
         b_mp = b_m
+
+    if USE_SINK:
+        b_acc += exp(b_sink - b_m)
     b_o = b_o / b_acc
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, ))
 
@@ -112,6 +123,8 @@ def attn_decoding_one_step(
     scale: float | None = None,
     cu_seqlens: torch.LongTensor = None,
     do_gate_scale: bool = False,
+    *,
+    sinks: torch.Tensor | None = None,
 ):
     r"""
     Args:
@@ -133,6 +146,8 @@ def attn_decoding_one_step(
         do_gate_scale (bool):
             Whether to apply gate scale. Default: `False`. If `True`, the attention scale will also be applied
             to the gating bias term in Forgetting Transformer or PaTH-FoX.
+        sinks (Optional[torch.Tensor]):
+            Per-query-head sink logits of shape `[HQ]`.
 
     Returns:
         o (torch.Tensor):
@@ -145,6 +160,8 @@ def attn_decoding_one_step(
     G = HQ // H
     if scale is None:
         scale = K ** -0.5
+    if sinks is not None:
+        assert sinks.shape == (HQ,), "sinks must have shape [HQ]"
 
     BK = max(triton.next_power_of_2(K), 16)
     if check_shared_mem('hopper', q.device.index):
@@ -168,6 +185,7 @@ def attn_decoding_one_step(
         v=v,
         o=o,
         g_cumsum=g_cumsum,
+        sinks=sinks,
         scale=scale,
         gate_scale=gate_scale,
         cu_seqlens=cu_seqlens,

--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -110,6 +110,8 @@ def naive_attn_decoding_kernel(
         b_mp = b_m
 
     if USE_SINK:
+        # Keep the sink merge finite when masking leaves a row with no valid key.
+        b_m = tl.where(b_m == float('-inf'), 0., b_m)
         b_acc += exp(b_sink - b_m)
     b_o = b_o / b_acc
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, ))

--- a/fla/ops/attn/naive.py
+++ b/fla/ops/attn/naive.py
@@ -86,6 +86,7 @@ def naive_parallel_attn(
     # max_logits: [B, H, G, TQ] -> [B, TQ, HQ]
     max_logits = scores.max(dim=-1).values
     if sinks is not None:
+        assert sinks.shape == (HQ,), "sinks must have shape [HQ]"
         sink_logits = sinks.reshape(H, G)[None, :, :, None]
         max_logits = torch.maximum(max_logits, sink_logits)
 

--- a/fla/ops/attn/naive.py
+++ b/fla/ops/attn/naive.py
@@ -18,87 +18,159 @@ def naive_parallel_attn(
     causal: bool = True,
     *,
     g: torch.Tensor | None = None,
-    g_scale: float = 1.0,
-    query_indices: torch.Tensor | None = None,
-    sinks: torch.Tensor | None = None,
+    sink_bias: torch.Tensor | None = None,
 ):
     """
     Reference PyTorch implementation of parallel attention that returns both output and max_logits.
 
     Args:
-        q: [B, TQ, HQ, D]
-        k: [B, TK, H, D]
-        v: [B, TK, H, D]
+        q: [B, T, HQ, D]
+        k: [B, T, H, D]
+        v: [B, T, H, D]
         scale: float, optional. If None, defaults to 1 / sqrt(D)
         window_size: int, optional. If provided, each query at position i only attends to
             keys in [i - window_size + 1, i]. If None, full causal attention is used.
         causal: bool, default True
-        g: [B, TK, HQ], optional per-query-head gating logits
-        g_scale: float, optional scaling applied to the gating bias term
-        query_indices: [TQ] or [B, TQ], optional absolute query positions relative to keys
-        sinks: [HQ], optional per-query-head sink logits
+        g: [B, T, HQ], optional per-query-head gating logits. Any scaling
+            (e.g. matching `attn_decoding_one_step(do_gate_scale=True)`) should
+            be applied by the caller before passing `g` in.
+        sink_bias: [HQ], optional per-query-head attention-sink bias logits
+            (GPT-OSS style). One scalar per query head added to the softmax
+            denominator without a corresponding key/value — absorbs probability
+            mass but does not contribute to the output.
 
     Returns:
-        output: [B, TQ, HQ, D]
-        max_logits: [B, TQ, HQ]
+        output: [B, T, HQ, D]
+        max_logits: [B, T, HQ]
     """
-    B, TQ, HQ, D = q.shape
-    TK = k.shape[1]
+    B, T, HQ, D = q.shape
     H = k.shape[2]
     G = HQ // H
 
     if scale is None:
         scale = D ** -0.5
 
-    # reshape q to separate groups: [B, TQ, HQ, D] -> [B, TQ, H, G, D]
-    q = q.reshape(B, TQ, H, G, D)
+    # reshape q to separate groups: [B, T, HQ, D] -> [B, T, H, G, D]
+    q = q.reshape(B, T, H, G, D)
 
-    # compute attention scores via einsum: [B, H, G, TQ, TK]
+    # compute attention scores via einsum: [B, H, G, T, T]
     # k is [B, T, H, D] — no group dim, so each group shares the same k
     scores = torch.einsum('bqhgd,bkhd->bhgqk', q, k) * scale
 
-    if query_indices is None:
-        query_positions = torch.arange(TQ, device=q.device).unsqueeze(0).expand(B, TQ)
-    else:
-        if query_indices.ndim == 1:
-            query_positions = query_indices.unsqueeze(0).expand(B, TQ)
-        else:
-            query_positions = query_indices
-        query_positions = query_positions.to(device=q.device, dtype=torch.long)
-        assert query_positions.shape == (B, TQ), "query_indices must have shape [TQ] or [B, TQ]"
-
     # apply causal mask
     if causal:
-        row_idx = query_positions[:, :, None]
-        col_idx = torch.arange(TK, device=q.device)[None, None, :]
+        row_idx = torch.arange(T, device=q.device)[None, :, None]
+        col_idx = torch.arange(T, device=q.device)[None, None, :]
         mask = col_idx > row_idx
         if window_size is not None:
             mask = mask | (row_idx - col_idx >= window_size)
         scores = scores.masked_fill(mask[:, None, None], float('-inf'))
 
     if g is not None:
-        assert g.shape == (B, TK, HQ), "g must have shape [B, TK, HQ]"
-        g_cumsum = g.float().cumsum(1).reshape(B, TK, H, G).permute(0, 2, 3, 1)
-        g_query_idx = query_positions[:, None, None, :].expand(B, H, G, TQ)
-        g_q = torch.gather(g_cumsum, dim=-1, index=g_query_idx)
-        scores = scores + (g_q[..., None] - g_cumsum[..., None, :]) * g_scale
+        assert g.shape == (B, T, HQ), "g must have shape [B, T, HQ]"
+        g_cumsum = g.float().cumsum(1).reshape(B, T, H, G).permute(0, 2, 3, 1)
+        scores = scores + (g_cumsum[..., :, None] - g_cumsum[..., None, :])
 
-    # max_logits: [B, H, G, TQ] -> [B, TQ, HQ]
+    # max_logits: [B, H, G, T] -> [B, T, HQ]
     max_logits = scores.max(dim=-1).values
-    if sinks is not None:
-        assert sinks.shape == (HQ,), "sinks must have shape [HQ]"
-        sink_logits = sinks.reshape(H, G)[None, :, :, None]
-        max_logits = torch.maximum(max_logits, sink_logits)
+    if sink_bias is not None:
+        assert sink_bias.shape == (HQ,), "sink_bias must have shape [HQ]"
+        sink_bias_logits = sink_bias.reshape(H, G)[None, :, :, None]
+        max_logits = torch.maximum(max_logits, sink_bias_logits)
 
-    if sinks is None:
-        # compute output via einsum: [B, H, G, TQ, TK] x [B, TK, H, D] -> [B, TQ, H, G, D]
+    if sink_bias is None:
+        # compute output via einsum: [B, H, G, T, T] x [B, T, H, D] -> [B, T, H, G, D]
         attn_weights = F.softmax(scores, dim=-1)
-        output = torch.einsum('bhgqk,bkhd->bqhgd', attn_weights, v).reshape(B, TQ, HQ, D)
+        output = torch.einsum('bhgqk,bkhd->bqhgd', attn_weights, v).reshape(B, T, HQ, D)
     else:
         probs_unnorm = torch.exp(scores - max_logits[..., None])
-        sink_unnorm = torch.exp(sink_logits - max_logits)
-        denom = probs_unnorm.sum(dim=-1) + sink_unnorm
+        sink_bias_unnorm = torch.exp(sink_bias_logits - max_logits)
+        denom = probs_unnorm.sum(dim=-1) + sink_bias_unnorm
         output = torch.einsum('bhgqk,bkhd->bqhgd', probs_unnorm, v)
-        output = (output / denom.permute(0, 3, 1, 2)[..., None]).reshape(B, TQ, HQ, D)
+        output = (output / denom.permute(0, 3, 1, 2)[..., None]).reshape(B, T, HQ, D)
 
-    return output, max_logits.permute(0, 3, 1, 2).reshape(B, TQ, HQ)
+    return output, max_logits.permute(0, 3, 1, 2).reshape(B, T, HQ)
+
+
+def naive_attn_decoding(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    do_gate_scale: bool = False,
+    *,
+    sink_bias: torch.Tensor | None = None,
+):
+    """
+    Reference PyTorch implementation of packed-varlen decoding attention,
+    mirroring `attn_decoding_one_step`. A single query per sequence attends
+    to all of its KV (no causal mask needed — query is at the last position).
+
+    Args:
+        q: [1, B, HQ, D] — one query token per sequence
+        k: [1, T_total, H, D]
+        v: [1, T_total, H, D]
+        g: [1, T_total, HQ], optional log decay factors
+        scale: float, defaults to 1/sqrt(D)
+        cu_seqlens: [B+1]
+        do_gate_scale: bool, if True scales `g` by `scale` before use
+            (matches PaTH / Forgetting Transformer convention).
+        sink_bias: [HQ], optional GPT-OSS-style sink bias logits
+
+    Returns:
+        o: [1, B, HQ, V]
+    """
+    assert cu_seqlens is not None, "cu_seqlens must be provided for varlen decoding"
+    HQ, D = q.shape[-2], q.shape[-1]
+    V = v.shape[-1]
+    H = k.shape[2]
+    G = HQ // H
+    if scale is None:
+        scale = D ** -0.5
+    if sink_bias is not None:
+        assert sink_bias.shape == (HQ,), "sink_bias must have shape [HQ]"
+
+    outputs = []
+    for i in range(len(cu_seqlens) - 1):
+        bos, eos = int(cu_seqlens[i]), int(cu_seqlens[i + 1])
+        T_i = eos - bos
+        qi = q[:, i:i + 1]  # [1, 1, HQ, D]
+
+        if T_i == 0:
+            # no KV for this sequence → output zeros (sink_bias has no value to contribute)
+            outputs.append(torch.zeros((1, 1, HQ, V), dtype=q.dtype, device=q.device))
+            continue
+
+        ki = k[:, bos:eos]  # [1, T_i, H, D]
+        vi = v[:, bos:eos]  # [1, T_i, H, D]
+
+        # scores: [1, H, G, 1, T_i]
+        qi_g = qi.reshape(1, 1, H, G, D)
+        scores = torch.einsum('bqhgd,bkhd->bhgqk', qi_g, ki) * scale
+
+        if g is not None:
+            gi = g[:, bos:eos].float()
+            if do_gate_scale:
+                gi = gi * scale
+            # query is at position T_i - 1 (end of sequence)
+            gi_cumsum = gi.cumsum(1).reshape(1, T_i, H, G).permute(0, 2, 3, 1)  # [1, H, G, T_i]
+            g_q = gi_cumsum[..., -1:].unsqueeze(-1)  # [1, H, G, 1, 1]
+            scores = scores + (g_q - gi_cumsum[..., None, :])
+
+        if sink_bias is None:
+            attn_weights = F.softmax(scores, dim=-1)
+            oi = torch.einsum('bhgqk,bkhd->bqhgd', attn_weights, vi).reshape(1, 1, HQ, V)
+        else:
+            sink_bias_logits = sink_bias.reshape(H, G)[None, :, :, None]  # [1, H, G, 1]
+            max_logits = torch.maximum(scores.max(dim=-1).values, sink_bias_logits)  # [1, H, G, 1]
+            probs_unnorm = torch.exp(scores - max_logits[..., None])
+            sink_bias_unnorm = torch.exp(sink_bias_logits - max_logits)
+            denom = probs_unnorm.sum(dim=-1) + sink_bias_unnorm  # [1, H, G, 1]
+            oi_pack = torch.einsum('bhgqk,bkhd->bqhgd', probs_unnorm, vi)
+            oi = (oi_pack / denom.permute(0, 3, 1, 2)[..., None]).reshape(1, 1, HQ, V)
+
+        outputs.append(oi)
+
+    return torch.cat(outputs, dim=1)  # [1, B, HQ, V]

--- a/fla/ops/attn/naive.py
+++ b/fla/ops/attn/naive.py
@@ -16,51 +16,88 @@ def naive_parallel_attn(
     scale: float | None = None,
     window_size: int | None = None,
     causal: bool = True,
+    *,
+    g: torch.Tensor | None = None,
+    g_scale: float = 1.0,
+    query_indices: torch.Tensor | None = None,
+    sinks: torch.Tensor | None = None,
 ):
     """
     Reference PyTorch implementation of parallel attention that returns both output and max_logits.
 
     Args:
-        q: [B, T, HQ, D]
-        k: [B, T, H, D]
-        v: [B, T, H, D]
+        q: [B, TQ, HQ, D]
+        k: [B, TK, H, D]
+        v: [B, TK, H, D]
         scale: float, optional. If None, defaults to 1 / sqrt(D)
         window_size: int, optional. If provided, each query at position i only attends to
             keys in [i - window_size + 1, i]. If None, full causal attention is used.
         causal: bool, default True
+        g: [B, TK, HQ], optional per-query-head gating logits
+        g_scale: float, optional scaling applied to the gating bias term
+        query_indices: [TQ] or [B, TQ], optional absolute query positions relative to keys
+        sinks: [HQ], optional per-query-head sink logits
 
     Returns:
-        output: [B, T, HQ, D]
-        max_logits: [B, T, HQ]
+        output: [B, TQ, HQ, D]
+        max_logits: [B, TQ, HQ]
     """
-    B, T, HQ, D = q.shape
+    B, TQ, HQ, D = q.shape
+    TK = k.shape[1]
     H = k.shape[2]
     G = HQ // H
 
     if scale is None:
         scale = D ** -0.5
 
-    # reshape q to separate groups: [B, T, HQ, D] -> [B, T, H, G, D]
-    q = q.reshape(B, T, H, G, D)
+    # reshape q to separate groups: [B, TQ, HQ, D] -> [B, TQ, H, G, D]
+    q = q.reshape(B, TQ, H, G, D)
 
-    # compute attention scores via einsum: [B, H, G, T, T]
+    # compute attention scores via einsum: [B, H, G, TQ, TK]
     # k is [B, T, H, D] — no group dim, so each group shares the same k
     scores = torch.einsum('bqhgd,bkhd->bhgqk', q, k) * scale
 
+    if query_indices is None:
+        query_positions = torch.arange(TQ, device=q.device).unsqueeze(0).expand(B, TQ)
+    else:
+        if query_indices.ndim == 1:
+            query_positions = query_indices.unsqueeze(0).expand(B, TQ)
+        else:
+            query_positions = query_indices
+        query_positions = query_positions.to(device=q.device, dtype=torch.long)
+        assert query_positions.shape == (B, TQ), "query_indices must have shape [TQ] or [B, TQ]"
+
     # apply causal mask
     if causal:
-        row_idx = torch.arange(T, device=q.device).unsqueeze(1)
-        col_idx = torch.arange(T, device=q.device).unsqueeze(0)
+        row_idx = query_positions[:, :, None]
+        col_idx = torch.arange(TK, device=q.device)[None, None, :]
         mask = col_idx > row_idx
         if window_size is not None:
             mask = mask | (row_idx - col_idx >= window_size)
-        scores = scores.masked_fill(mask, float('-inf'))
+        scores = scores.masked_fill(mask[:, None, None], float('-inf'))
 
-    # max_logits: [B, H, G, T] -> [B, T, HQ]
-    max_logits = scores.max(dim=-1).values.permute(0, 3, 1, 2).reshape(B, T, HQ)
+    if g is not None:
+        assert g.shape == (B, TK, HQ), "g must have shape [B, TK, HQ]"
+        g_cumsum = g.float().cumsum(1).reshape(B, TK, H, G).permute(0, 2, 3, 1)
+        g_query_idx = query_positions[:, None, None, :].expand(B, H, G, TQ)
+        g_q = torch.gather(g_cumsum, dim=-1, index=g_query_idx)
+        scores = scores + (g_q[..., None] - g_cumsum[..., None, :]) * g_scale
 
-    # compute output via einsum: [B, H, G, T, T] x [B, T, H, D] -> [B, T, H, G, D]
-    attn_weights = F.softmax(scores, dim=-1)
-    output = torch.einsum('bhgqk,bkhd->bqhgd', attn_weights, v).reshape(B, T, HQ, D)
+    # max_logits: [B, H, G, TQ] -> [B, TQ, HQ]
+    max_logits = scores.max(dim=-1).values
+    if sinks is not None:
+        sink_logits = sinks.reshape(H, G)[None, :, :, None]
+        max_logits = torch.maximum(max_logits, sink_logits)
 
-    return output, max_logits
+    if sinks is None:
+        # compute output via einsum: [B, H, G, TQ, TK] x [B, TK, H, D] -> [B, TQ, H, G, D]
+        attn_weights = F.softmax(scores, dim=-1)
+        output = torch.einsum('bhgqk,bkhd->bqhgd', attn_weights, v).reshape(B, TQ, HQ, D)
+    else:
+        probs_unnorm = torch.exp(scores - max_logits[..., None])
+        sink_unnorm = torch.exp(sink_logits - max_logits)
+        denom = probs_unnorm.sum(dim=-1) + sink_unnorm
+        output = torch.einsum('bhgqk,bkhd->bqhgd', probs_unnorm, v)
+        output = (output / denom.permute(0, 3, 1, 2)[..., None]).reshape(B, TQ, HQ, D)
+
+    return output, max_logits.permute(0, 3, 1, 2).reshape(B, TQ, HQ)

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -122,9 +122,9 @@ def parallel_attn_fwd_kernel(
 
         # [BT, BS]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
-        # when the key block is entirely before a query's window, b_m is still -inf.
-        # replace with 0 so that exp2(-inf - 0) = 0 instead of exp2(-inf - (-inf)) = NaN
-        b_mw = tl.where((i_s + BS - 1) < o_w, 0., b_m) if USE_WINDOW else b_m
+        # Keep the online softmax pivot finite for rows that still have no valid key.
+        # This matches sglang's masked-row stabilization and avoids -inf - (-inf) = NaN.
+        b_mw = tl.where(b_m == float('-inf'), 0., b_m)
         b_r = exp2(b_mp - b_mw)
         b_p = exp2(b_s - b_mw[:, None])
         # [BT]
@@ -159,7 +159,7 @@ def parallel_attn_fwd_kernel(
 
         # [BT]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
-        b_mw = tl.where((i_s + BS - 1) < o_w, 0., b_m) if USE_WINDOW else b_m
+        b_mw = tl.where(b_m == float('-inf'), 0., b_m)
         b_r = exp2(b_mp - b_mw)
         b_p = exp2(b_s - b_mw[:, None])
         # [BT]
@@ -169,6 +169,10 @@ def parallel_attn_fwd_kernel(
         b_mp = b_m
 
     if USE_SINK:
+        # When a row has no valid key at all, b_m is still -inf here.
+        # Use a finite pivot before merging the sink mass so lse becomes the sink logit
+        # instead of hitting the -inf + inf = NaN path.
+        b_m = tl.where(b_m == float('-inf'), 0., b_m)
         # Match sglang's denominator-only sink update in extend_attention.py:
         # https://github.com/sgl-project/sglang/blob/6760c790bd5401b6793adc6761a04b8872caebf7/python/sglang/srt/layers/attention/triton_ops/extend_attention.py#L940-L943
         b_acc += exp2(b_sink - b_m)

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -601,6 +601,7 @@ def parallel_attn_bwd(
     g_cumsum: torch.Tensor,
     lse: torch.Tensor,
     do: torch.Tensor,
+    sinks: torch.Tensor | None = None,
     scale: float = None,
     window_size: int | None = None,
     chunk_size: int = 128,
@@ -705,7 +706,13 @@ def parallel_attn_bwd(
     dv = reduce(dv, 'b t (h g) v -> b t h v', g=G, reduction='sum')
     if g_cumsum is not None:
         dg_cumsum.add_(dg_cumsum_k)
-    return dq, dk, dv, dg_cumsum, delta
+
+    dsinks = None
+    if sinks is not None:
+        p_sink = torch.exp2(sinks[None, None, :] - lse)
+        dsinks = -(p_sink * delta).sum((0, 1))
+
+    return dq, dk, dv, dg_cumsum, dsinks
 
 
 @torch.compile
@@ -742,7 +749,7 @@ class ParallelAttentionFunction(torch.autograd.Function):
     @autocast_custom_bwd
     def backward(ctx, do):
         q, k, v, o, g_cumsum, lse, sinks = ctx.saved_tensors
-        dq, dk, dv, dg, delta = parallel_attn_bwd(
+        dq, dk, dv, dg, dsinks = parallel_attn_bwd(
             q=q,
             k=k,
             v=v,
@@ -750,17 +757,13 @@ class ParallelAttentionFunction(torch.autograd.Function):
             g_cumsum=g_cumsum,
             lse=lse,
             do=do,
+            sinks=sinks,
             scale=ctx.scale,
             window_size=ctx.window_size,
             cu_seqlens=ctx.cu_seqlens,
         )
         if dg is not None:
             dg = chunk_global_cumsum(dg, cu_seqlens=ctx.cu_seqlens, reverse=True)
-
-        dsinks = None
-        if sinks is not None:
-            p_sink = torch.exp2(sinks[None, None, :] - lse)
-            dsinks = -(p_sink * delta).sum((0, 1))
 
         return dq.to(q), dk.to(k), dv.to(v), dg, dsinks, None, None, None, None
 

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -96,12 +96,6 @@ def parallel_attn_fwd_kernel(
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
     i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0) if USE_WINDOW else 0
 
-    # per-query window start: the earliest key position within its sliding window.
-    # used to detect when a query has not yet encountered any valid key,
-    # avoiding -inf - (-inf) = NaN in the online softmax rescaling.
-    if USE_WINDOW:
-        o_w = tl.where(o_q - W + 1 > 0, o_q - W + 1, 0)
-
     for i_s in range(i_start, i_t * BT, BS):
         p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
         p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -791,7 +791,7 @@ def parallel_attn(
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         g (Optional[torch.Tensor]):
-            log decay factors of shape `[B, T, H]`.
+            log decay factors of shape `[B, T, HQ]`.
         scale (Optional[float]):
             Scale factor for attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -11,6 +11,7 @@ import triton.language as tl
 from einops import reduce
 
 from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.cumsum import chunk_global_cumsum
 from fla.ops.utils.op import exp2, log2
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, contiguous
@@ -724,7 +725,6 @@ class ParallelAttentionFunction(torch.autograd.Function):
     def forward(ctx, q, k, v, g, sinks, scale, window_size, cu_seqlens, chunk_indices=None):
         ctx.dtype = q.dtype
 
-        RCP_LN2: float = 1.4426950216
         g_cumsum = chunk_global_cumsum(g, cu_seqlens=cu_seqlens, scale=RCP_LN2) if g is not None else None
         sinks = sinks * RCP_LN2 if sinks is not None else None
         o, lse = parallel_attn_fwd(

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -19,7 +19,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem
 
 @triton.heuristics({
     'USE_G': lambda args: args['g_cumsum'] is not None,
-    'USE_SINK': lambda args: args['sinks'] is not None,
+    'USE_SINK_BIAS': lambda args: args['sink_bias'] is not None,
     'USE_WINDOW': lambda args: args['W'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
@@ -30,7 +30,7 @@ def parallel_attn_fwd_kernel(
     v,
     o,
     g_cumsum,
-    sinks,
+    sink_bias,
     lse,
     scale,
     cu_seqlens,
@@ -48,7 +48,7 @@ def parallel_attn_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_SINK: tl.constexpr,
+    USE_SINK_BIAS: tl.constexpr,
     USE_WINDOW: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -84,10 +84,10 @@ def parallel_attn_fwd_kernel(
     else:
         b_gq = None
 
-    if USE_SINK:
-        b_sink = tl.load(sinks + i_hq).to(tl.float32)
+    if USE_SINK_BIAS:
+        b_sink_bias = tl.load(sink_bias + i_hq).to(tl.float32)
     else:
-        b_sink = None
+        b_sink_bias = None
 
     # [BT]
     o_q = i_t * BT + tl.arange(0, BT)
@@ -117,8 +117,8 @@ def parallel_attn_fwd_kernel(
 
         # [BT, BS]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s, 1)), b_m
-        # Keep the online softmax pivot finite for rows that still have no valid key.
-        # This matches sglang's masked-row stabilization and avoids -inf - (-inf) = NaN.
+        # keep the online softmax pivot finite for rows that still have no valid key.
+        # this matches sglang's masked-row stabilization and avoids -inf - (-inf) = NaN.
         b_mw = tl.where(b_m == float('-inf'), 0., b_m)
         b_r = exp2(b_mp - b_mw)
         b_p = exp2(b_s - b_mw[:, None])
@@ -163,14 +163,15 @@ def parallel_attn_fwd_kernel(
         b_o = b_o * b_r[:, None] + tl.dot(b_p.to(b_q.dtype), b_v)
         b_mp = b_m
 
-    if USE_SINK:
-        # When a row has no valid key at all, b_m is still -inf here.
-        # Use a finite pivot before merging the sink mass so lse becomes the sink logit
-        # instead of hitting the -inf + inf = NaN path.
+    if USE_SINK_BIAS:
+        # when a row has no valid key at all, b_m is still -inf here.
+        # use a finite pivot before merging the sink-bias mass so lse becomes
+        # the sink-bias logit instead of hitting the -inf + inf = NaN path.
         b_m = tl.where(b_m == float('-inf'), 0., b_m)
-        # Match sglang's denominator-only sink update in extend_attention.py:
-        # https://github.com/sgl-project/sglang/blob/6760c790bd5401b6793adc6761a04b8872caebf7/python/sglang/srt/layers/attention/triton_ops/extend_attention.py#L940-L943
-        b_acc += exp2(b_sink - b_m)
+        # denominator-only sink-bias update (matches GPT-OSS / sglang):
+        # the bias logit augments the softmax normalizer without contributing
+        # to the value matmul.
+        b_acc += exp2(b_sink_bias - b_m)
 
     b_o = b_o / b_acc[:, None]
     b_m += log2(b_acc)
@@ -508,7 +509,7 @@ def parallel_attn_fwd(
     k: torch.Tensor,
     v: torch.Tensor,
     g_cumsum: torch.Tensor,
-    sinks: torch.Tensor | None,
+    sink_bias: torch.Tensor | None,
     scale: float,
     window_size: int | None = None,
     cu_seqlens: torch.LongTensor | None = None,
@@ -550,7 +551,7 @@ def parallel_attn_fwd(
         v=v,
         o=o,
         g_cumsum=g_cumsum,
-        sinks=sinks,
+        sink_bias=sink_bias,
         lse=lse,
         scale=scale,
         cu_seqlens=cu_seqlens,
@@ -596,7 +597,7 @@ def parallel_attn_bwd(
     g_cumsum: torch.Tensor,
     lse: torch.Tensor,
     do: torch.Tensor,
-    sinks: torch.Tensor | None = None,
+    sink_bias: torch.Tensor | None = None,
     scale: float = None,
     window_size: int | None = None,
     chunk_size: int = 128,
@@ -702,12 +703,12 @@ def parallel_attn_bwd(
     if g_cumsum is not None:
         dg_cumsum.add_(dg_cumsum_k)
 
-    dsinks = None
-    if sinks is not None:
-        p_sink = torch.exp2(sinks[None, None, :] - lse)
-        dsinks = -(p_sink * delta).sum((0, 1))
+    dsink_bias = None
+    if sink_bias is not None:
+        p_sink_bias = torch.exp2(sink_bias[None, None, :] - lse)
+        dsink_bias = -(p_sink_bias * delta).sum((0, 1))
 
-    return dq, dk, dv, dg_cumsum, dsinks
+    return dq, dk, dv, dg_cumsum, dsink_bias
 
 
 @torch.compile
@@ -716,23 +717,23 @@ class ParallelAttentionFunction(torch.autograd.Function):
     @staticmethod
     @contiguous
     @autocast_custom_fwd
-    def forward(ctx, q, k, v, g, sinks, scale, window_size, cu_seqlens, chunk_indices=None):
+    def forward(ctx, q, k, v, g, sink_bias, scale, window_size, cu_seqlens, chunk_indices=None):
         ctx.dtype = q.dtype
 
         g_cumsum = chunk_global_cumsum(g, cu_seqlens=cu_seqlens, scale=RCP_LN2) if g is not None else None
-        sinks = sinks * RCP_LN2 if sinks is not None else None
+        sink_bias = sink_bias * RCP_LN2 if sink_bias is not None else None
         o, lse = parallel_attn_fwd(
             q=q,
             k=k,
             v=v,
             g_cumsum=g_cumsum,
-            sinks=sinks,
+            sink_bias=sink_bias,
             scale=scale,
             window_size=window_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
         )
-        ctx.save_for_backward(q, k, v, o, g_cumsum, lse, sinks)
+        ctx.save_for_backward(q, k, v, o, g_cumsum, lse, sink_bias)
         ctx.scale = scale
         ctx.window_size = window_size
         ctx.cu_seqlens = cu_seqlens
@@ -742,8 +743,8 @@ class ParallelAttentionFunction(torch.autograd.Function):
     @contiguous
     @autocast_custom_bwd
     def backward(ctx, do):
-        q, k, v, o, g_cumsum, lse, sinks = ctx.saved_tensors
-        dq, dk, dv, dg, dsinks = parallel_attn_bwd(
+        q, k, v, o, g_cumsum, lse, sink_bias = ctx.saved_tensors
+        dq, dk, dv, dg, dsink_bias = parallel_attn_bwd(
             q=q,
             k=k,
             v=v,
@@ -751,7 +752,7 @@ class ParallelAttentionFunction(torch.autograd.Function):
             g_cumsum=g_cumsum,
             lse=lse,
             do=do,
-            sinks=sinks,
+            sink_bias=sink_bias,
             scale=ctx.scale,
             window_size=ctx.window_size,
             cu_seqlens=ctx.cu_seqlens,
@@ -759,7 +760,7 @@ class ParallelAttentionFunction(torch.autograd.Function):
         if dg is not None:
             dg = chunk_global_cumsum(dg, cu_seqlens=ctx.cu_seqlens, reverse=True)
 
-        return dq.to(q), dk.to(k), dv.to(v), dg, dsinks, None, None, None, None
+        return dq.to(q), dk.to(k), dv.to(v), dg, dsink_bias, None, None, None, None
 
 
 def parallel_attn(
@@ -772,7 +773,7 @@ def parallel_attn(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
     *,
-    sinks: torch.Tensor | None = None,
+    sink_bias: torch.Tensor | None = None,
     **kwargs
 ) -> torch.Tensor:
     r"""
@@ -796,8 +797,18 @@ def parallel_attn(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
-        sinks (Optional[torch.Tensor]):
-            Per-query-head sink logits of shape `[HQ]`.
+        sink_bias (Optional[torch.Tensor]):
+            Per-query-head attention-sink bias logits of shape `[HQ]` — one
+            learnable scalar per query head, as introduced by GPT-OSS.
+
+            Augments the softmax denominator with `exp(sink_bias[h])` without
+            adding a corresponding key/value entry, so the model can route
+            attention mass to a learnable "no-op" target:
+                p_i    = exp(s_i)          / (sum_j exp(s_j) + exp(sink_bias[h]))
+                o      = sum_i p_i * v_i   # sink slot contributes no value
+            When `None`, standard softmax is used. Reserved name: the future
+            `sink_tokens_*` kwargs will support Xiao 2024-style K/V sink tokens
+            and may be combined with `sink_bias`.
 
     Returns:
         o (torch.Tensor):
@@ -812,10 +823,10 @@ def parallel_attn(
         scale = k.shape[-1] ** -0.5
     if cu_seqlens is not None:
         assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
-    if sinks is not None:
-        assert sinks.shape == (q.shape[2],), "sinks must have shape [HQ]"
+    if sink_bias is not None:
+        assert sink_bias.shape == (q.shape[2],), "sink_bias must have shape [HQ]"
 
     o = ParallelAttentionFunction.apply(
-        q, k, v, g, sinks, scale, window_size, cu_seqlens, chunk_indices
+        q, k, v, g, sink_bias, scale, window_size, cu_seqlens, chunk_indices
     )
     return o

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -18,6 +18,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem
 
 @triton.heuristics({
     'USE_G': lambda args: args['g_cumsum'] is not None,
+    'USE_SINK': lambda args: args['sinks'] is not None,
     'USE_WINDOW': lambda args: args['W'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
@@ -28,6 +29,7 @@ def parallel_attn_fwd_kernel(
     v,
     o,
     g_cumsum,
+    sinks,
     lse,
     scale,
     cu_seqlens,
@@ -45,6 +47,7 @@ def parallel_attn_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_SINK: tl.constexpr,
     USE_WINDOW: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -79,6 +82,11 @@ def parallel_attn_fwd_kernel(
         b_gq = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
     else:
         b_gq = None
+
+    if USE_SINK:
+        b_sink = tl.load(sinks + i_hq).to(tl.float32)
+    else:
+        b_sink = None
 
     # [BT]
     o_q = i_t * BT + tl.arange(0, BT)
@@ -159,6 +167,11 @@ def parallel_attn_fwd_kernel(
         # [BT, BV]
         b_o = b_o * b_r[:, None] + tl.dot(b_p.to(b_q.dtype), b_v)
         b_mp = b_m
+
+    if USE_SINK:
+        # Match sglang's denominator-only sink update in extend_attention.py:
+        # https://github.com/sgl-project/sglang/blob/6760c790bd5401b6793adc6761a04b8872caebf7/python/sglang/srt/layers/attention/triton_ops/extend_attention.py#L940-L943
+        b_acc += exp2(b_sink - b_m)
 
     b_o = b_o / b_acc[:, None]
     b_m += log2(b_acc)
@@ -496,6 +509,7 @@ def parallel_attn_fwd(
     k: torch.Tensor,
     v: torch.Tensor,
     g_cumsum: torch.Tensor,
+    sinks: torch.Tensor | None,
     scale: float,
     window_size: int | None = None,
     cu_seqlens: torch.LongTensor | None = None,
@@ -537,6 +551,7 @@ def parallel_attn_fwd(
         v=v,
         o=o,
         g_cumsum=g_cumsum,
+        sinks=sinks,
         lse=lse,
         scale=scale,
         cu_seqlens=cu_seqlens,
@@ -686,7 +701,7 @@ def parallel_attn_bwd(
     dv = reduce(dv, 'b t (h g) v -> b t h v', g=G, reduction='sum')
     if g_cumsum is not None:
         dg_cumsum.add_(dg_cumsum_k)
-    return dq, dk, dv, dg_cumsum
+    return dq, dk, dv, dg_cumsum, delta
 
 
 @torch.compile
@@ -695,22 +710,24 @@ class ParallelAttentionFunction(torch.autograd.Function):
     @staticmethod
     @contiguous
     @autocast_custom_fwd
-    def forward(ctx, q, k, v, g, scale, window_size, cu_seqlens, chunk_indices=None):
+    def forward(ctx, q, k, v, g, sinks, scale, window_size, cu_seqlens, chunk_indices=None):
         ctx.dtype = q.dtype
 
         RCP_LN2: float = 1.4426950216
         g_cumsum = chunk_global_cumsum(g, cu_seqlens=cu_seqlens, scale=RCP_LN2) if g is not None else None
+        sinks = sinks * RCP_LN2 if sinks is not None else None
         o, lse = parallel_attn_fwd(
             q=q,
             k=k,
             v=v,
             g_cumsum=g_cumsum,
+            sinks=sinks,
             scale=scale,
             window_size=window_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
         )
-        ctx.save_for_backward(q, k, v, o, g_cumsum, lse)
+        ctx.save_for_backward(q, k, v, o, g_cumsum, lse, sinks)
         ctx.scale = scale
         ctx.window_size = window_size
         ctx.cu_seqlens = cu_seqlens
@@ -720,8 +737,8 @@ class ParallelAttentionFunction(torch.autograd.Function):
     @contiguous
     @autocast_custom_bwd
     def backward(ctx, do):
-        q, k, v, o, g_cumsum, lse = ctx.saved_tensors
-        dq, dk, dv, dg = parallel_attn_bwd(
+        q, k, v, o, g_cumsum, lse, sinks = ctx.saved_tensors
+        dq, dk, dv, dg, delta = parallel_attn_bwd(
             q=q,
             k=k,
             v=v,
@@ -736,7 +753,12 @@ class ParallelAttentionFunction(torch.autograd.Function):
         if dg is not None:
             dg = chunk_global_cumsum(dg, cu_seqlens=ctx.cu_seqlens, reverse=True)
 
-        return dq.to(q), dk.to(k), dv.to(v), dg, None, None, None, None
+        dsinks = None
+        if sinks is not None:
+            p_sink = torch.exp2(sinks[None, None, :] - lse)
+            dsinks = -(p_sink * delta).sum((0, 1))
+
+        return dq.to(q), dk.to(k), dv.to(v), dg, dsinks, None, None, None, None
 
 
 def parallel_attn(
@@ -748,6 +770,8 @@ def parallel_attn(
     window_size: int | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    *,
+    sinks: torch.Tensor | None = None,
     **kwargs
 ) -> torch.Tensor:
     r"""
@@ -771,6 +795,8 @@ def parallel_attn(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
+        sinks (Optional[torch.Tensor]):
+            Per-query-head sink logits of shape `[HQ]`.
 
     Returns:
         o (torch.Tensor):
@@ -785,6 +811,10 @@ def parallel_attn(
         scale = k.shape[-1] ** -0.5
     if cu_seqlens is not None:
         assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
+    if sinks is not None:
+        assert sinks.shape == (q.shape[2],), "sinks must have shape [HQ]"
 
-    o = ParallelAttentionFunction.apply(q, k, v, g, scale, window_size, cu_seqlens, chunk_indices)
+    o = ParallelAttentionFunction.apply(
+        q, k, v, g, sinks, scale, window_size, cu_seqlens, chunk_indices
+    )
     return o

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -9,11 +9,171 @@ import os
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 from fla.ops.attn.decoding import attn_decoding_one_step
 from fla.ops.attn.naive import naive_parallel_attn
 from fla.ops.attn.parallel import parallel_attn
 from fla.utils import assert_close, device
+
+
+def _repeat_kv_for_gpt_oss(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    if n_rep == 1:
+        return hidden_states
+    batch_size, num_kv_heads, seq_len, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch_size, num_kv_heads, n_rep, seq_len, head_dim)
+    return hidden_states.reshape(batch_size, num_kv_heads * n_rep, seq_len, head_dim)
+
+
+def _gpt_oss_eager_sink_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sinks: torch.Tensor,
+    *,
+    scale: float,
+    window_size: int | None = None,
+    query_indices: torch.Tensor | None = None,
+):
+    """
+    Mirrors the sink path in transformers' GPT-OSS eager attention:
+    concat sink logits as an extra column, softmax once, then drop the sink column.
+    """
+    batch_size, q_len, num_heads, head_dim = q.shape
+    kv_len = k.shape[1]
+    num_kv_heads = k.shape[2]
+    num_key_value_groups = num_heads // num_kv_heads
+
+    query_states = q.transpose(1, 2)
+    key_states = _repeat_kv_for_gpt_oss(k.transpose(1, 2), num_key_value_groups)
+    value_states = _repeat_kv_for_gpt_oss(v.transpose(1, 2), num_key_value_groups)
+
+    attn_logits = torch.matmul(query_states, key_states.transpose(2, 3)) * scale
+
+    if query_indices is None:
+        query_positions = torch.arange(q_len, device=q.device).unsqueeze(0).expand(batch_size, q_len)
+    else:
+        if query_indices.ndim == 1:
+            query_positions = query_indices.unsqueeze(0).expand(batch_size, q_len)
+        else:
+            query_positions = query_indices
+        query_positions = query_positions.to(device=q.device, dtype=torch.long)
+        assert query_positions.shape == (batch_size, q_len), "query_indices must have shape [TQ] or [B, TQ]"
+
+    row_idx = query_positions[:, :, None]
+    col_idx = torch.arange(kv_len, device=q.device)[None, None, :]
+    invalid = col_idx > row_idx
+    if window_size is not None:
+        invalid = invalid | (row_idx - col_idx >= window_size)
+    attn_logits = attn_logits.masked_fill(invalid[:, None], float("-inf"))
+
+    sink_logits = sinks.view(1, num_heads, 1, 1).expand(batch_size, num_heads, q_len, 1)
+    combined_logits = torch.cat((attn_logits, sink_logits), dim=-1)
+    combined_logits = combined_logits - combined_logits.max(dim=-1, keepdim=True).values
+    probs = F.softmax(combined_logits, dim=-1, dtype=combined_logits.dtype)
+    attn_probs = probs[..., :-1]
+    output = torch.matmul(attn_probs, value_states).transpose(1, 2).contiguous()
+    return output, attn_probs
+
+
+@pytest.mark.parametrize(
+    ("window_size", "query_indices"),
+    [
+        pytest.param(None, None, id="full"),
+        pytest.param(64, None, id="swa"),
+        pytest.param(None, [0, 31, 63, 95], id="indexed"),
+        pytest.param(32, [31, 63, 95, 95], id="indexed_swa"),
+    ],
+)
+def test_attn_sink_ref_matches_gpt_oss_eager(window_size, query_indices):
+    torch.manual_seed(777)
+    dtype = torch.float64
+
+    batch_size, kv_len, q_len, num_kv_heads, num_heads, head_dim = 2, 96, 96, 2, 8, 64
+    if query_indices is not None:
+        q_len = len(query_indices)
+        query_indices = torch.tensor(query_indices, device=device)
+
+    q = torch.randn((batch_size, q_len, num_heads, head_dim), dtype=dtype, device=device)
+    k = torch.randn((batch_size, kv_len, num_kv_heads, head_dim), dtype=dtype, device=device)
+    v = torch.randn((batch_size, kv_len, num_kv_heads, head_dim), dtype=dtype, device=device)
+    sinks = torch.randn((num_heads,), dtype=dtype, device=device)
+    do = torch.randn((batch_size, q_len, num_heads, head_dim), dtype=dtype, device=device)
+
+    q_ref = q.detach().clone().requires_grad_(True)
+    k_ref = k.detach().clone().requires_grad_(True)
+    v_ref = v.detach().clone().requires_grad_(True)
+    sinks_ref = sinks.detach().clone().requires_grad_(True)
+    o_ref, _ = naive_parallel_attn(
+        q=q_ref,
+        k=k_ref,
+        v=v_ref,
+        sinks=sinks_ref,
+        scale=0.1,
+        window_size=window_size,
+        query_indices=query_indices,
+    )
+    o_ref.backward(do)
+
+    q_gpt = q.detach().clone().requires_grad_(True)
+    k_gpt = k.detach().clone().requires_grad_(True)
+    v_gpt = v.detach().clone().requires_grad_(True)
+    sinks_gpt = sinks.detach().clone().requires_grad_(True)
+    o_gpt, _ = _gpt_oss_eager_sink_reference(
+        q=q_gpt,
+        k=k_gpt,
+        v=v_gpt,
+        sinks=sinks_gpt,
+        scale=0.1,
+        window_size=window_size,
+        query_indices=query_indices,
+    )
+    o_gpt.backward(do)
+
+    assert_close(" o_ref_vs_gpt", o_ref, o_gpt, 1e-10, err_atol=1e-10)
+    assert_close("dq_ref_vs_gpt", q_ref.grad, q_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("dk_ref_vs_gpt", k_ref.grad, k_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("dv_ref_vs_gpt", v_ref.grad, v_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("ds_ref_vs_gpt", sinks_ref.grad, sinks_gpt.grad, 1e-10, err_atol=1e-10)
+
+
+def test_attn_sink_empty_row_ref_matches_gpt_oss_eager():
+    torch.manual_seed(778)
+    dtype = torch.float64
+
+    batch_size, seq_len, num_kv_heads, num_heads, head_dim = 2, 48, 2, 8, 64
+    q = torch.randn((batch_size, seq_len, num_heads, head_dim), dtype=dtype, device=device)
+    k = torch.randn((batch_size, seq_len, num_kv_heads, head_dim), dtype=dtype, device=device)
+    v = torch.randn((batch_size, seq_len, num_kv_heads, head_dim), dtype=dtype, device=device)
+    sinks = torch.randn((num_heads,), dtype=dtype, device=device)
+    do = torch.randn((batch_size, seq_len, num_heads, head_dim), dtype=dtype, device=device)
+
+    q_ref = q.detach().clone().requires_grad_(True)
+    k_ref = k.detach().clone().requires_grad_(True)
+    v_ref = v.detach().clone().requires_grad_(True)
+    sinks_ref = sinks.detach().clone().requires_grad_(True)
+    o_ref, _ = naive_parallel_attn(q=q_ref, k=k_ref, v=v_ref, sinks=sinks_ref, scale=0.1, window_size=0)
+    o_ref.backward(do)
+
+    q_gpt = q.detach().clone().requires_grad_(True)
+    k_gpt = k.detach().clone().requires_grad_(True)
+    v_gpt = v.detach().clone().requires_grad_(True)
+    sinks_gpt = sinks.detach().clone().requires_grad_(True)
+    o_gpt, _ = _gpt_oss_eager_sink_reference(
+        q=q_gpt,
+        k=k_gpt,
+        v=v_gpt,
+        sinks=sinks_gpt,
+        scale=0.1,
+        window_size=0,
+    )
+    o_gpt.backward(do)
+
+    assert_close(" o_empty_ref_vs_gpt", o_ref, o_gpt, 1e-10, err_atol=1e-10)
+    assert_close("dq_empty_ref_vs_gpt", q_ref.grad, q_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("dk_empty_ref_vs_gpt", k_ref.grad, k_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("dv_empty_ref_vs_gpt", v_ref.grad, v_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("ds_empty_ref_vs_gpt", sinks_ref.grad, sinks_gpt.grad, 1e-10, err_atol=1e-10)
 
 
 @pytest.mark.parametrize(

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -39,7 +39,7 @@ def _gpt_oss_eager_sink_reference(
     Mirrors the sink path in transformers' GPT-OSS eager attention:
     concat sink logits as an extra column, softmax once, then drop the sink column.
     """
-    batch_size, q_len, num_heads, head_dim = q.shape
+    batch_size, q_len, num_heads, _ = q.shape
     kv_len = k.shape[1]
     num_kv_heads = k.shape[2]
     num_key_value_groups = num_heads // num_kv_heads

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -77,6 +77,44 @@ def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
     assert_close("ds_ref_vs_sg", sinks_ref.grad, sinks_sg.grad, 0.02)
 
 
+def test_parallel_attn_sink_empty_row_matches_reference():
+    torch.manual_seed(987)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    dtype = torch.float16
+    B, T, H, HQ, D = 2, 96, 2, 8, 64
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+
+    q_ref = q.float().detach().clone().requires_grad_(True)
+    k_ref = k.float().detach().clone().requires_grad_(True)
+    v_ref = v.float().detach().clone().requires_grad_(True)
+    sinks_ref = sinks.detach().clone().requires_grad_(True)
+    o_ref, _ = naive_parallel_attn(
+        q_ref, k_ref, v_ref, sinks=sinks_ref, scale=0.1, window_size=0
+    )
+    o_ref = o_ref.to(dtype)
+    o_ref.backward(do)
+
+    q_tri = q.detach().clone().requires_grad_(True)
+    k_tri = k.detach().clone().requires_grad_(True)
+    v_tri = v.detach().clone().requires_grad_(True)
+    sinks_tri = sinks.detach().clone().requires_grad_(True)
+    o_tri = parallel_attn(
+        q=q_tri, k=k_tri, v=v_tri, sinks=sinks_tri, scale=0.1, window_size=0
+    )
+    o_tri.backward(do)
+
+    assert_close(" o_ref_vs_tri", o_ref, o_tri, 0.01)
+    assert_close("dq_ref_vs_tri", q_ref.grad.to(dtype), q_tri.grad, 0.02)
+    assert_close("dk_ref_vs_tri", k_ref.grad.to(dtype), k_tri.grad, 0.02)
+    assert_close("dv_ref_vs_tri", v_ref.grad.to(dtype), v_tri.grad, 0.02)
+    assert_close("ds_ref_vs_tri", sinks_ref.grad, sinks_tri.grad, 0.02)
+
+
 @pytest.mark.parametrize(
     ("window_size", "cu_seqlens"),
     [

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn.functional as F
 
 from fla.ops.attn.decoding import attn_decoding_one_step
-from fla.ops.attn.naive import naive_parallel_attn
+from fla.ops.attn.naive import naive_attn_decoding, naive_parallel_attn
 from fla.ops.attn.parallel import parallel_attn
 from fla.utils import assert_close, device
 
@@ -20,55 +20,43 @@ from fla.utils import assert_close, device
 def _repeat_kv_for_gpt_oss(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     if n_rep == 1:
         return hidden_states
-    batch_size, num_kv_heads, seq_len, head_dim = hidden_states.shape
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch_size, num_kv_heads, n_rep, seq_len, head_dim)
-    return hidden_states.reshape(batch_size, num_kv_heads * n_rep, seq_len, head_dim)
+    B, H, T, D = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(B, H, n_rep, T, D)
+    return hidden_states.reshape(B, H * n_rep, T, D)
 
 
 def _gpt_oss_eager_sink_reference(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    sinks: torch.Tensor,
+    sink_bias: torch.Tensor,
     *,
     scale: float,
     window_size: int | None = None,
-    query_indices: torch.Tensor | None = None,
 ):
     """
-    Mirrors the sink path in transformers' GPT-OSS eager attention:
+    Mirrors the sink path in GPT-OSS eager attention:
     concat sink logits as an extra column, softmax once, then drop the sink column.
     """
-    batch_size, q_len, num_heads, _ = q.shape
-    kv_len = k.shape[1]
-    num_kv_heads = k.shape[2]
-    num_key_value_groups = num_heads // num_kv_heads
+    B, T, HQ, _ = q.shape
+    H = k.shape[2]
+    G = HQ // H
 
     query_states = q.transpose(1, 2)
-    key_states = _repeat_kv_for_gpt_oss(k.transpose(1, 2), num_key_value_groups)
-    value_states = _repeat_kv_for_gpt_oss(v.transpose(1, 2), num_key_value_groups)
+    key_states = _repeat_kv_for_gpt_oss(k.transpose(1, 2), G)
+    value_states = _repeat_kv_for_gpt_oss(v.transpose(1, 2), G)
 
     attn_logits = torch.matmul(query_states, key_states.transpose(2, 3)) * scale
 
-    if query_indices is None:
-        query_positions = torch.arange(q_len, device=q.device).unsqueeze(0).expand(batch_size, q_len)
-    else:
-        if query_indices.ndim == 1:
-            query_positions = query_indices.unsqueeze(0).expand(batch_size, q_len)
-        else:
-            query_positions = query_indices
-        query_positions = query_positions.to(device=q.device, dtype=torch.long)
-        assert query_positions.shape == (batch_size, q_len), "query_indices must have shape [TQ] or [B, TQ]"
-
-    row_idx = query_positions[:, :, None]
-    col_idx = torch.arange(kv_len, device=q.device)[None, None, :]
+    row_idx = torch.arange(T, device=q.device)[None, :, None]
+    col_idx = torch.arange(T, device=q.device)[None, None, :]
     invalid = col_idx > row_idx
     if window_size is not None:
         invalid = invalid | (row_idx - col_idx >= window_size)
     attn_logits = attn_logits.masked_fill(invalid[:, None], float("-inf"))
 
-    sink_logits = sinks.view(1, num_heads, 1, 1).expand(batch_size, num_heads, q_len, 1)
-    combined_logits = torch.cat((attn_logits, sink_logits), dim=-1)
+    sink_bias_logits = sink_bias.view(1, HQ, 1, 1).expand(B, HQ, T, 1)
+    combined_logits = torch.cat((attn_logits, sink_bias_logits), dim=-1)
     combined_logits = combined_logits - combined_logits.max(dim=-1, keepdim=True).values
     probs = F.softmax(combined_logits, dim=-1, dtype=combined_logits.dtype)
     attn_probs = probs[..., :-1]
@@ -77,56 +65,49 @@ def _gpt_oss_eager_sink_reference(
 
 
 @pytest.mark.parametrize(
-    ("window_size", "query_indices"),
+    "window_size",
     [
-        pytest.param(None, None, id="full"),
-        pytest.param(64, None, id="swa"),
-        pytest.param(None, [0, 31, 63, 95], id="indexed"),
-        pytest.param(32, [31, 63, 95, 95], id="indexed_swa"),
+        pytest.param(None, id="full"),
+        pytest.param(64, id="swa"),
     ],
 )
-def test_attn_sink_ref_matches_gpt_oss_eager(window_size, query_indices):
+def test_attn_sink_ref_matches_gpt_oss_eager(window_size):
     torch.manual_seed(777)
     dtype = torch.float64
 
-    batch_size, kv_len, q_len, num_kv_heads, num_heads, head_dim = 2, 96, 96, 2, 8, 64
-    if query_indices is not None:
-        q_len = len(query_indices)
-        query_indices = torch.tensor(query_indices, device=device)
+    B, T, H, HQ, D = 2, 96, 2, 8, 64
 
-    q = torch.randn((batch_size, q_len, num_heads, head_dim), dtype=dtype, device=device)
-    k = torch.randn((batch_size, kv_len, num_kv_heads, head_dim), dtype=dtype, device=device)
-    v = torch.randn((batch_size, kv_len, num_kv_heads, head_dim), dtype=dtype, device=device)
-    sinks = torch.randn((num_heads,), dtype=dtype, device=device)
-    do = torch.randn((batch_size, q_len, num_heads, head_dim), dtype=dtype, device=device)
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    sink_bias = torch.randn((HQ,), dtype=dtype, device=device)
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.detach().clone().requires_grad_(True)
     k_ref = k.detach().clone().requires_grad_(True)
     v_ref = v.detach().clone().requires_grad_(True)
-    sinks_ref = sinks.detach().clone().requires_grad_(True)
+    sink_bias_ref = sink_bias.detach().clone().requires_grad_(True)
     o_ref, _ = naive_parallel_attn(
         q=q_ref,
         k=k_ref,
         v=v_ref,
-        sinks=sinks_ref,
+        sink_bias=sink_bias_ref,
         scale=0.1,
         window_size=window_size,
-        query_indices=query_indices,
     )
     o_ref.backward(do)
 
     q_gpt = q.detach().clone().requires_grad_(True)
     k_gpt = k.detach().clone().requires_grad_(True)
     v_gpt = v.detach().clone().requires_grad_(True)
-    sinks_gpt = sinks.detach().clone().requires_grad_(True)
+    sink_bias_gpt = sink_bias.detach().clone().requires_grad_(True)
     o_gpt, _ = _gpt_oss_eager_sink_reference(
         q=q_gpt,
         k=k_gpt,
         v=v_gpt,
-        sinks=sinks_gpt,
+        sink_bias=sink_bias_gpt,
         scale=0.1,
         window_size=window_size,
-        query_indices=query_indices,
     )
     o_gpt.backward(do)
 
@@ -134,36 +115,43 @@ def test_attn_sink_ref_matches_gpt_oss_eager(window_size, query_indices):
     assert_close("dq_ref_vs_gpt", q_ref.grad, q_gpt.grad, 1e-10, err_atol=1e-10)
     assert_close("dk_ref_vs_gpt", k_ref.grad, k_gpt.grad, 1e-10, err_atol=1e-10)
     assert_close("dv_ref_vs_gpt", v_ref.grad, v_gpt.grad, 1e-10, err_atol=1e-10)
-    assert_close("ds_ref_vs_gpt", sinks_ref.grad, sinks_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("ds_ref_vs_gpt", sink_bias_ref.grad, sink_bias_gpt.grad, 1e-10, err_atol=1e-10)
 
 
 def test_attn_sink_empty_row_ref_matches_gpt_oss_eager():
     torch.manual_seed(778)
     dtype = torch.float64
 
-    batch_size, seq_len, num_kv_heads, num_heads, head_dim = 2, 48, 2, 8, 64
-    q = torch.randn((batch_size, seq_len, num_heads, head_dim), dtype=dtype, device=device)
-    k = torch.randn((batch_size, seq_len, num_kv_heads, head_dim), dtype=dtype, device=device)
-    v = torch.randn((batch_size, seq_len, num_kv_heads, head_dim), dtype=dtype, device=device)
-    sinks = torch.randn((num_heads,), dtype=dtype, device=device)
-    do = torch.randn((batch_size, seq_len, num_heads, head_dim), dtype=dtype, device=device)
+    B, T, H, HQ, D = 2, 48, 2, 8, 64
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    sink_bias = torch.randn((HQ,), dtype=dtype, device=device)
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.detach().clone().requires_grad_(True)
     k_ref = k.detach().clone().requires_grad_(True)
     v_ref = v.detach().clone().requires_grad_(True)
-    sinks_ref = sinks.detach().clone().requires_grad_(True)
-    o_ref, _ = naive_parallel_attn(q=q_ref, k=k_ref, v=v_ref, sinks=sinks_ref, scale=0.1, window_size=0)
+    sink_bias_ref = sink_bias.detach().clone().requires_grad_(True)
+    o_ref, _ = naive_parallel_attn(
+        q=q_ref,
+        k=k_ref,
+        v=v_ref,
+        sink_bias=sink_bias_ref,
+        scale=0.1,
+        window_size=0,
+    )
     o_ref.backward(do)
 
     q_gpt = q.detach().clone().requires_grad_(True)
     k_gpt = k.detach().clone().requires_grad_(True)
     v_gpt = v.detach().clone().requires_grad_(True)
-    sinks_gpt = sinks.detach().clone().requires_grad_(True)
+    sink_bias_gpt = sink_bias.detach().clone().requires_grad_(True)
     o_gpt, _ = _gpt_oss_eager_sink_reference(
         q=q_gpt,
         k=k_gpt,
         v=v_gpt,
-        sinks=sinks_gpt,
+        sink_bias=sink_bias_gpt,
         scale=0.1,
         window_size=0,
     )
@@ -173,7 +161,7 @@ def test_attn_sink_empty_row_ref_matches_gpt_oss_eager():
     assert_close("dq_empty_ref_vs_gpt", q_ref.grad, q_gpt.grad, 1e-10, err_atol=1e-10)
     assert_close("dk_empty_ref_vs_gpt", k_ref.grad, k_gpt.grad, 1e-10, err_atol=1e-10)
     assert_close("dv_empty_ref_vs_gpt", v_ref.grad, v_gpt.grad, 1e-10, err_atol=1e-10)
-    assert_close("ds_empty_ref_vs_gpt", sinks_ref.grad, sinks_gpt.grad, 1e-10, err_atol=1e-10)
+    assert_close("ds_empty_ref_vs_gpt", sink_bias_ref.grad, sink_bias_gpt.grad, 1e-10, err_atol=1e-10)
 
 
 @pytest.mark.parametrize(
@@ -197,24 +185,33 @@ def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
     q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
     k = torch.randn((B, T, H, D), dtype=dtype, device=device)
     v = torch.randn((B, T, H, D), dtype=dtype, device=device)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
+    sink_bias = torch.randn((HQ,), dtype=torch.float32, device=device)
     do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.float().detach().clone().requires_grad_(True)
     k_ref = k.float().detach().clone().requires_grad_(True)
     v_ref = v.float().detach().clone().requires_grad_(True)
-    sinks_ref = sinks.detach().clone().requires_grad_(True)
+    sink_bias_ref = sink_bias.detach().clone().requires_grad_(True)
 
     if cu_seqlens is None:
         o_ref, _ = naive_parallel_attn(
-            q_ref, k_ref, v_ref, sinks=sinks_ref, scale=0.1, window_size=window_size
+            q=q_ref,
+            k=k_ref,
+            v=v_ref,
+            sink_bias=sink_bias_ref,
+            scale=0.1,
+            window_size=window_size,
         )
     else:
         outputs = []
         for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
             o_i, _ = naive_parallel_attn(
-                q_ref[:, bos:eos], k_ref[:, bos:eos], v_ref[:, bos:eos],
-                sinks=sinks_ref, scale=0.1, window_size=window_size
+                q=q_ref[:, bos:eos],
+                k=k_ref[:, bos:eos],
+                v=v_ref[:, bos:eos],
+                sink_bias=sink_bias_ref,
+                scale=0.1,
+                window_size=window_size,
             )
             outputs.append(o_i)
         o_ref = torch.cat(outputs, dim=1)
@@ -224,9 +221,15 @@ def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
     q_tri = q.detach().clone().requires_grad_(True)
     k_tri = k.detach().clone().requires_grad_(True)
     v_tri = v.detach().clone().requires_grad_(True)
-    sinks_tri = sinks.detach().clone().requires_grad_(True)
+    sink_bias_tri = sink_bias.detach().clone().requires_grad_(True)
     o_tri = parallel_attn(
-        q=q_tri, k=k_tri, v=v_tri, sinks=sinks_tri, scale=0.1, window_size=window_size, cu_seqlens=cu_seqlens
+        q=q_tri,
+        k=k_tri,
+        v=v_tri,
+        sink_bias=sink_bias_tri,
+        scale=0.1,
+        window_size=window_size,
+        cu_seqlens=cu_seqlens,
     )
     o_tri.backward(do)
 
@@ -234,7 +237,7 @@ def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
     assert_close("dq_ref_vs_tri", q_ref.grad.to(dtype), q_tri.grad, 0.02)
     assert_close("dk_ref_vs_tri", k_ref.grad.to(dtype), k_tri.grad, 0.02)
     assert_close("dv_ref_vs_tri", v_ref.grad.to(dtype), v_tri.grad, 0.02)
-    assert_close("ds_ref_vs_tri", sinks_ref.grad, sinks_tri.grad, 0.02)
+    assert_close("ds_ref_vs_tri", sink_bias_ref.grad, sink_bias_tri.grad, 0.02)
 
 
 def test_parallel_attn_sink_empty_row_matches_reference():
@@ -246,15 +249,20 @@ def test_parallel_attn_sink_empty_row_matches_reference():
     q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
     k = torch.randn((B, T, H, D), dtype=dtype, device=device)
     v = torch.randn((B, T, H, D), dtype=dtype, device=device)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
+    sink_bias = torch.randn((HQ,), dtype=torch.float32, device=device)
     do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.float().detach().clone().requires_grad_(True)
     k_ref = k.float().detach().clone().requires_grad_(True)
     v_ref = v.float().detach().clone().requires_grad_(True)
-    sinks_ref = sinks.detach().clone().requires_grad_(True)
+    sink_bias_ref = sink_bias.detach().clone().requires_grad_(True)
     o_ref, _ = naive_parallel_attn(
-        q_ref, k_ref, v_ref, sinks=sinks_ref, scale=0.1, window_size=0
+        q=q_ref,
+        k=k_ref,
+        v=v_ref,
+        sink_bias=sink_bias_ref,
+        scale=0.1,
+        window_size=0,
     )
     o_ref = o_ref.to(dtype)
     o_ref.backward(do)
@@ -262,9 +270,14 @@ def test_parallel_attn_sink_empty_row_matches_reference():
     q_tri = q.detach().clone().requires_grad_(True)
     k_tri = k.detach().clone().requires_grad_(True)
     v_tri = v.detach().clone().requires_grad_(True)
-    sinks_tri = sinks.detach().clone().requires_grad_(True)
+    sink_bias_tri = sink_bias.detach().clone().requires_grad_(True)
     o_tri = parallel_attn(
-        q=q_tri, k=k_tri, v=v_tri, sinks=sinks_tri, scale=0.1, window_size=0
+        q=q_tri,
+        k=k_tri,
+        v=v_tri,
+        sink_bias=sink_bias_tri,
+        scale=0.1,
+        window_size=0,
     )
     o_tri.backward(do)
 
@@ -272,7 +285,7 @@ def test_parallel_attn_sink_empty_row_matches_reference():
     assert_close("dq_ref_vs_tri", q_ref.grad.to(dtype), q_tri.grad, 0.02)
     assert_close("dk_ref_vs_tri", k_ref.grad.to(dtype), k_tri.grad, 0.02)
     assert_close("dv_ref_vs_tri", v_ref.grad.to(dtype), v_tri.grad, 0.02)
-    assert_close("ds_ref_vs_tri", sinks_ref.grad, sinks_tri.grad, 0.02)
+    assert_close("ds_ref_vs_tri", sink_bias_ref.grad, sink_bias_tri.grad, 0.02)
 
 
 @pytest.mark.parametrize(
@@ -297,14 +310,14 @@ def test_parallel_attn_sink_with_g_matches_reference(window_size, cu_seqlens):
     k = torch.randn((B, T, H, D), dtype=dtype, device=device)
     v = torch.randn((B, T, H, D), dtype=dtype, device=device)
     g = torch.empty((B, T, HQ), dtype=dtype, device=device).uniform_(-0.1, -0.01)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
+    sink_bias = torch.randn((HQ,), dtype=torch.float32, device=device)
     do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.float().detach().clone().requires_grad_(True)
     k_ref = k.float().detach().clone().requires_grad_(True)
     v_ref = v.float().detach().clone().requires_grad_(True)
     g_ref = g.float().detach().clone().requires_grad_(True)
-    sinks_ref = sinks.detach().clone().requires_grad_(True)
+    sink_bias_ref = sink_bias.detach().clone().requires_grad_(True)
 
     if cu_seqlens is None:
         o_ref, _ = naive_parallel_attn(
@@ -312,7 +325,7 @@ def test_parallel_attn_sink_with_g_matches_reference(window_size, cu_seqlens):
             k=k_ref,
             v=v_ref,
             g=g_ref,
-            sinks=sinks_ref,
+            sink_bias=sink_bias_ref,
             scale=0.1,
             window_size=window_size,
         )
@@ -324,7 +337,7 @@ def test_parallel_attn_sink_with_g_matches_reference(window_size, cu_seqlens):
                 k=k_ref[:, bos:eos],
                 v=v_ref[:, bos:eos],
                 g=g_ref[:, bos:eos],
-                sinks=sinks_ref,
+                sink_bias=sink_bias_ref,
                 scale=0.1,
                 window_size=window_size,
             )
@@ -337,13 +350,13 @@ def test_parallel_attn_sink_with_g_matches_reference(window_size, cu_seqlens):
     k_tri = k.detach().clone().requires_grad_(True)
     v_tri = v.detach().clone().requires_grad_(True)
     g_tri = g.detach().clone().requires_grad_(True)
-    sinks_tri = sinks.detach().clone().requires_grad_(True)
+    sink_bias_tri = sink_bias.detach().clone().requires_grad_(True)
     o_tri = parallel_attn(
         q=q_tri,
         k=k_tri,
         v=v_tri,
         g=g_tri,
-        sinks=sinks_tri,
+        sink_bias=sink_bias_tri,
         scale=0.1,
         window_size=window_size,
         cu_seqlens=cu_seqlens,
@@ -355,7 +368,7 @@ def test_parallel_attn_sink_with_g_matches_reference(window_size, cu_seqlens):
     assert_close("dk_ref_vs_tri", k_ref.grad.to(dtype), k_tri.grad, 0.02)
     assert_close("dv_ref_vs_tri", v_ref.grad.to(dtype), v_tri.grad, 0.02)
     assert_close("dg_ref_vs_tri", g_ref.grad.to(dtype), g_tri.grad, 0.02)
-    assert_close("ds_ref_vs_tri", sinks_ref.grad, sinks_tri.grad, 0.02)
+    assert_close("ds_ref_vs_tri", sink_bias_ref.grad, sink_bias_tri.grad, 0.02)
 
 
 def test_attn_decoding_sink_matches_reference():
@@ -367,24 +380,26 @@ def test_attn_decoding_sink_matches_reference():
     q = torch.randn((1, B, HQ, D), dtype=dtype, device=device)
     k = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
     v = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
+    sink_bias = torch.randn((HQ,), dtype=torch.float32, device=device)
     cu_seqlens = torch.tensor([i * T for i in range(B + 1)], dtype=torch.int32, device=device)
 
-    refs = []
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
-        query_idx = torch.tensor([eos - bos - 1], dtype=torch.long, device=device)
-        o_i, _ = naive_parallel_attn(
-            q=q[:, len(refs):len(refs)+1].float(),
-            k=k[:, bos:eos].float(),
-            v=v[:, bos:eos].float(),
-            query_indices=query_idx,
-            sinks=sinks,
-            scale=0.1,
-        )
-        refs.append(o_i)
-    ref = torch.cat(refs, dim=1).to(dtype)
+    ref = naive_attn_decoding(
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        sink_bias=sink_bias,
+        scale=0.1,
+        cu_seqlens=cu_seqlens,
+    ).to(dtype)
 
-    tri = attn_decoding_one_step(q=q, k=k, v=v, sinks=sinks, scale=0.1, cu_seqlens=cu_seqlens)
+    tri = attn_decoding_one_step(
+        q=q,
+        k=k,
+        v=v,
+        sink_bias=sink_bias,
+        scale=0.1,
+        cu_seqlens=cu_seqlens,
+    )
     assert_close("o_decode_ref_vs_tri", ref, tri, 0.01)
 
 
@@ -399,24 +414,26 @@ def test_attn_decoding_sink_empty_row_matches_reference():
     total_t = sum(lengths)
     k = torch.randn((1, total_t, H, D), dtype=dtype, device=device)
     v = torch.randn((1, total_t, H, D), dtype=dtype, device=device)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
+    sink_bias = torch.randn((HQ,), dtype=torch.float32, device=device)
     cu_seqlens = torch.tensor([0, *torch.tensor(lengths).cumsum(0).tolist()], dtype=torch.int32, device=device)
 
-    refs = []
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
-        query_idx = max(eos - bos - 1, 0)
-        o_i, _ = _gpt_oss_eager_sink_reference(
-            q=q[:, len(refs):len(refs)+1].float(),
-            k=k[:, bos:eos].float(),
-            v=v[:, bos:eos].float(),
-            sinks=sinks,
-            scale=0.1,
-            query_indices=torch.tensor([query_idx], dtype=torch.long, device=device),
-        )
-        refs.append(o_i)
-    ref = torch.cat(refs, dim=1).to(dtype)
+    ref = naive_attn_decoding(
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        sink_bias=sink_bias,
+        scale=0.1,
+        cu_seqlens=cu_seqlens,
+    ).to(dtype)
 
-    tri = attn_decoding_one_step(q=q, k=k, v=v, sinks=sinks, scale=0.1, cu_seqlens=cu_seqlens)
+    tri = attn_decoding_one_step(
+        q=q,
+        k=k,
+        v=v,
+        sink_bias=sink_bias,
+        scale=0.1,
+        cu_seqlens=cu_seqlens,
+    )
     assert torch.isfinite(tri).all()
     assert_close("o_decode_empty_row_ref_vs_tri", ref, tri, 0.01)
 
@@ -438,33 +455,25 @@ def test_attn_decoding_sink_with_g_matches_reference(do_gate_scale):
     k = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
     v = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
     g = torch.empty((1, T * B, HQ), dtype=dtype, device=device).uniform_(-0.1, -0.01)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    sink_bias = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
     cu_seqlens = torch.tensor([i * T for i in range(B + 1)], dtype=torch.int32, device=device)
 
-    refs = []
-    gate_scale = 0.1 if do_gate_scale else 1.0
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
-        q_i = q[:, len(refs):len(refs) + 1].float()
-        g_i = g[:, bos:eos].float()
-        query_idx = torch.tensor([eos - bos - 1], dtype=torch.long, device=device)
-        o_i, _ = naive_parallel_attn(
-            q=q_i,
-            k=k[:, bos:eos].float(),
-            v=v[:, bos:eos].float(),
-            g=g_i,
-            g_scale=gate_scale,
-            query_indices=query_idx,
-            sinks=sinks,
-            scale=0.1,
-        )
-        refs.append(o_i)
-    ref = torch.cat(refs, dim=1).to(dtype)
+    ref = naive_attn_decoding(
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        g=g.float(),
+        sink_bias=sink_bias,
+        scale=0.1,
+        cu_seqlens=cu_seqlens,
+        do_gate_scale=do_gate_scale,
+    ).to(dtype)
     tri = attn_decoding_one_step(
         q=q,
         k=k,
         v=v,
         g=g,
-        sinks=sinks,
+        sink_bias=sink_bias,
         scale=0.1,
         cu_seqlens=cu_seqlens,
         do_gate_scale=do_gate_scale,

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import os
+
+import pytest
+import torch
+
+from fla.ops.attn.decoding import attn_decoding_one_step
+from fla.ops.attn.naive import naive_parallel_attn
+from fla.ops.attn.parallel import parallel_attn
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize(
+    ("window_size", "cu_seqlens"),
+    [
+        pytest.param(None, None, id="full"),
+        pytest.param(64, None, id="swa"),
+        pytest.param(64, [0, 97, 173, 300], id="varlen_swa"),
+    ],
+)
+def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
+    torch.manual_seed(123)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    dtype = torch.float16
+    B, T, H, HQ, D = 2, 192, 2, 8, 64
+    if cu_seqlens is not None:
+        B, T = 1, cu_seqlens[-1]
+        cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+
+    q_ref = q.float().detach().clone().requires_grad_(True)
+    k_ref = k.float().detach().clone().requires_grad_(True)
+    v_ref = v.float().detach().clone().requires_grad_(True)
+    sinks_ref = sinks.detach().clone().requires_grad_(True)
+
+    if cu_seqlens is None:
+        o_ref, _ = naive_parallel_attn(
+            q_ref, k_ref, v_ref, sinks=sinks_ref, scale=0.1, window_size=window_size
+        )
+    else:
+        outputs = []
+        for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+            o_i, _ = naive_parallel_attn(
+                q_ref[:, bos:eos], k_ref[:, bos:eos], v_ref[:, bos:eos],
+                sinks=sinks_ref, scale=0.1, window_size=window_size
+            )
+            outputs.append(o_i)
+        o_ref = torch.cat(outputs, dim=1)
+    o_ref = o_ref.to(dtype)
+    o_ref.backward(do)
+
+    q_sg = q.detach().clone().requires_grad_(True)
+    k_sg = k.detach().clone().requires_grad_(True)
+    v_sg = v.detach().clone().requires_grad_(True)
+    sinks_sg = sinks.detach().clone().requires_grad_(True)
+    o_sg = parallel_attn(
+        q=q_sg, k=k_sg, v=v_sg, sinks=sinks_sg, scale=0.1, window_size=window_size, cu_seqlens=cu_seqlens
+    )
+    o_sg.backward(do)
+
+    assert_close(" o_ref_vs_sg", o_ref, o_sg, 0.01)
+    assert_close("dq_ref_vs_sg", q_ref.grad.to(dtype), q_sg.grad, 0.02)
+    assert_close("dk_ref_vs_sg", k_ref.grad.to(dtype), k_sg.grad, 0.02)
+    assert_close("dv_ref_vs_sg", v_ref.grad.to(dtype), v_sg.grad, 0.02)
+    assert_close("ds_ref_vs_sg", sinks_ref.grad, sinks_sg.grad, 0.02)
+
+
+@pytest.mark.parametrize(
+    ("window_size", "cu_seqlens"),
+    [
+        pytest.param(None, None, id="full"),
+        pytest.param(64, None, id="swa"),
+        pytest.param(64, [0, 97, 173, 300], id="varlen_swa"),
+    ],
+)
+def test_parallel_attn_sink_with_g_matches_reference(window_size, cu_seqlens):
+    torch.manual_seed(321)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    dtype = torch.float16
+    B, T, H, HQ, D = 2, 192, 2, 8, 64
+    if cu_seqlens is not None:
+        B, T = 1, cu_seqlens[-1]
+        cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+    q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    g = torch.empty((B, T, HQ), dtype=dtype, device=device).uniform_(-0.1, -0.01)
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
+
+    q_ref = q.float().detach().clone().requires_grad_(True)
+    k_ref = k.float().detach().clone().requires_grad_(True)
+    v_ref = v.float().detach().clone().requires_grad_(True)
+    g_ref = g.float().detach().clone().requires_grad_(True)
+    sinks_ref = sinks.detach().clone().requires_grad_(True)
+
+    if cu_seqlens is None:
+        o_ref, _ = naive_parallel_attn(
+            q=q_ref,
+            k=k_ref,
+            v=v_ref,
+            g=g_ref,
+            sinks=sinks_ref,
+            scale=0.1,
+            window_size=window_size,
+        )
+    else:
+        outputs = []
+        for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+            o_i, _ = naive_parallel_attn(
+                q=q_ref[:, bos:eos],
+                k=k_ref[:, bos:eos],
+                v=v_ref[:, bos:eos],
+                g=g_ref[:, bos:eos],
+                sinks=sinks_ref,
+                scale=0.1,
+                window_size=window_size,
+            )
+            outputs.append(o_i)
+        o_ref = torch.cat(outputs, dim=1)
+    o_ref = o_ref.to(dtype)
+    o_ref.backward(do)
+
+    q_tri = q.detach().clone().requires_grad_(True)
+    k_tri = k.detach().clone().requires_grad_(True)
+    v_tri = v.detach().clone().requires_grad_(True)
+    g_tri = g.detach().clone().requires_grad_(True)
+    sinks_tri = sinks.detach().clone().requires_grad_(True)
+    o_tri = parallel_attn(
+        q=q_tri,
+        k=k_tri,
+        v=v_tri,
+        g=g_tri,
+        sinks=sinks_tri,
+        scale=0.1,
+        window_size=window_size,
+        cu_seqlens=cu_seqlens,
+    )
+    o_tri.backward(do)
+
+    assert_close(" o_ref_vs_tri", o_ref, o_tri, 0.01)
+    assert_close("dq_ref_vs_tri", q_ref.grad.to(dtype), q_tri.grad, 0.02)
+    assert_close("dk_ref_vs_tri", k_ref.grad.to(dtype), k_tri.grad, 0.02)
+    assert_close("dv_ref_vs_tri", v_ref.grad.to(dtype), v_tri.grad, 0.02)
+    assert_close("dg_ref_vs_tri", g_ref.grad.to(dtype), g_tri.grad, 0.02)
+    assert_close("ds_ref_vs_tri", sinks_ref.grad, sinks_tri.grad, 0.02)
+
+
+def test_attn_decoding_sink_matches_reference():
+    torch.manual_seed(456)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    B, T, H, HQ, D = 3, 128, 2, 8, 64
+    dtype = torch.float16
+    q = torch.randn((1, B, HQ, D), dtype=dtype, device=device)
+    k = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
+    v = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    cu_seqlens = torch.tensor([i * T for i in range(B + 1)], dtype=torch.int32, device=device)
+
+    refs = []
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        query_idx = torch.tensor([eos - bos - 1], dtype=torch.long, device=device)
+        o_i, _ = naive_parallel_attn(
+            q=q[:, len(refs):len(refs)+1].float(),
+            k=k[:, bos:eos].float(),
+            v=v[:, bos:eos].float(),
+            query_indices=query_idx,
+            sinks=sinks,
+            scale=0.1,
+        )
+        refs.append(o_i)
+    ref = torch.cat(refs, dim=1).to(dtype)
+
+    tri = attn_decoding_one_step(q=q, k=k, v=v, sinks=sinks, scale=0.1, cu_seqlens=cu_seqlens)
+    assert_close("o_decode_ref_vs_sg", ref, tri, 0.01)
+
+
+@pytest.mark.parametrize(
+    "do_gate_scale",
+    [
+        pytest.param(False, id="no_gate_scale"),
+        pytest.param(True, id="with_gate_scale"),
+    ],
+)
+def test_attn_decoding_sink_with_g_matches_reference(do_gate_scale):
+    torch.manual_seed(654)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    B, T, H, HQ, D = 3, 128, 2, 8, 64
+    dtype = torch.float16
+    q = torch.randn((1, B, HQ, D), dtype=dtype, device=device)
+    k = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
+    v = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
+    g = torch.empty((1, T * B, HQ), dtype=dtype, device=device).uniform_(-0.1, -0.01)
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    cu_seqlens = torch.tensor([i * T for i in range(B + 1)], dtype=torch.int32, device=device)
+
+    refs = []
+    gate_scale = 0.1 if do_gate_scale else 1.0
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        q_i = q[:, len(refs):len(refs) + 1].float()
+        g_i = g[:, bos:eos].float()
+        query_idx = torch.tensor([eos - bos - 1], dtype=torch.long, device=device)
+        o_i, _ = naive_parallel_attn(
+            q=q_i,
+            k=k[:, bos:eos].float(),
+            v=v[:, bos:eos].float(),
+            g=g_i,
+            g_scale=gate_scale,
+            query_indices=query_idx,
+            sinks=sinks,
+            scale=0.1,
+        )
+        refs.append(o_i)
+    ref = torch.cat(refs, dim=1).to(dtype)
+    tri = attn_decoding_one_step(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        sinks=sinks,
+        scale=0.1,
+        cu_seqlens=cu_seqlens,
+        do_gate_scale=do_gate_scale,
+    )
+    assert_close("o_decode_g_ref_vs_tri", ref, tri, 0.01)

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -37,7 +37,7 @@ def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
     q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
     k = torch.randn((B, T, H, D), dtype=dtype, device=device)
     v = torch.randn((B, T, H, D), dtype=dtype, device=device)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
     do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.float().detach().clone().requires_grad_(True)
@@ -86,7 +86,7 @@ def test_parallel_attn_sink_empty_row_matches_reference():
     q = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
     k = torch.randn((B, T, H, D), dtype=dtype, device=device)
     v = torch.randn((B, T, H, D), dtype=dtype, device=device)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
     do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.float().detach().clone().requires_grad_(True)
@@ -137,7 +137,7 @@ def test_parallel_attn_sink_with_g_matches_reference(window_size, cu_seqlens):
     k = torch.randn((B, T, H, D), dtype=dtype, device=device)
     v = torch.randn((B, T, H, D), dtype=dtype, device=device)
     g = torch.empty((B, T, HQ), dtype=dtype, device=device).uniform_(-0.1, -0.01)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
     do = torch.randn((B, T, HQ, D), dtype=dtype, device=device)
 
     q_ref = q.float().detach().clone().requires_grad_(True)
@@ -207,7 +207,7 @@ def test_attn_decoding_sink_matches_reference():
     q = torch.randn((1, B, HQ, D), dtype=dtype, device=device)
     k = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
     v = torch.randn((1, T * B, H, D), dtype=dtype, device=device)
-    sinks = torch.randn((HQ,), dtype=torch.float32, device=device) * 0.7
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
     cu_seqlens = torch.tensor([i * T for i in range(B + 1)], dtype=torch.int32, device=device)
 
     refs = []

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -388,6 +388,39 @@ def test_attn_decoding_sink_matches_reference():
     assert_close("o_decode_ref_vs_tri", ref, tri, 0.01)
 
 
+def test_attn_decoding_sink_empty_row_matches_reference():
+    torch.manual_seed(457)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    B, H, HQ, D = 3, 2, 8, 64
+    lengths = [0, 128, 73]
+    dtype = torch.float16
+    q = torch.randn((1, B, HQ, D), dtype=dtype, device=device)
+    total_t = sum(lengths)
+    k = torch.randn((1, total_t, H, D), dtype=dtype, device=device)
+    v = torch.randn((1, total_t, H, D), dtype=dtype, device=device)
+    sinks = torch.randn((HQ,), dtype=torch.float32, device=device)
+    cu_seqlens = torch.tensor([0, *torch.tensor(lengths).cumsum(0).tolist()], dtype=torch.int32, device=device)
+
+    refs = []
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        query_idx = max(eos - bos - 1, 0)
+        o_i, _ = _gpt_oss_eager_sink_reference(
+            q=q[:, len(refs):len(refs)+1].float(),
+            k=k[:, bos:eos].float(),
+            v=v[:, bos:eos].float(),
+            sinks=sinks,
+            scale=0.1,
+            query_indices=torch.tensor([query_idx], dtype=torch.long, device=device),
+        )
+        refs.append(o_i)
+    ref = torch.cat(refs, dim=1).to(dtype)
+
+    tri = attn_decoding_one_step(q=q, k=k, v=v, sinks=sinks, scale=0.1, cu_seqlens=cu_seqlens)
+    assert torch.isfinite(tri).all()
+    assert_close("o_decode_empty_row_ref_vs_tri", ref, tri, 0.01)
+
+
 @pytest.mark.parametrize(
     "do_gate_scale",
     [

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -221,20 +221,20 @@ def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
     o_ref = o_ref.to(dtype)
     o_ref.backward(do)
 
-    q_sg = q.detach().clone().requires_grad_(True)
-    k_sg = k.detach().clone().requires_grad_(True)
-    v_sg = v.detach().clone().requires_grad_(True)
-    sinks_sg = sinks.detach().clone().requires_grad_(True)
-    o_sg = parallel_attn(
-        q=q_sg, k=k_sg, v=v_sg, sinks=sinks_sg, scale=0.1, window_size=window_size, cu_seqlens=cu_seqlens
+    q_tri = q.detach().clone().requires_grad_(True)
+    k_tri = k.detach().clone().requires_grad_(True)
+    v_tri = v.detach().clone().requires_grad_(True)
+    sinks_tri = sinks.detach().clone().requires_grad_(True)
+    o_tri = parallel_attn(
+        q=q_tri, k=k_tri, v=v_tri, sinks=sinks_tri, scale=0.1, window_size=window_size, cu_seqlens=cu_seqlens
     )
-    o_sg.backward(do)
+    o_tri.backward(do)
 
-    assert_close(" o_ref_vs_sg", o_ref, o_sg, 0.01)
-    assert_close("dq_ref_vs_sg", q_ref.grad.to(dtype), q_sg.grad, 0.02)
-    assert_close("dk_ref_vs_sg", k_ref.grad.to(dtype), k_sg.grad, 0.02)
-    assert_close("dv_ref_vs_sg", v_ref.grad.to(dtype), v_sg.grad, 0.02)
-    assert_close("ds_ref_vs_sg", sinks_ref.grad, sinks_sg.grad, 0.02)
+    assert_close(" o_ref_vs_tri", o_ref, o_tri, 0.01)
+    assert_close("dq_ref_vs_tri", q_ref.grad.to(dtype), q_tri.grad, 0.02)
+    assert_close("dk_ref_vs_tri", k_ref.grad.to(dtype), k_tri.grad, 0.02)
+    assert_close("dv_ref_vs_tri", v_ref.grad.to(dtype), v_tri.grad, 0.02)
+    assert_close("ds_ref_vs_tri", sinks_ref.grad, sinks_tri.grad, 0.02)
 
 
 def test_parallel_attn_sink_empty_row_matches_reference():
@@ -385,7 +385,7 @@ def test_attn_decoding_sink_matches_reference():
     ref = torch.cat(refs, dim=1).to(dtype)
 
     tri = attn_decoding_one_step(q=q, k=k, v=v, sinks=sinks, scale=0.1, cu_seqlens=cu_seqlens)
-    assert_close("o_decode_ref_vs_sg", ref, tri, 0.01)
+    assert_close("o_decode_ref_vs_tri", ref, tri, 0.01)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- this PR adds GPT-OSS-style attention sink support to `parallel_attn`
- add a local `gpt-oss eager` sink reference that mirrors the `transformers` GPT-OSS sink path:
  - concatenate one sink logit per query head as an extra attention column
  - apply a single softmax over `[token_logits, sink_logit]`
  - drop the sink column before the value matmul
- verify that our sink reference in `naive_parallel_attn` is semantically aligned with the GPT-OSS eager implementation
- keep the runtime sink semantics consistent with the denominator-only sink update used in `sglang`

## Source

- `transformers` GPT-OSS implementation:
  - [`src/transformers/models/gpt_oss/modeling_gpt_oss.py](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt_oss/modeling_gpt_oss.py)
- `sglang` reference:
  - GPT-OSS / MiMo sink plumbing in the model wrappers
  - denominator-only sink update in Triton decode / extend attention

## Float32 Error Summary

| case | output | dq | dk | dv | dsink |
| --- | ---: | ---: | ---: | ---: | ---: |
| `full` | `7.319450e-04` | `8.819103e-04` | `1.420081e-03` | `2.125859e-03` | `2.626896e-03` |
| `swa` | `6.992817e-04` | `7.513762e-04` | `1.618087e-03` | `2.214670e-03` | `2.434909e-03` |
| `indexed` | `6.468296e-04` | `6.054640e-04` | `7.749796e-04` | `4.768372e-07` | `2.619743e-03` |
| `indexed_swa` | `3.132820e-04` | `6.725043e-04` | `5.123019e-04` | `1.788139e-07` | `4.494488e-04` |
| `empty_row` | `0` | `0` | `0` | `0` | `0` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-head "sink" logits for attention and decoding, plus optional gated-score input for gating behavior.

* **Improvements**
  * Revised gating behavior and online-softmax stabilization to handle empty-row/edge cases and keep merges finite.
  * Better shape validation and docstring corrections for gated inputs.

* **Tests**
  * Extensive tests validating sink-enabled attention across forward/backward paths, variable-length and sliding-window scenarios, and decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->