### PR TITLE
[Typo] Fix typos in kernel comments [skip test]

### DIFF
--- a/fla/modules/fused_linear_cross_entropy.py
+++ b/fla/modules/fused_linear_cross_entropy.py
@@ -206,7 +206,7 @@ def cross_entropy_kernel(
 
         tl.debug_barrier()
 
-    # Orginal loss = H(q, p),  with label smoothing regularization = H(q', p) and (label_smoothing / V) = eps
+    # Original loss = H(q, p),  with label smoothing regularization = H(q', p) and (label_smoothing / V) = eps
     # H(q', p) = (1 - label_smoothing) * H(q, p) + label_smoothing * H(u, p)
     #          = (1 - label_smoothing) * H(q, p) + eps * sum(logsoftmax(x_i))
     # By using m (global max of xi) and d (sum of e^(xi-m)), we can simplify as:

--- a/fla/ops/rwkv4/fused_recurrent.py
+++ b/fla/ops/rwkv4/fused_recurrent.py
@@ -256,7 +256,7 @@ def fused_recurrent_rwkv4_backward_kernel(
     gk_ptr = gk_ptr + b_idx * gk_s_b
     gv_ptr = gv_ptr + b_idx * gv_s_b
 
-    # Pointers to gradients which were recieved by the function.
+    # Pointers to gradients which were received by the function.
     gwkv_ptr = gwkv_ptr + b_idx * gwkv_s_b
     galpha_out_ptr = gstate_out_ptr + b_idx * gstate_out_s_b
     gbeta_out_ptr = gstate_out_ptr + b_idx * gstate_out_s_b + gstate_out_s_abe


### PR DESCRIPTION
## Summary

Two single-character typos in source-code comments (no behavior change):

- `fla/modules/fused_linear_cross_entropy.py:209` — `Orginal` → `Original`
- `fla/ops/rwkv4/fused_recurrent.py:259` — `recieved` → `received`

## Test plan

Comments only — `[skip test]` per CONTRIBUTING.md.
