### PR TITLE
fix: moba __init__.py imports .native but file is named naive.py

### DIFF
--- a/fla/ops/moba/__init__.py
+++ b/fla/ops/moba/__init__.py
@@ -5,6 +5,6 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-from .native import moba_attn_varlen
+from .naive import moba_attn_varlen
 
 __all__ = ['moba_attn_varlen']


### PR DESCRIPTION
## Summary

Fix `ModuleNotFoundError` caused by a typo in `fla/ops/moba/__init__.py`.

The file imports from `.native`, but the actual module file is named `naive.py` (not `native.py`), causing:

```
ModuleNotFoundError: No module named 'fla.ops.moba.native'
```

on any `import fla` call.

## Change

```diff
- from .native import moba_attn_varlen
+ from .naive import moba_attn_varlen
```

## Context

Introduced in PR #840 ("[MoBA] Integrate MOBA and FlashMOBA"), merged 2026-04-17. The directory contains `naive.py` but `__init__.py` references `.native` — a one-character typo (`i` vs `t`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal implementation to use an alternative backend while preserving the public API and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->