### PR TITLE
chore: add standalone isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,14 @@ extend-select = ["RUF022"]
 known-first-party = ["fla"]
 force-sort-within-sections = false
 
+[tool.isort]
+profile = "black"
+line_length = 127
+known_first_party = ["fla"]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "fla/utils.py" = ["TCH004"]


### PR DESCRIPTION
## Summary

- Add `[tool.isort]` section to `pyproject.toml` so standalone isort (IDE / pre-commit) matches ruff's import sorting
- `line_length=127`, `multi_line_output=3` (hanging indent + trailing comma), `profile=black`

## Test plan

- [x] `isort --check-only` passes on existing files
- [x] Output matches `ruff check --select I`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration settings for code formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->