### PR TITLE
[CI] Post benchmark comment via workflow_run for fork-safe PRs

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,0 +1,183 @@
+name: Post benchmark comment
+
+# Runs in the base repo context after a benchmark workflow completes.
+# Needed because pull_request runs from forks have a read-only GITHUB_TOKEN
+# and cannot post comments directly. workflow_run runs with a write token
+# and does NOT execute PR code, so it is safe to grant pull-requests: write.
+
+on:
+  workflow_run:
+    workflows:
+      - nvidia-h100-ci
+      - nvidia-a100-ci
+      - nvidia-4090-ci
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: benchmark-results-*
+          path: artifacts
+
+      - name: Post / update PR comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const artifactsDir = 'artifacts';
+            if (!fs.existsSync(artifactsDir)) {
+              console.log('No artifacts downloaded, nothing to comment on.');
+              return;
+            }
+
+            const subdirs = fs.readdirSync(artifactsDir, { withFileTypes: true })
+              .filter(d => d.isDirectory())
+              .map(d => d.name);
+
+            if (subdirs.length === 0) {
+              console.log('No artifact directories found.');
+              return;
+            }
+
+            for (const subdir of subdirs) {
+              const dir = path.join(artifactsDir, subdir);
+              const resultsPath = path.join(dir, 'benchmark_results.json');
+              const metaPath = path.join(dir, 'benchmark_meta.json');
+
+              if (!fs.existsSync(metaPath)) {
+                console.log(`Skipping ${subdir}: no benchmark_meta.json`);
+                continue;
+              }
+
+              const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+              const prNumber = meta.pr_number;
+              const runnerName = meta.runner;
+              const threshold = meta.threshold;
+
+              if (!prNumber) {
+                console.log(`Skipping ${subdir}: missing pr_number in metadata`);
+                continue;
+              }
+
+              if (!fs.existsSync(resultsPath)) {
+                console.log(`Skipping ${subdir}: no benchmark_results.json (benchmark may have failed)`);
+                continue;
+              }
+
+              const data = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+              const {
+                base_sha,
+                head_sha,
+                machine_info,
+                base_results,
+                head_results,
+                regressions,
+                has_regression,
+              } = data;
+
+              const gpuName = machine_info?.gpu_name || 'Unknown';
+              const cudaVersion = machine_info?.cuda_version || 'Unknown';
+              const pytorchVersion = machine_info?.pytorch_version || 'Unknown';
+
+              const makeKey = (r) => `${r.op}|${r.mode}|${r.B}|${r.T}|${r.H}|${r.D}`;
+              const baseMap = {};
+              for (const r of (base_results || [])) baseMap[makeKey(r)] = r;
+              const headMap = {};
+              for (const r of (head_results || [])) headMap[makeKey(r)] = r;
+
+              const allKeys = [...new Set([...Object.keys(baseMap), ...Object.keys(headMap)])];
+              allKeys.sort((a, b) => {
+                const [, aMode] = a.split('|');
+                const [, bMode] = b.split('|');
+                if (aMode !== bMode) return aMode === 'fwd' ? -1 : 1;
+                return a.localeCompare(b);
+              });
+
+              let table = '| Op | Mode | B | T | H | D | Base (ms) | Head (ms) | Speedup | Change |\n';
+              table += '|:---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|\n';
+
+              for (const key of allKeys) {
+                const b = baseMap[key];
+                const h = headMap[key];
+                const [op, mode, B, T, H, D] = key.split('|');
+
+                if (b && h) {
+                  const changePct = (h.median_ms - b.median_ms) / b.median_ms * 100;
+                  const speedup = b.median_ms / h.median_ms;
+                  const sign = changePct > 0 ? '+' : '';
+                  let marker = '';
+                  if (changePct > threshold) marker = ' 🔴';
+                  else if (changePct < -threshold) marker = ' 🟢';
+                  table += `| ${op} | ${mode} | ${B} | ${T} | ${H} | ${D} | ${b.median_ms.toFixed(3)} | ${h.median_ms.toFixed(3)} | ${speedup.toFixed(2)}x | ${sign}${changePct.toFixed(1)}%${marker} |\n`;
+                } else if (h) {
+                  table += `| ${op} | ${mode} | ${B} | ${T} | ${H} | ${D} | - | ${h.median_ms.toFixed(3)} | - | new |\n`;
+                } else if (b) {
+                  table += `| ${op} | ${mode} | ${B} | ${T} | ${H} | ${D} | ${b.median_ms.toFixed(3)} | - | - | removed |\n`;
+                }
+              }
+
+              const statusEmoji = has_regression ? '⚠️' : '✅';
+              const nReg = (regressions || []).length;
+              const statusText = has_regression
+                ? `${nReg} regression(s) detected`
+                : 'No significant performance regressions detected';
+
+              let body = `## ${statusEmoji} Benchmark Results (${runnerName.toUpperCase()})\n\n`;
+              body += `**Status:** ${statusText}\n\n`;
+              body += `| | |\n`;
+              body += `|:---|:---|\n`;
+              body += `| **GPU** | ${gpuName} |\n`;
+              body += `| **CUDA** | ${cudaVersion} |\n`;
+              body += `| **PyTorch** | ${pytorchVersion} |\n`;
+              body += `| **Base** | \`${base_sha}\` |\n`;
+              body += `| **Head** | \`${head_sha}\` |\n`;
+              body += `| **Threshold** | ${threshold}% |\n\n`;
+              body += table;
+              body += '\n---\n';
+              body += '*This comment is automatically updated with the latest benchmark results.*';
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+
+              const botComment = comments.find(c =>
+                c.user.type === 'Bot' &&
+                c.body.includes(`Benchmark Results (${runnerName.toUpperCase()})`)
+              );
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body,
+                });
+                console.log(`Updated benchmark comment on PR #${prNumber} for ${runnerName}`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+                console.log(`Created benchmark comment on PR #${prNumber} for ${runnerName}`);
+              }
+            }

--- a/.github/workflows/reusable-ci-benchmarks.yml
+++ b/.github/workflows/reusable-ci-benchmarks.yml
@@ -129,128 +129,37 @@ jobs:
             --no-fail-on-regression \
             --output benchmark_results.json
 
+      - name: Write benchmark metadata
+        if: always() && steps.check_skip.outputs.skip_bench == 'false'
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUNNER: ${{ inputs.runner }}
+          THRESHOLD: ${{ inputs.threshold }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -e
+          PR_JSON="null"
+          if [ -n "${PR_NUMBER:-}" ]; then
+            PR_JSON="${PR_NUMBER}"
+          fi
+          cat > benchmark_meta.json <<EOF
+          {
+            "pr_number": ${PR_JSON},
+            "runner": "${RUNNER}",
+            "threshold": ${THRESHOLD},
+            "event_name": "${EVENT_NAME}"
+          }
+          EOF
+          cat benchmark_meta.json
+
       - name: Upload benchmark results
         if: always() && steps.check_skip.outputs.skip_bench == 'false'
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ inputs.runner }}
-          path: benchmark_results.json
+          path: |
+            benchmark_results.json
+            benchmark_meta.json
           if-no-files-found: ignore
           retention-days: 30
-
-      - name: Post benchmark results to PR
-        if: steps.check_skip.outputs.skip_bench == 'false' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = 'benchmark_results.json';
-
-            if (!fs.existsSync(path)) {
-              console.log('No benchmark results file found');
-              return;
-            }
-
-            const data = JSON.parse(fs.readFileSync(path, 'utf8'));
-            const { base_sha, head_sha, machine_info, base_results, head_results, regressions, speedups, has_regression } = data;
-
-            const gpuName = machine_info?.gpu_name || 'Unknown';
-            const cudaVersion = machine_info?.cuda_version || 'Unknown';
-            const pytorchVersion = machine_info?.pytorch_version || 'Unknown';
-            const runnerName = '${{ inputs.runner }}';
-            const threshold = parseFloat('${{ inputs.threshold }}');
-
-            // Build a map of base results keyed by (op, mode, B, T, H, D)
-            const makeKey = (r) => `${r.op}|${r.mode}|${r.B}|${r.T}|${r.H}|${r.D}`;
-            const baseMap = {};
-            for (const r of (base_results || [])) baseMap[makeKey(r)] = r;
-            const headMap = {};
-            for (const r of (head_results || [])) headMap[makeKey(r)] = r;
-
-            // Merge all keys and sort by mode (fwd first), then op, then params
-            const allKeys = [...new Set([...Object.keys(baseMap), ...Object.keys(headMap)])];
-            allKeys.sort((a, b) => {
-              const [aOp, aMode] = a.split('|');
-              const [bOp, bMode] = b.split('|');
-              if (aMode !== bMode) return aMode === 'fwd' ? -1 : 1;
-              return a.localeCompare(b);
-            });
-
-            // Format results table with all entries
-            let table = '| Op | Mode | B | T | H | D | Base (ms) | Head (ms) | Speedup | Change |\n';
-            table += '|:---|:---:|---:|---:|---:|---:|---:|---:|---:|---:|\n';
-
-            for (const key of allKeys) {
-              const b = baseMap[key];
-              const h = headMap[key];
-              const [op, mode, B, T, H, D] = key.split('|');
-
-              if (b && h) {
-                const changePct = (h.median_ms - b.median_ms) / b.median_ms * 100;
-                const speedup = b.median_ms / h.median_ms;
-                const sign = changePct > 0 ? '+' : '';
-                let marker = '';
-                if (changePct > threshold) marker = ' 🔴';
-                else if (changePct < -threshold) marker = ' 🟢';
-                table += `| ${op} | ${mode} | ${B} | ${T} | ${H} | ${D} | ${b.median_ms.toFixed(3)} | ${h.median_ms.toFixed(3)} | ${speedup.toFixed(2)}x | ${sign}${changePct.toFixed(1)}%${marker} |\n`;
-              } else if (h) {
-                table += `| ${op} | ${mode} | ${B} | ${T} | ${H} | ${D} | - | ${h.median_ms.toFixed(3)} | - | new |\n`;
-              } else if (b) {
-                table += `| ${op} | ${mode} | ${B} | ${T} | ${H} | ${D} | ${b.median_ms.toFixed(3)} | - | - | removed |\n`;
-              }
-            }
-
-            // Build the comment body
-            const statusEmoji = has_regression ? '⚠️' : '✅';
-            const nReg = (regressions || []).length;
-            const statusText = has_regression
-              ? `${nReg} regression(s) detected`
-              : 'No significant performance regressions detected';
-
-            let body = `## ${statusEmoji} Benchmark Results (${runnerName.toUpperCase()})\n\n`;
-            body += `**Status:** ${statusText}\n\n`;
-            body += `| | |\n`;
-            body += `|:---|:---|\n`;
-            body += `| **GPU** | ${gpuName} |\n`;
-            body += `| **CUDA** | ${cudaVersion} |\n`;
-            body += `| **PyTorch** | ${pytorchVersion} |\n`;
-            body += `| **Base** | \`${base_sha}\` |\n`;
-            body += `| **Head** | \`${head_sha}\` |\n`;
-            body += `| **Threshold** | ${{ inputs.threshold }}% |\n\n`;
-
-            body += table;
-
-            body += '\n---\n';
-            body += '*This comment is automatically updated with the latest benchmark results.*';
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes(`Benchmark Results (${runnerName.toUpperCase()})`)
-            );
-
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body,
-              });
-              console.log(`Updated existing benchmark comment for ${runnerName}`);
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body,
-              });
-              console.log(`Created new benchmark comment for ${runnerName}`);
-            }


### PR DESCRIPTION
## Summary

Fork PRs receive a read-only `GITHUB_TOKEN`, so the inline comment step in `reusable-ci-benchmarks.yml` fails with `403 Resource not accessible by integration` when trying to post the benchmark result comment (seen on #831).

This splits the flow so the comment step runs in base-repo context with a write token.

- `reusable-ci-benchmarks.yml` now only runs the benchmark and uploads an artifact containing results and metadata (PR number, runner, threshold). No write token needed — works fine for fork PRs.
- `benchmark-comment.yml` (new) triggers on `workflow_run` completion of `nvidia-h100-ci` / `nvidia-a100-ci` / `nvidia-4090-ci`, downloads artifacts, and posts / updates PR comments. Runs in base-repo context with a write token and does not execute PR code, which is the GitHub-recommended pattern for fork-safe PR commenting.

Also switched `listComments` to `github.paginate` with `per_page: 100` so long PRs reliably find the existing bot comment to update instead of creating duplicates.

## Deployment note

`workflow_run` only fires for workflow files present on the default branch, so this fix only starts working for PRs opened **after** it lands on `main`. Existing fork PRs will need a rebase / new push to pick it up.

## Test plan

- [ ] Merge to `main`
- [ ] Re-trigger CI on a fork PR (e.g. #831) and confirm the benchmark comment posts successfully
- [ ] Verify same-repo PRs still get the comment as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark comparison results are now automatically posted to pull requests as comments, providing detailed performance analysis including speedup ratios and identified regressions across multiple GPU configurations

* **Chores**
  * Refactored continuous integration workflows to improve organization and efficiency of benchmark result collection and reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->