### PR TITLE
[GDN/KDA] Fuse gate activation into fused_recurrent kernels

### DIFF
--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -19,7 +19,6 @@ from torch.nn import functional as F
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
-from fla.ops.gated_delta_rule.gate import fused_gdn_gate
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -279,17 +278,19 @@ class GatedDeltaNet(nn.Module):
                 dt_bias=self.dt_bias,
             )
         elif mode == 'fused_recurrent':
-            g = fused_gdn_gate(g=self.a_proj(hidden_states), A_log=self.A_log, dt_bias=self.dt_bias)
             o, recurrent_state = fused_recurrent_gated_delta_rule(
                 q=q,
                 k=k,
                 v=v,
-                g=g,
+                g=self.a_proj(hidden_states),
                 beta=beta,
                 initial_state=recurrent_state,
                 output_final_state=use_cache,
                 cu_seqlens=cu_seqlens,
                 use_qk_l2norm_in_kernel=True,
+                use_gate_in_kernel=True,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
             )
         else:
             raise NotImplementedError(f"Not supported mode `{mode}`.")

--- a/fla/layers/kda.py
+++ b/fla/layers/kda.py
@@ -18,7 +18,6 @@ from torch.nn import functional as F
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, ShortConvolution
 from fla.ops.kda import chunk_kda, fused_recurrent_kda
-from fla.ops.kda.gate import fused_kda_gate
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -278,16 +277,19 @@ class KimiDeltaAttention(nn.Module):
                 cu_seqlens=cu_seqlens,
             )
         elif mode == "fused_recurrent":
-            g = fused_kda_gate(g=g, A_log=self.A_log, dt_bias=self.dt_bias, lower_bound=self.lower_bound)
             o, recurrent_state = fused_recurrent_kda(
                 q=q,
                 k=k,
                 v=v,
                 g=g,
                 beta=beta,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
                 initial_state=recurrent_state,
                 output_final_state=use_cache,
                 use_qk_l2norm_in_kernel=True,
+                use_gate_in_kernel=True,
+                lower_bound=self.lower_bound,
                 cu_seqlens=cu_seqlens,
             )
         else:

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -10,6 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.softplus import softplus
 from fla.utils import input_guard
 
 
@@ -20,6 +21,8 @@ from fla.utils import input_guard
     'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
     'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+    'USE_GATE_IN_KERNEL': lambda args: args['A_log'] is not None,
+    'HAS_DT_BIAS': lambda args: args['dt_bias'] is not None,
 })
 @triton.jit(do_not_specialize=['T'])
 def fused_recurrent_gated_delta_rule_fwd_kernel(
@@ -30,6 +33,8 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     gk,
     gv,
     beta,
+    A_log,
+    dt_bias,
     o,
     h0,
     ht,
@@ -52,6 +57,8 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     USE_EXP2: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GATE_IN_KERNEL: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -114,7 +121,13 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
 
         if USE_G:
             b_g = tl.load(p_g).to(tl.float32)
-            if USE_EXP2:
+            if USE_GATE_IN_KERNEL:
+                b_A = tl.load(A_log + i_hv).to(tl.float32)
+                if HAS_DT_BIAS:
+                    b_g = b_g + tl.load(dt_bias + i_hv).to(tl.float32)
+                b_g = -exp(b_A) * softplus(b_g)
+                b_h *= exp(b_g)
+            elif USE_EXP2:
                 b_h *= exp2(b_g)
             else:
                 b_h *= exp(b_g)
@@ -183,6 +196,8 @@ def fused_recurrent_gated_delta_rule_fwd(
     gk: torch.Tensor | None = None,
     gv: torch.Tensor | None = None,
     beta: torch.Tensor | None = None,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
     scale: float = None,
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
@@ -216,6 +231,8 @@ def fused_recurrent_gated_delta_rule_fwd(
         gk=gk,
         gv=gv,
         beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
         o=o,
         h0=initial_state,
         ht=final_state,
@@ -251,6 +268,8 @@ class FusedRecurrentFunction(torch.autograd.Function):
         gk: torch.Tensor | None = None,
         gv: torch.Tensor | None = None,
         beta: torch.Tensor | None = None,
+        A_log: torch.Tensor | None = None,
+        dt_bias: torch.Tensor | None = None,
         scale: float = None,
         initial_state: torch.Tensor = None,
         output_final_state: bool = False,
@@ -267,6 +286,8 @@ class FusedRecurrentFunction(torch.autograd.Function):
             gk=gk,
             gv=gv,
             beta=beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
             scale=scale,
             initial_state=initial_state,
             output_final_state=output_final_state,
@@ -300,6 +321,9 @@ def fused_recurrent_gated_delta_rule(
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
+    use_gate_in_kernel: bool = False,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     use_exp2: bool = False,
     transpose_state_layout: bool = False,
@@ -315,6 +339,9 @@ def fused_recurrent_gated_delta_rule(
             GVA (Grouped Value Attention) is applied if `HV > H`, where `HV` must be divisible by `H`.
         g (torch.Tensor):
             g (decays) of shape `[B, T, HV]`. Default: `None`.
+            When `use_gate_in_kernel=False` (default), `g` must be in log space (pre-computed decay).
+            When `use_gate_in_kernel=True`, `g` is the raw pre-activation input; the kernel fuses
+            `-exp(A_log) * softplus(g + dt_bias)` internally per step.
         gk (torch.Tensor):
             gk (decays) of shape `[B, T, HV, K]`. Default: `None`.
         gv (torch.Tensor):
@@ -332,6 +359,15 @@ def fused_recurrent_gated_delta_rule(
             Whether to output the final state of shape `[N, HV, K, V]`. Default: `False`.
         use_qk_l2norm_in_kernel (Optional[bool]):
             Whether to use L2 normalization in the kernel. Default: `False`.
+        use_gate_in_kernel (bool):
+            Whether to compute the log-space GDN decay internally.
+            When `True`, `g` is the raw input and `A_log` must be provided; the kernel fuses
+            gate activation into the recurrence. Default: `False`.
+        A_log (Optional[torch.Tensor]):
+            Decay parameter of shape `[HV]`. Required when `use_gate_in_kernel=True`.
+        dt_bias (Optional[torch.Tensor]):
+            Bias added to `g` before activation, of shape `[HV]`.
+            Only used when `use_gate_in_kernel=True`.
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
@@ -388,6 +424,16 @@ def fused_recurrent_gated_delta_rule(
         scale = k.shape[-1] ** -0.5
     if beta is None:
         beta = torch.ones_like(q[..., 0])
+    if use_gate_in_kernel:
+        if A_log is None:
+            raise ValueError("`A_log` must be provided when `use_gate_in_kernel=True`.")
+        if g is None:
+            raise ValueError("`g` (raw pre-activation) must be provided when `use_gate_in_kernel=True`.")
+        if use_exp2:
+            raise ValueError("`use_exp2=True` is not supported together with `use_gate_in_kernel=True`.")
+    else:
+        A_log = None
+        dt_bias = None
 
     o, final_state = FusedRecurrentFunction.apply(
         q,
@@ -397,6 +443,8 @@ def fused_recurrent_gated_delta_rule(
         gk,
         gv,
         beta,
+        A_log,
+        dt_bias,
         scale,
         initial_state,
         output_final_state,

--- a/fla/ops/kda/fused_recurrent.py
+++ b/fla/ops/kda/fused_recurrent.py
@@ -154,10 +154,10 @@ def fused_recurrent_kda_fwd_kernel(
         b_g = tl.load(p_g, eviction_policy='evict_last').to(tl.float32)
 
         if USE_GATE_IN_KERNEL:
-            b_A = tl.load(A_log + i_h).to(tl.float32)
+            b_A = tl.load(A_log + i_hv).to(tl.float32)
 
             if HAS_DT_BIAS:
-                b_bias = tl.load(dt_bias + i_h * K + o_k, mask=mask_k, other=0).to(tl.float32)
+                b_bias = tl.load(dt_bias + i_hv * K + o_k, mask=mask_k, other=0).to(tl.float32)
                 b_g = b_g + b_bias
 
             if USE_LOWER_BOUND:

--- a/tests/ops/test_gated_delta.py
+++ b/tests/ops/test_gated_delta.py
@@ -79,105 +79,29 @@ def test_fused_recurrent(
 
 
 @pytest.mark.parametrize(
-    ('B', 'T', 'H', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),
+    ('B', 'T', 'Hq', 'H', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),
     [
         pytest.param(
             *test,
-            id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
+            id="B{}-T{}-Hq{}-H{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
         )
         for test in [
-            (2, 75, 4, 64, 1, 0.01, 0, False, torch.float16),
-            (2, 500, 3, 60, 1, 1, 0, False, torch.float16),
-            (2, 1000, 3, 64, 0.1, 1, 0.5, False, torch.float16),
-            (3, 1024, 4, 100, 1, 0.1, 0, False, torch.float16),
-            (4, 1024, 4, 128, 0.1, 1, 0, False, torch.float16),
-            (4, 1024, 4, 128, 0.1, 1, 0, True, torch.float16),
-            (2, 1500, 4, 128, 0.1, 10, 0, False, torch.float16),
-            (4, 2048, 8, 64, 0.1, 1, 0, False, torch.float16),
+            # non-GQA (Hq == H)
+            (2, 75, 4, 4, 64, 1, 0.01, 0, False, torch.float16),
+            (2, 500, 3, 3, 60, 1, 1, 0, False, torch.float16),
+            (2, 1000, 3, 3, 64, 0.1, 1, 0.5, False, torch.float16),
+            (3, 1024, 4, 4, 100, 1, 0.1, 0, False, torch.float16),
+            (4, 1024, 4, 4, 128, 0.1, 1, 0, True, torch.float16),
+            (2, 1500, 4, 4, 128, 0.1, 10, 0, False, torch.float16),
+            (4, 2048, 8, 8, 64, 0.1, 1, 0, False, torch.float16),
+            # GQA (Hq < H)
+            (2, 256, 2, 4, 64, 1, 1, 0, False, torch.float16),
+            (2, 512, 2, 8, 64, 1, 0.1, 0, True, torch.float16),
+            (2, 1024, 4, 8, 128, 0.1, 1, 0, False, torch.float16),
         ]
     ],
 )
 def test_chunk(
-    B: int,
-    T: int,
-    H: int,
-    D: int,
-    scale: float,
-    gate_logit_normalizer: float,
-    mask_p: float,
-    use_qk_l2norm_in_kernel: bool,
-    dtype: torch.dtype,
-):
-    torch.manual_seed(42)
-    if IS_INTEL_ALCHEMIST and D > 128:
-        pytest.skip(reason='chunk_gated_delta_rule is not supported on alchemist for D>128')
-
-    q = torch.rand(B, T, H, D, dtype=dtype)
-    k = torch.rand(B, T, H, D, dtype=dtype)
-    v = torch.rand(B, T, H, D, dtype=dtype)
-    beta = torch.rand(B, T, H, dtype=torch.float).sigmoid()
-    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
-    g = g / gate_logit_normalizer
-    g = g * (torch.rand_like(g) > mask_p)
-    h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
-    q, k, v, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, beta, g, h0))
-
-    tri, tri_ht = chunk_gated_delta_rule(
-        q=F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone(),
-        k=F.normalize(k.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else k.clone(),
-        v=v.clone(),
-        g=g.clone(),
-        beta=beta.clone(),
-        scale=scale,
-        initial_state=h0.clone(),
-        output_final_state=True,
-        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-    )
-    do = torch.randn_like(v)
-    dht = torch.randn_like(h0)
-    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
-    tri_dq, tri_dk, tri_dv, tri_dbeta, tri_dg, tri_dh0 = q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad
-    q.grad = k.grad = v.grad = beta.grad = g.grad = h0.grad = None
-
-    ref, ref_ht = naive_recurrent_gated_delta_rule(
-        q=F.normalize(q.clone(), p=2, dim=-1),
-        k=F.normalize(k.clone(), p=2, dim=-1),
-        v=v.clone(),
-        beta=beta.clone(),
-        g=g.clone(),
-        scale=scale,
-        output_final_state=True,
-        initial_state=h0.clone(),
-    )
-
-    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
-    ref_dq, ref_dk, ref_dv, ref_dbeta, ref_dg, ref_dh0 = q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad
-    assert_close('o', ref, tri, 0.005)
-    assert_close('ht', ref_ht, tri_ht, 0.005)
-    assert_close('dq', ref_dq, tri_dq, 0.008)
-    assert_close('dk', ref_dk, tri_dk, 0.008)
-    assert_close('dv', ref_dv, tri_dv, 0.008)
-    assert_close('db', ref_dbeta, tri_dbeta, 0.02)
-    assert_close('dg', ref_dg, tri_dg, 0.02)
-    assert_close('dh0', ref_dh0, tri_dh0, 0.008)
-
-
-@pytest.mark.parametrize(
-    ('B', 'T', 'Hq', 'H', 'D', 'scale', 'gate_logit_normalizer', 'use_qk_l2norm_in_kernel', 'dtype'),
-    [
-        pytest.param(
-            *test,
-            id="B{}-T{}-Hq{}-H{}-D{}-scale{}-gate_logit_normalizer{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
-        )
-        for test in [
-            (2, 256, 2, 4, 64, 1, 1, False, torch.float16),
-            (2, 512, 1, 4, 64, 0.1, 1, False, torch.float16),
-            (2, 512, 2, 8, 64, 1, 0.1, True, torch.float16),
-            (2, 1024, 4, 8, 128, 0.1, 1, False, torch.float16),
-        ]
-    ],
-)
-def test_chunk_gqa(
     B: int,
     T: int,
     Hq: int,
@@ -185,6 +109,7 @@ def test_chunk_gqa(
     D: int,
     scale: float,
     gate_logit_normalizer: float,
+    mask_p: float,
     use_qk_l2norm_in_kernel: bool,
     dtype: torch.dtype,
 ):
@@ -200,6 +125,7 @@ def test_chunk_gqa(
     beta = torch.rand(B, T, H, dtype=torch.float).sigmoid()
     g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
     g = g / gate_logit_normalizer
+    g = g * (torch.rand_like(g) > mask_p)
     h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
     q, k, v, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, beta, g, h0))
 

--- a/tests/ops/test_gated_delta.py
+++ b/tests/ops/test_gated_delta.py
@@ -79,14 +79,14 @@ def test_fused_recurrent(
 
 
 @pytest.mark.parametrize(
-    ('B', 'T', 'Hq', 'H', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),
+    ('B', 'T', 'H', 'HV', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),
     [
         pytest.param(
             *test,
-            id="B{}-T{}-Hq{}-H{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
+            id="B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
         )
         for test in [
-            # non-GQA (Hq == H)
+            # non-GVA (HV == H)
             (2, 75, 4, 4, 64, 1, 0.01, 0, False, torch.float16),
             (2, 500, 3, 3, 60, 1, 1, 0, False, torch.float16),
             (2, 1000, 3, 3, 64, 0.1, 1, 0.5, False, torch.float16),
@@ -94,7 +94,7 @@ def test_fused_recurrent(
             (4, 1024, 4, 4, 128, 0.1, 1, 0, True, torch.float16),
             (2, 1500, 4, 4, 128, 0.1, 10, 0, False, torch.float16),
             (4, 2048, 8, 8, 64, 0.1, 1, 0, False, torch.float16),
-            # GQA (Hq < H)
+            # GVA (HV > H)
             (2, 256, 2, 4, 64, 1, 1, 0, False, torch.float16),
             (2, 512, 2, 8, 64, 1, 0.1, 0, True, torch.float16),
             (2, 1024, 4, 8, 128, 0.1, 1, 0, False, torch.float16),
@@ -104,8 +104,8 @@ def test_fused_recurrent(
 def test_chunk(
     B: int,
     T: int,
-    Hq: int,
     H: int,
+    HV: int,
     D: int,
     scale: float,
     gate_logit_normalizer: float,
@@ -116,17 +116,17 @@ def test_chunk(
     torch.manual_seed(42)
     if IS_INTEL_ALCHEMIST and D > 128:
         pytest.skip(reason='chunk_gated_delta_rule is not supported on alchemist for D>128')
-    assert H % Hq == 0
-    G = H // Hq
+    assert HV % H == 0
+    G = HV // H
 
-    q = torch.rand(B, T, Hq, D, dtype=dtype)
-    k = torch.rand(B, T, Hq, D, dtype=dtype)
-    v = torch.rand(B, T, H, D, dtype=dtype)
-    beta = torch.rand(B, T, H, dtype=torch.float).sigmoid()
-    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, HV, D, dtype=dtype)
+    beta = torch.rand(B, T, HV, dtype=torch.float).sigmoid()
+    g = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32))
     g = g / gate_logit_normalizer
     g = g * (torch.rand_like(g) > mask_p)
-    h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
+    h0 = torch.zeros(B, HV, D, D, dtype=torch.float32)
     q, k, v, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, beta, g, h0))
 
     tri, tri_ht = chunk_gated_delta_rule(

--- a/tests/ops/test_gated_delta.py
+++ b/tests/ops/test_gated_delta.py
@@ -384,6 +384,137 @@ def test_fused_recurrent_transpose_state(
 
 
 @pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HV', 'D', 'scale', 'has_dt_bias', 'dtype'),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-HV{}-D{}-scale{}-has_dt_bias{}-{}".format(*test),
+        )
+        for test in [
+            (1, 64, 1, 1, 64, 1, False, torch.float),
+            (2, 256, 2, 2, 64, 1, True, torch.float),
+            (2, 512, 2, 4, 64, 0.1, True, torch.float16),
+            (3, 1000, 2, 8, 128, 1, False, torch.float16),
+            (4, 1024, 4, 4, 128, 0.1, True, torch.float16),
+        ]
+    ],
+)
+def test_fused_recurrent_gate_in_kernel(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    scale: float,
+    has_dt_bias: bool,
+    dtype: torch.dtype,
+):
+    """fused_recurrent_gated_delta_rule with use_gate_in_kernel=True matches manual gate."""
+    torch.manual_seed(42)
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
+    g_raw = torch.randn(B, T, HV, dtype=torch.float32, device=device)
+    A_log = torch.log(torch.empty(HV, dtype=torch.float32, device=device).uniform_(1, 16))
+    dt_bias = torch.randn(HV, dtype=torch.float32, device=device) if has_dt_bias else None
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device)
+
+    g_ref = naive_gdn_gate(g_raw, A_log, dt_bias)
+    ref, ref_ht = fused_recurrent_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g_ref,
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+    )
+    tri, tri_ht = fused_recurrent_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g_raw.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        A_log=A_log.clone(),
+        dt_bias=dt_bias.clone() if dt_bias is not None else None,
+    )
+    assert_close('o', ref, tri, 0.002)
+    assert_close('ht', ref_ht, tri_ht, 0.002)
+
+
+@pytest.mark.parametrize(
+    ('H', 'HV', 'D', 'has_dt_bias', 'cu_seqlens', 'dtype'),
+    [
+        pytest.param(*test, id="H{}-HV{}-D{}-has_dt_bias{}-cu_seqlens{}-{}".format(*test))
+        for test in [
+            (2, 2, 64, True, [0, 15, 100, 300], torch.float16),
+            (2, 4, 64, False, [0, 256, 500, 1000], torch.float16),
+            (4, 4, 128, True, [0, 15, 100, 300, 1200, 2000], torch.float16),
+        ]
+    ],
+)
+def test_fused_recurrent_gate_in_kernel_varlen(
+    H: int,
+    HV: int,
+    D: int,
+    has_dt_bias: bool,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+):
+    """Varlen fused_recurrent_gated_delta_rule with use_gate_in_kernel=True."""
+    torch.manual_seed(42)
+    cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
+    T = cu_seqlens[-1].item()
+    N = len(cu_seqlens) - 1
+
+    q = torch.randn(1, T, H, D, dtype=dtype, device=device)
+    k = torch.randn(1, T, H, D, dtype=dtype, device=device)
+    v = torch.randn(1, T, HV, D, dtype=dtype, device=device)
+    beta = torch.rand(1, T, HV, dtype=dtype, device=device).sigmoid()
+    g_raw = torch.randn(1, T, HV, dtype=torch.float32, device=device)
+    A_log = torch.log(torch.empty(HV, dtype=torch.float32, device=device).uniform_(1, 16))
+    dt_bias = torch.randn(HV, dtype=torch.float32, device=device) if has_dt_bias else None
+    h0 = torch.randn(N, HV, D, D, dtype=torch.float32, device=device)
+
+    g_ref = naive_gdn_gate(g_raw, A_log, dt_bias)
+    ref, ref_ht = fused_recurrent_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g_ref,
+        beta=beta.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=True,
+    )
+    tri, tri_ht = fused_recurrent_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g_raw.clone(),
+        beta=beta.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        A_log=A_log.clone(),
+        dt_bias=dt_bias.clone() if dt_bias is not None else None,
+    )
+    assert_close('o', ref, tri, 0.002)
+    assert_close('ht', ref_ht, tri_ht, 0.002)
+
+
+@pytest.mark.parametrize(
     ('H', 'D', 'mask_p', 'cu_seqlens', 'dtype'),
     [
         pytest.param(*test, id="H{}-D{}-mask_p{}-cu_seqlens{}-{}".format(*test))

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -210,6 +210,81 @@ def test_fused_recurrent_transpose_state(
 
 
 @pytest.mark.parametrize(
+    ("B", "T", "H", "HV", "D", "scale", "has_dt_bias", "safe_gate", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-HV{}-D{}-scale{}-has_dt_bias{}-safe_gate{}-{}".format(*test),
+        )
+        for test in [
+            (1, 64, 1, 1, 64, 1, False, False, torch.float),
+            (2, 256, 2, 2, 64, 1, True, False, torch.float),
+            (2, 512, 2, 4, 64, 0.1, True, True, torch.float16),
+            (3, 1000, 2, 8, 128, 1, False, False, torch.float16),
+            (4, 1024, 4, 4, 128, 0.1, True, True, torch.float16),
+        ]
+    ],
+)
+def test_fused_recurrent_gate_in_kernel(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    scale: float,
+    has_dt_bias: bool,
+    safe_gate: bool,
+    dtype: torch.dtype,
+):
+    """fused_recurrent_kda with use_gate_in_kernel=True matches manual gate path."""
+    torch.manual_seed(42)
+    if IS_INTEL_ALCHEMIST and D > 128:
+        pytest.skip(reason="fused_recurrent_kda is not supported on alchemist for D>128")
+
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, HV, D, dtype=dtype, device=device)
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
+    g_raw = torch.randn(B, T, HV, D, dtype=torch.float32, device=device)
+    A_log = torch.log(torch.empty(HV, dtype=torch.float32, device=device).uniform_(1, 16))
+    dt_bias = torch.randn(HV * D, dtype=torch.float32, device=device) if has_dt_bias else None
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device)
+
+    lower_bound = -5.0 if safe_gate else None
+    naive_gate_fn = naive_kda_lowerbound_gate if safe_gate else naive_kda_gate
+    g_ref = naive_gate_fn(g_raw, A_log, dt_bias)
+
+    ref, ref_ht = fused_recurrent_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g_ref,
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+    )
+    tri, tri_ht = fused_recurrent_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g_raw.clone(),
+        beta=beta.clone(),
+        A_log=A_log.clone(),
+        dt_bias=dt_bias.clone() if dt_bias is not None else None,
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        lower_bound=lower_bound,
+    )
+    assert_close("o", ref, tri, 0.002)
+    assert_close("ht", ref_ht, tri_ht, 0.002)
+
+
+@pytest.mark.parametrize(
     ("B", "H", "D", "scale", "gate_logit_normalizer", "use_qk_l2norm_in_kernel", "use_gate_in_kernel", "safe_gate", "dtype"),
     [
         pytest.param(


### PR DESCRIPTION
## Summary

- Extend `fused_recurrent_gated_delta_rule` to accept `A_log`/`dt_bias` and fuse `-exp(A_log) * softplus(g + dt_bias)` into the per-token recurrence, mirroring `chunk_gated_delta_rule`'s `use_gate_in_kernel` interface. `fused_recurrent_kda` already supported it.
- Drop the separate `fused_kda_gate` / `fused_gdn_gate` calls in the KDA and GDN layers; pass the raw gate + `A_log`/`dt_bias` (+ `lower_bound` for KDA) straight into the fused_recurrent op with `use_gate_in_kernel=True`.
- The chunk and fused_recurrent paths now share a consistent fused-gate API across KDA and GDN.

## Test plan

- [x] New pytest cases (GPU required):
  - `tests/ops/test_gated_delta.py::test_fused_recurrent_gate_in_kernel` — compares `use_gate_in_kernel=True` vs `g=naive_gdn_gate(...)` across GVA / `has_dt_bias` / dtypes.
  - `tests/ops/test_gated_delta.py::test_fused_recurrent_gate_in_kernel_varlen` — varlen `cu_seqlens` variant.
  - `tests/ops/test_kda.py::test_fused_recurrent_gate_in_kernel` — same comparison for KDA, covering `safe_gate` / `lower_bound` and GVA.
- [ ] `pytest tests/ops/test_gated_delta.py tests/ops/test_kda.py` green on a CUDA box.
- [ ] Existing `test_fused_recurrent` / `test_fused_recurrent_transpose_state` / `test_fused_recurrent_vllm_decode` still pass (unchanged default path preserved via `A_log=None` → `USE_GATE_IN_KERNEL=False` heuristic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Gate computation is moved into fused recurrent kernels, improving throughput and efficiency for recurrent and attention-like operations.

* **Stability**
  * Kernels now accept additional decay/bias inputs and safer gate handling, yielding more accurate and stable per-step updates across head/value configurations.

* **Tests**
  * Added tests validating in-kernel gate paths (fixed and variable lengths) and updated coverage for multi-head/value layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->