### PR TITLE
[KDA] Add Grouped Value Attention (GVA) support

### DIFF
--- a/fla/layers/kda.py
+++ b/fla/layers/kda.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
-from einops import rearrange, repeat
+from einops import rearrange
 from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
@@ -164,19 +164,22 @@ class KimiDeltaAttention(nn.Module):
                 activation="silu",
             )
 
+        # Gate dim = HV * K: per value-head, per key-dim gating.
+        self.gate_dim = int(self.num_v_heads * self.head_k_dim)
         self.f_proj = nn.Sequential(
             nn.Linear(hidden_size, self.head_v_dim, bias=False),
-            nn.Linear(self.head_v_dim, self.key_dim, bias=False),
+            nn.Linear(self.head_v_dim, self.gate_dim, bias=False),
         )
-        self.b_proj = nn.Linear(hidden_size, self.num_heads, bias=False)
+        self.b_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
 
+        # A_log and dt_bias are per value-head for native GVA support.
         if safe_gate:
-            self.A_log = nn.Parameter(torch.zeros(self.num_heads, dtype=torch.float32))
+            self.A_log = nn.Parameter(torch.zeros(self.num_v_heads, dtype=torch.float32))
         else:
-            self.A_log = nn.Parameter(torch.log(torch.empty(self.num_heads, dtype=torch.float32).uniform_(1, 16)))
+            self.A_log = nn.Parameter(torch.log(torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(1, 16)))
         self.A_log._no_weight_decay = True
         dt = torch.exp(
-            torch.rand(self.key_dim, dtype=torch.float32) * (math.log(0.1) - math.log(0.001)) + math.log(0.001)
+            torch.rand(self.gate_dim, dtype=torch.float32) * (math.log(0.1) - math.log(0.001)) + math.log(0.001)
         ).clamp(min=1e-4)
         inv_dt = dt + torch.log(-torch.expm1(-dt))
         self.dt_bias = nn.Parameter(inv_dt)
@@ -248,13 +251,10 @@ class KimiDeltaAttention(nn.Module):
         g = self.f_proj(hidden_states)
         beta = self.b_proj(hidden_states).sigmoid()
 
-        q, k, g = (rearrange(x, "... (h d) -> ... h d", d=self.head_k_dim) for x in (q, k, g))
+        q, k = (rearrange(x, "... (h d) -> ... h d", d=self.head_k_dim) for x in (q, k))
+        # g and v are at value-head dimension (HV); q/k are at qk-head dimension (H).
+        g = rearrange(g, "... (h d) -> ... h d", d=self.head_k_dim)
         v = rearrange(v, "... (h d) -> ... h d", d=self.head_v_dim)
-
-        # for multi-value attention, we repeat the inputs for simplicity.
-        if self.num_v_heads > self.num_heads:
-            q, k, g = (repeat(x, "... h d -> ... (h g) d", g=self.num_v_heads // self.num_heads) for x in (q, k, g))
-            beta = repeat(beta, "... h -> ... (h g)", g=self.num_v_heads // self.num_heads)
 
         if self.allow_neg_eigval:
             beta = beta * 2.0

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -306,7 +306,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'TRANSPOSE_STATE'],
+    key=['BT', 'HV', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -322,6 +322,7 @@ def chunk_gla_fwd_kernel_o(
     scale,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
@@ -332,7 +333,8 @@ def chunk_gla_fwd_kernel_o(
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
@@ -346,14 +348,21 @@ def chunk_gla_fwd_kernel_o(
 
     m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
 
+    q += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    v += (bos * HV + i_hv) * V
+    o += (bos * HV + i_hv) * V
+    h += (i_tg * HV + i_hv).to(tl.int64) * K * V
+    A += (bos * HV + i_hv) * BT
+
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         if TRANSPOSE_STATE:
-            p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
         else:
-            p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
 
         # [BT, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -371,9 +380,9 @@ def chunk_gla_fwd_kernel_o(
             else:
                 b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
     b_o *= scale
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_o = tl.make_block_ptr(o, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_A = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
     # [BT, BV]
     b_v = tl.load(p_v, boundary_check=(0, 1))
     # [BT, BT]
@@ -878,7 +887,7 @@ def chunk_gla_fwd_o_gk(
     use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ):
-    B, T, H, K, V = *q.shape, v.shape[-1]
+    B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
     BT = chunk_size
 
     if chunk_indices is None and cu_seqlens is not None:
@@ -887,7 +896,7 @@ def chunk_gla_fwd_o_gk(
 
     # Please ensure zeros, since vllm will use padding v
     o = torch.zeros_like(v)
-    def grid(meta): return (triton.cdiv(V, meta['BV']), NT, B * H)
+    def grid(meta): return (triton.cdiv(V, meta['BV']), NT, B * HV)
     chunk_gla_fwd_kernel_o[grid](
         q=q,
         v=v,
@@ -900,6 +909,7 @@ def chunk_gla_fwd_o_gk(
         scale=scale,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         V=V,
         BT=BT,

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -172,94 +172,95 @@ def chunk_kda(
     r"""
     Args:
         q (torch.Tensor):
-            queries of shape `[B, T, H, K]`.
+            queries of shape ``[B, T, H, K]``.
         k (torch.Tensor):
-            keys of shape `[B, T, H, K]`.
+            keys of shape ``[B, T, H, K]``.
         v (torch.Tensor):
-            values of shape `[B, T, H, V]`.
+            values of shape ``[B, T, HV, V]``.
+            GVA (Grouped Value Attention) is applied if ``HV > H``, where ``HV`` must be divisible by ``H``.
         g (torch.Tensor):
-            (forget) gating tensor (in log space!) of shape `[B, T, H, K]`.
+            (forget) gating tensor (in log space!) of shape ``[B, T, HV, K]``.
+            When ``use_gate_in_kernel=False`` (default), ``g`` should be the pre-computed decay value.
+            When ``use_gate_in_kernel=True``, ``g`` is the raw input before gate activation;
+            the kernel fuses ``-exp(A_log) * softplus(g + dt_bias)`` + chunk cumsum internally.
         beta (torch.Tensor):
-            betas of shape `[B, T, H]`.
+            betas of shape ``[B, T, HV]``.
         scale (Optional[float]):
             Scale factor for the KDA attention scores.
-            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+            If not provided, it will default to ``1 / sqrt(K)``. Default: ``None``.
         initial_state (Optional[torch.Tensor]):
-            Initial state of shape `[N, H, K, V]` for `N` input sequences.
-            For equal-length input sequences, `N` equals the batch size `B`.
-            Default: `None`.
+            Initial state of shape ``[N, HV, K, V]`` for ``N`` input sequences.
+            For equal-length input sequences, ``N`` equals the batch size ``B``.
+            Default: ``None``.
         output_final_state (Optional[bool]):
-            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+            Whether to output the final state of shape ``[N, HV, K, V]``. Default: ``False``.
         use_qk_l2norm_in_kernel (bool):
-            Whether to apply L2norm to the q,k tensor internally. Default: `False`.
+            Whether to apply L2norm to the q,k tensor internally. Default: ``False``.
         use_gate_in_kernel (bool):
             Whether to compute the log-space KDA decay internally.
-            - If `True`:
-              The passed `g` acts as the raw input for `-exp(A_log).view(H, -1) * softplus(g + dt_bias.view(H, K))`.
+            - If ``True``:
+              The passed ``g`` acts as the raw input for ``-exp(A_log) * softplus(g + dt_bias.view(HV, K))``.
               Note that as part of the input arguments,
-              `A_log` (shape `[H]`) and the optional `dt_bias` (shape `[H * K]`) should be provided.
-            - If `False`, `g` is expected to be the pre-computed decay value.
-            Default: `False`.
+              ``A_log`` (shape ``[HV]``) and the optional ``dt_bias`` (shape ``[HV * K]``) should be provided.
+            - If ``False``, ``g`` is expected to be the pre-computed decay value.
+            Default: ``False``.
         cu_seqlens (torch.LongTensor):
-            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            Cumulative sequence lengths of shape ``[N+1]`` used for variable-length training,
             consistent with the FlashAttention API.
         cu_seqlens_cpu (torch.LongTensor):
-            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            Cumulative sequence lengths of shape ``[N+1]`` used for variable-length training,
             consistent with the FlashAttention API.
         safe_gate (bool):
-            Whether the kernel can assume the gate values (in log space) are in a safe range
-            and use M=16 TensorCore acceleration for higher throughput.
-            The safe range is ``[lower_bound, 0)``. With the default ``lower_bound=-5``,
-            the per-step decay factor ``exp(g)`` is bounded in ``[exp(-5), 1) ≈ [0.0067, 1)``,
-            meaning each step retains at least ~0.67% of the state — a negligible loss that
-            has minimal impact on model quality while enabling significant speedup.
-            Requires ``lower_bound`` to be set. Default: ``False``.
+            Whether to clamp the gate to ``[lower_bound, 0)`` and enable M=16 TensorCore
+            acceleration for higher throughput. Requires ``lower_bound`` to be set.
+            Default: ``False``.
         lower_bound (Optional[float]):
-            Lower bound for the forget gate (in log space) when ``use_gate_in_kernel=True``.
-            Changes the gate activation from ``-exp(A_log) * softplus(g + dt_bias)``
-            to ``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``,
+            Lower bound for the forget gate (in log space). When set together with
+            ``safe_gate=True``, changes the gate activation from
+            ``-exp(A_log) * softplus(g + dt_bias)`` to
+            ``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``,
             which naturally clamps the output to ``[lower_bound, 0)``.
-            Recommended value: ``-5`` (i.e., ``exp(-5) ≈ 0.0067``). Default: ``None``.
+            Recommended value: ``-5`` (i.e., per-step decay ``exp(-5) ≈ 0.0067``).
+            Default: ``None``.
         disable_recompute (bool):
-            Whether to disable gradient recomputation in the kernel. When `True`, the kernel
+            Whether to disable gradient recomputation in the kernel. When ``True``, the kernel
             will save all intermediate activations for backward pass, which is beneficial
-            for training small models at the cost of increased memory usage. Default: `False`.
+            for training small models at the cost of increased memory usage. Default: ``False``.
         return_intermediate_states (bool):
-            If True, returns intermediate state `h` for inference scenarios (e.g., vLLM).
-            Must be used within `torch.inference_mode()` and will return a 3-tuple instead of 2-tuple.
-            This is not intended for training as it bypasses autograd. Default: `False`.
+            If True, returns intermediate state ``h`` for inference scenarios (e.g., vLLM).
+            Must be used within ``torch.inference_mode()`` and will return a 3-tuple instead of 2-tuple.
+            This is not intended for training as it bypasses autograd. Default: ``False``.
         cp_context (Optional[FLACPContext]):
             Context parallel context for distributed training across multiple devices.
-            When provided, `initial_state` and `output_final_state` are not supported,
-            and `cu_seqlens` will be overridden by the context. Default: `None`.
+            When provided, ``initial_state`` and ``output_final_state`` are not supported,
+            and ``cu_seqlens`` will be overridden by the context. Default: ``None``.
         transpose_state_layout (Optional[bool]):
             Whether to use the transposed state layout for the hidden state.
-            Default: `False`.
+            Default: ``False``.
 
     Returns:
         - Normal mode (return_intermediate_states=False): A tuple (o, final_state)
             o (torch.Tensor):
-                Outputs of shape `[B, T, H, V]`.
+                Outputs of shape ``[B, T, HV, V]``.
             final_state (torch.Tensor):
-                Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+                Final state of shape ``[N, HV, K, V]`` if ``output_final_state=True`` else ``None``.
         - Inference mode (return_intermediate_states=True): A tuple (o, final_state, h)
             o (torch.Tensor):
-                Outputs of shape `[B, T, H, V]`.
+                Outputs of shape ``[B, T, HV, V]``.
             final_state (torch.Tensor):
-                Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+                Final state of shape ``[N, HV, K, V]`` if ``output_final_state=True`` else ``None``.
             h (torch.Tensor):
-                Intermediate states of shape `[B, NT, H, K, V]` and dtype `bfloat16` for caching or further processing.
-                - For equal-length sequences: `NT = #chunks_per_sequence` (typically `ceil(T / chunk_size)`)
+                Intermediate states of shape ``[B, NT, HV, K, V]`` and dtype ``bfloat16``.
+                - For equal-length sequences: ``NT = ceil(T / chunk_size)``
                 - For variable-length sequences (cu_seqlens): B is always 1 (flattened),
-                  NT is the total number of chunks across all sequences,
-                  determined by `prepare_chunk_indices(cu_seqlens, chunk_size)`
+                  NT is the total number of chunks across all sequences.
 
     Examples::
         >>> import torch
         >>> import torch.nn.functional as F
         >>> from einops import rearrange
         >>> from fla.ops.kda import chunk_kda
-        # inputs with equal lengths
+        # inputs with equal lengths (no GVA, HV == H)
         >>> B, T, H, K, V = 4, 2048, 4, 512, 512
         >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
         >>> k = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
@@ -269,6 +270,23 @@ def chunk_kda(
         >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
         >>> A_log = torch.randn(H, dtype=torch.float32, device='cuda')
         >>> dt_bias = torch.randn(H * K, dtype=torch.float32, device='cuda')
+        >>> o, ht = chunk_kda(
+            q, k, v, g, beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # GVA mode (HV > H)
+        >>> HV = 8  # 2x more value heads than qk heads
+        >>> v = torch.randn(B, T, HV, V, dtype=torch.bfloat16, device='cuda')
+        >>> g = torch.rand(B, T, HV, K, dtype=torch.bfloat16, device='cuda')
+        >>> beta = torch.rand(B, T, HV, dtype=torch.bfloat16, device='cuda')
+        >>> h0 = torch.randn(B, HV, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> A_log = torch.randn(HV, dtype=torch.float32, device='cuda')
+        >>> dt_bias = torch.randn(HV * K, dtype=torch.float32, device='cuda')
         >>> o, ht = chunk_kda(
             q, k, v, g, beta,
             A_log=A_log,
@@ -328,13 +346,19 @@ def chunk_kda(
         if not (-5 <= lower_bound < 0):
             raise ValueError(f"`lower_bound` must be in the safe range [-5, 0), got {lower_bound}.")
 
-    assert q.shape == k.shape == g.shape, "q, k, g must have the same shape."
-    assert k.shape[-1] <= 256, "Currently we only support key headdim <=256 for KDA :-("
-    assert beta.shape == q.shape[:3], "beta must be of shape (batch size, seq len, num of head)."
-    assert v.shape == (*q.shape[:3], v.shape[-1]), "v must be of shape (batch size, seq len, num of head, head dim)."
+    # Validate head dimensions for GVA
+    B, T, H, K, HV = *q.shape, v.shape[2]
+    assert q.shape == k.shape, f"q and k must have the same shape, got q={q.shape} vs k={k.shape}"
+    assert K <= 256, f"Currently we only support key headdim <=256 for KDA, got {K}."
+    assert HV % H == 0, (
+        f"For GVA, num_v_heads (HV={HV}) must be evenly divisible by num_qk_heads (H={H}), "
+        f"but got HV % H = {HV % H}"
+    )
+    assert g.shape == (B, T, HV, K), f"g must have shape [B, T, HV, K]={[B, T, HV, K]}, got {list(g.shape)}"
+    assert beta.shape == (B, T, HV), f"beta must have shape [B, T, HV]={[B, T, HV]}, got {list(beta.shape)}"
 
     if scale is None:
-        scale = k.shape[-1] ** -0.5
+        scale = K ** -0.5
     return ChunkKDAFunction.apply(
         q,
         k,

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -11,21 +11,14 @@ import triton.language as tl
 
 from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
 from fla.ops.cp import FLACPContext
-from fla.ops.cp.chunk_delta_h import (
-    chunk_gated_delta_rule_bwd_dhu_pre_process,
-    expand_h0,
-)
+from fla.ops.cp.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu_pre_process, expand_h0
 from fla.ops.kda.chunk_intra import chunk_kda_bwd_intra
 from fla.ops.kda.gate import kda_gate_bwd, kda_gate_chunk_cumsum
 from fla.ops.kda.wy_fast import recompute_w_u_fwd
 from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
 from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.op import exp2
-from fla.utils import (
-    IS_NVIDIA_HOPPER,
-    autotune_cache_kwargs,
-    check_shared_mem,
-)
+from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
@@ -41,7 +34,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -58,6 +51,7 @@ def chunk_kda_bwd_kernel_dAv(
     scale,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
@@ -66,7 +60,8 @@ def chunk_kda_bwd_kernel_dAv(
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
@@ -77,12 +72,12 @@ def chunk_kda_bwd_kernel_dAv(
     # offset calculation
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
-    v += (bos * H + i_h) * V
-    do += (bos * H + i_h) * V
-    dv += (bos * H + i_h) * V
-    dA += (bos * H + i_h) * BT
+    v += (bos * HV + i_hv) * V
+    do += (bos * HV + i_hv) * V
+    dv += (bos * HV + i_hv) * V
+    dA += (bos * HV + i_hv) * BT
 
-    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    p_A = tl.make_block_ptr(A + (bos * HV + i_hv) * BT, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
     b_A = tl.load(p_A, boundary_check=(0, 1))
 
     o_t = i_t * BT + tl.arange(0, BT)
@@ -92,9 +87,9 @@ def chunk_kda_bwd_kernel_dAv(
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(v, (V, T), (1, HV*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
+        p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         # [BV, BT]
         b_v = tl.load(p_v, boundary_check=(0, 1))
         # [BT, BV]
@@ -105,7 +100,7 @@ def chunk_kda_bwd_kernel_dAv(
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_dA = tl.make_block_ptr(dA, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
     b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.)
     tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
 
@@ -122,7 +117,7 @@ def chunk_kda_bwd_kernel_dAv(
         for num_stages in [2, 3, 4]
         if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
     ],
-    key=['BT', 'TRANSPOSE_STATE'],
+    key=['BT', 'HV', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -149,6 +144,7 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     scale,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
@@ -158,7 +154,8 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
@@ -177,26 +174,26 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
-    v += (bos * H + i_h) * V
-    v_new += (bos * H + i_h) * V
-    g += (bos * H + i_h) * K
-    beta += bos * H + i_h
-    A += (bos * H + i_h) * BT
-    h += (i_tg * H + i_h) * K*V
-    do += (bos * H + i_h) * V
-    dh += (i_tg * H + i_h) * K*V
-    dq += (bos * H + i_h) * K
-    dk += (bos * H + i_h) * K
-    dv += (bos * H + i_h) * V
-    dv2 += (bos * H + i_h) * V
-    dg += (bos * H + i_h) * K
-    db += bos * H + i_h
-    dA += (bos * H + i_h) * BT
+    v += (bos * HV + i_hv) * V
+    v_new += (bos * HV + i_hv) * V
+    g += (bos * HV + i_hv) * K
+    beta += bos * HV + i_hv
+    A += (bos * HV + i_hv) * BT
+    h += (i_tg * HV + i_hv) * K*V
+    do += (bos * HV + i_hv) * V
+    dh += (i_tg * HV + i_hv) * K*V
+    dq += (bos * HV + i_hv) * K
+    dk += (bos * HV + i_hv) * K
+    dv += (bos * HV + i_hv) * V
+    dv2 += (bos * HV + i_hv) * V
+    dg += (bos * HV + i_hv) * K
+    db += bos * HV + i_hv
+    dA += (bos * HV + i_hv) * BT
 
-    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
     b_beta = tl.load(p_beta, boundary_check=(0,))
 
-    p_A = tl.make_block_ptr(A, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1))
+    p_A = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
     b_A = tl.load(p_A, boundary_check=(0, 1))
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
@@ -207,11 +204,11 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         m_k = o_k < K
 
         p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
 
-        p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * H*K + o_k
+        p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * HV*K + o_k
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
 
         b_dq = tl.zeros([BT, BK], dtype=tl.float32)
@@ -220,15 +217,15 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         b_dgk = tl.zeros([BK], dtype=tl.float32)
 
         for i_v in range(tl.cdiv(V, BV)):
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_v_new = tl.make_block_ptr(v_new, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             if TRANSPOSE_STATE:
                 p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
                 p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
             else:
                 p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
                 p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             # [BT, BV]
             b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
             b_do = tl.load(p_do, boundary_check=(0, 1))
@@ -244,8 +241,8 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
             b_dw += tl.dot(b_dv.to(b_v_new.dtype), b_h.to(b_v_new.dtype))
             tl.debug_barrier()  # DO NOT REMOVE THIS LINE!
             if i_k == 0:
-                p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-                p_dv2 = tl.make_block_ptr(dv2, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_dv2 = tl.make_block_ptr(dv2, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
 
                 b_v = tl.load(p_v, boundary_check=(0, 1))
 
@@ -278,9 +275,9 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         b_dg = b_q * b_dq - b_kdk + m_last[:, None] * b_dgk + b_kg * b_dkgb * b_beta[:, None]
         b_dk = b_dk + b_dkgb * b_gb
 
-        p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dq = tl.make_block_ptr(dq, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dg = tl.make_block_ptr(dg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
@@ -291,8 +288,8 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
     b_dA = tl.where(m_A, -b_dA, 0)
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_db = tl.make_block_ptr(db, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    p_dA = tl.make_block_ptr(dA, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_t * BT,), (BT,), (0,))
     tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
 
@@ -308,7 +305,7 @@ def chunk_kda_bwd_dAv(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    B, T, H, K, V = *k.shape, do.shape[-1]
+    B, T, H, K, HV, V = *k.shape, do.shape[2], do.shape[-1]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -323,9 +320,9 @@ def chunk_kda_bwd_dAv(
     BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    dA = v.new_empty(B, T, H, BT, dtype=torch.float)
+    dA = v.new_empty(B, T, HV, BT, dtype=torch.float)
     dv = torch.empty_like(do)
-    grid = (NT, B * H)
+    grid = (NT, B * HV)
     chunk_kda_bwd_kernel_dAv[grid](
         q=q,
         k=k,
@@ -339,6 +336,7 @@ def chunk_kda_bwd_dAv(
         scale=scale,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         V=V,
         BT=BT,
@@ -366,21 +364,22 @@ def chunk_kda_bwd_wy_dqkg_fused(
     chunk_indices: torch.LongTensor | None = None,
     transpose_state_layout: bool = False,
 ):
-    B, T, H, K, V = *k.shape, v.shape[-1]
+    B, T, H, K, HV, V = *k.shape, v.shape[2], v.shape[-1]
     BT = chunk_size
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    dq = torch.empty_like(q, dtype=torch.float)
-    dk = torch.empty_like(k, dtype=torch.float)
+    # dq, dk are allocated at HV dimension; caller reduces to H if GVA
+    dq = g.new_empty(B, T, HV, K, dtype=torch.float)
+    dk = g.new_empty(B, T, HV, K, dtype=torch.float)
     dv2 = torch.empty_like(v)
     dg = torch.empty_like(g, dtype=torch.float)
     db = torch.empty_like(beta, dtype=torch.float)
     dA = torch.empty_like(A, dtype=torch.float)
 
-    grid = (NT, B * H)
+    grid = (NT, B * HV)
     chunk_kda_bwd_kernel_wy_dqkg_fused[grid](
         q=q,
         k=k,
@@ -404,6 +403,7 @@ def chunk_kda_bwd_wy_dqkg_fused(
         scale=scale,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         V=V,
         BT=BT,
@@ -439,6 +439,9 @@ def chunk_kda_bwd(
     transpose_state_layout: bool = False,
     **kwargs,
 ):
+    H, HV = q.shape[2], v.shape[2]
+    G = HV // H
+
     if disable_recompute is False:
         if use_gate_in_kernel:
             g = kda_gate_chunk_cumsum(
@@ -568,6 +571,11 @@ def chunk_kda_bwd(
         chunk_indices=chunk_indices,
         safe_gate=safe_gate
     )
+
+    # For GVA, reduce dq and dk from [B, T, HV, K] back to [B, T, H, K]
+    if HV > H:
+        dq = dq.view(*dq.shape[:2], H, G, dq.shape[-1]).sum(dim=3)
+        dk = dk.view(*dk.shape[:2], H, G, dk.shape[-1]).sum(dim=3)
 
     dA, dbias = None, None
     dg = chunk_local_cumsum(

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -9,10 +9,7 @@ import torch
 
 from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from fla.ops.cp import FLACPContext
-from fla.ops.cp.chunk_delta_h import (
-    chunk_gated_delta_rule_fwd_h_pre_process,
-    compress_h0,
-)
+from fla.ops.cp.chunk_delta_h import chunk_gated_delta_rule_fwd_h_pre_process, compress_h0
 from fla.ops.gla.chunk import chunk_gla_fwd_o_gk
 from fla.ops.kda.chunk_intra import chunk_kda_fwd_intra
 from fla.ops.kda.gate import kda_gate_chunk_cumsum
@@ -132,7 +129,6 @@ def chunk_kda_fwd(
         # Delete to save memory
         w, u, qg, kg, v_new = None, None, None, None, None
         if not return_intermediate_states:
-            # Only delete h if not requested for inference
             h = None
         if use_gate_in_kernel:
             g = None

--- a/fla/ops/kda/chunk_intra.py
+++ b/fla/ops/kda/chunk_intra.py
@@ -34,7 +34,7 @@ else:
         for BK in [32, 64]
         for num_warps in [1, 2, 4]
     ],
-    key=["H", "K", "BC"],
+    key=["H", "HV", "K", "BC"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -51,6 +51,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
@@ -71,7 +72,8 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     6. Writes Akk_inv to Akk
     """
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
@@ -90,10 +92,10 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
-    g += (bos * H + i_h) * K
-    Aqk += (bos * H + i_h) * BT
-    Akk += (bos * H + i_h) * BT
-    Akkd += (bos * H + i_h) * BC
+    g += (bos * HV + i_hv) * K
+    Aqk += (bos * HV + i_hv) * BT
+    Akk += (bos * HV + i_hv) * BT
+    Akkd += (bos * HV + i_hv) * BC
 
     o_i = tl.arange(0, BC)
     m_tc1 = (i_tc1 + o_i) < T
@@ -123,20 +125,20 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         m_k = o_k < K
 
         p_k0 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-        p_g0 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+        p_g0 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
         b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
         b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
 
         if i_tc1 < T:
             p_q1 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
             p_k1 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_g1 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_g1 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
             # [BC, BK]
             b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
             b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
             b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
             # [BK]
-            b_gn1 = tl.load(g + i_tc1 * H*K + o_k, mask=m_k, other=0).to(tl.float32)
+            b_gn1 = tl.load(g + i_tc1 * HV*K + o_k, mask=m_k, other=0).to(tl.float32)
             # [BC, BK]
             b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
             # [BK, BC]
@@ -148,13 +150,13 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
             if i_tc2 < T:
                 p_q2 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
                 p_k2 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                p_g2 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                p_g2 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
                 # [BC, BK]
                 b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
                 b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
                 b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
                 # [BK]
-                b_gn2 = tl.load(g + i_tc2 * H*K + o_k, mask=m_k, other=0).to(tl.float32)
+                b_gn2 = tl.load(g + i_tc2 * HV*K + o_k, mask=m_k, other=0).to(tl.float32)
                 # [BC, BK]
                 b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
                 b_qg2 = b_q2 * b_gqn2
@@ -172,13 +174,13 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
                 if i_tc3 < T:
                     p_q3 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
                     p_k3 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    p_g3 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                    p_g3 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
                     # [BC, BK]
                     b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
                     b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
                     b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
                     # [BK]
-                    b_gn3 = tl.load(g + i_tc3 * H*K + o_k, mask=m_k, other=0).to(tl.float32)
+                    b_gn3 = tl.load(g + i_tc3 * HV*K + o_k, mask=m_k, other=0).to(tl.float32)
                     # [BC, BK]
                     b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
                     b_qg3 = b_q3 * b_gqn3
@@ -203,40 +205,40 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     # save off-diagonal Aqk blocks and prepare Akk
     ################################################################################
     if i_tc1 < T:
-        p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
         tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_b1 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+        p_b1 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,))
         b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
         b_Akk10 = b_Akk10 * b_b1[:, None]
     if i_tc2 < T:
-        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
         tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_b2 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+        p_b2 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,))
         b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
         b_Akk20 = b_Akk20 * b_b2[:, None]
         b_Akk21 = b_Akk21 * b_b2[:, None]
     if i_tc3 < T:
-        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
+        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
         tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_b3 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+        p_b3 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,))
         b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
         b_Akk30 = b_Akk30 * b_b3[:, None]
         b_Akk31 = b_Akk31 * b_b3[:, None]
         b_Akk32 = b_Akk32 * b_b3[:, None]
 
-    p_Akk00 = tl.make_block_ptr(Akkd, (T, BC), (H*BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akkd, (T, BC), (H*BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (H*BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (H*BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
+    p_Akk00 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_Akk11 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
+    p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
     b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
     b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
     b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
@@ -256,22 +258,22 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         b_Ai33 = -tl.where(m_A, b_Ai33, 0)
 
         for i in range(2, min(BC, T - i_tc0)):
-            b_a00 = -tl.load(Akkd + (i_tc0 + i) * H*BC + o_i)
+            b_a00 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
             b_a00 = tl.where(o_i < i, b_a00, 0.)
             b_a00 += tl.sum(b_a00[:, None] * b_Ai00, 0)
             b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
         for i in range(BC + 2, min(2*BC, T - i_tc0)):
-            b_a11 = -tl.load(Akkd + (i_tc0 + i) * H*BC + o_i)
+            b_a11 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
             b_a11 = tl.where(o_i < i - BC, b_a11, 0.)
             b_a11 += tl.sum(b_a11[:, None] * b_Ai11, 0)
             b_Ai11 = tl.where((o_i == i - BC)[:, None], b_a11, b_Ai11)
         for i in range(2*BC + 2, min(3*BC, T - i_tc0)):
-            b_a22 = -tl.load(Akkd + (i_tc0 + i) * H*BC + o_i)
+            b_a22 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
             b_a22 = tl.where(o_i < i - 2*BC, b_a22, 0.)
             b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
             b_Ai22 = tl.where((o_i == i - 2*BC)[:, None], b_a22, b_Ai22)
         for i in range(3*BC + 2, min(4*BC, T - i_tc0)):
-            b_a33 = -tl.load(Akkd + (i_tc0 + i) * H*BC + o_i)
+            b_a33 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
             b_a33 = tl.where(o_i < i - 3*BC, b_a33, 0.)
             b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
             b_Ai33 = tl.where((o_i == i - 3*BC)[:, None], b_a33, b_Ai33)
@@ -326,16 +328,16 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     # store full Akk_inv to Akk
     ################################################################################
 
-    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
-    p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
-    p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-    p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
+    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+    p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+    p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+    p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
+    p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+    p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+    p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
+    p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
 
     tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
@@ -358,7 +360,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BK', 'NC', 'BT'],
+    key=['BK', 'NC', 'BT', 'HV'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['B', 'T'])
@@ -381,6 +383,7 @@ def chunk_kda_bwd_kernel_intra(
     B,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
@@ -391,7 +394,8 @@ def chunk_kda_bwd_kernel_intra(
     USE_GATHER: tl.constexpr,
 ):
     i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
     i_k, i_i = i_kc // NC, i_kc % NC
 
     all = B * T
@@ -411,36 +415,36 @@ def chunk_kda_bwd_kernel_intra(
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
-    g += (bos * H + i_h) * K
-    beta += bos * H + i_h
+    g += (bos * HV + i_hv) * K
+    beta += bos * HV + i_hv
 
-    dAqk += (bos * H + i_h) * BT
-    dAkk += (bos * H + i_h) * BT
-    dq += (bos * H + i_h) * K
-    dq2 += (bos * H + i_h) * K
-    dk += (bos * H + i_h) * K
-    dk2 += (bos * H + i_h) * K
-    dg += (bos * H + i_h) * K
-    dg2 += (bos * H + i_h) * K
-    db += (i_k * all + bos) * H + i_h
+    dAqk += (bos * HV + i_hv) * BT
+    dAkk += (bos * HV + i_hv) * BT
+    dq += (bos * HV + i_hv) * K
+    dq2 += (bos * HV + i_hv) * K
+    dk += (bos * HV + i_hv) * K
+    dk2 += (bos * HV + i_hv) * K
+    dg += (bos * HV + i_hv) * K
+    dg2 += (bos * HV + i_hv) * K
+    db += (i_k * all + bos) * HV + i_hv
 
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
     b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
 
-    p_b = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
+    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
     b_b = tl.load(p_b, boundary_check=(0,))
 
     b_dq2 = tl.zeros([BC, BK], dtype=tl.float32)
     b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
     if i_i > 0:
-        p_gn = g + i_ti * H*K + o_k
+        p_gn = g + i_ti * HV*K + o_k
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
         for i_j in range(0, i_i):
             p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
-            p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+            p_gk = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+            p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+            p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
             # [BC, BK]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
@@ -457,9 +461,9 @@ def chunk_kda_bwd_kernel_intra(
 
     o_i = tl.arange(0, BC)
     m_dA = (i_ti + o_i) < T
-    o_dA = (i_ti + o_i) * H*BT + i_i * BC
+    o_dA = (i_ti + o_i) * HV*BT + i_i * BC
     p_kj = k + i_ti * H*K + o_k
-    p_gkj = g + i_ti * H*K + o_k
+    p_gkj = g + i_ti * HV*K + o_k
 
     p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
     p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
@@ -470,11 +474,11 @@ def chunk_kda_bwd_kernel_intra(
         if USE_GATHER:
             b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
         else:
-            p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + o_k
+            p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV*K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0)[None, :]
 
-        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
         b_dAqk_diag_qk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
         b_dAkk_diag_qk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
 
@@ -506,14 +510,14 @@ def chunk_kda_bwd_kernel_intra(
             b_dk2 += tl.where(m_i, b_dAkk[:, None] * b_kj[None, :] * b_gqk, 0.)
 
             p_kj += H*K
-            p_gkj += H*K
+            p_gkj += HV*K
 
     b_db = tl.sum(b_dk2 * b_k, 1)
     b_dk2 *= b_b[:, None]
 
-    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dq2 = tl.make_block_ptr(dq2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_db = tl.make_block_ptr(db, (T,), (H,), (i_ti,), (BC,), (0,))
+    p_dq = tl.make_block_ptr(dq, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dq2 = tl.make_block_ptr(dq2, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_ti,), (BC,), (0,))
 
     b_dg2 = b_q * b_dq2
     b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
@@ -525,16 +529,16 @@ def chunk_kda_bwd_kernel_intra(
 
     NC = min(NC, tl.cdiv(T - i_t * BT, BC))
     if i_i < NC - 1:
-        p_gn = g + (min(i_ti + BC, T) - 1) * H*K + o_k
+        p_gn = g + (min(i_ti + BC, T) - 1) * HV*K + o_k
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
         for i_j in range(i_i + 1, NC):
             p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
             p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k*BK), (BC, BK), (1, 0))
-            p_b = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT + i_j * BC,), (BC,), (0,))
-            p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, H*BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-            p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, H*BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
+            p_gk = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT + i_j * BC, i_k*BK), (BC, BK), (1, 0))
+            p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT + i_j * BC,), (BC,), (0,))
+            p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV*BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
+            p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV*BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
             # [BC]
             b_b = tl.load(p_b, boundary_check=(0,))
             # [BC, BK]
@@ -556,25 +560,25 @@ def chunk_kda_bwd_kernel_intra(
             b_dkt += tl.dot(b_dAqk, b_qg)
             b_dkt += tl.dot(b_dAkk, b_kbg)
         b_dkt *= exp2(b_gn - b_g)
-    o_dA = i_ti * H*BT + i_i * BC + o_i
+    o_dA = i_ti * HV*BT + i_i * BC + o_i
     p_qj = q + i_ti * H*K + o_k
     p_kj = k + i_ti * H*K + o_k
-    p_gkj = g + i_ti * H*K + o_k
-    p_bj = beta + i_ti * H
+    p_gkj = g + i_ti * HV*K + o_k
+    p_bj = beta + i_ti * HV
 
     if SAFE_GATE:
         if USE_GATHER:
             b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
         else:
-            p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + o_k
+            p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV*K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
         p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
         b_q = tl.load(p_q, boundary_check=(0, 1))
-        p_b = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
+        p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
         b_b = tl.load(p_b, boundary_check=(0,))
 
-        p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, H*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, H*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
+        p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
+        p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
         b_dAqk_diag_kk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
         b_dAkk_diag_kk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
 
@@ -596,8 +600,8 @@ def chunk_kda_bwd_kernel_intra(
     else:
         for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
             # [BC,]
-            b_dAqk = tl.load(dAqk + o_dA + j * H*BT)
-            b_dAkk = tl.load(dAkk + o_dA + j * H*BT)
+            b_dAqk = tl.load(dAqk + o_dA + j * HV*BT)
+            b_dAkk = tl.load(dAkk + o_dA + j * HV*BT)
             # [BK,]
             b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
             b_kbj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32) * tl.load(p_bj)
@@ -610,12 +614,12 @@ def chunk_kda_bwd_kernel_intra(
 
             p_qj += H*K
             p_kj += H*K
-            p_gkj += H*K
-            p_bj += H
-    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dk2 = tl.make_block_ptr(dk2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg2 = tl.make_block_ptr(dg2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_gkj += HV*K
+            p_bj += HV
+    p_dk = tl.make_block_ptr(dk, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk2 = tl.make_block_ptr(dk2, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dg = tl.make_block_ptr(dg, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dg2 = tl.make_block_ptr(dg2, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
 
     b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, boundary_check=(0, 1))
     b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
@@ -634,7 +638,7 @@ def chunk_kda_bwd_kernel_intra(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BT", "BC"],
+    key=["BT", "BC", "HV"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -650,6 +654,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
@@ -658,7 +663,8 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     USE_GATHER: tl.constexpr,
 ):
     i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
@@ -676,16 +682,16 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
 
     q = q + (bos * H + i_h) * K
     k = k + (bos * H + i_h) * K
-    g = g + (bos * H + i_h) * K
-    beta = beta + bos * H + i_h
-    Aqk = Aqk + (bos * H + i_h) * BT
-    Akk = Akk + (bos * H + i_h) * BC
+    g = g + (bos * HV + i_hv) * K
+    beta = beta + bos * HV + i_hv
+    Aqk = Aqk + (bos * HV + i_hv) * BT
+    Akk = Akk + (bos * HV + i_hv) * BC
 
     p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
     p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_ti, 0), (BC, BK), (1, 0))
 
-    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
+    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
 
     b_q = tl.load(p_q, boundary_check=(0, 1))
     b_k = tl.load(p_k, boundary_check=(0, 1))
@@ -696,7 +702,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
         b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
     else:
         # caculate offset
-        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + tl.arange(0, BK)
+        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV*K + tl.arange(0, BK)
         b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
         b_gn = b_gn[None, :]
 
@@ -720,8 +726,8 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
     b_Akk = tl.where(m_Akk, b_Akk, 0.0)
 
-    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-    p_Akk = tl.make_block_ptr(Akk, (T, BC), (H*BC, 1), (i_ti, 0), (BC, BC), (1, 0))
+    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+    p_Akk = tl.make_block_ptr(Akk, (T, BC), (HV*BC, 1), (i_ti, 0), (BC, BC), (1, 0))
     tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
 
@@ -733,7 +739,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
 
     b_Ai = -b_Akk
     for i in range(2, min(BC, T - i_ti)):
-        b_a = -tl.load(Akk + (i_ti + i) * H*BC + o_i)
+        b_a = -tl.load(Akk + (i_ti + i) * HV*BC + o_i)
         b_a = tl.where(o_i < i, b_a, 0.)
         b_a += tl.sum(b_a[:, None] * b_Ai, 0)
         b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
@@ -754,7 +760,7 @@ def chunk_kda_fwd_intra(
     safe_gate: bool = False,
     disable_recompute: bool = False,
 ):
-    B, T, H, K = k.shape
+    B, T, H, K, HV = *k.shape, gk.shape[2]
     BT = chunk_size
     BC = 16
     if chunk_indices is None and cu_seqlens is not None:
@@ -762,16 +768,16 @@ def chunk_kda_fwd_intra(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
 
-    Aqk = torch.empty(B, T, H, BT, device=k.device, dtype=k.dtype)
+    Aqk = torch.empty(B, T, HV, BT, device=k.device, dtype=k.dtype)
     # Akk must be zero-initialized - kernel only writes lower triangular
-    Akk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    Akk = torch.zeros(B, T, HV, BT, device=k.device, dtype=k.dtype)
     # Separate fp32 buffer for diagonal 16x16 blocks (for precision in solve_tril)
-    Akkd = torch.empty(B, T, H, BC, device=k.device, dtype=torch.float32)
+    Akkd = torch.empty(B, T, HV, BC, device=k.device, dtype=torch.float32)
 
     # Step 1: Run token_parallel first to compute diagonal blocks into Akkd (fp32)
     # Step 1: compute diagonal blocks into Akk_diag (fp32)
     if safe_gate:
-        grid = (NT, NC, B * H)
+        grid = (NT, NC, B * HV)
         BK = triton.next_power_of_2(K)
         chunk_kda_fwd_kernel_intra_sub_chunk[grid](
             q=q,
@@ -785,6 +791,7 @@ def chunk_kda_fwd_intra(
             chunk_indices=chunk_indices,
             T=T,
             H=H,
+            HV=HV,
             K=K,
             BT=BT,
             BC=BC,
@@ -806,7 +813,7 @@ def chunk_kda_fwd_intra(
         )
 
     # Step 2: Fused inter + solve_tril (works for both fixed-len and varlen)
-    grid = (NT, B * H)
+    grid = (NT, B * HV)
     chunk_kda_fwd_kernel_inter_solve_fused[grid](
         q=q,
         k=k,
@@ -820,6 +827,7 @@ def chunk_kda_fwd_intra(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         BT=BT,
         BC=BC,
@@ -854,7 +862,7 @@ def chunk_kda_bwd_intra(
     chunk_size: int = 64,
     safe_gate: bool = False,
 ):
-    B, T, H, K = k.shape
+    B, T, H, K, HV = *k.shape, g.shape[2]
     BT = chunk_size
     BC = min(16, BT)
     BK = min(32, triton.next_power_of_2(K))
@@ -865,11 +873,11 @@ def chunk_kda_bwd_intra(
     NC = triton.cdiv(BT, BC)
     NK = triton.cdiv(K, BK)
 
-    dq2 = torch.empty_like(q)
-    dk2 = torch.empty_like(k)
+    dq2 = torch.empty_like(dq)
+    dk2 = torch.empty_like(dk)
     db2 = beta.new_empty(NK, *beta.shape, dtype=torch.float)
     dg2 = torch.empty_like(dg, dtype=torch.float)
-    grid = (NK * NC, NT, B * H)
+    grid = (NK * NC, NT, B * HV)
     chunk_kda_bwd_kernel_intra[grid](
         q=q,
         k=k,
@@ -889,6 +897,7 @@ def chunk_kda_bwd_intra(
         B=B,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         BT=BT,
         BC=BC,

--- a/fla/ops/kda/chunk_intra_token_parallel.py
+++ b/fla/ops/kda/chunk_intra_token_parallel.py
@@ -24,7 +24,7 @@ from fla.utils import autotune_cache_kwargs
         for BH in [1, 2, 4, 8]
         for num_warps in [1, 2, 4, 8]
     ],
-    key=["K", "H"],
+    key=["K", "H", "HV"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T', 'N'])
@@ -40,6 +40,7 @@ def chunk_kda_fwd_kernel_intra_token_parallel(
     N,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
@@ -79,45 +80,45 @@ def chunk_kda_fwd_kernel_intra_token_parallel(
     i_tc = i_c * BT
     i_ts = i_tc + i_s * BC
 
+    G: tl.constexpr = HV // H
+
     q += bos * H*K
     k += bos * H*K
-    g += bos * H*K
-    Aqk += bos * H*BT
-    Akk += bos * H*BC
-    beta += bos * H
+    g += bos * HV*K
+    Aqk += bos * HV*BT
+    Akk += bos * HV*BC
+    beta += bos * HV
 
     BK: tl.constexpr = triton.next_power_of_2(K)
-    o_h = tl.arange(0, BH)
+    o_hv = i_hg * BH + tl.arange(0, BH)
+    o_h = o_hv // G
     o_k = tl.arange(0, BK)
-    m_h = (i_hg * BH + o_h) < H
+    m_hv = o_hv < HV
     m_k = o_k < K
+    m_hk = m_hv[:, None] & m_k[None, :]
 
-    p_q = tl.make_block_ptr(q + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_g = tl.make_block_ptr(g + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_beta = tl.make_block_ptr(beta + i_t * H, (H,), (1,), (i_hg * BH,), (BH,), (0,))
-    # [BH, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
-    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+    # q/k: [B, T, H, K], manual load via mapped qk head index
+    p_qk = o_h[:, None] * K + o_k[None, :]
+    b_q = tl.load(q + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+    b_k = tl.load(k + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+
+    # g: [B, T, HV, K], beta: [B, T, HV]
+    p_g = tl.make_block_ptr(g + i_t * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_beta = tl.make_block_ptr(beta + i_t * HV, (HV,), (1,), (i_hg * BH,), (BH,), (0,))
     b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
     b_k = b_k * tl.load(p_beta, boundary_check=(0,)).to(tl.float32)[:, None]
 
     for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
-        p_kj = tl.make_block_ptr(k + j * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-        p_gj = tl.make_block_ptr(g + j * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-        # [BH, BK]
-        b_kj = tl.load(p_kj, boundary_check=(0, 1)).to(tl.float32)
+        b_kj = tl.load(k + j * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+        p_gj = tl.make_block_ptr(g + j * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
         b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
 
-        b_kgj = b_kj * exp2(b_g - b_gj)
-
-        b_kgj = tl.where(m_k[None, :], b_kgj, 0.0)
-        # [BH]
+        b_kgj = tl.where(m_k[None, :], b_kj * exp2(b_g - b_gj), 0.0)
         b_Aqk = tl.sum(b_q * b_kgj, axis=1) * scale
         b_Akk = tl.sum(b_k * b_kgj, axis=1) * tl.where(j < i_t, 1.0, 0.0)
 
-        tl.store(Aqk + i_t * H*BT + (i_hg * BH + o_h) * BT + j % BT, b_Aqk.to(Aqk.dtype.element_ty), mask=m_h)
-        tl.store(Akk + i_t * H*BC + (i_hg * BH + o_h) * BC + j - i_ts, b_Akk.to(Akk.dtype.element_ty), mask=m_h)
+        tl.store(Aqk + i_t * HV * BT + o_hv * BT + j % BT, b_Aqk.to(Aqk.dtype.element_ty), mask=m_hv)
+        tl.store(Akk + i_t * HV * BC + o_hv * BC + j - i_ts, b_Akk.to(Akk.dtype.element_ty), mask=m_hv)
 
 
 def chunk_kda_fwd_intra_token_parallel(
@@ -142,20 +143,20 @@ def chunk_kda_fwd_intra_token_parallel(
     Args:
         q: [B, T, H, K]
         k: [B, T, H, K]
-        gk: [B, T, H, K] cumsum of gates
-        beta: [B, T, H]
-        Aqk: [B, T, H, BT] output tensor to write to
-        Akk: [B, T, H, BC] output tensor for diagonal blocks (fp32)
+        gk: [B, T, HV, K] cumsum of gates (HV >= H for GVA)
+        beta: [B, T, HV]
+        Aqk: [B, T, HV, BT] output tensor to write to
+        Akk: [B, T, HV, BC] output tensor for diagonal blocks (fp32)
         scale: attention scale
         chunk_size: BT (default 64)
         sub_chunk_size: BC (default 16)
     """
-    B, T, H, K = q.shape
+    B, T, H, K, HV = *q.shape, gk.shape[2]
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
     BT = chunk_size
     BC = sub_chunk_size
 
-    def grid(meta): return (B * T, triton.cdiv(H, meta['BH']))
+    def grid(meta): return (B * T, triton.cdiv(HV, meta['BH']))
     chunk_kda_fwd_kernel_intra_token_parallel[grid](
         q=q,
         k=k,
@@ -168,6 +169,7 @@ def chunk_kda_fwd_intra_token_parallel(
         N=N,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         BT=BT,
         BC=BC,

--- a/fla/ops/kda/naive.py
+++ b/fla/ops/kda/naive.py
@@ -19,15 +19,40 @@ def naive_recurrent_kda(
     initial_state: torch.Tensor | None = None,
     output_final_state: bool = False,
 ):
+    r"""
+    Args:
+        q (torch.Tensor):
+            Queries of shape ``[B, T, H, K]``.
+        k (torch.Tensor):
+            Keys of shape ``[B, T, H, K]``.
+        v (torch.Tensor):
+            Values of shape ``[B, T, HV, V]``. ``HV`` must be divisible by ``H``.
+        g (torch.Tensor):
+            Per-dimension decay gates (log-space) of shape ``[B, T, HV, K]``.
+        beta (torch.Tensor):
+            Beta scalars of shape ``[B, T, HV]``.
+        scale (Optional[float]):
+            Scale factor. Defaults to ``1 / sqrt(K)``.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape ``[B, HV, K, V]``.
+        output_final_state (bool):
+            Whether to return the final state.
+
+    Returns:
+        A tuple ``(o, S)`` where ``o`` has shape ``[B, T, HV, V]`` and
+        ``S`` has shape ``[B, HV, K, V]`` if ``output_final_state`` else ``None``.
+    """
     dtype = v.dtype
-    B, T, H, K, V = *q.shape, v.shape[-1]
+    B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
+    G = HV // H
     if scale is None:
         scale = K ** -0.5
 
     q, k, v, g, beta = map(lambda x: x.to(torch.float), [q, k, v, g, beta])
-    q = q * scale
+    q = q.repeat_interleave(G, dim=2) * scale   # [B, T, HV, K]
+    k = k.repeat_interleave(G, dim=2)           # [B, T, HV, K]
 
-    S = k.new_zeros(B, H, K, V).to(q)
+    S = k.new_zeros(B, HV, K, V).to(q)
     if initial_state is not None:
         S += initial_state
     o = torch.zeros_like(v)
@@ -52,22 +77,53 @@ def naive_chunk_kda(
     output_final_state: bool = False,
     chunk_size: int = 64,
 ):
+    r"""
+    Args:
+        q (torch.Tensor):
+            Queries of shape ``[B, T, H, K]``.
+        k (torch.Tensor):
+            Keys of shape ``[B, T, H, K]``.
+        v (torch.Tensor):
+            Values of shape ``[B, T, HV, V]``. ``HV`` must be divisible by ``H``.
+        g (torch.Tensor):
+            Per-dimension decay gates (log-space) of shape ``[B, T, HV, K]``.
+        beta (torch.Tensor):
+            Beta scalars of shape ``[B, T, HV]``.
+        scale (Optional[float]):
+            Scale factor. Defaults to ``1 / sqrt(K)``.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape ``[B, HV, K, V]``.
+        output_final_state (bool):
+            Whether to return the final state.
+        chunk_size (int):
+            Chunk size for the chunked computation. Default: 64.
+
+    Returns:
+        A tuple ``(o, S)`` where ``o`` has shape ``[B, T, HV, V]`` and
+        ``S`` has shape ``[B, HV, K, V]`` if ``output_final_state`` else ``None``.
+    """
     dtype = v.dtype
-    B, T, H, K, V = *q.shape, v.shape[-1]
+    B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
+    G = HV // H
     BT = chunk_size
     NT = T // BT
     if scale is None:
         scale = K ** -0.5
     assert T % BT == 0
 
-    q, k, v, g, beta = map(lambda x: rearrange(x, 'b (n c) h ... -> b h n c ...', c=BT).to(torch.float), [q, k, v, g, beta])
-    q = q * scale
+    # Rearrange into chunks: [B, head, NT, BT, ...]
+    q, k = [rearrange(x, 'b (n c) h ... -> b h n c ...', c=BT).to(torch.float) for x in [q, k]]
+    v, g, beta = [rearrange(x, 'b (n c) h ... -> b h n c ...', c=BT).to(torch.float) for x in [v, g, beta]]
+    # Expand q/k to value head dim for GVA: [B, H, ...] -> [B, HV, ...]
+    q = q.repeat_interleave(G, dim=1) * scale  # [B, HV, NT, BT, K]
+    k = k.repeat_interleave(G, dim=1)          # [B, HV, NT, BT, K]
     g = g.cumsum(-2)
 
     # note that diagonal is masked.
     mask = torch.triu(torch.ones(BT, BT, dtype=torch.bool, device=q.device), diagonal=0)
 
-    A = torch.zeros(*q.shape[:-1], BT, dtype=torch.float, device=q.device)
+    # Akk uses k (expanded to HV) and g (per value head)
+    A = torch.zeros(*g.shape[:-1], BT, dtype=torch.float, device=q.device)
     for i in range(BT):
         k_i = k[..., i, :]
         g_i = g[..., i:i+1, :]
@@ -82,22 +138,27 @@ def naive_chunk_kda(
     w = A @ (g.exp() * k)
     u = A @ v
 
-    S = k.new_zeros(B, H, K, V).to(q)
+    S = k.new_zeros(B, HV, K, V).to(q)
     if initial_state is not None:
         S += initial_state
     o = torch.zeros_like(v)
     mask = torch.triu(torch.ones(BT, BT, dtype=torch.bool, device=q.device), diagonal=1)
     for i in range(0, NT):
-        # [B, H, BT, ...]
-        q_i, k_i, u_i, g_i, w_i = q[:, :, i], k[:, :, i], u[:, :, i], g[:, :, i], w[:, :, i]
-        A = torch.zeros(B, H, BT, BT, dtype=torch.float, device=q.device)
+        # [B, HV, BT, ...]
+        q_i = q[:, :, i]      # [B, HV, BT, K]
+        k_i = k[:, :, i]      # [B, HV, BT, K]
+        u_i = u[:, :, i]        # [B, HV, BT, V]
+        g_i = g[:, :, i]        # [B, HV, BT, K]
+        w_i = w[:, :, i]        # [B, HV, BT, K]
+        # Aqk: per value head (q from qk head, g from value head, k from qk head)
+        Aqk = torch.zeros(B, HV, BT, BT, dtype=torch.float, device=q.device)
         for j in range(BT):
             k_j = k[:, :, i, j]
             g_j = g[:, :, i, j:j+1, :]
-            A[..., j] = torch.einsum('... c d, ... d -> ... c', q_i * (g_i - g_j).exp(), k_j)
-        A = A.masked_fill(mask, 0)
+            Aqk[..., j] = torch.einsum('... c d, ... d -> ... c', q_i * (g_i - g_j).exp(), k_j)
+        Aqk = Aqk.masked_fill(mask, 0)
         v_i = u_i - w_i @ S
-        o[:, :, i] = (q_i * g_i.exp()) @ S + A @ v_i
+        o[:, :, i] = (q_i * g_i.exp()) @ S + Aqk @ v_i
         S = S * rearrange(g_i[:, :, -1].exp(), 'b h k -> b h k 1')
         S += rearrange((g_i[:, :, -1:] - g_i).exp() * k_i, 'b h c k -> b h k c') @ v_i
     if not output_final_state:

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -264,10 +264,10 @@ def recompute_w_u_fwd(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    w = torch.empty_like(gk)
+    w = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype)
     u = torch.empty_like(v)
     qg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype) if q is not None else None
-    kg = torch.empty_like(gk)
+    kg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype)
     recompute_w_u_fwd_kda_kernel[(NT, B*HV)](
         q=q,
         k=k,

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -25,7 +25,7 @@ from fla.utils import autotune_cache_kwargs, check_shared_mem
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -44,6 +44,7 @@ def recompute_w_u_fwd_kda_kernel(
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
@@ -54,39 +55,54 @@ def recompute_w_u_fwd_kda_kernel(
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
-    p_b = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    v += (bos * HV + i_hv) * V
+    u += (bos * HV + i_hv) * V
+    w += (bos * HV + i_hv) * K
+    gk += (bos * HV + i_hv) * K
+    beta += bos * HV + i_hv
+    A += (bos * HV + i_hv) * BT
+    if STORE_QG:
+        qg += (bos * H + i_h) * K
+    if STORE_KG:
+        kg += (bos * H + i_h) * K
+
+    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
     b_b = tl.load(p_b, boundary_check=(0,))
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_A = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
     b_A = tl.load(p_A, boundary_check=(0, 1))
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_u = tl.make_block_ptr(u, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb)
         tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_w = tl.make_block_ptr(w + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_w = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_kb = b_k * b_b[:, None]
 
-        p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_gk = tl.make_block_ptr(gk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
         b_kb *= exp2(b_gk)
         if STORE_QG:
-            p_q = tl.make_block_ptr(q + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            p_qg = tl.make_block_ptr(qg + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_qg = tl.make_block_ptr(qg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_qg = b_q * exp2(b_gk)
             tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
@@ -94,9 +110,9 @@ def recompute_w_u_fwd_kda_kernel(
             last_idx = min(i_t * BT + BT, T) - 1
             o_k = i_k * BK + tl.arange(0, BK)
             m_k = o_k < K
-            b_gn = tl.load(gk + ((bos + last_idx) * H + i_h) * K + o_k, mask=m_k, other=0.).to(tl.float32)
+            b_gn = tl.load(gk + last_idx * HV*K + o_k, mask=m_k, other=0.).to(tl.float32)
             b_kg = b_k * tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], exp2(b_gn[None, :] - b_gk), 0)
-            p_kg = tl.make_block_ptr(kg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_kg = tl.make_block_ptr(kg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
             tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
 
         b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
@@ -112,7 +128,7 @@ def recompute_w_u_fwd_kda_kernel(
         for num_warps in [2, 4]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -135,6 +151,7 @@ def prepare_wy_repr_bwd_kda_kernel(
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
@@ -143,7 +160,8 @@ def prepare_wy_repr_bwd_kda_kernel(
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
@@ -151,9 +169,24 @@ def prepare_wy_repr_bwd_kda_kernel(
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_b = tl.make_block_ptr(beta + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    k += (bos * H + i_h) * K
+    v += (bos * HV + i_hv) * V
+    beta += bos * HV + i_hv
+    gk += (bos * HV + i_hv) * K
+    A += (bos * HV + i_hv) * BT
+    dA += (bos * HV + i_hv) * BT
+    dk += (bos * HV + i_hv) * K
+    dk2 += (bos * HV + i_hv) * K
+    dw += (bos * HV + i_hv) * K
+    du += (bos * HV + i_hv) * V
+    dv += (bos * HV + i_hv) * V
+    db += bos * HV + i_hv
+    dg += (bos * HV + i_hv) * K
+    dg2 += (bos * HV + i_hv) * K
+
+    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    p_A = tl.make_block_ptr(A, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
 
     b_b = tl.load(p_b, boundary_check=(0,))
     b_db = tl.zeros([BT], dtype=tl.float32)
@@ -161,16 +194,16 @@ def prepare_wy_repr_bwd_kda_kernel(
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk2 = tl.make_block_ptr(dk2 + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg2 = tl.make_block_ptr(dg2 + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk2 = tl.make_block_ptr(dk2, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dw = tl.make_block_ptr(dw, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dg = tl.make_block_ptr(dg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dg2 = tl.make_block_ptr(dg2, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
 
         # [BT, BK]
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_gk = tl.make_block_ptr(gk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_gk_exp = exp2(tl.load(p_gk, boundary_check=(0, 1)))
         b_kbg = b_k * b_b[:, None] * b_gk_exp
         b_dw = tl.load(p_dw, boundary_check=(0, 1))
@@ -185,9 +218,9 @@ def prepare_wy_repr_bwd_kda_kernel(
         tl.store(p_dg2, b_dg.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_du = tl.make_block_ptr(du, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
         b_du = tl.load(p_du, boundary_check=(0, 1))
@@ -206,8 +239,7 @@ def prepare_wy_repr_bwd_kda_kernel(
 
     b_dA = tl.where(m_A, -b_dA, 0)
 
-    # if using gk, save dA first and handle dk in another kernel
-    p_dA = tl.make_block_ptr(dA + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_dA = tl.make_block_ptr(dA, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
     tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
 
@@ -223,6 +255,7 @@ def recompute_w_u_fwd(
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     B, T, H, K, V = *k.shape, v.shape[-1]
+    HV = v.shape[2]
     BT = A.shape[-1]
     BK = 64
     BV = 64
@@ -231,11 +264,11 @@ def recompute_w_u_fwd(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    w = torch.empty_like(k)
+    w = torch.empty_like(gk)
     u = torch.empty_like(v)
     qg = torch.empty_like(q) if q is not None else None
     kg = torch.empty_like(k) if gk is not None else None
-    recompute_w_u_fwd_kda_kernel[(NT, B*H)](
+    recompute_w_u_fwd_kda_kernel[(NT, B*HV)](
         q=q,
         k=k,
         qg=qg,
@@ -250,6 +283,7 @@ def recompute_w_u_fwd(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         V=V,
         BT=BT,
@@ -273,6 +307,7 @@ def prepare_wy_repr_bwd(
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
+    HV = v.shape[2]
     BT = 64
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -286,7 +321,7 @@ def prepare_wy_repr_bwd(
     dg2 = torch.empty_like(gk, dtype=torch.float)
     dA = torch.empty_like(A, dtype=torch.float)
     db = torch.empty_like(beta, dtype=torch.float)
-    prepare_wy_repr_bwd_kda_kernel[(NT, B * H)](
+    prepare_wy_repr_bwd_kda_kernel[(NT, B * HV)](
         k=k,
         v=v,
         beta=beta,
@@ -305,6 +340,7 @@ def prepare_wy_repr_bwd(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         V=V,
         BT=BT,

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -64,7 +64,6 @@ def recompute_w_u_fwd_kda_kernel(
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
     v += (bos * HV + i_hv) * V
     u += (bos * HV + i_hv) * V
@@ -73,9 +72,10 @@ def recompute_w_u_fwd_kda_kernel(
     beta += bos * HV + i_hv
     A += (bos * HV + i_hv) * BT
     if STORE_QG:
-        qg += (bos * H + i_h) * K
+        q += (bos * H + i_h) * K
+        qg += (bos * HV + i_hv) * K
     if STORE_KG:
-        kg += (bos * H + i_h) * K
+        kg += (bos * HV + i_hv) * K
 
     p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
     b_b = tl.load(p_b, boundary_check=(0,))
@@ -102,7 +102,7 @@ def recompute_w_u_fwd_kda_kernel(
         b_kb *= exp2(b_gk)
         if STORE_QG:
             p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            p_qg = tl.make_block_ptr(qg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_qg = tl.make_block_ptr(qg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_qg = b_q * exp2(b_gk)
             tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
@@ -112,7 +112,7 @@ def recompute_w_u_fwd_kda_kernel(
             m_k = o_k < K
             b_gn = tl.load(gk + last_idx * HV*K + o_k, mask=m_k, other=0.).to(tl.float32)
             b_kg = b_k * tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], exp2(b_gn[None, :] - b_gk), 0)
-            p_kg = tl.make_block_ptr(kg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_kg = tl.make_block_ptr(kg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
             tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
 
         b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
@@ -266,8 +266,8 @@ def recompute_w_u_fwd(
 
     w = torch.empty_like(gk)
     u = torch.empty_like(v)
-    qg = torch.empty_like(q) if q is not None else None
-    kg = torch.empty_like(k) if gk is not None else None
+    qg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype) if q is not None else None
+    kg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype) if gk is not None else None
     recompute_w_u_fwd_kda_kernel[(NT, B*HV)](
         q=q,
         k=k,

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -249,8 +249,8 @@ def recompute_w_u_fwd(
     v: torch.Tensor,
     beta: torch.Tensor,
     A: torch.Tensor,
+    gk: torch.Tensor,
     q: torch.Tensor | None = None,
-    gk: torch.Tensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
@@ -267,7 +267,7 @@ def recompute_w_u_fwd(
     w = torch.empty_like(gk)
     u = torch.empty_like(v)
     qg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype) if q is not None else None
-    kg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype) if gk is not None else None
+    kg = torch.empty_like(gk)
     recompute_w_u_fwd_kda_kernel[(NT, B*HV)](
         q=q,
         k=k,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,14 @@ extend-select = ["RUF022"]
 known-first-party = ["fla"]
 force-sort-within-sections = false
 
+[tool.isort]
+profile = "black"
+line_length = 127
+known_first_party = ["fla"]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "fla/utils.py" = ["TCH004"]

--- a/tests/ops/test_intracard_cache.py
+++ b/tests/ops/test_intracard_cache.py
@@ -7,6 +7,8 @@
 
 """End-to-end cache tests for intracard CP via chunk_kda."""
 
+import os
+
 import pytest
 import torch
 
@@ -23,6 +25,7 @@ def clear_intracard_cache():
     _intracard_cache.clear()
 
 
+@pytest.mark.skipif(os.environ.get("FLA_DISABLE_BACKEND_DISPATCH") == "1", reason="backend dispatch disabled")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_chunk_kda_intracard_cache_hit_same_cu_seqlens_object(monkeypatch):
     """E2E: chunk_kda should reuse intracard precompute cache on second call.
@@ -123,6 +126,7 @@ def test_intracard_backend_enabled_when_env_var_is_one(monkeypatch):
     assert IntraCardCPBackend.is_enabled() is True
 
 
+@pytest.mark.skipif(os.environ.get("FLA_DISABLE_BACKEND_DISPATCH") == "1", reason="backend dispatch disabled")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_chunk_gdn_intracard_gqa(monkeypatch):
     """E2E: chunk_gated_delta_rule intracard path produces correct results with GQA (Hq < H).

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -17,17 +17,20 @@ from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
 
 
 @pytest.mark.parametrize(
-    ("B", "T", "H", "D", "scale", "gate_logit_normalizer", "dtype"),
+    ("B", "T", "H", "HV", "D", "scale", "gate_logit_normalizer", "dtype"),
     [
         pytest.param(
             *test,
-            id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
+            id="B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
         )
         for test in [
-            (1, 64, 1, 64, 1, 1, torch.float),
-            (2, 512, 3, 60, 1, 1, torch.float),
-            (4, 1024, 4, 128, 0.1, 1, torch.float),
-            (4, 1024, 4, 128, 1, 10, torch.float),
+            (1, 64, 1, 1, 64, 1, 1, torch.float),
+            (2, 512, 3, 3, 60, 1, 1, torch.float),
+            (4, 1024, 4, 4, 128, 0.1, 1, torch.float),
+            (4, 1024, 4, 4, 128, 1, 10, torch.float),
+
+            (1, 64, 1, 2, 64, 1, 1, torch.float),
+            (2, 512, 2, 4, 60, 1, 1, torch.float),
         ]
     ],
 )
@@ -35,6 +38,7 @@ def test_naive_chunk(
     B: int,
     T: int,
     H: int,
+    HV: int,
     D: int,
     scale: float,
     gate_logit_normalizer: float,
@@ -46,10 +50,10 @@ def test_naive_chunk(
 
     q = torch.rand(B, T, H, D, dtype=dtype)
     k = torch.rand(B, T, H, D, dtype=dtype)
-    v = torch.rand(B, T, H, D, dtype=dtype)
-    g = F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float)) / gate_logit_normalizer
-    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
-    h0 = torch.randn(B, H, D, D, dtype=torch.float32)
+    v = torch.rand(B, T, HV, D, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, HV, D, dtype=torch.float)) / gate_logit_normalizer
+    beta = torch.randn(B, T, HV, dtype=dtype).sigmoid()
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
 
     ref, ref_ht = naive_recurrent_kda(
@@ -78,17 +82,19 @@ def test_naive_chunk(
 
 
 @pytest.mark.parametrize(
-    ("B", "T", "H", "D", "scale", "gate_logit_normalizer", "use_qk_l2norm_in_kernel", "dtype"),
+    ("B", "T", "H", "HV", "D", "scale", "gate_logit_normalizer", "use_qk_l2norm_in_kernel", "dtype"),
     [
         pytest.param(
             *test,
-            id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
+            id="B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-use_qk_l2norm{}-{}".format(*test),
         )
         for test in [
-            (1, 64, 1, 64, 1, 1, False, torch.float),
-            (2, 512, 3, 60, 1, 1, False, torch.float),
-            (3, 1000, 4, 100, 0.1, 1, True, torch.float),
-            (4, 1024, 4, 128, 0.1, 1, False, torch.float),
+            (1, 64, 1, 1, 64, 1, 1, False, torch.float),
+            (2, 512, 3, 3, 60, 1, 1, False, torch.float),
+            (3, 1000, 4, 4, 100, 0.1, 1, True, torch.float),
+            (4, 1024, 4, 4, 128, 0.1, 1, False, torch.float),
+            (2, 512, 2, 4, 60, 1, 1, False, torch.float),
+            (2, 1024, 2, 8, 128, 0.1, 1, True, torch.float),
         ]
     ],
 )
@@ -96,6 +102,7 @@ def test_fused_recurrent(
     B: int,
     T: int,
     H: int,
+    HV: int,
     D: int,
     scale: float,
     gate_logit_normalizer: float,
@@ -108,10 +115,10 @@ def test_fused_recurrent(
 
     q = torch.rand(B, T, H, D, dtype=dtype)
     k = torch.rand(B, T, H, D, dtype=dtype)
-    v = torch.rand(B, T, H, D, dtype=dtype)
-    g = F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float)) / gate_logit_normalizer
-    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
-    h0 = torch.randn(B, H, D, D, dtype=torch.float32)
+    v = torch.rand(B, T, HV, D, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, HV, D, dtype=torch.float)) / gate_logit_normalizer
+    beta = torch.randn(B, T, HV, dtype=dtype).sigmoid()
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
 
     ref, ref_ht = naive_recurrent_kda(
@@ -341,6 +348,7 @@ def test_fused_recurrent_vllm_decode(
         "B",
         "T",
         "H",
+        "HV",
         "D",
         "scale",
         "gate_logit_normalizer",
@@ -354,18 +362,22 @@ def test_fused_recurrent_vllm_decode(
     [
         pytest.param(
             *test,
-            id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-qk_l2norm{}-gate{}-dtype{}-safe_gate{}-disable_recompute{}".format(
-                *test),
+            id=("B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}"
+                "-use_qk_l2norm{}-use_gate{}-{}-safe_gate{}-disable_recompute{}").format(*test),
         )
         for test in [
-            (1, 63, 1, 64, 1, 1, 0, False, False, torch.float16, True, False),
-            (2, 500, 3, 60, 1, 1, 0, False, False, torch.float16, True, True),
-            (2, 1000, 3, 64, 0.1, 1, 0.5, False, False, torch.float16, False, True),
-            (3, 1024, 4, 100, 1, 0.1, 0, False, False, torch.float16, False, False),
-            (4, 1024, 4, 128, 0.1, 1, 0, False, False, torch.float16, True, True),
-            (4, 1024, 4, 128, 0.1, 1, 0, True, False, torch.float16, True, False),
-            (2, 1500, 4, 128, 0.1, 10, 0, False, True, torch.float16, False, True),
-            (4, 2048, 8, 64, 0.1, 1, 0, False, True, torch.float16, True, True),
+            (1, 63, 1, 1, 64, 1, 1, 0, False, False, torch.float16, True, False),
+            (2, 500, 3, 3, 60, 1, 1, 0, False, False, torch.float16, True, True),
+            (2, 1000, 3, 3, 64, 0.1, 1, 0.5, False, False, torch.float16, False, True),
+            (3, 1024, 4, 4, 100, 1, 0.1, 0, False, False, torch.float16, False, False),
+            (4, 1024, 4, 4, 128, 0.1, 1, 0, False, False, torch.float16, True, True),
+            (4, 1024, 4, 4, 128, 0.1, 1, 0, True, False, torch.float16, True, False),
+            (2, 1500, 4, 4, 128, 0.1, 10, 0, False, True, torch.float16, False, True),
+            (4, 2048, 8, 8, 64, 0.1, 1, 0, False, True, torch.float16, True, True),
+
+            (2, 1024, 2, 4, 64, 0.1, 1, 0, False, False, torch.float16, False, False),
+            (2, 1024, 2, 8, 64, 0.1, 1, 0, False, True, torch.float16, False, False),
+            (2, 1024, 4, 8, 128, 0.1, 1, 0, True, True, torch.float16, False, False),
         ]
     ],
 )
@@ -373,6 +385,7 @@ def test_chunk(
     B: int,
     T: int,
     H: int,
+    HV: int,
     D: int,
     scale: float,
     gate_logit_normalizer: float,
@@ -386,11 +399,11 @@ def test_chunk(
     torch.manual_seed(42)
     q = torch.rand(B, T, H, D, dtype=dtype)
     k = torch.rand(B, T, H, D, dtype=dtype)
-    v = torch.rand(B, T, H, D, dtype=dtype)
-    g = torch.randn(B, T, H, D, dtype=torch.float if not use_gate_in_kernel else dtype)
+    v = torch.rand(B, T, HV, D, dtype=dtype)
+    g = torch.randn(B, T, HV, D, dtype=torch.float if not use_gate_in_kernel else dtype)
     if use_gate_in_kernel:
-        A_log = torch.randn(H, dtype=torch.float)
-        dt_bias = torch.randn(H * D, dtype=torch.float)
+        A_log = torch.randn(HV, dtype=torch.float)
+        dt_bias = torch.randn(HV * D, dtype=torch.float)
     else:
         g = F.logsigmoid(g) / gate_logit_normalizer
         g = g * (torch.rand_like(g) > mask_p)
@@ -403,8 +416,8 @@ def test_chunk(
         lower_bound = None
         naive_kda_gate_fn = naive_kda_gate
 
-    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
-    h0 = torch.randn(B, H, D, D, dtype=torch.float32)
+    beta = torch.randn(B, T, HV, dtype=dtype).sigmoid()
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     if use_gate_in_kernel:
         A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
     q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))


### PR DESCRIPTION
## Summary

- Support `HV > H` (num_v_heads > num_qk_heads) in KDA ops and layer, following the gated_delta_rule GVA pattern
- All Triton kernels use `i_h = i_hv // (HV // H)` for qk-head mapping; backward compatible when `HV == H`
- Layer projections (`f_proj`, `b_proj`, `A_log`, `dt_bias`) output at value-head dimension directly, no repeat needed
- GVA test cases added inline to existing `test_naive_chunk`, `test_fused_recurrent`, `test_chunk`

## Changed files

| File | Change |
|------|--------|
| `fla/ops/kda/chunk_intra.py` | `inter_solve_fused`, `sub_chunk`, `bwd_intra` kernels: add HV, grid B*HV |
| `fla/ops/kda/chunk_intra_token_parallel.py` | Token-parallel kernel: add HV, manual q/k indexing |
| `fla/ops/kda/wy_fast.py` | Forward/backward WY kernels: add HV, ptr += offset style |
| `fla/ops/kda/chunk_bwd.py` | `dAv`, `wy_dqkg_fused` kernels: add HV; dq/dk reduce from HV→H |
| `fla/ops/kda/chunk_fwd.py` | Pass through to GVA-aware output kernel |
| `fla/ops/kda/chunk.py` | API validation for GVA shapes |
| `fla/ops/kda/naive.py` | Reference impl with GVA docstrings |
| `fla/ops/gla/chunk.py` | `chunk_gla_fwd_o_gk` kernel: native GVA via HV from v.shape |
| `fla/layers/kda.py` | Projections at HV dim, no repeat |
| `tests/ops/test_kda.py` | GVA cases in existing tests |
| `pyproject.toml` | isort config (line_length=127, hanging indent) |

## Test plan

- [ ] `pytest tests/ops/test_kda.py::test_gva_naive_chunk` — naive recurrent vs chunk (HV > H)
- [ ] `pytest tests/ops/test_kda.py::test_fused_recurrent` — includes HV > H cases
- [ ] `pytest tests/ops/test_kda.py::test_chunk` — includes HV > H cases with backward + use_gate_in_kernel
- [ ] `pytest tests/ops/test_kda.py` — full suite, verify no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broad support for grouped value attention (expanded value-head / HV/GVA mode) across KDA paths.

* **Refactor**
  * Unified head/value-dimension handling, tensor layouts, and kernel indexing to operate in HV mode for correctness and performance.
  * Removed redundant runtime duplication logic for grouped value attention.

* **Documentation**
  * Expanded and clarified KDA docstrings and usage examples for HV/GVA modes.

* **Tests**
  * Extended tests for HV/GVA configurations and added conditional skips for certain CUDA E2E tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->