### PR TITLE
[Fix] respect user-provided cu_seqlens when attention_mask is present

### DIFF
--- a/fla/layers/comba.py
+++ b/fla/layers/comba.py
@@ -233,7 +233,7 @@ class Comba(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/delta_net.py
+++ b/fla/layers/delta_net.py
@@ -190,7 +190,7 @@ class DeltaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -224,7 +224,7 @@ class GatedDeltaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/gated_deltaproduct.py
+++ b/fla/layers/gated_deltaproduct.py
@@ -186,7 +186,7 @@ class GatedDeltaProduct(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/gla.py
+++ b/fla/layers/gla.py
@@ -196,7 +196,7 @@ class GatedLinearAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/gsa.py
+++ b/fla/layers/gsa.py
@@ -151,7 +151,7 @@ class GatedSlotAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/hgrn2.py
+++ b/fla/layers/hgrn2.py
@@ -124,7 +124,7 @@ class HGRN2Attention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/mesa_net.py
+++ b/fla/layers/mesa_net.py
@@ -145,7 +145,7 @@ class MesaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -190,7 +190,7 @@ class MultiScaleRetention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 

--- a/fla/layers/rodimus.py
+++ b/fla/layers/rodimus.py
@@ -149,7 +149,7 @@ class RodimusAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 


### PR DESCRIPTION
## Summary

Fixes #838.

When both `cu_seqlens` and `attention_mask` are passed to a layer's `forward`, the previous logic unconditionally recomputed `cu_seqlens` from `attention_mask` via `get_unpad_data`, silently overwriting the caller-provided value:

```python
cu_seqlens = kwargs.get('cu_seqlens')
if attention_mask is not None:
    indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])   # ← overwrites
    hidden_states = index_first_axis(...).unsqueeze(0)
```

This bites in **packed training**: HF often injects a default all-ones `attention_mask`, and the mask-derived `cu_seqlens` then collapses to `[0, total]`, losing the real packed sample boundaries the caller supplied.

### Why `cu_seqlens` takes precedence

`cu_seqlens` carries strictly more information than a 2D padding mask:
- A `[B, T]` 0/1 mask can only describe padding (one contiguous valid span per row).
- `cu_seqlens` can describe an arbitrary number of packed samples, including multiple samples per row.

So a mask-derived `cu_seqlens` is only a degenerate special case. If the caller explicitly supplies `cu_seqlens`, trust them.

### Fix

Only take the unpad path when `cu_seqlens` was not provided:

```python
cu_seqlens = kwargs.get('cu_seqlens')
if cu_seqlens is None and attention_mask is not None:
    indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
    hidden_states = index_first_axis(...).unsqueeze(0)
```

Applied consistently to all layers that shared this pattern:

- `fla/layers/comba.py`
- `fla/layers/delta_net.py`
- `fla/layers/gated_deltanet.py`
- `fla/layers/gated_deltaproduct.py`
- `fla/layers/gla.py`
- `fla/layers/gsa.py`
- `fla/layers/hgrn2.py`
- `fla/layers/mesa_net.py`
- `fla/layers/multiscale_retention.py`
- `fla/layers/rodimus.py`

Other layers (`mom.py`, `abc.py`, `simple_gla.py`, `hgrn.py`, `lightnet.py`, and the attention-style layers) use different paths for `cu_seqlens`/`attention_mask` and are not affected.

## Test plan

- [ ] Existing tests for affected layers still pass
- [ ] With `cu_seqlens` provided and an all-ones `attention_mask`, packed boundaries are preserved (no fallback to `[0, total]`)
- [ ] With only `attention_mask` (padded batch, no `cu_seqlens`), behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sequence length metadata handling across multiple attention layers to respect externally-supplied sequence length information and avoid redundant recomputation or conflicts with attention masks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->