### PR TITLE
allow neg eigvals for delta-net

### DIFF
--- a/fla/models/delta_net/configuration_delta_net.py
+++ b/fla/models/delta_net/configuration_delta_net.py
@@ -23,6 +23,7 @@ class DeltaNetConfig(PretrainedConfig):
         expand_v: float = 1.0,
         use_gate: bool = False,
         use_short_conv: bool = True,
+        allow_neg_eigval: bool = False,
         conv_size: int = 4,
         use_beta: bool = True,
         use_output_norm: bool = True,
@@ -78,6 +79,7 @@ class DeltaNetConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.allow_neg_eigval = allow_neg_eigval
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -67,6 +67,7 @@ class DeltaNetBlock(GradientCheckpointingLayer):
                 use_gate=config.use_gate,
                 use_beta=config.use_beta,
                 use_short_conv=config.use_short_conv,
+                allow_neg_eigval=config.allow_neg_eigval,
                 use_output_norm=config.use_output_norm,
                 conv_size=config.conv_size,
                 qk_norm=config.qk_norm,


### PR DESCRIPTION
This fixes the issue that setting `allow_neg_eigval` in the config is being silently ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `allow_neg_eigval` configuration parameter to the DeltaNet model, enabling control over this behavior throughout the architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->