### PR TITLE
[Common] Support transpose_state_layout in fused_recurrent (GLA / SimpleGLA / RetNet)

### DIFF
--- a/fla/ops/common/fused_recurrent.py
+++ b/fla/ops/common/fused_recurrent.py
@@ -23,7 +23,7 @@ from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_k
         triton.Config({}, num_warps=num_warps)
         for num_warps in [4, 8]
     ],
-    key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV'],
+    key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['B', 'T'])
@@ -55,6 +55,7 @@ def fused_recurrent_fwd_kernel(
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr = False,
 ):
     i_v, i_k, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_n, i_h = i_nh // H, i_nh % H
@@ -83,11 +84,18 @@ def fused_recurrent_fwd_kernel(
 
     m_k = o_k < K
     m_v = o_v < V
-    m_h = m_k[:, None] & m_v[None, :]
-    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if TRANSPOSE_STATE:
+        m_h = m_v[:, None] & m_k[None, :]
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        m_h = m_k[:, None] & m_v[None, :]
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
 
     if USE_INITIAL_STATE:
-        p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        if TRANSPOSE_STATE:
+            p_h0 = h0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         b_h += tl.load(p_h0, mask=m_h, other=0).to(tl.float32)
 
     for _ in range(0, T):
@@ -101,13 +109,22 @@ def fused_recurrent_fwd_kernel(
             b_h = b_h * exp(b_g_gamma)
         if USE_GK:
             b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-            b_h = b_h * exp(b_gk[:, None])
+            if TRANSPOSE_STATE:
+                b_h = b_h * exp(b_gk[None, :])
+            else:
+                b_h = b_h * exp(b_gk[:, None])
         if USE_GV:
             b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
-            b_h = b_h * exp(b_gv[None, :])
-        b_h += b_k[:, None] * b_v[None, :]
-        b_o = b_h * b_q[:, None]
-        b_o = tl.sum(b_o, axis=0)
+            if TRANSPOSE_STATE:
+                b_h = b_h * exp(b_gv[:, None])
+            else:
+                b_h = b_h * exp(b_gv[None, :])
+        if TRANSPOSE_STATE:
+            b_h += b_v[:, None] * b_k[None, :]
+            b_o = tl.sum(b_h * b_q[None, :], axis=1)
+        else:
+            b_h += b_k[:, None] * b_v[None, :]
+            b_o = tl.sum(b_h * b_q[:, None], axis=0)
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
         p_q += (-1 if REVERSE else 1) * H*K
         p_k += (-1 if REVERSE else 1) * H*K
@@ -121,7 +138,10 @@ def fused_recurrent_fwd_kernel(
             p_gv += (-1 if REVERSE else 1) * H*V
 
     if STORE_FINAL_STATE:
-        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        if TRANSPOSE_STATE:
+            p_ht = ht + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_h)
 
 
@@ -136,7 +156,7 @@ def fused_recurrent_fwd_kernel(
         triton.Config({}, num_warps=num_warps)
         for num_warps in [4]
     ],
-    key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV'],
+    key=['BK', 'BV', 'USE_G', 'USE_G_GAMMA', 'USE_GK', 'USE_GV', 'TRANSPOSE_STATE'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['B', 'T'])
@@ -177,6 +197,7 @@ def fused_recurrent_bwd_kernel(
     STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr = False,
 ):
     i_v, i_k, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_n, i_h = i_nh // H, i_nh % H
@@ -193,7 +214,10 @@ def fused_recurrent_bwd_kernel(
     o_v = i_v * BV + tl.arange(0, BV)
     m_k = o_k < K
     m_v = o_v < V
-    m_h = m_k[:, None] & m_v[None, :]
+    if TRANSPOSE_STATE:
+        m_h = m_v[:, None] & m_k[None, :]
+    else:
+        m_h = m_k[:, None] & m_v[None, :]
 
     p_k = k + (bos + ((T-1) if REVERSE else 0)) * H*K + i_h * K + o_k
     p_v = v + (bos + ((T-1) if REVERSE else 0)) * H*V + i_h * V + o_v
@@ -208,9 +232,15 @@ def fused_recurrent_bwd_kernel(
     if USE_G_GAMMA:
         b_g_gamma = tl.load(g_gamma + i_h)
 
-    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if TRANSPOSE_STATE:
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        if TRANSPOSE_STATE:
+            p_h0 = h0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         b_h += tl.load(p_h0, mask=m_h, other=0).to(tl.float32)
 
     for _ in range(0, T):
@@ -224,13 +254,22 @@ def fused_recurrent_bwd_kernel(
             b_h = b_h * exp(b_g_gamma)
         if USE_GK:
             b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-            b_h = b_h * exp(b_gk[:, None])
+            if TRANSPOSE_STATE:
+                b_h = b_h * exp(b_gk[None, :])
+            else:
+                b_h = b_h * exp(b_gk[:, None])
         if USE_GV:
             b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
-            b_h = b_h * exp(b_gv[None, :])
-        b_h += b_k[:, None] * b_v[None, :]
-        b_dq = b_h * b_do[None, :]
-        b_dq = tl.sum(b_dq, axis=1) * scale
+            if TRANSPOSE_STATE:
+                b_h = b_h * exp(b_gv[:, None])
+            else:
+                b_h = b_h * exp(b_gv[None, :])
+        if TRANSPOSE_STATE:
+            b_h += b_v[:, None] * b_k[None, :]
+            b_dq = tl.sum(b_h * b_do[:, None], axis=0) * scale
+        else:
+            b_h += b_k[:, None] * b_v[None, :]
+            b_dq = tl.sum(b_h * b_do[None, :], axis=1) * scale
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_k)
 
         p_k += (-1 if REVERSE else 1) * H*K
@@ -266,26 +305,43 @@ def fused_recurrent_bwd_kernel(
         p_gv = gv + (bos + ((T - 1) if not REVERSE else 0)) * H*V + i_h * V + o_v
         p_dgv = dgv + ((i_k * all + bos) + ((T - 1) if not REVERSE else 0)) * H*V + i_h * V + o_v
 
-    b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    if TRANSPOSE_STATE:
+        b_dh = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_FINAL_STATE_GRADIENT:
-        p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        if TRANSPOSE_STATE:
+            p_dht = dht + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         b_dh += tl.load(p_dht, mask=m_h, other=0).to(tl.float32)
 
     if USE_G:
         b_dg = tl.sum(b_h * b_dh)
     if USE_GK:
-        b_dgk = tl.sum(b_h * b_dh, 1)
+        if TRANSPOSE_STATE:
+            b_dgk = tl.sum(b_h * b_dh, 0)
+        else:
+            b_dgk = tl.sum(b_h * b_dh, 1)
     if USE_GV:
-        b_dgv = tl.sum(b_h * b_dh, 0)
+        if TRANSPOSE_STATE:
+            b_dgv = tl.sum(b_h * b_dh, 1)
+        else:
+            b_dgv = tl.sum(b_h * b_dh, 0)
 
     for _ in range(T):
         b_q = tl.load(p_q, mask=m_k, other=0).to(tl.float32)
         b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
         b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
         b_do = tl.load(p_do, mask=m_v, other=0).to(tl.float32)
-        b_dh += (b_q * scale)[:, None] * b_do[None, :]
-        b_dk = tl.sum(b_dh * b_v[None, :], axis=1)
-        b_dv = tl.sum(b_dh * b_k[:, None], axis=0)
+        if TRANSPOSE_STATE:
+            b_dh += b_do[:, None] * (b_q * scale)[None, :]
+            b_dk = tl.sum(b_dh * b_v[:, None], axis=0)
+            b_dv = tl.sum(b_dh * b_k[None, :], axis=1)
+        else:
+            b_dh += (b_q * scale)[:, None] * b_do[None, :]
+            b_dk = tl.sum(b_dh * b_v[None, :], axis=1)
+            b_dv = tl.sum(b_dh * b_k[:, None], axis=0)
 
         if USE_G:
             b_g = tl.load(p_g).to(tl.float32)
@@ -299,7 +355,10 @@ def fused_recurrent_bwd_kernel(
             b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
             b_dq = tl.load(p_dq, mask=m_k, other=0).to(tl.float32)
             b_dgk += b_q * b_dq - b_k * b_dk
-            b_dh *= exp(b_gk)[:, None]
+            if TRANSPOSE_STATE:
+                b_dh *= exp(b_gk)[None, :]
+            else:
+                b_dh *= exp(b_gk)[:, None]
             tl.store(p_dgk, b_dgk.to(p_dgk.dtype.element_ty), mask=m_k)
         if USE_GV:
             b_o = tl.load(p_o, mask=m_v, other=0).to(tl.float32)
@@ -307,7 +366,10 @@ def fused_recurrent_bwd_kernel(
             if i_k == 0:
                 b_dgv += b_o * b_do
             b_dgv -= b_v * b_dv
-            b_dh *= exp(b_gv)[None, :]
+            if TRANSPOSE_STATE:
+                b_dh *= exp(b_gv)[:, None]
+            else:
+                b_dh *= exp(b_gv)[None, :]
             tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), mask=m_v)
 
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
@@ -333,7 +395,10 @@ def fused_recurrent_bwd_kernel(
             p_dgv += (1 if REVERSE else -1) * H*V
 
     if STORE_INITIAL_STATE_GRADIENT:
-        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        if TRANSPOSE_STATE:
+            p_dh0 = dh0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_h)
 
 
@@ -350,6 +415,7 @@ def fused_recurrent_fwd(
     output_final_state: bool = False,
     reverse: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
@@ -357,7 +423,13 @@ def fused_recurrent_fwd(
     NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
 
     h0 = initial_state
-    ht = q.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
+    if output_final_state:
+        if transpose_state_layout:
+            ht = q.new_empty(N, H, V, K, dtype=torch.float32)
+        else:
+            ht = q.new_empty(N, H, K, V, dtype=torch.float32)
+    else:
+        ht = None
     o = q.new_empty(NK, *v.shape, dtype=torch.float32)
 
     grid = (NV, NK, N * H)
@@ -386,6 +458,7 @@ def fused_recurrent_fwd(
         USE_GK=gk is not None,
         USE_GV=gv is not None,
         REVERSE=reverse,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     o = o.sum(0)
     return o, ht
@@ -406,6 +479,7 @@ def fused_recurrent_bwd(
     initial_state: torch.Tensor | None = None,
     reverse: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
@@ -461,6 +535,7 @@ def fused_recurrent_bwd(
         USE_GK=gk is not None,
         USE_GV=gv is not None,
         REVERSE=reverse,
+        TRANSPOSE_STATE=transpose_state_layout,
     )
     dq = dq.sum(0)
     dk = dk.sum(0)
@@ -494,6 +569,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
         output_final_state: bool = False,
         reverse: bool = False,
         cu_seqlens: torch.LongTensor | None = None,
+        transpose_state_layout: bool = False,
     ):
         o, ht = fused_recurrent_fwd(
             q=q,
@@ -508,11 +584,13 @@ class FusedRecurrentFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             reverse=reverse,
             cu_seqlens=cu_seqlens,
+            transpose_state_layout=transpose_state_layout,
         )
         ctx.save_for_backward(q, k, v, g, g_gamma, gk, gv, initial_state, o)
         ctx.scale = scale
         ctx.reverse = reverse
         ctx.cu_seqlens = cu_seqlens
+        ctx.transpose_state_layout = transpose_state_layout
         return o.to(q.dtype), ht
 
     @staticmethod
@@ -535,8 +613,9 @@ class FusedRecurrentFunction(torch.autograd.Function):
             initial_state=initial_state,
             reverse=ctx.reverse,
             cu_seqlens=ctx.cu_seqlens,
+            transpose_state_layout=ctx.transpose_state_layout,
         )
-        return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), dg, None, dgk, dgv, None, dh0, None, None, None
+        return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), dg, None, dgk, dgv, None, dh0, None, None, None, None
 
 
 def fused_recurrent(
@@ -552,6 +631,7 @@ def fused_recurrent(
     output_final_state: bool = False,
     reverse: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ):
     if scale is None:
         scale = k.shape[-1] ** -0.5
@@ -568,4 +648,5 @@ def fused_recurrent(
         output_final_state,
         reverse,
         cu_seqlens,
+        transpose_state_layout,
     )

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -663,10 +663,11 @@ def chunk_gla_bwd_kernel_dv(
 })
 @fla_cache_autotune(
     configs=[
-        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps)
+        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
         for BK in BK_LIST
         for BV in BV_LIST
         for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
     ],
     key=['BT'],
     **autotune_cache_kwargs,

--- a/fla/ops/gla/fused_recurrent.py
+++ b/fla/ops/gla/fused_recurrent.py
@@ -21,6 +21,7 @@ def fused_recurrent_gla(
     output_final_state: bool = False,
     reverse: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""
     Args:
@@ -48,6 +49,12 @@ def fused_recurrent_gla(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
+        transpose_state_layout (Optional[bool]):
+            Whether to use the transposed `[N, H, V, K]` layout for the hidden state,
+            instead of the default `[N, H, K, V]`.
+            Useful for inference backends that expect a V-major state.
+            `initial_state`, `output_final_state`, and `dh0`/`dht` all follow the chosen layout.
+            Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -109,5 +116,6 @@ def fused_recurrent_gla(
         output_final_state=output_final_state,
         reverse=reverse,
         cu_seqlens=cu_seqlens,
+        transpose_state_layout=transpose_state_layout,
     )
     return o, final_state

--- a/fla/ops/gla/fused_recurrent.py
+++ b/fla/ops/gla/fused_recurrent.py
@@ -53,7 +53,7 @@ def fused_recurrent_gla(
             Whether to use the transposed `[N, H, V, K]` layout for the hidden state,
             instead of the default `[N, H, K, V]`.
             Useful for inference backends that expect a V-major state.
-            `initial_state`, `output_final_state`, and `dh0`/`dht` all follow the chosen layout.
+            `initial_state`, `final_state`, and `dh0`/`dht` all follow the chosen layout.
             Default: `False`.
 
     Returns:

--- a/fla/ops/retention/fused_recurrent.py
+++ b/fla/ops/retention/fused_recurrent.py
@@ -19,6 +19,7 @@ def fused_recurrent_retention(
     output_final_state: bool = False,
     reverse: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if cu_seqlens is not None:
         if q.shape[0] != 1:
@@ -42,5 +43,6 @@ def fused_recurrent_retention(
         output_final_state=output_final_state,
         reverse=reverse,
         cu_seqlens=cu_seqlens,
+        transpose_state_layout=transpose_state_layout,
     )
     return o, final_state

--- a/fla/ops/simple_gla/fused_recurrent.py
+++ b/fla/ops/simple_gla/fused_recurrent.py
@@ -56,7 +56,7 @@ def fused_recurrent_simple_gla(
             Whether to use the transposed `[N, H, V, K]` layout for the hidden state,
             instead of the default `[N, H, K, V]`.
             Useful for inference backends that expect a V-major state.
-            `initial_state`, `output_final_state`, and `dh0`/`dht` all follow the chosen layout.
+            `initial_state`, `final_state`, and `dh0`/`dht` all follow the chosen layout.
             Default: `False`.
 
     Returns:

--- a/fla/ops/simple_gla/fused_recurrent.py
+++ b/fla/ops/simple_gla/fused_recurrent.py
@@ -21,6 +21,7 @@ def fused_recurrent_simple_gla(
     output_final_state: bool = False,
     reverse: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""
     Args:
@@ -51,6 +52,12 @@ def fused_recurrent_simple_gla(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
+        transpose_state_layout (Optional[bool]):
+            Whether to use the transposed `[N, H, V, K]` layout for the hidden state,
+            instead of the default `[N, H, K, V]`.
+            Useful for inference backends that expect a V-major state.
+            `initial_state`, `output_final_state`, and `dh0`/`dht` all follow the chosen layout.
+            Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -110,5 +117,6 @@ def fused_recurrent_simple_gla(
         output_final_state=output_final_state,
         reverse=reverse,
         cu_seqlens=cu_seqlens,
+        transpose_state_layout=transpose_state_layout,
     )
     return o, final_state

--- a/tests/ops/test_gla.py
+++ b/tests/ops/test_gla.py
@@ -94,6 +94,63 @@ def test_fused_recurrent(
 
 
 @pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 256, 4, 64, torch.float),
+            (2, 1024, 4, 128, torch.float16),
+        ]
+    ],
+)
+@pytest.mark.skipif(
+    device_platform == 'intel',
+    reason='Intel Triton Failure',
+)
+def test_fused_recurrent_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+
+    q = torch.rand((B, T, H, D), dtype=dtype, device=device)
+    k = torch.rand((B, T, H, D), dtype=dtype, device=device)
+    v = torch.rand((B, T, H, D), dtype=dtype, device=device)
+    g = F.logsigmoid(torch.rand((B, T, H, D), dtype=dtype, device=device))
+    h0 = torch.rand(B, H, D, D, device=device)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    def run(transpose: bool):
+        q_, k_, v_, g_ = (x.detach().clone().requires_grad_() for x in (q, k, v, g))
+        h0_in = h0.transpose(-1, -2).contiguous() if transpose else h0.clone()
+        dht_in = dht.transpose(-1, -2).contiguous() if transpose else dht
+        h0_in = h0_in.requires_grad_()
+        out, ht = fused_recurrent_gla(
+            q=q_, k=k_, v=v_, gk=g_,
+            initial_state=h0_in,
+            output_final_state=True,
+            transpose_state_layout=transpose,
+        )
+        ((out * do).sum() + (ht * dht_in).sum()).backward()
+        return out, ht, q_.grad, k_.grad, v_.grad, g_.grad, h0_in.grad
+
+    ref_o, ref_ht, ref_dq, ref_dk, ref_dv, ref_dg, ref_dh0 = run(False)
+    tri_o, tri_ht, tri_dq, tri_dk, tri_dv, tri_dg, tri_dh0 = run(True)
+
+    assert_close('o', ref_o, tri_o, 0.005)
+    assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)
+    assert_close('dg', ref_dg, tri_dg, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0.transpose(-1, -2), 0.005)
+
+
+@pytest.mark.parametrize(
     ('H', 'D', 'cu_seqlens', 'dtype'),
     [
         pytest.param(*test, id="H{}-D{}-cu_seqlens{}-{}".format(*test))

--- a/tests/ops/test_retention.py
+++ b/tests/ops/test_retention.py
@@ -312,3 +312,57 @@ def test_parallel(
     assert_close('dq', ref_dq, tri_dq, 0.005)
     assert_close('dk', ref_dk, tri_dk, 0.005)
     assert_close('dv', ref_dv, tri_dv, 0.005)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'K', 'expand_ratio', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-K{}-expand_ratio{}-{}".format(*test))
+        for test in [
+            (2, 256, 4, 64, 1, torch.float16),
+            (2, 1024, 4, 128, 2, torch.float16),
+        ]
+    ],
+)
+def test_fused_recurrent_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    expand_ratio: int,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    V = K * expand_ratio
+
+    q = torch.randn((B, T, H, K), dtype=dtype, device=device)
+    k = torch.randn((B, T, H, K), dtype=dtype, device=device)
+    v = torch.randn((B, T, H, V), dtype=dtype, device=device)
+    h0 = torch.randn((B, H, K, V), dtype=dtype, device=device)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    def run(transpose: bool):
+        q_, k_, v_ = (x.detach().clone().requires_grad_() for x in (q, k, v))
+        h0_in = h0.transpose(-1, -2).contiguous() if transpose else h0.clone()
+        dht_in = dht.transpose(-1, -2).contiguous() if transpose else dht
+        h0_in = h0_in.requires_grad_()
+        out, ht = fused_recurrent_retention(
+            q_, k_, v_,
+            initial_state=h0_in,
+            output_final_state=True,
+            transpose_state_layout=transpose,
+        )
+        ((out * do).sum() + (ht * dht_in).sum()).backward()
+        return out, ht, q_.grad, k_.grad, v_.grad, h0_in.grad
+
+    ref_o, ref_ht, ref_dq, ref_dk, ref_dv, ref_dh0 = run(False)
+    tri_o, tri_ht, tri_dq, tri_dk, tri_dv, tri_dh0 = run(True)
+
+    assert tri_ht.shape == (B, H, V, K)
+    assert_close('o', ref_o, tri_o, 0.005)
+    assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)
+    assert_close('dh0', ref_dh0, tri_dh0.transpose(-1, -2), 0.005)

--- a/tests/ops/test_simple_gla.py
+++ b/tests/ops/test_simple_gla.py
@@ -96,6 +96,59 @@ def test_fused_recurrent(
 
 
 @pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 256, 4, 64, torch.float),
+            (2, 1024, 4, 128, torch.float16),
+        ]
+    ],
+)
+def test_fused_recurrent_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+
+    q = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn((B, T, H), dtype=dtype, device=device))
+    h0 = torch.randn(B, H, D, D, device=device)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    def run(transpose: bool):
+        q_, k_, v_, g_ = (x.detach().clone().requires_grad_() for x in (q, k, v, g))
+        h0_in = h0.transpose(-1, -2).contiguous() if transpose else h0.clone()
+        dht_in = dht.transpose(-1, -2).contiguous() if transpose else dht
+        h0_in = h0_in.requires_grad_()
+        out, ht = fused_recurrent_simple_gla(
+            q=q_, k=k_, v=v_, g=g_,
+            initial_state=h0_in,
+            output_final_state=True,
+            transpose_state_layout=transpose,
+        )
+        ((out * do).sum() + (ht * dht_in).sum()).backward()
+        return out, ht, q_.grad, k_.grad, v_.grad, g_.grad, h0_in.grad
+
+    ref_o, ref_ht, ref_dq, ref_dk, ref_dv, ref_dg, ref_dh0 = run(False)
+    tri_o, tri_ht, tri_dq, tri_dk, tri_dv, tri_dg, tri_dh0 = run(True)
+
+    assert_close('o', ref_o, tri_o, 0.005)
+    assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)
+    assert_close('dg', ref_dg, tri_dg, 0.005, err_atol=2e-4)
+    assert_close('dh0', ref_dh0, tri_dh0.transpose(-1, -2), 0.005)
+
+
+@pytest.mark.parametrize(
     ('H', 'D', 'scale', 'gate_logit_normalizer', 'cu_seqlens', 'dtype'),
     [
         pytest.param(*test, id="H{}-D{}-scale{}-gate_logit_normalizer{}-cu_seqlens{}-{}".format(*test))


### PR DESCRIPTION
## Summary
Plumbs the `transpose_state_layout` knob — already available in `gated_delta_rule` and `kda` — through the shared `fla.ops.common.fused_recurrent` kernels and the wrappers that depend on them.

When `transpose_state_layout=True`:
- the recurrent state `b_h` is laid out as `[BV, BK]` inside the kernel,
- `initial_state` / final state / `dh0` / `dht` are allocated as `[N, H, V, K]` instead of `[N, H, K, V]`,
- this matches the expectation of inference backends like FlashKDA that consume V-major state.

Wrappers updated:
- `fla.ops.common.fused_recurrent` (kernels + `fused_recurrent_fwd` / `fused_recurrent_bwd` / `FusedRecurrentFunction` / `fused_recurrent`)
- `fla.ops.simple_gla.fused_recurrent_simple_gla`
- `fla.ops.gla.fused_recurrent_gla`
- `fla.ops.retention.fused_recurrent_retention`

`gsa` continues to call the kernels directly with the default layout — the new `TRANSPOSE_STATE: tl.constexpr` defaults to `False` so no GSA-side change is required.

## Why this is a draft
- I haven't been able to run the existing GPU tests in this sandbox (no CUDA), so the changes are compile-checked only.
- No numerical-parity test has been added yet for `transpose_state_layout=True` in `tests/ops/test_gla.py` / `test_simple_gla.py` / `test_retention.py`. The follow-up should add a parametrized `transpose_state_layout` axis to the existing `test_fused_recurrent` cases and verify that the transposed final state agrees with `ref_ht.transpose(-1, -2)`.
- Other ops that have their own `fused_recurrent` (e.g. `mesa`, `forgetting_attn`, `linear_attn`, `lightning_attn`, `hgrn*`, `rwkv6/7`, `oja`, `comba`, `path_attn`, `dplr_delta`, `iplr_delta`, ...) are out of scope for this PR; happy to follow up if there is interest.

## Test plan
- [ ] `pytest tests/ops/test_gla.py -k fused_recurrent` (existing — must still pass)
- [ ] `pytest tests/ops/test_simple_gla.py -k fused_recurrent`
- [ ] `pytest tests/ops/test_retention.py -k fused_recurrent`
- [ ] Add a parametrized `transpose_state_layout=True` case to each of those tests asserting:
  - `o` matches the default-layout output
  - `final_state.transpose(-1, -2)` matches the default-layout `final_state`
  - `dh0.transpose(-1, -2)` matches the default-layout `dh0`
  - `dq/dk/dv/dg(k|v)` match the default-layout grads