### PR TITLE
[Common] Switch chunk paths to exp2

### DIFF
--- a/fla/ops/comba/chunk.py
+++ b/fla/ops/comba/chunk.py
@@ -74,7 +74,6 @@ def chunk_comba_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     o = chunk_fwd_o(
         q=q,
@@ -85,7 +84,6 @@ def chunk_comba_fwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     return g0, g, o, A, final_state
 
@@ -125,7 +123,6 @@ def chunk_comba_bwd(
         output_final_state=False,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     dv = chunk_bwd_dv_local(
         q=q,
@@ -135,7 +132,6 @@ def chunk_comba_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
         q=q,
@@ -149,7 +145,6 @@ def chunk_comba_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     dq, dk, dw, dg = chunk_bwd_dqkwg(
         q=q,
@@ -164,7 +159,6 @@ def chunk_comba_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     dk2, dv, dp, db, dg0, dg2 = prepare_wy_repr_bwd(
         k=k,

--- a/fla/ops/comba/chunk.py
+++ b/fla/ops/comba/chunk.py
@@ -47,7 +47,6 @@ def chunk_comba_fwd(
         cu_seqlens=cu_seqlens,
         output_dtype=torch.float32,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     A = solve_tril(
         A=A,
@@ -63,7 +62,6 @@ def chunk_comba_fwd(
         g_cumsum=g0,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
         k=k,
@@ -112,7 +110,6 @@ def chunk_comba_bwd(
         g_cumsum=g0,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     h, v_new, _ = chunk_gated_delta_rule_fwd_h(
         k=k,
@@ -172,7 +169,6 @@ def chunk_comba_bwd(
         du=dv,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     dk.add_(dk2)
     dg.add_(dg2)
@@ -210,8 +206,9 @@ class ChunkCombaFunction(torch.autograd.Function):
         else:
             q_rstd, k_rstd, p_rstd = None, None, None
 
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, 64, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        chunk_indices = None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, 64, cu_seqlens_cpu=cu_seqlens_cpu)
 
         g0, g, o, A, final_state = chunk_comba_fwd(
             q=q,
@@ -226,8 +223,22 @@ class ChunkCombaFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
         )
-        ctx.save_for_backward(q, q_rstd, k, k_rstd, p, p_rstd, v, g0, g, beta, A, initial_state, cu_seqlens,
-                              chunk_indices)
+        ctx.save_for_backward(
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            p,
+            p_rstd,
+            v,
+            g0,
+            g,
+            beta,
+            A,
+            initial_state,
+            cu_seqlens,
+            chunk_indices,
+        )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
         return o.to(q.dtype), final_state
@@ -240,9 +251,22 @@ class ChunkCombaFunction(torch.autograd.Function):
         do: torch.Tensor,
         dht: torch.Tensor,
     ):
-        q, q_rstd, k, k_rstd, p, p_rstd, v, g0, g, beta, A, initial_state, cu_seqlens, chunk_indices = (
-            ctx.saved_tensors
-        )
+        (
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            p,
+            p_rstd,
+            v,
+            g0,
+            g,
+            beta,
+            A,
+            initial_state,
+            cu_seqlens,
+            chunk_indices,
+        ) = ctx.saved_tensors
         dq, dk, dv, dp, db, dg, dh0 = chunk_comba_bwd(
             q=q,
             k=k,

--- a/fla/ops/comba/fused_recurrent.py
+++ b/fla/ops/comba/fused_recurrent.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp
 from fla.utils import input_guard
 
 
@@ -44,7 +44,6 @@ def fused_recurrent_comba_fwd_kernel(
     IS_BETA_HEADWISE: tl.constexpr,  # whether beta is headwise vector or scalar,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -94,10 +93,7 @@ def fused_recurrent_comba_fwd_kernel(
         # [BV]
         b_v -= tl.sum(b_h * b_p[:, None], 0)
         # [BK, BV]
-        if USE_EXP2:
-            b_h *= exp2(b_g)
-        else:
-            b_h *= exp(b_g)
+        b_h *= exp(b_g)
         if IS_BETA_HEADWISE:
             b_beta = tl.load(p_beta, mask=mask_v, other=0).to(tl.float32)
         else:
@@ -134,7 +130,6 @@ def fused_recurrent_comba_fwd(
     output_final_state: bool,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     HV = v.shape[2]
@@ -174,7 +169,6 @@ def fused_recurrent_comba_fwd(
         BV=BV,
         IS_BETA_HEADWISE=beta.ndim == v.ndim,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
-        USE_EXP2=use_exp2,
         num_warps=num_warps,
         num_stages=num_stages,
     )

--- a/fla/ops/comba/wy_fast.py
+++ b/fla/ops/comba/wy_fast.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 
@@ -45,7 +45,6 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
@@ -75,10 +74,7 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
         p_g = tl.make_block_ptr(g + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
         b_g0 = tl.load(p_g0, boundary_check=(0,))
         b_g = tl.load(p_g, boundary_check=(0,))
-        if USE_EXP2:
-            b_A = b_A * exp2(b_g0[:, None] - b_g[None, :])
-        else:
-            b_A = b_A * exp(b_g0[:, None] - b_g[None, :])
+        b_A = b_A * exp2(b_g0[:, None] - b_g[None, :])
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
@@ -96,7 +92,6 @@ def chunk_scaled_dot_comba_pkt_fwd(
     chunk_size: int = 64,
     output_dtype: torch.dtype = torch.float32,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> torch.Tensor:
     r"""
     Compute beta \mathcal{A}(i-1/j) * P * K^T.
@@ -144,7 +139,6 @@ def chunk_scaled_dot_comba_pkt_fwd(
         H=H,
         K=K,
         BT=BT,
-        USE_EXP2=use_exp2,
     )
     return A
 
@@ -188,7 +182,6 @@ def prepare_wy_repr_bwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
@@ -207,10 +200,7 @@ def prepare_wy_repr_bwd_kernel(
     b_A = tl.load(p_A, boundary_check=(0, 1))
     b_beta = tl.load(p_beta, boundary_check=(0,))
     b_g0 = tl.load(p_g0, boundary_check=(0,))
-    if USE_EXP2:
-        b_g0_exp = exp2(b_g0)
-    else:
-        b_g0_exp = tl.exp(b_g0)
+    b_g0_exp = exp2(b_g0)
     b_g = tl.load(p_g, boundary_check=(0,))
 
     b_dbeta = tl.zeros([BT], dtype=tl.float32)
@@ -250,10 +240,7 @@ def prepare_wy_repr_bwd_kernel(
     b_dA = tl.where(m_A, b_dA, 0)
     b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
     b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
-    if USE_EXP2:
-        b_dA = tl.where(m_A, -b_dA * exp2(b_g0[:, None] - b_g[None, :]), 0).to(k.dtype.element_ty)
-    else:
-        b_dA = tl.where(m_A, -b_dA * exp(b_g0[:, None] - b_g[None, :]), 0).to(k.dtype.element_ty)
+    b_dA = tl.where(m_A, -b_dA * exp2(b_g0[:, None] - b_g[None, :]), 0).to(k.dtype.element_ty)
     b_dA = b_dA.to(k.dtype.element_ty)
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
 
@@ -316,7 +303,6 @@ def recompute_w_u_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
@@ -331,10 +317,7 @@ def recompute_w_u_fwd_kernel(
     p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
     b_beta = tl.load(p_beta, boundary_check=(0,))
     b_A = tl.load(p_A, boundary_check=(0, 1))
-    if USE_EXP2:
-        b_g = exp2(tl.load(p_g, boundary_check=(0,)))
-    else:
-        b_g = tl.exp(tl.load(p_g, boundary_check=(0,)))
+    b_g = exp2(tl.load(p_g, boundary_check=(0,)))
 
     for i_v in range(tl.cdiv(V, BV)):
         p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
@@ -361,7 +344,6 @@ def recompute_w_u_fwd(
     A: torch.Tensor,
     cu_seqlens: torch.LongTensor | None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = A.shape[-1]
@@ -391,7 +373,6 @@ def recompute_w_u_fwd(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     return w, u
 
@@ -408,7 +389,6 @@ def prepare_wy_repr_bwd(
     du: torch.Tensor,
     cu_seqlens: torch.LongTensor | None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = 64
@@ -450,6 +430,5 @@ def prepare_wy_repr_bwd(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     return dk, dv, dp, dbeta, dg0, dg

--- a/fla/ops/common/backends/intracard.py
+++ b/fla/ops/common/backends/intracard.py
@@ -52,7 +52,6 @@ class IntraCardCPBackend(BaseBackend):
         cu_seqlens: torch.LongTensor | None = None,
         cu_seqlens_cpu: torch.LongTensor | None = None,
         chunk_indices: torch.LongTensor | None = None,
-        use_exp2: bool = False,
         transpose_state_layout: bool = False,
     ) -> tuple[bool, str | None]:
         """Check if intracard CP should handle this call."""
@@ -80,7 +79,6 @@ class IntraCardCPBackend(BaseBackend):
         cu_seqlens: torch.LongTensor | None = None,
         cu_seqlens_cpu: torch.LongTensor | None = None,
         chunk_indices: torch.LongTensor | None = None,
-        use_exp2: bool = False,
         transpose_state_layout: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         """Intra-card CP implementation of chunk_gated_delta_rule_fwd_h."""
@@ -95,7 +93,6 @@ class IntraCardCPBackend(BaseBackend):
             cu_seqlens=cu_seqlens,
             cu_seqlens_cpu=cu_seqlens_cpu,
             chunk_indices=chunk_indices,
-            use_exp2=use_exp2,
             max_splits=MAX_SUBSEQS,
             transpose_state_layout=transpose_state_layout,
         )

--- a/fla/ops/common/backends/tilelang/__init__.py
+++ b/fla/ops/common/backends/tilelang/__init__.py
@@ -48,7 +48,6 @@ class TileLangBackend(BaseBackend):
         cu_seqlens: torch.LongTensor | None = None,
         chunk_size: int = 64,
         chunk_indices: torch.LongTensor | None = None,
-        use_exp2: bool = False,
         transpose_state_layout: bool = False,
     ) -> tuple[bool, str | None]:
         if g is None:
@@ -83,18 +82,27 @@ class TileLangBackend(BaseBackend):
         cu_seqlens: torch.LongTensor | None = None,
         chunk_size: int = 64,
         chunk_indices: torch.LongTensor | None = None,
-        use_exp2: bool = False,
         transpose_state_layout: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         from fla.ops.common.backends.tilelang.chunk_bwd import (
             chunk_bwd_dqkwg_tilelang,
         )
         return chunk_bwd_dqkwg_tilelang(
-            q=q, k=k, v=v, do=do, h=h, dh=dh,
-            w=w, g=g, g_gamma=g_gamma, dv=dv,
-            scale=scale, cu_seqlens=cu_seqlens,
-            chunk_size=chunk_size, chunk_indices=chunk_indices,
-            use_exp2=use_exp2, transpose_state_layout=transpose_state_layout,
+            q=q,
+            k=k,
+            v=v,
+            do=do,
+            h=h,
+            dh=dh,
+            w=w,
+            g=g,
+            g_gamma=g_gamma,
+            dv=dv,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            chunk_indices=chunk_indices,
+            transpose_state_layout=transpose_state_layout,
         )
 
     def parallel_attn_fwd_verifier(

--- a/fla/ops/common/backends/tilelang/chunk_bwd.py
+++ b/fla/ops/common/backends/tilelang/chunk_bwd.py
@@ -19,10 +19,21 @@ from fla.utils import check_shared_mem
     tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
 })
 def _build_kernel(
-    B, H, K, V, BT, BK, BV, NK,
-    hD1, hD2,
+    B,
+    H,
+    K,
+    V,
+    BT,
+    BK,
+    BV,
+    NK,
+    hD1,
+    hD2,
     dtype_str,
-    USE_G, USE_DW, USE_EXP2, TRANSPOSE_STATE, IS_VARLEN=False,
+    USE_G,
+    USE_DW,
+    TRANSPOSE_STATE,
+    IS_VARLEN=False,
     num_warps=4,
 ):
     dtype_map = {'float16': T.float16, 'bfloat16': T.bfloat16, 'float32': T.float32}
@@ -39,7 +50,7 @@ def _build_kernel(
     _NV = NV
     _hD1, _hD2, _thD1, _thD2 = hD1, hD2, tile_hD1, tile_hD2
     _threads = threads
-    _USE_G, _USE_DW, _USE_EXP2 = USE_G, USE_DW, USE_EXP2
+    _USE_G, _USE_DW = USE_G, USE_DW
     _TS, _VAR = TRANSPOSE_STATE, IS_VARLEN
 
     # T, NT, total_h are dynamic (vary with sequence length, no recompilation).
@@ -154,18 +165,18 @@ def _build_kernel(
             last_pos = T.max(0, T.min(_BT, T_seq - i_t_local * _BT) - 1)
             g_last = s_g[last_pos]
             b_dg_last = T.alloc_var(T.float32)
-            b_dg_last = s_dg_last_acc[0] * (T.exp2(g_last) if _USE_EXP2 else T.exp(g_last))
+            b_dg_last = s_dg_last_acc[0] * T.exp2(g_last)
 
-            # b_dq *= exp(g) * scale  (inline, no extra fragment)
+            # b_dq *= exp2(g) * scale  (inline, no extra fragment)
             for _i, _j in T.Parallel(_BT, _BK):
-                b_dq[_i, _j] = b_dq[_i, _j] * (T.exp2(s_g[_i]) if _USE_EXP2 else T.exp(s_g[_i])) * scale
+                b_dq[_i, _j] = b_dq[_i, _j] * T.exp2(s_g[_i]) * scale
 
             # Gate b_dk with m_t mask: zero out OOB positions
             for _i, _j in T.Parallel(_BT, _BK):
                 m_t = (i_t_local * _BT + _i) < T_seq
                 b_dk[_i, _j] = T.if_then_else(
                     m_t,
-                    b_dk[_i, _j] * (T.exp2(-s_g[_i] + g_last) if _USE_EXP2 else T.exp(-s_g[_i] + g_last)),
+                    b_dk[_i, _j] * T.exp2(-s_g[_i] + g_last),
                     0.0)
 
             # dk*k reduction (before ds gemms): compute product directly in
@@ -180,12 +191,12 @@ def _build_kernel(
             T.reduce_sum(f_dg2, f_dkk_scalar, dim=0)
             b_dg_last = b_dg_last + f_dkk_scalar[0]
 
-            # b_ds = where(causal, b_ds * exp(g_i - g_j), 0) * scale
+            # b_ds = where(causal, b_ds * exp2(g_i - g_j), 0) * scale
             for _i, _j in T.Parallel(_BT, _BT):
                 causal = (_i >= _j) & ((i_t_local * _BT + _i) < T_seq) & ((i_t_local * _BT + _j) < T_seq)
                 b_ds[_i, _j] = T.if_then_else(
                     causal,
-                    b_ds[_i, _j] * (T.exp2(s_g[_i] - s_g[_j]) if _USE_EXP2 else T.exp(s_g[_i] - s_g[_j])) * scale,
+                    b_ds[_i, _j] * T.exp2(s_g[_i] - s_g[_j]) * scale,
                     0.0)
 
             # cast ds for final gemms
@@ -284,10 +295,21 @@ def _build_kernel(
 
 
 def chunk_bwd_dqkwg_tilelang(
-    q, k, v, do, h, dh,
-    w=None, g=None, g_gamma=None, dv=None,
-    scale=None, cu_seqlens=None, chunk_size=64,
-    chunk_indices=None, use_exp2=False, transpose_state_layout=False,
+    q,
+    k,
+    v,
+    do,
+    h,
+    dh,
+    w=None,
+    g=None,
+    g_gamma=None,
+    dv=None,
+    scale=None,
+    cu_seqlens=None,
+    chunk_size=64,
+    chunk_indices=None,
+    transpose_state_layout=False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = chunk_size
@@ -318,9 +340,21 @@ def chunk_bwd_dqkwg_tilelang(
 
     # Cache key: B, H, tile sizes, flags. T is dynamic (no recompilation for different seq lengths).
     kernel = _build_kernel(
-        B, H, K, V, BT, BK, BV, NK,
-        hD1, hD2, dtype_str,
-        USE_G, USE_DW, use_exp2, transpose_state_layout, IS_VARLEN,
+        B,
+        H,
+        K,
+        V,
+        BT,
+        BK,
+        BV,
+        NK,
+        hD1,
+        hD2,
+        dtype_str,
+        USE_G,
+        USE_DW,
+        transpose_state_layout,
+        IS_VARLEN,
     )
 
     # Unused optional params still need shape-matching tensors for TileLang

--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -12,7 +12,7 @@ import triton.language as tl
 from fla.ops.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.cache import fla_cache_autotune
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_HOPPER, USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem
 
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
@@ -33,7 +33,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
         for num_stages in ([2, 3, 4] if check_shared_mem('ampere') else [2, 1])
         for BV in ([32, 64] if check_shared_mem('ada') else [32])
     ],
-    key=['H', 'HV', 'K', 'V', 'BT', 'USE_EXP2', 'TRANSPOSE_STATE'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'TRANSPOSE_STATE'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -62,7 +62,6 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -201,12 +200,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             b_g_last = tl.load(g + (bos * HV + last_idx * HV + i_h).to(tl.int64)).to(tl.float32)
             p_g = tl.make_block_ptr(g + (bos * HV + i_h).to(tl.int64), (T,), (HV,), (i_t * BT,), (BT,), (0,))
             b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-            if USE_EXP2:
-                b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
-                b_g_last = exp2(b_g_last)
-            else:
-                b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
-                b_g_last = exp(b_g_last)
+            b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+            b_g_last = exp2(b_g_last)
             b_h1 *= b_g_last
             if K > 64:
                 b_h2 *= b_g_last
@@ -219,55 +214,30 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(gk + (bos + last_idx) * HV*K + i_h * K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
             if TRANSPOSE_STATE:
-                if USE_EXP2:
-                    b_h1 *= exp2(b_gk_last1)[None, :]
-                else:
-                    b_h1 *= exp(b_gk_last1)[None, :]
+                b_h1 *= exp2(b_gk_last1)[None, :]
             else:
-                if USE_EXP2:
-                    b_h1 *= exp2(b_gk_last1)[:, None]
-                else:
-                    b_h1 *= exp(b_gk_last1)[:, None]
+                b_h1 *= exp2(b_gk_last1)[:, None]
             if K > 64:
                 o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(gk + (bos + last_idx) * HV*K + i_h * K + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
                 if TRANSPOSE_STATE:
-                    if USE_EXP2:
-                        b_h2 *= exp2(b_gk_last2)[None, :]
-                    else:
-                        b_h2 *= exp(b_gk_last2)[None, :]
+                    b_h2 *= exp2(b_gk_last2)[None, :]
                 else:
-                    if USE_EXP2:
-                        b_h2 *= exp2(b_gk_last2)[:, None]
-                    else:
-                        b_h2 *= exp(b_gk_last2)[:, None]
+                    b_h2 *= exp2(b_gk_last2)[:, None]
             if K > 128:
                 o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(gk + (bos + last_idx) * HV*K + i_h * K + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
                 if TRANSPOSE_STATE:
-                    if USE_EXP2:
-                        b_h3 *= exp2(b_gk_last3)[None, :]
-                    else:
-                        b_h3 *= exp(b_gk_last3)[None, :]
+                    b_h3 *= exp2(b_gk_last3)[None, :]
                 else:
-                    if USE_EXP2:
-                        b_h3 *= exp2(b_gk_last3)[:, None]
-                    else:
-                        b_h3 *= exp(b_gk_last3)[:, None]
+                    b_h3 *= exp2(b_gk_last3)[:, None]
             if K > 192:
                 o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(gk + (bos + last_idx) * HV*K + i_h * K + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
                 if TRANSPOSE_STATE:
-                    if USE_EXP2:
-                        b_h4 *= exp2(b_gk_last4)[None, :]
-                    else:
-                        b_h4 *= exp(b_gk_last4)[None, :]
+                    b_h4 *= exp2(b_gk_last4)[None, :]
                 else:
-                    if USE_EXP2:
-                        b_h4 *= exp2(b_gk_last4)[:, None]
-                    else:
-                        b_h4 *= exp(b_gk_last4)[:, None]
-
+                    b_h4 *= exp2(b_gk_last4)[:, None]
         b_v = b_v.to(k.dtype.element_ty)
 
         p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (0, i_t * BT), (64, BT), (0, 1))
@@ -338,7 +308,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         for num_stages in ([2, 3, 4] if check_shared_mem('ampere') else [1])
         for BV in ([32, 64] if check_shared_mem('ada') else [32])
     ],
-    key=['H', 'HV', 'K', 'V', 'BT', 'BV', 'USE_G', 'USE_EXP2', 'TRANSPOSE_STATE'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'BV', 'USE_G', 'TRANSPOSE_STATE'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -369,7 +339,6 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
     USE_GK: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -474,13 +443,8 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             bg_last = tl.load(g + (bos + last_idx) * HV + i_h).to(tl.float32)
             p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
             b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-            if USE_EXP2:
-                bg_last_exp = exp2(bg_last)
-                b_g_exp = exp2(b_g)
-            else:
-                bg_last_exp = exp(bg_last)
-                b_g_exp = exp(b_g)
-
+            bg_last_exp = exp2(bg_last)
+            b_g_exp = exp2(b_g)
         p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         p_dv2 = tl.make_block_ptr(dv2, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
@@ -533,10 +497,7 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
 
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
-            if USE_EXP2:
-                b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
-            else:
-                b_dv *= tl.where(m_t, exp(bg_last - b_g), 0)[:, None]
+            b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
         b_dv += tl.load(p_dv, boundary_check=(0, 1))
 
         tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
@@ -550,15 +511,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             b_q = b_q * b_g_exp[None, :]
         if USE_GK:
             if TRANSPOSE_STATE:
-                if USE_EXP2:
-                    b_dh1 *= exp2(b_gk_last1)[None, :]
-                else:
-                    b_dh1 *= exp(b_gk_last1)[None, :]
+                b_dh1 *= exp2(b_gk_last1)[None, :]
             else:
-                if USE_EXP2:
-                    b_dh1 *= exp2(b_gk_last1[:, None])
-                else:
-                    b_dh1 *= exp(b_gk_last1[:, None])
+                b_dh1 *= exp2(b_gk_last1[:, None])
         if TRANSPOSE_STATE:
             b_dh1 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
         else:
@@ -573,15 +528,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_q = b_q * b_g_exp[None, :]
             if USE_GK:
                 if TRANSPOSE_STATE:
-                    if USE_EXP2:
-                        b_dh2 *= exp2(b_gk_last2)[None, :]
-                    else:
-                        b_dh2 *= exp(b_gk_last2)[None, :]
+                    b_dh2 *= exp2(b_gk_last2)[None, :]
                 else:
-                    if USE_EXP2:
-                        b_dh2 *= exp2(b_gk_last2[:, None])
-                    else:
-                        b_dh2 *= exp(b_gk_last2[:, None])
+                    b_dh2 *= exp2(b_gk_last2[:, None])
             if TRANSPOSE_STATE:
                 b_dh2 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
             else:
@@ -596,15 +545,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_q = b_q * b_g_exp[None, :]
             if USE_GK:
                 if TRANSPOSE_STATE:
-                    if USE_EXP2:
-                        b_dh3 *= exp2(b_gk_last3)[None, :]
-                    else:
-                        b_dh3 *= exp(b_gk_last3)[None, :]
+                    b_dh3 *= exp2(b_gk_last3)[None, :]
                 else:
-                    if USE_EXP2:
-                        b_dh3 *= exp2(b_gk_last3[:, None])
-                    else:
-                        b_dh3 *= exp(b_gk_last3[:, None])
+                    b_dh3 *= exp2(b_gk_last3[:, None])
             if TRANSPOSE_STATE:
                 b_dh3 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
             else:
@@ -619,15 +562,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_q = b_q * b_g_exp[None, :]
             if USE_GK:
                 if TRANSPOSE_STATE:
-                    if USE_EXP2:
-                        b_dh4 *= exp2(b_gk_last4)[None, :]
-                    else:
-                        b_dh4 *= exp(b_gk_last4)[None, :]
+                    b_dh4 *= exp2(b_gk_last4)[None, :]
                 else:
-                    if USE_EXP2:
-                        b_dh4 *= exp2(b_gk_last4[:, None])
-                    else:
-                        b_dh4 *= exp(b_gk_last4[:, None])
+                    b_dh4 *= exp2(b_gk_last4[:, None])
             if TRANSPOSE_STATE:
                 b_dh4 += tl.trans(tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype)))
             else:
@@ -673,7 +610,6 @@ def chunk_gated_delta_rule_fwd_h(
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     B, T, H, K, V, HV = *k.shape, u.shape[-1], u.shape[2]
@@ -715,7 +651,6 @@ def chunk_gated_delta_rule_fwd_h(
         K=K,
         V=V,
         BT=BT,
-        USE_EXP2=use_exp2,
         TRANSPOSE_STATE=transpose_state_layout,
     )
     return h, v_new, final_state
@@ -735,7 +670,6 @@ def chunk_gated_delta_rule_bwd_dhu(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V, HV = *q.shape, do.shape[-1], do.shape[2]
@@ -779,7 +713,6 @@ def chunk_gated_delta_rule_bwd_dhu(
         K=K,
         V=V,
         BT=BT,
-        USE_EXP2=use_exp2,
         TRANSPOSE_STATE=transpose_state_layout,
     )
     return dh, dh0, dv2

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_offsets
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp, exp2
 from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
@@ -29,7 +29,7 @@ BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'USE_EXP2'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -57,6 +57,7 @@ def chunk_fwd_kernel_h(
     USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -106,13 +107,21 @@ def chunk_fwd_kernel_h(
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
             p_g = g + bos*H + (i_t * BT + tl.arange(0, BT)) * H + i_h
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
-            b_h *= exp(b_g_last)
-            b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            if USE_EXP2:
+                b_h *= exp2(b_g_last)
+                b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            else:
+                b_h *= exp(b_g_last)
+                b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            b_h *= exp(b_g_last)
-            b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            if USE_EXP2:
+                b_h *= exp2(b_g_last)
+                b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            else:
+                b_h *= exp(b_g_last)
+                b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
         # vector decay, h = Diag(gk) @ h
         if USE_GK:
@@ -120,10 +129,13 @@ def chunk_fwd_kernel_h(
             p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
-            b_h *= exp(b_gk_last)[:, None]
-
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
+            if USE_EXP2:
+                b_h *= exp2(b_gk_last)[:, None]
+                b_k = (b_k * exp2(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
+            else:
+                b_h *= exp(b_gk_last)[:, None]
+                b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
 
         # vector decay, h = h @ Diag(gv)
         if USE_GV:
@@ -131,10 +143,13 @@ def chunk_fwd_kernel_h(
             p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
 
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
-            b_h *= exp(b_gv_last)[None, :]
-
             b_gv = tl.load(p_gv, boundary_check=(0, 1))
-            b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
+            if USE_EXP2:
+                b_h *= exp2(b_gv_last)[None, :]
+                b_v = (b_v * exp2(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
+            else:
+                b_h *= exp(b_gv_last)[None, :]
+                b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
 
         b_h += tl.dot(b_k, b_v)
 
@@ -156,7 +171,7 @@ def chunk_fwd_kernel_h(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'USE_EXP2'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -187,6 +202,7 @@ def chunk_bwd_kernel_dh(
     USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -236,32 +252,47 @@ def chunk_bwd_kernel_dh(
             p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
-            b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
-            b_dh *= exp(b_g_last)
+            if USE_EXP2:
+                b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+                b_dh *= exp2(b_g_last)
+            else:
+                b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
+                b_dh *= exp(b_g_last)
 
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
-            b_dh *= exp(b_g_last)
+            if USE_EXP2:
+                b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+                b_dh *= exp2(b_g_last)
+            else:
+                b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
+                b_dh *= exp(b_g_last)
 
         if USE_GK:
             p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
             p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_q = (b_q * exp(b_gk)).to(b_q.dtype)
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
-            b_dh *= exp(b_gk_last)[:, None]
+            if USE_EXP2:
+                b_q = (b_q * exp2(b_gk)).to(b_q.dtype)
+                b_dh *= exp2(b_gk_last)[:, None]
+            else:
+                b_q = (b_q * exp(b_gk)).to(b_q.dtype)
+                b_dh *= exp(b_gk_last)[:, None]
 
         if USE_GV:
             p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
 
             b_gv = tl.load(p_gv, boundary_check=(0, 1))
-            b_do = (b_do * exp(b_gv))
-
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
-            b_dh *= exp(b_gv_last)[None, :]
+            if USE_EXP2:
+                b_do = (b_do * exp2(b_gv))
+                b_dh *= exp2(b_gv_last)[None, :]
+            else:
+                b_do = (b_do * exp(b_gv))
+                b_dh *= exp(b_gv_last)[None, :]
 
         b_dh += tl.dot(b_q, b_do.to(b_q.dtype))
 
@@ -282,6 +313,7 @@ def chunk_fwd_h(
     cu_seqlens: torch.Tensor | None = None,
     chunk_size: int = 64,
     split_size: int | None = None,
+    use_exp2: bool = False,
     states_in_fp32: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
@@ -320,6 +352,7 @@ def chunk_fwd_h(
         USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
+        USE_EXP2=use_exp2,
     )
     return h, ht
 
@@ -339,6 +372,7 @@ def chunk_bwd_dh(
     cu_seqlens: torch.Tensor | None = None,
     chunk_size: int = 64,
     split_size: int | None = None,
+    use_exp2: bool = False,
     states_in_fp32: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
@@ -384,5 +418,6 @@ def chunk_bwd_dh(
         USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
+        USE_EXP2=use_exp2,
     )
     return dh, dh0

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_offsets
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
@@ -154,7 +154,7 @@ def chunk_fwd_kernel_h(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'USE_EXP2'],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -185,7 +185,6 @@ def chunk_bwd_kernel_dh(
     USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -235,21 +234,13 @@ def chunk_bwd_kernel_dh(
             p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
-            if USE_EXP2:
-                b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
-                b_dh *= exp2(b_g_last)
-            else:
-                b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
-                b_dh *= exp(b_g_last)
+            b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp2(b_g_last)
 
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            if USE_EXP2:
-                b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
-                b_dh *= exp2(b_g_last)
-            else:
-                b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
-                b_dh *= exp(b_g_last)
+            b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp2(b_g_last)
 
         if USE_GK:
             p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
@@ -257,12 +248,8 @@ def chunk_bwd_kernel_dh(
 
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
-            if USE_EXP2:
-                b_q = (b_q * exp2(b_gk)).to(b_q.dtype)
-                b_dh *= exp2(b_gk_last)[:, None]
-            else:
-                b_q = (b_q * exp(b_gk)).to(b_q.dtype)
-                b_dh *= exp(b_gk_last)[:, None]
+            b_q = (b_q * exp2(b_gk)).to(b_q.dtype)
+            b_dh *= exp2(b_gk_last)[:, None]
 
         if USE_GV:
             p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
@@ -270,12 +257,8 @@ def chunk_bwd_kernel_dh(
 
             b_gv = tl.load(p_gv, boundary_check=(0, 1))
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
-            if USE_EXP2:
-                b_do = (b_do * exp2(b_gv))
-                b_dh *= exp2(b_gv_last)[None, :]
-            else:
-                b_do = (b_do * exp(b_gv))
-                b_dh *= exp(b_gv_last)[None, :]
+            b_do = (b_do * exp2(b_gv))
+            b_dh *= exp2(b_gv_last)[None, :]
 
         b_dh += tl.dot(b_q, b_do.to(b_q.dtype))
 
@@ -353,7 +336,6 @@ def chunk_bwd_dh(
     cu_seqlens: torch.Tensor | None = None,
     chunk_size: int = 64,
     split_size: int | None = None,
-    use_exp2: bool = False,
     states_in_fp32: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
@@ -399,6 +381,5 @@ def chunk_bwd_dh(
         USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
-        USE_EXP2=use_exp2,
     )
     return dh, dh0

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -29,7 +29,7 @@ BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'USE_EXP2'],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -57,7 +57,6 @@ def chunk_fwd_kernel_h(
     USE_G_GAMMA: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_GV: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -107,21 +106,13 @@ def chunk_fwd_kernel_h(
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
             p_g = g + bos*H + (i_t * BT + tl.arange(0, BT)) * H + i_h
             b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
-            if USE_EXP2:
-                b_h *= exp2(b_g_last)
-                b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
-            else:
-                b_h *= exp(b_g_last)
-                b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            b_h *= exp2(b_g_last)
+            b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            if USE_EXP2:
-                b_h *= exp2(b_g_last)
-                b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
-            else:
-                b_h *= exp(b_g_last)
-                b_v = (b_v * exp(b_g_last - b_g)[:, None]).to(b_v.dtype)
+            b_h *= exp2(b_g_last)
+            b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
 
         # vector decay, h = Diag(gk) @ h
         if USE_GK:
@@ -130,12 +121,8 @@ def chunk_fwd_kernel_h(
 
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            if USE_EXP2:
-                b_h *= exp2(b_gk_last)[:, None]
-                b_k = (b_k * exp2(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
-            else:
-                b_h *= exp(b_gk_last)[:, None]
-                b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
+            b_h *= exp2(b_gk_last)[:, None]
+            b_k = (b_k * exp2(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
 
         # vector decay, h = h @ Diag(gv)
         if USE_GV:
@@ -144,12 +131,8 @@ def chunk_fwd_kernel_h(
 
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
             b_gv = tl.load(p_gv, boundary_check=(0, 1))
-            if USE_EXP2:
-                b_h *= exp2(b_gv_last)[None, :]
-                b_v = (b_v * exp2(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
-            else:
-                b_h *= exp(b_gv_last)[None, :]
-                b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
+            b_h *= exp2(b_gv_last)[None, :]
+            b_v = (b_v * exp2(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
 
         b_h += tl.dot(b_k, b_v)
 
@@ -313,7 +296,6 @@ def chunk_fwd_h(
     cu_seqlens: torch.Tensor | None = None,
     chunk_size: int = 64,
     split_size: int | None = None,
-    use_exp2: bool = False,
     states_in_fp32: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
@@ -352,7 +334,6 @@ def chunk_fwd_h(
         USE_G_GAMMA=g_gamma is not None,
         USE_GK=gk is not None,
         USE_GV=gv is not None,
-        USE_EXP2=use_exp2,
     )
     return h, ht
 

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -12,7 +12,7 @@ import triton.language as tl
 from fla.ops.common.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
@@ -55,7 +55,6 @@ def chunk_fwd_kernel_o(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -108,23 +107,13 @@ def chunk_fwd_kernel_o(
         g += bos * HV + i_h
         p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
-        if USE_EXP2:
-            b_o = b_o * exp2(b_g)[:, None]
-            b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
-        else:
-            b_o = b_o * exp(b_g)[:, None]
-            b_A = b_A * exp(b_g[:, None] - b_g[None, :])
-
+        b_o = b_o * exp2(b_g)[:, None]
+        b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
     if USE_G_GAMMA:
         b_gamma = tl.load(g_gamma + i_h)
         b_g = b_gamma * (tl.arange(0, BT) + 1)
-        if USE_EXP2:
-            b_o = b_o * exp2(b_g)[:, None]
-            b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
-        else:
-            b_o = b_o * exp(b_g)[:, None]
-            b_A = b_A * exp(b_g[:, None] - b_g[None, :])
-
+        b_o = b_o * exp2(b_g)[:, None]
+        b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
@@ -184,7 +173,6 @@ def chunk_bwd_kernel_dqkwg(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     USE_DW: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -281,24 +269,12 @@ def chunk_bwd_kernel_dqkwg(
         p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
         b_g_last = tl.load(g + (min(i_t * BT + BT, T) - 1) * HV)
-        if USE_EXP2:
-            b_dg_last *= exp2(b_g_last)
-            b_dq = b_dq * exp2(b_g)[:, None] * scale
-        else:
-            b_dg_last *= exp(b_g_last)
-            b_dq = b_dq * exp(b_g)[:, None] * scale
-
-        if USE_EXP2:
-            b_dk = b_dk * tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
-        else:
-            b_dk = b_dk * tl.where(m_t, exp(-b_g + b_g_last), 0)[:, None]
+        b_dg_last *= exp2(b_g_last)
+        b_dq = b_dq * exp2(b_g)[:, None] * scale
+        b_dk = b_dk * tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
         b_dg_last += tl.sum(b_dk * b_k)
 
-        if USE_EXP2:
-            b_ds = tl.where(m_A, b_ds * exp2(b_g[:, None] - b_g[None, :]), 0) * scale
-        else:
-            b_ds = tl.where(m_A, b_ds * exp(b_g[:, None] - b_g[None, :]), 0) * scale
-
+        b_ds = tl.where(m_A, b_ds * exp2(b_g[:, None] - b_g[None, :]), 0) * scale
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
@@ -315,14 +291,9 @@ def chunk_bwd_kernel_dqkwg(
         tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
 
     elif USE_G_GAMMA:
-        if USE_EXP2:
-            b_dq = b_dq * exp2(b_g)[:, None] * scale
-            b_dk = b_dk * tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
-            b_ds = tl.where(m_A, b_ds * exp2(b_g[:, None] - b_g[None, :]), 0) * scale
-        else:
-            b_dq = b_dq * exp(b_g)[:, None] * scale
-            b_dk = b_dk * tl.where(m_t, exp(-b_g + b_g_last), 0)[:, None]
-            b_ds = tl.where(m_A, b_ds * exp(b_g[:, None] - b_g[None, :]), 0) * scale
+        b_dq = b_dq * exp2(b_g)[:, None] * scale
+        b_dk = b_dk * tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
+        b_ds = tl.where(m_A, b_ds * exp2(b_g[:, None] - b_g[None, :]), 0) * scale
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
@@ -376,7 +347,6 @@ def chunk_bwd_kernel_dv(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -426,12 +396,8 @@ def chunk_bwd_kernel_dv(
 
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
     if USE_G or USE_G_GAMMA:
-        if USE_EXP2:
-            b_A = tl.where(m_A, b_A * exp2(b_g[None, :] - b_g[:, None]) * scale, 0).to(do.dtype.element_ty)
-            b_dv *= tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
-        else:
-            b_A = tl.where(m_A, b_A * exp(b_g[None, :] - b_g[:, None]) * scale, 0).to(do.dtype.element_ty)
-            b_dv *= tl.where(m_t, exp(-b_g + b_g_last), 0)[:, None]
+        b_A = tl.where(m_A, b_A * exp2(b_g[None, :] - b_g[:, None]) * scale, 0).to(do.dtype.element_ty)
+        b_dv *= tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
     else:
         b_A = tl.where(m_A, b_A * scale, 0).to(do.dtype.element_ty)
     p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
@@ -478,7 +444,6 @@ def chunk_bwd_kernel_dv_local(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     USE_A: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -518,11 +483,7 @@ def chunk_bwd_kernel_dv_local(
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_A += tl.dot(b_k, b_q) * scale
         if USE_G or USE_G_GAMMA:
-            if USE_EXP2:
-                b_A *= exp2(b_g[None, :] - b_g[:, None])
-            else:
-                b_A *= exp(b_g[None, :] - b_g[:, None])
-
+            b_A *= exp2(b_g[None, :] - b_g[:, None])
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
@@ -547,7 +508,6 @@ def chunk_fwd_o(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ) -> torch.Tensor:
     B, T, H, K, V, HV = *q.shape, v.shape[-1], v.shape[2]
@@ -577,7 +537,6 @@ def chunk_fwd_o(
         K=K,
         V=V,
         BT=BT,
-        USE_EXP2=use_exp2,
         TRANSPOSE_STATE=transpose_state_layout,
     )
     return o
@@ -594,7 +553,6 @@ def chunk_bwd_dv(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> torch.Tensor:
     B, T, H, K, V, HV = *k.shape, do.shape[-1], do.shape[2]
     BT = chunk_size
@@ -635,7 +593,6 @@ def chunk_bwd_dv(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     return dv
 
@@ -651,7 +608,6 @@ def chunk_bwd_dv_local(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> torch.Tensor:
     B, T, H, K, V, HV = *k.shape, do.shape[-1], do.shape[2]
     BT = chunk_size
@@ -689,7 +645,6 @@ def chunk_bwd_dv_local(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     return dv
 
@@ -710,7 +665,6 @@ def chunk_bwd_dqkwg(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if g is not None and IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0:
@@ -767,7 +721,6 @@ def chunk_bwd_dqkwg(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
         TRANSPOSE_STATE=transpose_state_layout,
     )
 

--- a/fla/ops/common/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/chunk_scaled_dot_kkt.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp, exp2
 from fla.utils import autotune_cache_kwargs
 
 
@@ -25,7 +25,7 @@ from fla.utils import autotune_cache_kwargs
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN'],
+    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN', 'USE_EXP2'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -44,6 +44,7 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_EXP2: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // HV, i_bh % HV
@@ -69,7 +70,10 @@ def chunk_scaled_dot_kkt_fwd_kernel(
         p_g = tl.make_block_ptr(g + bos*HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
         b_g_diff = b_g[:, None] - b_g[None, :]
-        b_A *= exp(b_g_diff)
+        if USE_EXP2:
+            b_A *= exp2(b_g_diff)
+        else:
+            b_A *= exp(b_g_diff)
     b_A *= b_b[:, None]
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
@@ -86,6 +90,7 @@ def chunk_scaled_dot_kkt_fwd(
     chunk_size: int = 64,
     output_dtype: torch.dtype = torch.float32,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ) -> torch.Tensor:
     r"""
     Compute beta * K * K^T.
@@ -93,12 +98,10 @@ def chunk_scaled_dot_kkt_fwd(
     Args:
         k (torch.Tensor):
             The key tensor of shape `[B, T, H, K]` where `H` is the number of query/key heads.
-        beta (torch.Tensor):
-            The beta tensor of shape `[B, T, HV]` where `HV` is the number of value/output heads.
         g (torch.Tensor):
             The cumulative sum of the gate tensor of shape `[B, T, HV]`. Default: `None`.
-        gk (torch.Tensor):
-            The cumulative sum of the gate tensor of shape `[B, T, HV, K]` applied to the key tensor. Default: `None`.
+        beta (torch.Tensor):
+            The beta tensor of shape `[B, T, HV]` where `HV` is the number of value/output heads.
         cu_seqlens (torch.LongTensor):
             The cumulative sequence lengths of the input tensor.
             Default: None
@@ -106,6 +109,10 @@ def chunk_scaled_dot_kkt_fwd(
             The chunk size. Default: 64.
         output_dtype (torch.dtype):
             The dtype of the output tensor. Default: `torch.float32`
+        chunk_indices (torch.LongTensor):
+            The chunk indices of the input tensor. Default: None.
+        use_exp2 (bool):
+            Whether `g` is stored in log2 units and should be applied with `exp2`. Default: `False`.
 
     Returns:
         beta * K * K^T of shape `[B, T, HV, BT]` where `BT` is the chunk size.
@@ -129,5 +136,6 @@ def chunk_scaled_dot_kkt_fwd(
         HV=HV,
         K=K,
         BT=BT,
+        USE_EXP2=use_exp2,
     )
     return A

--- a/fla/ops/common/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/chunk_scaled_dot_kkt.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs
 
 
@@ -25,7 +25,7 @@ from fla.utils import autotune_cache_kwargs
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN', 'USE_EXP2'],
+    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -44,7 +44,6 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // HV, i_bh % HV
@@ -70,10 +69,7 @@ def chunk_scaled_dot_kkt_fwd_kernel(
         p_g = tl.make_block_ptr(g + bos*HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
         b_g_diff = b_g[:, None] - b_g[None, :]
-        if USE_EXP2:
-            b_A *= exp2(b_g_diff)
-        else:
-            b_A *= exp(b_g_diff)
+        b_A *= exp2(b_g_diff)
     b_A *= b_b[:, None]
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
@@ -90,7 +86,6 @@ def chunk_scaled_dot_kkt_fwd(
     chunk_size: int = 64,
     output_dtype: torch.dtype = torch.float32,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> torch.Tensor:
     r"""
     Compute beta * K * K^T.
@@ -111,9 +106,6 @@ def chunk_scaled_dot_kkt_fwd(
             The dtype of the output tensor. Default: `torch.float32`
         chunk_indices (torch.LongTensor):
             The chunk indices of the input tensor. Default: None.
-        use_exp2 (bool):
-            Whether `g` is stored in log2 units and should be applied with `exp2`. Default: `False`.
-
     Returns:
         beta * K * K^T of shape `[B, T, HV, BT]` where `BT` is the chunk size.
         For GVA, H < HV and HV % H == 0. For standard attention, H == HV.
@@ -136,6 +128,5 @@ def chunk_scaled_dot_kkt_fwd(
         HV=HV,
         K=K,
         BT=BT,
-        USE_EXP2=use_exp2,
     )
     return A

--- a/fla/ops/common/fused_chunk.py
+++ b/fla/ops/common/fused_chunk.py
@@ -10,7 +10,8 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import chunk_local_cumsum
-from fla.ops.utils.op import exp
+from fla.ops.utils.constant import RCP_LN2
+from fla.ops.utils.op import exp, exp2
 from fla.utils import (
     IS_NVIDIA_HOPPER,
     autocast_custom_bwd,
@@ -38,7 +39,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT'],
+    key=['H', 'K', 'V', 'BT', 'USE_EXP2'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -63,6 +64,7 @@ def fused_chunk_fwd_kernel(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -85,9 +87,14 @@ def fused_chunk_fwd_kernel(
         b_gamma = tl.load(g_gamma + i_h)
         b_g = b_gamma * (o_i + 1)
         b_g_last = b_gamma * BT
-        b_gq = exp(b_g)
-        b_gk = exp(b_g_last - b_g)
-        b_gn = exp(b_g_last)
+        if USE_EXP2:
+            b_gq = exp2(b_g)
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
+        else:
+            b_gq = exp(b_g)
+            b_gk = exp(b_g_last - b_g)
+            b_gn = exp(b_g_last)
 
     # [BT, BT]
     m_s = o_i[:, None] >= o_i[None, :]
@@ -129,15 +136,27 @@ def fused_chunk_fwd_kernel(
             b_g = tl.load(p_g, mask=(o_t < T), other=0.)
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
 
-            b_gq = exp(b_g)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
+            if USE_EXP2:
+                b_gq = exp2(b_g)
+                b_gk = exp2(b_g_last - b_g)
+                b_gn = exp2(b_g_last)
+            else:
+                b_gq = exp(b_g)
+                b_gk = exp(b_g_last - b_g)
+                b_gn = exp(b_g_last)
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
+            if USE_EXP2:
+                b_gk = exp2(b_g_last - b_g)
+                b_gn = exp2(b_g_last)
+            else:
+                b_gk = exp(b_g_last - b_g)
+                b_gn = exp(b_g_last)
         if USE_G or USE_G_GAMMA:
-            b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
+            if USE_EXP2:
+                b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
+            else:
+                b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
             # [BT, BT]
             b_s *= b_gs
             # [BT, BV]
@@ -172,7 +191,7 @@ def fused_chunk_fwd_kernel(
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT'],
+    key=['H', 'K', 'V', 'BT', 'USE_EXP2'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -202,6 +221,7 @@ def fused_chunk_bwd_kernel(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     USE_FINAL_STATE: tl.constexpr,
@@ -223,9 +243,14 @@ def fused_chunk_bwd_kernel(
         b_gamma = tl.load(g_gamma + i_h)
         b_g = b_gamma * (o_i + 1)
         b_g_last = b_gamma * BT
-        b_gq = exp(b_g)
-        b_gk = exp(b_g_last - b_g)
-        b_gn = exp(b_g_last)
+        if USE_EXP2:
+            b_gq = exp2(b_g)
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
+        else:
+            b_gq = exp(b_g)
+            b_gk = exp(b_g_last - b_g)
+            b_gn = exp(b_g_last)
 
     m_s = o_i[:, None] >= o_i[None, :]
 
@@ -269,13 +294,21 @@ def fused_chunk_bwd_kernel(
             b_g = tl.load(p_g, mask=(o_t < T), other=0.)
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
 
-            b_gq = exp(b_g)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
+            if USE_EXP2:
+                b_gq = exp2(b_g)
+                b_gk = exp2(b_g_last - b_g)
+                b_gn = exp2(b_g_last)
+            else:
+                b_gq = exp(b_g)
+                b_gk = exp(b_g_last - b_g)
+                b_gn = exp(b_g_last)
 
             p_dg = dg + ((i_k * NV + i_v) * all + (bos + o_t)).to(tl.int64) * H + i_h
             # [BT, BT]
-            b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
+            if USE_EXP2:
+                b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
+            else:
+                b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
             b_ds = b_ds * b_gs
             # [BT, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -288,11 +321,18 @@ def fused_chunk_bwd_kernel(
 
         elif USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
+            if USE_EXP2:
+                b_gk = exp2(b_g_last - b_g)
+                b_gn = exp2(b_g_last)
+            else:
+                b_gk = exp(b_g_last - b_g)
+                b_gn = exp(b_g_last)
 
             # [BT, BT]
-            b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
+            if USE_EXP2:
+                b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
+            else:
+                b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
             b_ds = b_ds * b_gs
             # [BT, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -352,10 +392,16 @@ def fused_chunk_bwd_kernel(
             b_g = tl.load(p_g, mask=m_t, other=0.)
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
 
-            b_gq = exp(b_g)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
-            b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp(b_g[:, None] - b_g[None, :]), 0)) * scale
+            if USE_EXP2:
+                b_gq = exp2(b_g)
+                b_gk = exp2(b_g_last - b_g)
+                b_gn = exp2(b_g_last)
+                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp2(b_g[:, None] - b_g[None, :]), 0)) * scale
+            else:
+                b_gq = exp(b_g)
+                b_gk = exp(b_g_last - b_g)
+                b_gn = exp(b_g_last)
+                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp(b_g[:, None] - b_g[None, :]), 0)) * scale
 
             b_s = b_s * b_gs
             b_ds = b_ds * b_gs
@@ -377,9 +423,14 @@ def fused_chunk_bwd_kernel(
 
         elif USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
-            b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp(b_g[:, None] - b_g[None, :]), 0)) * scale
+            if USE_EXP2:
+                b_gk = exp2(b_g_last - b_g)
+                b_gn = exp2(b_g_last)
+                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp2(b_g[:, None] - b_g[None, :]), 0)) * scale
+            else:
+                b_gk = exp(b_g_last - b_g)
+                b_gn = exp(b_g_last)
+                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp(b_g[:, None] - b_g[None, :]), 0)) * scale
 
             b_s = b_s * b_gs
             b_ds = b_ds * b_gs
@@ -420,6 +471,7 @@ def fused_chunk_fwd(
     output_final_state: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
+    use_exp2: bool = False,
 ):
     B, T, H, K, V = *q.shape, v.shape[-1]
     BT = chunk_size
@@ -448,6 +500,7 @@ def fused_chunk_fwd(
         V=V,
         BT=BT,
         BK=BK,
+        USE_EXP2=use_exp2,
     )
     if NK > 1:
         o = o.sum(0).to(v)
@@ -466,6 +519,7 @@ def fused_chunk_bwd(
     dht: torch.Tensor,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
+    use_exp2: bool = False,
 ):
     B, T, H, K, V = *q.shape, v.shape[-1]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
@@ -505,6 +559,7 @@ def fused_chunk_bwd(
         BT=BT,
         BK=BK,
         BV=BV,
+        USE_EXP2=use_exp2,
     )
     dq = dq.sum(0) if NV > 1 else dq
     dk = dk.sum(0) if NV > 1 else dk
@@ -533,7 +588,16 @@ class FusedChunkFunction(torch.autograd.Function):
         cu_seqlens,
     ):
         chunk_size = min(64, max(16, triton.next_power_of_2(q.shape[1])))
-        g = chunk_local_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens) if g is not None else None
+        # Pre-scale by RCP_LN2 so downstream kernels can use exp2 directly.
+        if g is not None:
+            g = chunk_local_cumsum(
+                g,
+                chunk_size=chunk_size,
+                scale=RCP_LN2,
+                cu_seqlens=cu_seqlens,
+            )
+        if g_gamma is not None:
+            g_gamma = g_gamma * RCP_LN2
         o, ht = fused_chunk_fwd(
             q=q,
             k=k,
@@ -545,6 +609,7 @@ class FusedChunkFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
+            use_exp2=True,
         )
 
         ctx.save_for_backward(q, k, v, g, g_gamma, initial_state)
@@ -571,6 +636,7 @@ class FusedChunkFunction(torch.autograd.Function):
             dht=dht,
             cu_seqlens=ctx.cu_seqlens,
             chunk_size=ctx.chunk_size,
+            use_exp2=True,
         )
         if g is not None:
             dg = dg.to(g)

--- a/fla/ops/common/fused_chunk.py
+++ b/fla/ops/common/fused_chunk.py
@@ -11,7 +11,7 @@ import triton.language as tl
 
 from fla.ops.utils import chunk_local_cumsum
 from fla.ops.utils.constant import RCP_LN2
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import (
     IS_NVIDIA_HOPPER,
     autocast_custom_bwd,
@@ -39,7 +39,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'USE_EXP2'],
+    key=['H', 'K', 'V', 'BT'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -64,7 +64,6 @@ def fused_chunk_fwd_kernel(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -87,14 +86,9 @@ def fused_chunk_fwd_kernel(
         b_gamma = tl.load(g_gamma + i_h)
         b_g = b_gamma * (o_i + 1)
         b_g_last = b_gamma * BT
-        if USE_EXP2:
-            b_gq = exp2(b_g)
-            b_gk = exp2(b_g_last - b_g)
-            b_gn = exp2(b_g_last)
-        else:
-            b_gq = exp(b_g)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
+        b_gq = exp2(b_g)
+        b_gk = exp2(b_g_last - b_g)
+        b_gn = exp2(b_g_last)
 
     # [BT, BT]
     m_s = o_i[:, None] >= o_i[None, :]
@@ -136,27 +130,15 @@ def fused_chunk_fwd_kernel(
             b_g = tl.load(p_g, mask=(o_t < T), other=0.)
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
 
-            if USE_EXP2:
-                b_gq = exp2(b_g)
-                b_gk = exp2(b_g_last - b_g)
-                b_gn = exp2(b_g_last)
-            else:
-                b_gq = exp(b_g)
-                b_gk = exp(b_g_last - b_g)
-                b_gn = exp(b_g_last)
+            b_gq = exp2(b_g)
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
         if USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            if USE_EXP2:
-                b_gk = exp2(b_g_last - b_g)
-                b_gn = exp2(b_g_last)
-            else:
-                b_gk = exp(b_g_last - b_g)
-                b_gn = exp(b_g_last)
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
         if USE_G or USE_G_GAMMA:
-            if USE_EXP2:
-                b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
-            else:
-                b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
+            b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
             # [BT, BT]
             b_s *= b_gs
             # [BT, BV]
@@ -191,7 +173,7 @@ def fused_chunk_fwd_kernel(
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'USE_EXP2'],
+    key=['H', 'K', 'V', 'BT'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -221,7 +203,6 @@ def fused_chunk_bwd_kernel(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     USE_FINAL_STATE: tl.constexpr,
@@ -243,14 +224,9 @@ def fused_chunk_bwd_kernel(
         b_gamma = tl.load(g_gamma + i_h)
         b_g = b_gamma * (o_i + 1)
         b_g_last = b_gamma * BT
-        if USE_EXP2:
-            b_gq = exp2(b_g)
-            b_gk = exp2(b_g_last - b_g)
-            b_gn = exp2(b_g_last)
-        else:
-            b_gq = exp(b_g)
-            b_gk = exp(b_g_last - b_g)
-            b_gn = exp(b_g_last)
+        b_gq = exp2(b_g)
+        b_gk = exp2(b_g_last - b_g)
+        b_gn = exp2(b_g_last)
 
     m_s = o_i[:, None] >= o_i[None, :]
 
@@ -294,21 +270,13 @@ def fused_chunk_bwd_kernel(
             b_g = tl.load(p_g, mask=(o_t < T), other=0.)
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
 
-            if USE_EXP2:
-                b_gq = exp2(b_g)
-                b_gk = exp2(b_g_last - b_g)
-                b_gn = exp2(b_g_last)
-            else:
-                b_gq = exp(b_g)
-                b_gk = exp(b_g_last - b_g)
-                b_gn = exp(b_g_last)
+            b_gq = exp2(b_g)
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
 
             p_dg = dg + ((i_k * NV + i_v) * all + (bos + o_t)).to(tl.int64) * H + i_h
             # [BT, BT]
-            if USE_EXP2:
-                b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
-            else:
-                b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
+            b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
             b_ds = b_ds * b_gs
             # [BT, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -321,18 +289,11 @@ def fused_chunk_bwd_kernel(
 
         elif USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            if USE_EXP2:
-                b_gk = exp2(b_g_last - b_g)
-                b_gn = exp2(b_g_last)
-            else:
-                b_gk = exp(b_g_last - b_g)
-                b_gn = exp(b_g_last)
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
 
             # [BT, BT]
-            if USE_EXP2:
-                b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
-            else:
-                b_gs = tl.where(m_s & m_t, exp(b_g[:, None] - b_g[None, :]), 0)
+            b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
             b_ds = b_ds * b_gs
             # [BT, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
@@ -392,16 +353,10 @@ def fused_chunk_bwd_kernel(
             b_g = tl.load(p_g, mask=m_t, other=0.)
             b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
 
-            if USE_EXP2:
-                b_gq = exp2(b_g)
-                b_gk = exp2(b_g_last - b_g)
-                b_gn = exp2(b_g_last)
-                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp2(b_g[:, None] - b_g[None, :]), 0)) * scale
-            else:
-                b_gq = exp(b_g)
-                b_gk = exp(b_g_last - b_g)
-                b_gn = exp(b_g_last)
-                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp(b_g[:, None] - b_g[None, :]), 0)) * scale
+            b_gq = exp2(b_g)
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
+            b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp2(b_g[:, None] - b_g[None, :]), 0)) * scale
 
             b_s = b_s * b_gs
             b_ds = b_ds * b_gs
@@ -423,14 +378,9 @@ def fused_chunk_bwd_kernel(
 
         elif USE_G_GAMMA:
             b_g_last = b_gamma * min(BT, T - i_t * BT)
-            if USE_EXP2:
-                b_gk = exp2(b_g_last - b_g)
-                b_gn = exp2(b_g_last)
-                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp2(b_g[:, None] - b_g[None, :]), 0)) * scale
-            else:
-                b_gk = exp(b_g_last - b_g)
-                b_gn = exp(b_g_last)
-                b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp(b_g[:, None] - b_g[None, :]), 0)) * scale
+            b_gk = exp2(b_g_last - b_g)
+            b_gn = exp2(b_g_last)
+            b_gs = tl.trans(tl.where(m_s & (m_t[:, None] & m_t), exp2(b_g[:, None] - b_g[None, :]), 0)) * scale
 
             b_s = b_s * b_gs
             b_ds = b_ds * b_gs
@@ -471,7 +421,6 @@ def fused_chunk_fwd(
     output_final_state: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
-    use_exp2: bool = False,
 ):
     B, T, H, K, V = *q.shape, v.shape[-1]
     BT = chunk_size
@@ -500,7 +449,6 @@ def fused_chunk_fwd(
         V=V,
         BT=BT,
         BK=BK,
-        USE_EXP2=use_exp2,
     )
     if NK > 1:
         o = o.sum(0).to(v)
@@ -519,7 +467,6 @@ def fused_chunk_bwd(
     dht: torch.Tensor,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
-    use_exp2: bool = False,
 ):
     B, T, H, K, V = *q.shape, v.shape[-1]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
@@ -559,7 +506,6 @@ def fused_chunk_bwd(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     dq = dq.sum(0) if NV > 1 else dq
     dk = dk.sum(0) if NV > 1 else dk
@@ -609,7 +555,6 @@ class FusedChunkFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
-            use_exp2=True,
         )
 
         ctx.save_for_backward(q, k, v, g, g_gamma, initial_state)
@@ -636,7 +581,6 @@ class FusedChunkFunction(torch.autograd.Function):
             dht=dht,
             cu_seqlens=ctx.cu_seqlens,
             chunk_size=ctx.chunk_size,
-            use_exp2=True,
         )
         if g is not None:
             dg = dg.to(g)

--- a/fla/ops/common/intracard_cp.py
+++ b/fla/ops/common/intracard_cp.py
@@ -90,7 +90,6 @@ def _raw_chunk_gated_delta_rule_fwd_h(
     save_new_value: bool = True,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     B, T, H, K, V, HV = *k.shape, u.shape[-1], u.shape[2]
@@ -115,10 +114,23 @@ def _raw_chunk_gated_delta_rule_fwd_h(
         return (triton.cdiv(V, meta['BV']), N * HV)
 
     chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
-        k=k, v=u, w=w, v_new=v_new,
-        g=g, gk=gk, h=h, h0=initial_state, ht=final_state,
-        cu_seqlens=cu_seqlens, chunk_offsets=chunk_offsets,
-        T=T, HV=HV, H=H, K=K, V=V, BT=BT, USE_EXP2=use_exp2,
+        k=k,
+        v=u,
+        w=w,
+        v_new=v_new,
+        g=g,
+        gk=gk,
+        h=h,
+        h0=initial_state,
+        ht=final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        HV=HV,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
         TRANSPOSE_STATE=transpose_state_layout,
     )
     return h, v_new, final_state
@@ -247,7 +259,6 @@ def intracard_pre_scan(
     cu_seqlens_subseq_split: torch.Tensor,
     S_split: int,
     chunk_size: int = 64,
-    use_exp2: bool = True,
 ):
     H, K, V, HV = kg.shape[2], kg.shape[3], u.shape[3], u.shape[2]
     BK = triton.next_power_of_2(K)
@@ -274,7 +285,6 @@ def intracard_pre_scan(
         BT=chunk_size,
         BLOCK_SIZE=BLOCK_SIZE,
         BK1=BK,
-        USE_EXP2=use_exp2,
         MULTI_SEQS=True,
     )
 
@@ -316,8 +326,8 @@ def intracard_merge(
     n_so = len(merge_seq_offsets)
     n_io = len(merge_init_offsets)
     seq_offsets = all_tensor[:n_so]
-    init_offsets = all_tensor[n_so:n_so + n_io]
-    h0_seq_ids = all_tensor[n_so + n_io:]
+    init_offsets = all_tensor[n_so:n_so+n_io]
+    h0_seq_ids = all_tensor[n_so+n_io:]
 
     if transpose_state_layout:
         initial_states_merge = hm.new_empty(num_non_first, HV, V, K, dtype=torch.float32)
@@ -374,7 +384,7 @@ def _precompute_intracard_indices(
     cu_seqlens_split_values: list[int] = []
     S_split_total = 0
     for s, n in zip(starts, num_ss):
-        cu_seqlens_split_values.extend(cu_seqlens_subseq_values[s:s + n + 1])
+        cu_seqlens_split_values.extend(cu_seqlens_subseq_values[s:s+n+1])
         S_split_total += n
 
     # num_subseqs_per_seq: [N_orig], default 1 for unsplit sequences
@@ -435,7 +445,6 @@ def intracard_fwd_h(
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     max_splits: int = 32,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
@@ -502,14 +511,17 @@ def intracard_fwd_h(
 
     if early_return or not split_info:
         return _raw_chunk_gated_delta_rule_fwd_h(
-            k=k, w=w, u=u, g=g, gk=gk,
+            k=k,
+            w=w,
+            u=u,
+            g=g,
+            gk=gk,
             initial_state=initial_state,
             output_final_state=output_final_state,
             chunk_size=chunk_size,
             save_new_value=save_new_value,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
-            use_exp2=use_exp2,
             transpose_state_layout=transpose_state_layout,
         )
 
@@ -555,11 +567,14 @@ def intracard_fwd_h(
             _intracard_cache.popitem(last=False)
 
     hm = intracard_pre_scan(
-        kg=k, w=w, u=u, g=g, gk=gk,
+        kg=k,
+        w=w,
+        u=u,
+        g=g,
+        gk=gk,
         cu_seqlens_subseq_split=cu_seqlens_split_flat,
         S_split=S_split_total,
         chunk_size=chunk_size,
-        use_exp2=use_exp2,
     )
 
     initial_states_merge, num_non_first = intracard_merge(
@@ -598,7 +613,6 @@ def intracard_fwd_h(
         save_new_value=save_new_value,
         cu_seqlens=cu_seqlens_subseq_gpu,
         chunk_indices=chunk_indices_subseq,
-        use_exp2=use_exp2,
         transpose_state_layout=transpose_state_layout,
     )
 

--- a/fla/ops/cp/README.md
+++ b/fla/ops/cp/README.md
@@ -249,7 +249,7 @@ The following examples show how CP integrates with the existing kernel interface
 ### GDN Forward
 
 ```python
-g = chunk_local_cumsum(g, chunk_size=64)
+g = chunk_local_cumsum(g, chunk_size=64, scale=RCP_LN2)
 w, u = recompute_w_u_fwd(k, v, beta, A, g=g)
 
 # CP pre-process: original k, scalar g
@@ -295,7 +295,7 @@ w, u, qg, kg, Aqk, Akk = chunk_kda_fwd_intra(q, k, v, gk=g, beta, ...)
 
 # 2. CP pre-process: pre-gated kg, per-dim gk=g
 initial_state = chunk_gated_delta_rule_fwd_h_pre_process(
-    k=kg, w=w, u=u, gk=g,     # USE_G=False, USE_GK=True, use_exp2=True
+    k=kg, w=w, u=u, gk=g,     # USE_G=False, USE_GK=True
     context=cp_context,
 )
 
@@ -303,7 +303,6 @@ initial_state = chunk_gated_delta_rule_fwd_h_pre_process(
 h, v_new, _ = chunk_gated_delta_rule_fwd_h(
     k=kg, w=w, u=u, gk=g,
     initial_state=initial_state,
-    use_exp2=True,
 )
 ```
 
@@ -322,7 +321,7 @@ dAqk, dv = chunk_kda_bwd_dAv(q, k, v=v_new, do, A=Aqk, ...)
 
 # 4. CP pre-process: pre-gated qg, kg, per-dim gk=g
 dht, initial_state = chunk_gated_delta_rule_bwd_dhu_pre_process(
-    q=qg, k=kg, w=w, do=do, dv=dv, gk=g,  # USE_G=False, USE_GK=True, use_exp2=True
+    q=qg, k=kg, w=w, do=do, dv=dv, gk=g,  # USE_G=False, USE_GK=True
     context=cp_context,
 )
 
@@ -330,7 +329,6 @@ dht, initial_state = chunk_gated_delta_rule_bwd_dhu_pre_process(
 dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
     q=qg, k=kg, w=w, gk=g,
     dht=dht, ...
-    use_exp2=True,
 )
 ```
 

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
         for num_warps in [2, 4]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'HV', 'K', 'V', 'BT', 'USE_EXP2'],
+    key=['H', 'HV', 'K', 'V', 'BT'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -60,7 +60,6 @@ def pre_process_fwd_kernel_merged(
     USE_G: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_BG: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     MULTI_SEQS: tl.constexpr,
 ):
@@ -151,12 +150,8 @@ def pre_process_fwd_kernel_merged(
                 b_g_last = tl.load(g + bos * HV + last_idx * HV + i_h).to(tl.float32)
                 p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-                if USE_EXP2:
-                    b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
-                    b_g_last = exp2(b_g_last)
-                else:
-                    b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
-                    b_g_last = exp(b_g_last)
+                b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp2(b_g_last)
                 b_h1 *= b_g_last
                 if K > 64:
                     b_h2 *= b_g_last
@@ -169,35 +164,22 @@ def pre_process_fwd_kernel_merged(
             if USE_GK:
                 o_k1 = tl.arange(0, 64)
                 b_gk_last1 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
-                if USE_EXP2:
-                    b_h1 *= exp2(b_gk_last1)[:, None]
-                else:
-                    b_h1 *= exp(b_gk_last1)[:, None]
+                b_h1 *= exp2(b_gk_last1)[:, None]
                 if K > 64:
                     o_k2 = 64 + o_k1
                     b_gk_last2 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
                                          o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
-                    if USE_EXP2:
-                        b_h2 *= exp2(b_gk_last2)[:, None]
-                    else:
-                        b_h2 *= exp(b_gk_last2)[:, None]
+                    b_h2 *= exp2(b_gk_last2)[:, None]
                 if K > 128:
                     o_k3 = 128 + o_k1
                     b_gk_last3 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
                                          o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
-                    if USE_EXP2:
-                        b_h3 *= exp2(b_gk_last3)[:, None]
-                    else:
-                        b_h3 *= exp(b_gk_last3)[:, None]
+                    b_h3 *= exp2(b_gk_last3)[:, None]
                 if K > 192:
                     o_k4 = 192 + o_k1
                     b_gk_last4 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
                                          o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
-                    if USE_EXP2:
-                        b_h4 *= exp2(b_gk_last4)[:, None]
-                    else:
-                        b_h4 *= exp(b_gk_last4)[:, None]
-
+                    b_h4 *= exp2(b_gk_last4)[:, None]
             b_v = b_v.to(k.dtype.element_ty)
 
             # Update h
@@ -291,19 +273,12 @@ def pre_process_fwd_kernel_merged(
                 b_g_last = tl.load(g + bos * HV + last_idx * HV + i_h).to(tl.float32)
                 p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-                if USE_EXP2:
-                    b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
-                    b_g_last = exp2(b_g_last)
-                else:
-                    b_k = b_k * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
-                    b_g_last = exp(b_g_last)
+                b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp2(b_g_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_g_last, 0.0)
             elif USE_GK:
                 b_gk_last = tl.load(gk + (bos + last_idx) * HV * K + i_h * K + row, mask=(row < K), other=0.).to(tl.float32)
-                if USE_EXP2:
-                    b_gk_last = exp2(b_gk_last)
-                else:
-                    b_gk_last = exp(b_gk_last)
+                b_gk_last = exp2(b_gk_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_gk_last[:, None], 0.0)
             else:
                 b_diag = tl.where(row[:, None] == row[None, :], 1.0, 0.0)
@@ -336,7 +311,7 @@ def pre_process_fwd_kernel_merged(
         for num_stages in [2, 3, 4]
         for BV in [32, 64]
     ],
-    key=['HV', 'K', 'V', 'BT', 'USE_EXP2'],
+    key=['HV', 'K', 'V', 'BT'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -491,7 +466,7 @@ def merge_fwd_bwd_kernel(
         for num_warps in [2, 4]
         for num_stages in ([4, 3, 2] if check_shared_mem('ampere') else [1])
     ],
-    key=['H', 'HV', 'K', 'V', 'BT', 'USE_EXP2'],
+    key=['H', 'HV', 'K', 'V', 'BT'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -518,7 +493,6 @@ def pre_process_bwd_kernel_merged(
     USE_G: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_BG: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     """
@@ -592,12 +566,8 @@ def pre_process_bwd_kernel_merged(
             b_k = tl.load(p_k, boundary_check=(0, 1))
             if USE_GK:
                 o_k1 = tl.arange(0, 64)
-                if USE_EXP2:
-                    b_gk_last1 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
-                else:
-                    b_gk_last1 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
+                b_gk_last1 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
+                                     o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
             b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
 
             if K > 64:
@@ -605,12 +575,8 @@ def pre_process_bwd_kernel_merged(
                 b_k = tl.load(p_k, boundary_check=(0, 1))
                 if USE_GK:
                     o_k2 = 64 + o_k1
-                    if USE_EXP2:
-                        b_gk_last2 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                             o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
-                    else:
-                        b_gk_last2 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                             o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
+                    b_gk_last2 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
+                                         o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
 
             if K > 128:
@@ -618,12 +584,8 @@ def pre_process_bwd_kernel_merged(
                 b_k = tl.load(p_k, boundary_check=(0, 1))
                 if USE_GK:
                     o_k3 = 128 + o_k1
-                    if USE_EXP2:
-                        b_gk_last3 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                             o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
-                    else:
-                        b_gk_last3 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                             o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
+                    b_gk_last3 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
+                                         o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
 
             if K > 192:
@@ -631,12 +593,8 @@ def pre_process_bwd_kernel_merged(
                 b_k = tl.load(p_k, boundary_check=(0, 1))
                 if USE_GK:
                     o_k4 = 192 + o_k1
-                    if USE_EXP2:
-                        b_gk_last4 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                             o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
-                    else:
-                        b_gk_last4 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                             o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
+                    b_gk_last4 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
+                                         o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
 
             if USE_G:
@@ -654,10 +612,7 @@ def pre_process_bwd_kernel_merged(
                 b_dh1 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
             if USE_GK:
-                if USE_EXP2:
-                    b_dh1 *= exp2(b_gk_last1[:, None])
-                else:
-                    b_dh1 *= exp(b_gk_last1[:, None])
+                b_dh1 *= exp2(b_gk_last1[:, None])
             if USE_BG:
                 # DPLR mode: dh += q^T @ do + w^T @ dv2 (no scale)
                 b_dh1 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) + tl.dot(b_w, b_dv.to(b_w.dtype))
@@ -673,10 +628,7 @@ def pre_process_bwd_kernel_merged(
                     b_dh2 *= bg_last_exp
                     b_q = b_q * b_g_exp[None, :]
                 if USE_GK:
-                    if USE_EXP2:
-                        b_dh2 *= exp2(b_gk_last2[:, None])
-                    else:
-                        b_dh2 *= exp(b_gk_last2[:, None])
+                    b_dh2 *= exp2(b_gk_last2[:, None])
                 if USE_BG:
                     b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) + tl.dot(b_w, b_dv.to(b_w.dtype))
                 else:
@@ -691,10 +643,7 @@ def pre_process_bwd_kernel_merged(
                     b_dh3 *= bg_last_exp
                     b_q = b_q * b_g_exp[None, :]
                 if USE_GK:
-                    if USE_EXP2:
-                        b_dh3 *= exp2(b_gk_last3[:, None])
-                    else:
-                        b_dh3 *= exp(b_gk_last3[:, None])
+                    b_dh3 *= exp2(b_gk_last3[:, None])
                 if USE_BG:
                     b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) + tl.dot(b_w, b_dv.to(b_w.dtype))
                 else:
@@ -709,10 +658,7 @@ def pre_process_bwd_kernel_merged(
                     b_dh4 *= bg_last_exp
                     b_q = b_q * b_g_exp[None, :]
                 if USE_GK:
-                    if USE_EXP2:
-                        b_dh4 *= exp2(b_gk_last4[:, None])
-                    else:
-                        b_dh4 *= exp(b_gk_last4[:, None])
+                    b_dh4 *= exp2(b_gk_last4[:, None])
                 if USE_BG:
                     b_dh4 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) + tl.dot(b_w, b_dv.to(b_w.dtype))
                 else:
@@ -761,19 +707,12 @@ def pre_process_bwd_kernel_merged(
                 b_g_last = tl.load(g + bos * HV + last_idx * HV + i_h).to(tl.float32)
                 p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-                if USE_EXP2:
-                    b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
-                    b_g_last = exp2(b_g_last)
-                else:
-                    b_k = b_k * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
-                    b_g_last = exp(b_g_last)
+                b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp2(b_g_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_g_last, 0.0)
             elif USE_GK:
                 b_gk_last = tl.load(gk + (bos + last_idx) * HV * K + i_h * K + row, mask=(row < K), other=0.).to(tl.float32)
-                if USE_EXP2:
-                    b_gk_last = exp2(b_gk_last)
-                else:
-                    b_gk_last = exp(b_gk_last)
+                b_gk_last = exp2(b_gk_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_gk_last[:, None], 0.0)
             else:
                 b_diag = tl.where(row[:, None] == row[None, :], 1.0, 0.0)
@@ -804,7 +743,6 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
     v: torch.Tensor | None = None,
     chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     initial_state: torch.Tensor | None = None,
     context: FLACPContext = None,
     transpose_state_layout: bool = False,
@@ -852,7 +790,6 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
             V=V,
             BT=BT,
             BK1=BK,
-            USE_EXP2=use_exp2,
             BLOCK_SIZE=BLOCK_SIZE,
             MULTI_SEQS=False,
         )
@@ -891,7 +828,6 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
     bg: torch.Tensor | None = None,
     scale: float | None = None,
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     dht: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     context: FLACPContext | None = None,
@@ -940,7 +876,6 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
             V=V,
             BT=BT,
             BK1=BK,
-            USE_EXP2=use_exp2,
             BLOCK_SIZE=BLOCK_SIZE,
             USE_BG=bg is not None,
         )

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -91,6 +91,10 @@ def pre_process_fwd_kernel_merged(
         bg += ((bos * H + i_h // (HV // H)) * K).to(tl.int64)
     else:
         w += ((bos * HV + i_h) * K).to(tl.int64)
+    if USE_G:
+        g += (bos * HV + i_h).to(tl.int64)
+    if USE_GK:
+        gk += ((bos * HV + i_h) * K).to(tl.int64)
     stride_k = H * K
     stride_w = H * K if USE_BG else HV * K
 
@@ -147,8 +151,8 @@ def pre_process_fwd_kernel_merged(
             # Apply g decay
             if USE_G:
                 m_t = (i_t * BT + tl.arange(0, BT)) < T
-                b_g_last = tl.load(g + bos * HV + last_idx * HV + i_h).to(tl.float32)
-                p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+                b_g_last = tl.load(g + last_idx * HV).to(tl.float32)
+                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
                 b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
@@ -163,22 +167,20 @@ def pre_process_fwd_kernel_merged(
             # Apply gk decay
             if USE_GK:
                 o_k1 = tl.arange(0, 64)
-                b_gk_last1 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
+                p_gk_last = gk + last_idx * HV * K
+                b_gk_last1 = tl.load(p_gk_last + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
                 b_h1 *= exp2(b_gk_last1)[:, None]
                 if K > 64:
                     o_k2 = 64 + o_k1
-                    b_gk_last2 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
+                    b_gk_last2 = tl.load(p_gk_last + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
                     b_h2 *= exp2(b_gk_last2)[:, None]
                 if K > 128:
                     o_k3 = 128 + o_k1
-                    b_gk_last3 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
+                    b_gk_last3 = tl.load(p_gk_last + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
                     b_h3 *= exp2(b_gk_last3)[:, None]
                 if K > 192:
                     o_k4 = 192 + o_k1
-                    b_gk_last4 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
+                    b_gk_last4 = tl.load(p_gk_last + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
                     b_h4 *= exp2(b_gk_last4)[:, None]
             b_v = b_v.to(k.dtype.element_ty)
 
@@ -270,14 +272,14 @@ def pre_process_fwd_kernel_merged(
 
             if USE_G:
                 m_t = (i_t * BT + tl.arange(0, BT)) < T
-                b_g_last = tl.load(g + bos * HV + last_idx * HV + i_h).to(tl.float32)
-                p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+                b_g_last = tl.load(g + last_idx * HV).to(tl.float32)
+                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
                 b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_g_last, 0.0)
             elif USE_GK:
-                b_gk_last = tl.load(gk + (bos + last_idx) * HV * K + i_h * K + row, mask=(row < K), other=0.).to(tl.float32)
+                b_gk_last = tl.load(gk + last_idx * HV * K + row, mask=(row < K), other=0.).to(tl.float32)
                 b_gk_last = exp2(b_gk_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_gk_last[:, None], 0.0)
             else:
@@ -524,6 +526,10 @@ def pre_process_bwd_kernel_merged(
         w += ((bos * H + i_h // (HV // H)) * K).to(tl.int64)
     else:
         w += ((bos * HV + i_h) * K).to(tl.int64)
+    if USE_G:
+        g += (bos * HV + i_h).to(tl.int64)
+    if USE_GK:
+        gk += ((bos * HV + i_h) * K).to(tl.int64)
     dhm += i_h * K * (V + K)
     stride_qk = H * K
     stride_w = H * K if USE_BG else HV * K
@@ -551,9 +557,9 @@ def pre_process_bwd_kernel_merged(
             if USE_G:
                 # Note: pre_process_bwd_kernel_stage1 always uses exp for USE_G,
                 # regardless of USE_EXP2. This is for consistency with the original design.
-                bg_last = tl.load(g + (bos + last_idx) * HV + i_h).to(tl.float32)
+                bg_last = tl.load(g + last_idx * HV).to(tl.float32)
                 bg_last_exp = exp(bg_last)
-                p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
                 b_g_exp = exp(b_g)
 
@@ -566,8 +572,8 @@ def pre_process_bwd_kernel_merged(
             b_k = tl.load(p_k, boundary_check=(0, 1))
             if USE_GK:
                 o_k1 = tl.arange(0, 64)
-                b_gk_last1 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                     o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
+                p_gk_last = gk + last_idx * HV * K
+                b_gk_last1 = tl.load(p_gk_last + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
             b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
 
             if K > 64:
@@ -575,8 +581,7 @@ def pre_process_bwd_kernel_merged(
                 b_k = tl.load(p_k, boundary_check=(0, 1))
                 if USE_GK:
                     o_k2 = 64 + o_k1
-                    b_gk_last2 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
+                    b_gk_last2 = tl.load(p_gk_last + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
 
             if K > 128:
@@ -584,8 +589,7 @@ def pre_process_bwd_kernel_merged(
                 b_k = tl.load(p_k, boundary_check=(0, 1))
                 if USE_GK:
                     o_k3 = 128 + o_k1
-                    b_gk_last3 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
+                    b_gk_last3 = tl.load(p_gk_last + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
 
             if K > 192:
@@ -593,8 +597,7 @@ def pre_process_bwd_kernel_merged(
                 b_k = tl.load(p_k, boundary_check=(0, 1))
                 if USE_GK:
                     o_k4 = 192 + o_k1
-                    b_gk_last4 = tl.load(gk + (bos + last_idx) * HV * K + i_h * K +
-                                         o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
+                    b_gk_last4 = tl.load(p_gk_last + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
 
             if USE_G:
@@ -704,14 +707,14 @@ def pre_process_bwd_kernel_merged(
 
             if USE_G:
                 m_t = (i_t * BT + tl.arange(0, BT)) < T
-                b_g_last = tl.load(g + bos * HV + last_idx * HV + i_h).to(tl.float32)
-                p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+                b_g_last = tl.load(g + last_idx * HV).to(tl.float32)
+                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
                 b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_g_last, 0.0)
             elif USE_GK:
-                b_gk_last = tl.load(gk + (bos + last_idx) * HV * K + i_h * K + row, mask=(row < K), other=0.).to(tl.float32)
+                b_gk_last = tl.load(gk + last_idx * HV * K + row, mask=(row < K), other=0.).to(tl.float32)
                 b_gk_last = exp2(b_gk_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_gk_last[:, None], 0.0)
             else:

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -15,7 +15,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.cp.comm import all_gather_into_tensor
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem
 
 if TYPE_CHECKING:
@@ -555,13 +555,11 @@ def pre_process_bwd_kernel_merged(
             last_idx = min((i_t + 1) * BT, T) - 1
 
             if USE_G:
-                # Note: pre_process_bwd_kernel_stage1 always uses exp for USE_G,
-                # regardless of USE_EXP2. This is for consistency with the original design.
                 bg_last = tl.load(g + last_idx * HV).to(tl.float32)
-                bg_last_exp = exp(bg_last)
                 p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-                b_g_exp = exp(b_g)
+                bg_last_exp = exp2(bg_last)
+                b_g_exp = exp2(b_g)
 
             p_dv = tl.make_block_ptr(dv, (T, V), (stride_v, 1), (i_t * BT, i_v * BLOCK_SIZE), (BT, BLOCK_SIZE), (1, 0))
             p_do = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, i_v * BLOCK_SIZE), (BT, BLOCK_SIZE), (1, 0))
@@ -602,8 +600,7 @@ def pre_process_bwd_kernel_merged(
 
             if USE_G:
                 m_t = (i_t * BT + tl.arange(0, BT)) < T
-                # Note: pre_process_bwd_kernel_stage1 always uses exp for USE_G
-                b_dv *= tl.where(m_t, exp(bg_last - b_g), 0)[:, None]
+                b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
             b_dv += tl.load(p_dv, boundary_check=(0, 1))
 
             # Update dh

--- a/fla/ops/delta_rule/wy_fast.py
+++ b/fla/ops/delta_rule/wy_fast.py
@@ -11,6 +11,7 @@ import triton.language as tl
 
 from fla.ops.common.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.op import safe_dot
 from fla.ops.utils.solve_tril import solve_tril
 from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
 
@@ -173,7 +174,7 @@ def prepare_wy_repr_bwd_kernel(
 
         b_dk_beta = tl.dot(b_dA, b_k, allow_tf32=False)
         b_dbeta += tl.sum(b_dk_beta * b_k, 1)
-        b_dk += tl.dot(tl.trans(b_dA), b_k_beta, allow_tf32=False)
+        b_dk += safe_dot(tl.trans(b_dA), b_k_beta, allow_tf32=False)
         b_dk += b_dk_beta * b_beta[:, None]
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 

--- a/fla/ops/gated_delta_product/chunk.py
+++ b/fla/ops/gated_delta_product/chunk.py
@@ -17,6 +17,7 @@ from fla.ops.gated_delta_product.chunk_deltaproduct_o import chunk_gated_delta_p
 from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_bwd
 from fla.ops.gated_delta_rule.wy_fast import recompute_w_u_fwd as gdn_recompute_w_u_fwd
 from fla.ops.utils import chunk_local_cumsum, solve_tril
+from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.index import prepare_chunk_indices
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
@@ -40,10 +41,21 @@ def chunk_gated_delta_product_fwd(
         g_interleaved = g.new_zeros(g.shape[0], g.shape[1], num_householder, g.shape[2], dtype=torch.float32)
         g_interleaved[:, :, 0] = g
         g_interleaved = rearrange(g_interleaved, 'b l n h -> b (l n) h').contiguous()
-        g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens,
-                               output_dtype=torch.float32, chunk_indices=chunk_indices)
+        g = chunk_local_cumsum(
+            g,
+            chunk_size=64,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+            output_dtype=torch.float32,
+            chunk_indices=chunk_indices,
+        )
         g_interleaved = chunk_local_cumsum(
-            g_interleaved, chunk_size=64, cu_seqlens=cu_seqlens_dp, output_dtype=torch.float32, chunk_indices=chunk_indices_dp
+            g_interleaved,
+            chunk_size=64,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens_dp,
+            output_dtype=torch.float32,
+            chunk_indices=chunk_indices_dp,
         )
     else:
         g_interleaved = None
@@ -56,12 +68,13 @@ def chunk_gated_delta_product_fwd(
         cu_seqlens=cu_seqlens_dp,
         output_dtype=torch.float32,
         chunk_indices=chunk_indices_dp,
+        use_exp2=True,
     )
     A = solve_tril(
         A=A,
         cu_seqlens=cu_seqlens_dp,
-        output_dtype=k.dtype,
         chunk_indices=chunk_indices_dp,
+        output_dtype=k.dtype,
     )
     if g is not None:
         w, u = gdn_recompute_w_u_fwd(
@@ -72,6 +85,7 @@ def chunk_gated_delta_product_fwd(
             g=g_interleaved,
             cu_seqlens=cu_seqlens_dp,
             chunk_indices=chunk_indices_dp,
+            use_exp2=True,
         )
     else:
         w, u = dn_recompute_w_u_fwd(
@@ -192,7 +206,7 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
                 dht=dht,
                 cu_seqlens=cu_seqlens * ctx.num_householder if cu_seqlens is not None else None,
                 chunk_indices=chunk_indices_dp,
-                use_exp2=False,
+                use_exp2=True,
             )
             dg = rearrange(dg, 'b (l n) h  -> b l n h ', n=ctx.num_householder)[:, :, 0].contiguous().to(g)
         else:

--- a/fla/ops/gated_delta_product/chunk.py
+++ b/fla/ops/gated_delta_product/chunk.py
@@ -68,7 +68,6 @@ def chunk_gated_delta_product_fwd(
         cu_seqlens=cu_seqlens_dp,
         output_dtype=torch.float32,
         chunk_indices=chunk_indices_dp,
-        use_exp2=True,
     )
     A = solve_tril(
         A=A,
@@ -85,7 +84,6 @@ def chunk_gated_delta_product_fwd(
             g=g_interleaved,
             cu_seqlens=cu_seqlens_dp,
             chunk_indices=chunk_indices_dp,
-            use_exp2=True,
         )
     else:
         w, u = dn_recompute_w_u_fwd(
@@ -147,13 +145,16 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
         else:
             q_rstd, k_rstd = None, None
 
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, 64, cu_seqlens_cpu=cu_seqlens_cpu
-        ) if cu_seqlens is not None else None
-        cu_seqlens_cpu_dp = cu_seqlens_cpu * num_householder if cu_seqlens_cpu is not None else None
-        chunk_indices_dp = prepare_chunk_indices(
-            cu_seqlens * num_householder, 64, cu_seqlens_cpu=cu_seqlens_cpu_dp
-        ) if cu_seqlens is not None else None
+        chunk_indices = None
+        chunk_indices_dp = None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, 64, cu_seqlens_cpu=cu_seqlens_cpu)
+            cu_seqlens_cpu_dp = None
+            if cu_seqlens_cpu is not None:
+                cu_seqlens_cpu_dp = cu_seqlens_cpu * num_householder
+            chunk_indices_dp = prepare_chunk_indices(
+                cu_seqlens * num_householder, 64, cu_seqlens_cpu=cu_seqlens_cpu_dp
+            )
 
         g, g_interleaved, o, A, final_state = chunk_gated_delta_product_fwd(
             q=q,
@@ -169,7 +170,19 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
             chunk_indices=chunk_indices,
             chunk_indices_dp=chunk_indices_dp,
         )
-        ctx.save_for_backward(q, q_rstd, k, k_rstd, v, g_interleaved, beta, A, initial_state, cu_seqlens, chunk_indices_dp)
+        ctx.save_for_backward(
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            v,
+            g_interleaved,
+            beta,
+            A,
+            initial_state,
+            cu_seqlens,
+            chunk_indices_dp,
+        )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
         ctx.num_householder = num_householder
@@ -183,7 +196,19 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
         do: torch.Tensor,
         dht: torch.Tensor,
     ):
-        q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens, chunk_indices_dp = ctx.saved_tensors
+        (
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            v,
+            g,
+            beta,
+            A,
+            initial_state,
+            cu_seqlens,
+            chunk_indices_dp,
+        ) = ctx.saved_tensors
         q_new = q.new_zeros(q.shape[0], q.shape[1], ctx.num_householder, q.shape[2], q.shape[3])
         q_new[:, :, -1] = q
         do_new = do.new_zeros(do.shape[0], do.shape[1], ctx.num_householder, do.shape[2], do.shape[3])
@@ -206,7 +231,6 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
                 dht=dht,
                 cu_seqlens=cu_seqlens * ctx.num_householder if cu_seqlens is not None else None,
                 chunk_indices=chunk_indices_dp,
-                use_exp2=True,
             )
             dg = rearrange(dg, 'b (l n) h  -> b l n h ', n=ctx.num_householder)[:, :, 0].contiguous().to(g)
         else:

--- a/fla/ops/gated_delta_product/chunk_deltaproduct_h.py
+++ b/fla/ops/gated_delta_product/chunk_deltaproduct_h.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_HOPPER, USE_CUDA_GRAPH, autotune_cache_kwargs
 
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
@@ -156,8 +156,8 @@ def chunk_gated_delta_product_fwd_kernel_h_blockdim64(
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
             p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
             b_g = tl.load(p_g, boundary_check=(0,))
-            b_v_new = b_v_new * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
-            b_g_last = exp(b_g_last)
+            b_v_new = b_v_new * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+            b_g_last = exp2(b_g_last)
             b_h1 = b_h1 * b_g_last
             if K > 64:
                 b_h2 = b_h2 * b_g_last
@@ -305,10 +305,10 @@ def chunk_gated_delta_product_bwd_kernel_dhu_blockdim64(
         if USE_G:
             last_idx = min((i_t + 1) * BT, T) - 1
             bg_last = tl.load(g + (bos + last_idx) * H + i_h)
-            bg_last_exp = exp(bg_last)
+            bg_last_exp = exp2(bg_last)
             p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
             b_g = tl.load(p_g, boundary_check=(0,))
-            b_g_exp = exp(b_g)
+            b_g_exp = exp2(b_g)
         else:
             bg_last = None
             last_idx = None
@@ -344,7 +344,7 @@ def chunk_gated_delta_product_bwd_kernel_dhu_blockdim64(
 
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
-            b_dv *= tl.where(m_t, exp(bg_last - b_g), 0)[:, None]
+            b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
         b_dv += tl.load(p_dv, boundary_check=(0, 1))
 
         tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))

--- a/fla/ops/gated_delta_product/chunk_deltaproduct_o.py
+++ b/fla/ops/gated_delta_product/chunk_deltaproduct_o.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
@@ -94,8 +94,8 @@ def chunk_fwd_kernel_o(
         p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
         m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
-        b_m = tl.where(m_A, exp(b_g[:, None] - b_g[None, :]), 0)
-        b_o = b_o * exp(b_g)[:, None]
+        b_m = tl.where(m_A, exp2(b_g[:, None] - b_g[None, :]), 0)
+        b_o = b_o * exp2(b_g)[:, None]
     else:
         b_m = ((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)).to(tl.float32)
 

--- a/fla/ops/gated_delta_rule/chunk.py
+++ b/fla/ops/gated_delta_rule/chunk.py
@@ -84,7 +84,6 @@ def chunk_gated_delta_rule_fwd(
             cu_seqlens=cu_seqlens,
             initial_state=initial_state,
             context=cp_context,
-            use_exp2=use_exp2,
             transpose_state_layout=transpose_state_layout,
         )
 
@@ -97,7 +96,6 @@ def chunk_gated_delta_rule_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
         transpose_state_layout=transpose_state_layout,
     )
 
@@ -113,7 +111,6 @@ def chunk_gated_delta_rule_fwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
         transpose_state_layout=transpose_state_layout,
     )
     return g, o, A, final_state, initial_state, g_input
@@ -163,7 +160,6 @@ def chunk_gated_delta_rule_bwd(
         output_final_state=False,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
         transpose_state_layout=transpose_state_layout,
     )
     dv = chunk_bwd_dv_local(
@@ -174,7 +170,6 @@ def chunk_gated_delta_rule_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
 
     if cp_context is not None:
@@ -192,7 +187,6 @@ def chunk_gated_delta_rule_bwd(
             dht=dht,
             initial_state=initial_state,
             context=cp_context,
-            use_exp2=use_exp2,
             transpose_state_layout=transpose_state_layout,
         )
 
@@ -208,7 +202,6 @@ def chunk_gated_delta_rule_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
         transpose_state_layout=transpose_state_layout,
     )
     dq, dk, dw, dg = chunk_bwd_dqkwg(
@@ -224,7 +217,6 @@ def chunk_gated_delta_rule_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
         transpose_state_layout=transpose_state_layout,
     )
     dk2, dv, db, dg2 = prepare_wy_repr_bwd(

--- a/fla/ops/gated_delta_rule/chunk.py
+++ b/fla/ops/gated_delta_rule/chunk.py
@@ -38,7 +38,6 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = True,
     transpose_state_layout: bool = False,
     use_gate_in_kernel: bool = False,
     A_log: torch.Tensor | None = None,
@@ -50,7 +49,7 @@ def chunk_gated_delta_rule_fwd(
             g=g,
             A_log=A_log,
             chunk_size=64,
-            scale=RCP_LN2 if use_exp2 else None,
+            scale=RCP_LN2,
             dt_bias=dt_bias,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
@@ -59,7 +58,7 @@ def chunk_gated_delta_rule_fwd(
         g = chunk_local_cumsum(
             g,
             chunk_size=64,
-            scale=RCP_LN2 if use_exp2 else None,
+            scale=RCP_LN2,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
         )
@@ -72,7 +71,6 @@ def chunk_gated_delta_rule_fwd(
         beta=beta,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
 
     if cp_context is not None:
@@ -130,7 +128,6 @@ def chunk_gated_delta_rule_bwd(
     cu_seqlens: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = True,
     transpose_state_layout: bool = False,
     use_gate_in_kernel: bool = False,
     g_input: torch.Tensor | None = None,
@@ -145,7 +142,6 @@ def chunk_gated_delta_rule_bwd(
         g=g,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
 
     if cp_context is not None:
@@ -229,7 +225,6 @@ def chunk_gated_delta_rule_bwd(
         du=dv,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
     dk.add_(dk2)
     dg.add_(dg2)
@@ -269,8 +264,9 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             q, q_rstd = l2norm_fwd(q)
             k, k_rstd = l2norm_fwd(k)
 
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, 64, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        chunk_indices = None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, 64, cu_seqlens_cpu=cu_seqlens_cpu)
         g, o, A, final_state, initial_state, g_input = chunk_gated_delta_rule_fwd(
             q=q,
             k=k,
@@ -289,9 +285,20 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             dt_bias=dt_bias,
         )
         ctx.save_for_backward(
-            q, q_rstd, k, k_rstd, v, g, beta, A,
-            initial_state, cu_seqlens, chunk_indices,
-            g_input, A_log, dt_bias,
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            v,
+            g,
+            beta,
+            A,
+            initial_state,
+            cu_seqlens,
+            chunk_indices,
+            g_input,
+            A_log,
+            dt_bias,
         )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
@@ -308,9 +315,22 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         do: torch.Tensor,
         dht: torch.Tensor,
     ):
-        (q, q_rstd, k, k_rstd, v, g, beta, A,
-         initial_state, cu_seqlens, chunk_indices,
-         g_input, A_log, dt_bias) = ctx.saved_tensors
+        (
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            v,
+            g,
+            beta,
+            A,
+            initial_state,
+            cu_seqlens,
+            chunk_indices,
+            g_input,
+            A_log,
+            dt_bias,
+        ) = ctx.saved_tensors
         dq, dk, dv, db, dg, dh0, dA_log, ddt_bias = chunk_gated_delta_rule_bwd(
             q=q,
             k=k,

--- a/fla/ops/gated_delta_rule/chunk_fwd.py
+++ b/fla/ops/gated_delta_rule/chunk_fwd.py
@@ -12,7 +12,7 @@ import triton.language as tl
 from fla.ops.gated_delta_rule.wy_fast import recompute_w_u_fwd
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import IS_TF32_SUPPORTED, autotune_cache_kwargs
 
 if IS_TF32_SUPPORTED:
@@ -50,7 +50,6 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     BC: tl.constexpr,
     BK: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     """
@@ -173,35 +172,22 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     # apply gate, beta scaling, and masking
     # m_d: strictly lower triangular mask for diagonal blocks
     # m_tc: boundary mask to prevent NaN from 0 * inf (IEEE 754) when
-    #   out-of-bounds g loads as 0 via boundary_check and exp(0 - g_inbounds) overflows
+    #   out-of-bounds g loads as 0 via boundary_check and exp2(0 - g_inbounds) overflows
     m_d = o_i[:, None] > o_i[None, :]
     m_I = o_i[:, None] == o_i[None, :]
 
     if USE_G:
-        if USE_EXP2:
-            b_A00 *= tl.where(m_d & m_tc0[:, None] & m_tc0[None, :], exp2(b_g0[:, None] - b_g0[None, :]), 0.)
-            b_A11 *= tl.where(m_d & m_tc1[:, None] & m_tc1[None, :], exp2(b_g1[:, None] - b_g1[None, :]), 0.)
-            b_A22 *= tl.where(m_d & m_tc2[:, None] & m_tc2[None, :], exp2(b_g2[:, None] - b_g2[None, :]), 0.)
-            b_A33 *= tl.where(m_d & m_tc3[:, None] & m_tc3[None, :], exp2(b_g3[:, None] - b_g3[None, :]), 0.)
+        b_A00 *= tl.where(m_d & m_tc0[:, None] & m_tc0[None, :], exp2(b_g0[:, None] - b_g0[None, :]), 0.)
+        b_A11 *= tl.where(m_d & m_tc1[:, None] & m_tc1[None, :], exp2(b_g1[:, None] - b_g1[None, :]), 0.)
+        b_A22 *= tl.where(m_d & m_tc2[:, None] & m_tc2[None, :], exp2(b_g2[:, None] - b_g2[None, :]), 0.)
+        b_A33 *= tl.where(m_d & m_tc3[:, None] & m_tc3[None, :], exp2(b_g3[:, None] - b_g3[None, :]), 0.)
 
-            b_A10 *= tl.where(m_tc1[:, None] & m_tc0[None, :], exp2(b_g1[:, None] - b_g0[None, :]), 0.)
-            b_A20 *= tl.where(m_tc2[:, None] & m_tc0[None, :], exp2(b_g2[:, None] - b_g0[None, :]), 0.)
-            b_A21 *= tl.where(m_tc2[:, None] & m_tc1[None, :], exp2(b_g2[:, None] - b_g1[None, :]), 0.)
-            b_A30 *= tl.where(m_tc3[:, None] & m_tc0[None, :], exp2(b_g3[:, None] - b_g0[None, :]), 0.)
-            b_A31 *= tl.where(m_tc3[:, None] & m_tc1[None, :], exp2(b_g3[:, None] - b_g1[None, :]), 0.)
-            b_A32 *= tl.where(m_tc3[:, None] & m_tc2[None, :], exp2(b_g3[:, None] - b_g2[None, :]), 0.)
-        else:
-            b_A00 *= tl.where(m_d & m_tc0[:, None] & m_tc0[None, :], exp(b_g0[:, None] - b_g0[None, :]), 0.)
-            b_A11 *= tl.where(m_d & m_tc1[:, None] & m_tc1[None, :], exp(b_g1[:, None] - b_g1[None, :]), 0.)
-            b_A22 *= tl.where(m_d & m_tc2[:, None] & m_tc2[None, :], exp(b_g2[:, None] - b_g2[None, :]), 0.)
-            b_A33 *= tl.where(m_d & m_tc3[:, None] & m_tc3[None, :], exp(b_g3[:, None] - b_g3[None, :]), 0.)
-
-            b_A10 *= tl.where(m_tc1[:, None] & m_tc0[None, :], exp(b_g1[:, None] - b_g0[None, :]), 0.)
-            b_A20 *= tl.where(m_tc2[:, None] & m_tc0[None, :], exp(b_g2[:, None] - b_g0[None, :]), 0.)
-            b_A21 *= tl.where(m_tc2[:, None] & m_tc1[None, :], exp(b_g2[:, None] - b_g1[None, :]), 0.)
-            b_A30 *= tl.where(m_tc3[:, None] & m_tc0[None, :], exp(b_g3[:, None] - b_g0[None, :]), 0.)
-            b_A31 *= tl.where(m_tc3[:, None] & m_tc1[None, :], exp(b_g3[:, None] - b_g1[None, :]), 0.)
-            b_A32 *= tl.where(m_tc3[:, None] & m_tc2[None, :], exp(b_g3[:, None] - b_g2[None, :]), 0.)
+        b_A10 *= tl.where(m_tc1[:, None] & m_tc0[None, :], exp2(b_g1[:, None] - b_g0[None, :]), 0.)
+        b_A20 *= tl.where(m_tc2[:, None] & m_tc0[None, :], exp2(b_g2[:, None] - b_g0[None, :]), 0.)
+        b_A21 *= tl.where(m_tc2[:, None] & m_tc1[None, :], exp2(b_g2[:, None] - b_g1[None, :]), 0.)
+        b_A30 *= tl.where(m_tc3[:, None] & m_tc0[None, :], exp2(b_g3[:, None] - b_g0[None, :]), 0.)
+        b_A31 *= tl.where(m_tc3[:, None] & m_tc1[None, :], exp2(b_g3[:, None] - b_g1[None, :]), 0.)
+        b_A32 *= tl.where(m_tc3[:, None] & m_tc2[None, :], exp2(b_g3[:, None] - b_g2[None, :]), 0.)
     else:
         b_A00 = tl.where(m_d, b_A00, 0.)
         b_A11 = tl.where(m_d, b_A11, 0.)
@@ -336,7 +322,6 @@ def chunk_gated_delta_rule_fwd_intra(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     r"""
     GDN intra-chunk forward: fused kkt + solve_tril + recompute_w_u.
@@ -393,7 +378,6 @@ def chunk_gated_delta_rule_fwd_intra(
         K=K,
         BT=BT,
         BC=BC,
-        USE_EXP2=use_exp2,
     )
 
     # Step 2: recompute_w_u
@@ -405,6 +389,5 @@ def chunk_gated_delta_rule_fwd_intra(
         g=g,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
     return w, u, A

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp
 from fla.ops.utils.softplus import softplus
 from fla.utils import input_guard
 
@@ -54,7 +54,6 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     IS_BETA_HEADWISE: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_GATE_IN_KERNEL: tl.constexpr,
@@ -126,37 +125,21 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
                 if HAS_DT_BIAS:
                     b_g = b_g + tl.load(dt_bias + i_hv).to(tl.float32)
                 b_g = -exp(b_A) * softplus(b_g)
-                b_h *= exp(b_g)
-            elif USE_EXP2:
-                b_h *= exp2(b_g)
-            else:
-                b_h *= exp(b_g)
+            b_h *= exp(b_g)
 
         if USE_GK:
             b_gk = tl.load(p_gk).to(tl.float32)
-            if USE_EXP2:
-                if TRANSPOSE_STATE:
-                    b_h *= exp2(b_gk[None, :])
-                else:
-                    b_h *= exp2(b_gk[:, None])
+            if TRANSPOSE_STATE:
+                b_h *= exp(b_gk[None, :])
             else:
-                if TRANSPOSE_STATE:
-                    b_h *= exp(b_gk[None, :])
-                else:
-                    b_h *= exp(b_gk[:, None])
+                b_h *= exp(b_gk[:, None])
 
         if USE_GV:
             b_gv = tl.load(p_gv).to(tl.float32)
-            if USE_EXP2:
-                if TRANSPOSE_STATE:
-                    b_h *= exp2(b_gv[:, None])
-                else:
-                    b_h *= exp2(b_gv[None, :])
+            if TRANSPOSE_STATE:
+                b_h *= exp(b_gv[:, None])
             else:
-                if TRANSPOSE_STATE:
-                    b_h *= exp(b_gv[:, None])
-                else:
-                    b_h *= exp(b_gv[None, :])
+                b_h *= exp(b_gv[None, :])
 
         if TRANSPOSE_STATE:
             b_v = b_beta * (b_v - tl.sum(b_h * b_k[None, :], 1))
@@ -203,7 +186,6 @@ def fused_recurrent_gated_delta_rule_fwd(
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
@@ -247,7 +229,6 @@ def fused_recurrent_gated_delta_rule_fwd(
         BV=BV,
         IS_BETA_HEADWISE=beta.ndim != v.ndim,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
-        USE_EXP2=use_exp2,
         TRANSPOSE_STATE=transpose_state_layout,
         num_warps=1,
         num_stages=3,
@@ -275,7 +256,6 @@ class FusedRecurrentFunction(torch.autograd.Function):
         output_final_state: bool = False,
         use_qk_l2norm_in_kernel: bool = False,
         cu_seqlens: torch.LongTensor | None = None,
-        use_exp2: bool = False,
         transpose_state_layout: bool = False,
     ):
         o, final_state = fused_recurrent_gated_delta_rule_fwd(
@@ -293,7 +273,6 @@ class FusedRecurrentFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
             cu_seqlens=cu_seqlens,
-            use_exp2=use_exp2,
             transpose_state_layout=transpose_state_layout,
         )
 
@@ -325,7 +304,6 @@ def fused_recurrent_gated_delta_rule(
     A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""
@@ -429,8 +407,6 @@ def fused_recurrent_gated_delta_rule(
             raise ValueError("`A_log` must be provided when `use_gate_in_kernel=True`.")
         if g is None:
             raise ValueError("`g` (raw pre-activation) must be provided when `use_gate_in_kernel=True`.")
-        if use_exp2:
-            raise ValueError("`use_exp2=True` is not supported together with `use_gate_in_kernel=True`.")
     else:
         A_log = None
         dt_bias = None
@@ -450,7 +426,6 @@ def fused_recurrent_gated_delta_rule(
         output_final_state,
         use_qk_l2norm_in_kernel,
         cu_seqlens,
-        use_exp2,
         transpose_state_layout,
     )
     return o, final_state

--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -11,7 +11,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
 
 if IS_NVIDIA_BLACKWELL:
@@ -74,7 +74,6 @@ def recompute_w_u_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
@@ -101,10 +100,7 @@ def recompute_w_u_fwd_kernel(
 
     if USE_G:
         p_g = tl.make_block_ptr(g + (bos*HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        if USE_EXP2:
-            b_g = exp2(tl.load(p_g, boundary_check=(0,)))
-        else:
-            b_g = exp(tl.load(p_g, boundary_check=(0,)))
+        b_g = exp2(tl.load(p_g, boundary_check=(0,)))
 
     for i_k in range(tl.cdiv(K, BK)):
         p_k = tl.make_block_ptr(k + (bos*H + i_h // (HV // H)) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
@@ -154,7 +150,6 @@ def prepare_wy_repr_bwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
@@ -178,10 +173,7 @@ def prepare_wy_repr_bwd_kernel(
     if USE_G:
         p_g = tl.make_block_ptr(g + (bos*HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
-        if USE_EXP2:
-            b_g_exp = exp2(b_g)
-        else:
-            b_g_exp = tl.exp(b_g)
+        b_g_exp = exp2(b_g)
         b_dg = tl.zeros([BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
@@ -225,10 +217,7 @@ def prepare_wy_repr_bwd_kernel(
     b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
 
     if USE_G:
-        if USE_EXP2:
-            b_dA *= exp2(b_g[:, None] - b_g[None, :])
-        else:
-            b_dA *= exp(b_g[:, None] - b_g[None, :])
+        b_dA *= exp2(b_g[:, None] - b_g[None, :])
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     b_dA = tl.where(m_A, -b_dA, 0).to(k.dtype.element_ty)
@@ -266,7 +255,6 @@ def recompute_w_u_fwd(
     g: torch.Tensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V, HV = *k.shape, v.shape[-1], v.shape[2]
     BT = A.shape[-1]
@@ -297,7 +285,6 @@ def recompute_w_u_fwd(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     return w, u
 
@@ -312,7 +299,6 @@ def prepare_wy_repr_bwd(
     g: torch.Tensor = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V, HV = *k.shape, v.shape[-1], v.shape[2]
     BT = 64
@@ -349,7 +335,6 @@ def prepare_wy_repr_bwd(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     if H != HV:
         dk = dk.view(B, T, H, HV // H, K).sum(3)

--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -12,33 +12,7 @@ import triton.language as tl
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
-
-if IS_NVIDIA_BLACKWELL:
-    """
-    Compute tl.dot with SM100 workaround.
-
-    On SM100 (Blackwell) GPUs, wraps the result in inline assembly to prevent
-    the TritonGPUHoistTMEMAlloc pass from incorrectly fusing add and dot operations.
-    See: https://github.com/fla-org/flash-linear-attention/issues/638
-
-    TODO: Remove this workaround once the Triton compiler bug is fixed.
-    Track upstream issue at: https://github.com/triton-lang/triton/issues/8695
-    """
-    @triton.jit
-    def safe_dot(a, b):
-        return tl.inline_asm_elementwise(
-            asm="mov.f32 $0, $1;",
-            constraints="=r,r",
-            args=[tl.dot(a, b)],
-            dtype=tl.float32,
-            is_pure=True,
-            pack=1,
-        )
-else:
-    @triton.jit
-    def safe_dot(a, b):
-        return tl.dot(a, b)
+from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 
 @triton.heuristics({

--- a/fla/ops/generalized_delta_rule/dplr/chunk.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk.py
@@ -26,6 +26,7 @@ from fla.ops.generalized_delta_rule.dplr.wy_fast_bwd import chunk_dplr_bwd_wy
 from fla.ops.generalized_delta_rule.dplr.wy_fast_fwd import prepare_wy_repr_fwd
 from fla.ops.rwkv6.chunk import chunk_rwkv6_fwd_cumsum
 from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.constant import RCP_LN2
 from fla.utils import TRITON_ABOVE_3_4_0, autocast_custom_bwd, autocast_custom_fwd, input_guard
 
 
@@ -46,7 +47,13 @@ def chunk_dplr_fwd(
     disable_recompute: bool = False,
     cp_context: FLACPContext | None = None,
 ):
-    gi, ge = chunk_rwkv6_fwd_cumsum(gk, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    gi, ge = chunk_rwkv6_fwd_cumsum(
+        gk,
+        chunk_size,
+        scale=RCP_LN2,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
 
     A_ab, A_qk, A_ak, A_qb, qg, kg, ag, bg = chunk_dplr_fwd_intra(
         q=q,
@@ -162,8 +169,9 @@ class ChunkDPLRDeltaRuleFunction(torch.autograd.Function):
                 stacklevel=2,
             )
             chunk_size = 16
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        chunk_indices = None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu)
 
         # chunk_dplr_fwd returns the possibly CP-merged + compressed initial_state;
         # for CP this is the [1, HV, K, V] state we must save for backward so the
@@ -188,8 +196,28 @@ class ChunkDPLRDeltaRuleFunction(torch.autograd.Function):
 
         if disable_recompute:
             gi, ge, A_qk, A_qb, A_ak, qg, kg, ag, bg, w, h, v_new, A_ab_inv = cache
-            ctx.save_for_backward(q, k, v, a, b, gk, initial_state, gi, ge, A_qk,
-                                  A_qb, A_ak, qg, kg, ag, bg, w, h, v_new, A_ab_inv)
+            ctx.save_for_backward(
+                q,
+                k,
+                v,
+                a,
+                b,
+                gk,
+                initial_state,
+                gi,
+                ge,
+                A_qk,
+                A_qb,
+                A_ak,
+                qg,
+                kg,
+                ag,
+                bg,
+                w,
+                h,
+                v_new,
+                A_ab_inv,
+            )
         else:
             ctx.save_for_backward(q, k, v, a, b, gk, initial_state)
         ctx.cu_seqlens = cu_seqlens
@@ -211,8 +239,26 @@ class ChunkDPLRDeltaRuleFunction(torch.autograd.Function):
     ):
         if ctx.disable_recompute:
             (
-                q, k, v, a, b, gk, initial_state,
-                gi, ge, A_qk, A_qb, A_ak, qg, kg, ag, bg, w, h, v_new, A_ab_inv,
+                q,
+                k,
+                v,
+                a,
+                b,
+                gk,
+                initial_state,
+                gi,
+                ge,
+                A_qk,
+                A_qb,
+                A_ak,
+                qg,
+                kg,
+                ag,
+                bg,
+                w,
+                h,
+                v_new,
+                A_ab_inv,
             ) = ctx.saved_tensors
         else:
             q, k, v, a, b, gk, initial_state = ctx.saved_tensors
@@ -230,7 +276,13 @@ class ChunkDPLRDeltaRuleFunction(torch.autograd.Function):
 
         if not ctx.disable_recompute:
             # ******* start recomputing everything, otherwise i believe the gpu memory will be exhausted *******
-            gi, ge = chunk_rwkv6_fwd_cumsum(gk, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=ctx.chunk_indices)
+            gi, ge = chunk_rwkv6_fwd_cumsum(
+                gk,
+                chunk_size,
+                scale=RCP_LN2,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=ctx.chunk_indices,
+            )
 
             A_ab, A_qk, A_ak, A_qb, qg, kg, ag, bg = chunk_dplr_fwd_intra(
                 q=q,

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp, gather
+from fla.ops.utils.op import exp2, gather
 from fla.utils import IS_AMD, IS_GATHER_SUPPORTED, USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]
@@ -176,8 +176,8 @@ def chunk_dplr_bwd_kernel_intra(
 
         m_e = o_i[:, None] > j
         m_i = o_i[:, None] >= j
-        tmp1 = exp(b_gi - b_gij)
-        tmp2 = exp(b_ge - b_gij)
+        tmp1 = exp2(b_gi - b_gij)
+        tmp2 = exp2(b_ge - b_gij)
         b_dq += tl.where(m_i, b_dAqk_j * b_kj * tmp1, 0.)
         b_dq += tl.where(m_i, b_dAqb_j * b_bj * tmp1, 0.)
         b_da += tl.where(m_e, b_dAab_j * b_bj * tmp2, 0.)
@@ -185,8 +185,8 @@ def chunk_dplr_bwd_kernel_intra(
 
         m_i = o_i[:, None] <= j
         m_e = o_i[:, None] < j
-        tmp1 = exp(b_gij - b_gi)
-        tmp2 = exp(b_gej - b_gi)
+        tmp1 = exp2(b_gij - b_gi)
+        tmp2 = exp2(b_gej - b_gi)
         b_dk += tl.where(m_i, b_dA_qk_j * b_qj * tmp1, 0.)
         b_dk += tl.where(m_e, b_dA_ak_j * b_aj * tmp2, 0.)
         b_db += tl.where(m_i, b_dA_qb_j * b_qj * tmp1, 0.)
@@ -206,9 +206,9 @@ def chunk_dplr_bwd_kernel_intra(
     p_gn = gi + (min(i_t * BT + BT, T) - 1)*stride_qk + o_k
     p_gn = tl.max_contiguous(tl.multiple_of(p_gn, BK), BK)
     b_gn = tl.load(p_gn, mask=m_k, other=0)
-    b_da += tl.load(p_dag, boundary_check=(0, 1)) * exp(b_ge)
-    b_dq += tl.load(p_dqg, boundary_check=(0, 1)) * exp(b_gi) * scale
-    tmp = exp(b_gn[None, :] - b_gi)
+    b_da += tl.load(p_dag, boundary_check=(0, 1)) * exp2(b_ge)
+    b_dq += tl.load(p_dqg, boundary_check=(0, 1)) * exp2(b_gi) * scale
+    tmp = exp2(b_gn[None, :] - b_gi)
     b_dk += tl.load(p_dkg, boundary_check=(0, 1)).to(tl.float32) * tmp
     b_db += tl.load(p_dbg, boundary_check=(0, 1)).to(tl.float32) * tmp
     tl.store(p_dq, (b_dq).to(p_dq.dtype.element_ty), boundary_check=(0, 1))
@@ -308,9 +308,9 @@ def chunk_dplr_bwd_kernel_intra_tensorcore(
 
     b_gi_shifted = b_gi_val - b_offset[None, :]
     b_ge_shifted = b_ge_val - b_offset[None, :]
-    exp_gi_shifted = tl.exp(b_gi_shifted)
-    inv_exp_gi_shifted = tl.exp(-b_gi_shifted)
-    exp_ge_shifted = tl.exp(b_ge_shifted)
+    exp_gi_shifted = exp2(b_gi_shifted)
+    inv_exp_gi_shifted = exp2(-b_gi_shifted)
+    exp_ge_shifted = exp2(b_ge_shifted)
 
     q_ops = (b_q * exp_gi_shifted).to(tl.float32)
     k_ops = (b_k * inv_exp_gi_shifted).to(tl.float32)
@@ -366,9 +366,9 @@ def chunk_dplr_bwd_kernel_intra_tensorcore(
     p_g_last = gi + offset_base_k + last_idx * H * K + tl.arange(0, BK) + i_k * BK
     b_g_last = tl.load(p_g_last, mask=m_k, other=0.0)
 
-    b_dq = b_dq_intra * exp_gi_shifted + b_dqg * tl.exp(b_gi_val) * scale
-    b_da = b_da_intra * exp_ge_shifted + b_dag * tl.exp(b_ge_val)
-    term_inter_stabilized = tl.exp(b_g_last[None, :] - b_gi_val)
+    b_dq = b_dq_intra * exp_gi_shifted + b_dqg * exp2(b_gi_val) * scale
+    b_da = b_da_intra * exp_ge_shifted + b_dag * exp2(b_ge_val)
+    term_inter_stabilized = exp2(b_g_last[None, :] - b_gi_val)
     b_dk = b_dk_intra * inv_exp_gi_shifted + b_dkg * term_inter_stabilized
     b_db = b_db_intra * inv_exp_gi_shifted + b_dbg * term_inter_stabilized
 

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp, gather
+from fla.ops.utils.op import exp2, gather
 from fla.utils import IS_AMD, IS_GATHER_SUPPORTED, USE_CUDA_GRAPH, autotune_cache_kwargs
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]
@@ -97,12 +97,12 @@ def chunk_dplr_fwd_A_kernel_intra_sub_intra(
     b_ge = tl.load(p_ge, boundary_check=(0, 1)).to(tl.float32)
 
     # deal with decay term.
-    g_exp = exp(b_gi)
-    g_exp_inv = exp(-b_gi + b_g_last[None, :])
+    g_exp = exp2(b_gi)
+    g_exp_inv = exp2(-b_gi + b_g_last[None, :])
     b_qg = b_q * g_exp
     b_kg = b_k * g_exp_inv
     b_bg = b_b * g_exp_inv
-    b_ag = b_a * exp(b_ge)
+    b_ag = b_a * exp2(b_ge)
     tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
     tl.store(p_bg, b_bg.to(p_bg.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
     tl.store(p_ag, b_ag.to(p_ag.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
@@ -124,13 +124,13 @@ def chunk_dplr_fwd_A_kernel_intra_sub_intra(
             b_k_j = tl.sum(tl.where(mask[:, None], b_k, 0), 0)[None, :]
             b_gk_j = tl.sum(tl.where(mask[:, None], b_gi, 0), 0)[None, :]
             b_b_j = tl.sum(tl.where(mask[:, None], b_b, 0), 0)[None, :]
-        tmp = exp(b_gi - b_gk_j)
+        tmp = exp2(b_gi - b_gk_j)
         b_A_qk = tl.sum(b_q * b_k_j * tmp, 1)
         m_i = (o_i >= j).to(tl.float32)
         b_A_qk = b_A_qk * m_i
         b_A_qb = tl.sum(b_q * b_b_j * tmp, 1)
         b_A_qb = b_A_qb * m_i
-        tmp2 = exp(b_ge - b_gk_j)
+        tmp2 = exp2(b_ge - b_gk_j)
         b_A_ak = tl.sum(b_a * b_k_j * tmp2, 1)
         m_i2 = (o_i > j).to(tl.float32)
         b_A_ak = b_A_ak * m_i2
@@ -231,11 +231,11 @@ def chunk_dplr_fwd_A_kernel_intra_tensorcore(
     b_ge_val = b_ge_val - b_offset[None, :]
 
     # Apply decay factors (now numerically safe)
-    # q_term ~ exp(gi - offset)
-    # k_term ~ exp(-gi + offset)
-    exp_gi = tl.exp(b_gi_val)
-    inv_exp_gi = tl.exp(-b_gi_val)
-    exp_ge = tl.exp(b_ge_val)
+    # q_term ~ exp2(gi - offset)
+    # k_term ~ exp2(-gi + offset)
+    exp_gi = exp2(b_gi_val)
+    inv_exp_gi = exp2(-b_gi_val)
+    exp_ge = exp2(b_ge_val)
 
     b_q = (b_q * scale).to(tl.float32)
 
@@ -251,9 +251,9 @@ def chunk_dplr_fwd_A_kernel_intra_tensorcore(
     p_g_last = gi + offset_base + last_idx * H * K + tl.arange(0, BK)
     b_g_last = tl.load(p_g_last, mask=m_k, other=0.0)
 
-    exp_offset = tl.exp(b_offset)
+    exp_offset = exp2(b_offset)
     b_g_centered = b_g_last - b_offset
-    exp_g_centered = tl.exp(b_g_centered)
+    exp_g_centered = exp2(b_g_centered)
 
     # Create pointers for writing
     p_qg = tl.make_block_ptr(qg + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import IS_AMD, USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]
@@ -27,7 +27,7 @@ NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]
         for num_warps in NUM_WARPS_AUTOTUNE
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'BK', 'BV', "V"],
+    key=['BT', 'BK', 'BV', 'V'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -102,7 +102,7 @@ def chunk_dplr_bwd_kernel_dhu(
             b_dh_tmp += tl.dot(b_w, b_dv2.to(b_qg.dtype))
         last_idx = min((i_t + 1) * BT, T) - 1
         bg_last = tl.load(gk + ((bos + last_idx) * H + i_h) * K + tl.arange(0, BK), mask=mask_k)
-        b_dh *= exp(bg_last)[:, None]
+        b_dh *= exp2(bg_last)[:, None]
         b_dh += b_dh_tmp
 
     if USE_INITIAL_STATE:

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import IS_AMD, USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]
@@ -101,7 +101,7 @@ def chunk_dplr_fwd_kernel_h(
 
         last_idx = min((i_t + 1) * BT, T) - 1
         b_g_last = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k, mask=o_k < K).to(tl.float32)
-        b_h *= exp(b_g_last[:, None])
+        b_h *= exp2(b_g_last[:, None])
         b_h += b_hc
 
     if STORE_FINAL_STATE:

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import IS_AMD, USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]
@@ -200,7 +200,7 @@ def chunk_dplr_bwd_o_kernel(
     m_k = (i_k*BK+tl.arange(0, BK)) < K
     last_idx = min(i_t * BT + BT, T) - 1
     b_gk_last = tl.load(gk + last_idx * stride_qk + i_k*BK + tl.arange(0, BK), mask=m_k, other=float('-inf'))
-    b_dgk_last *= exp(b_gk_last)
+    b_dgk_last *= exp2(b_gk_last)
     p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
     p_b = tl.make_block_ptr(b, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
     b_k = tl.load(p_k, boundary_check=(0, 1))

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -12,6 +12,7 @@ import triton.language as tl
 from fla.ops.common.chunk_h import chunk_bwd_dh, chunk_fwd_h
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
+from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.cumsum import chunk_local_cumsum
 from fla.ops.utils.op import exp, exp2
 from fla.utils import autotune_cache_kwargs, check_shared_mem, input_guard
@@ -49,6 +50,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
     BC: tl.constexpr,
     BK: tl.constexpr,
     NC: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -82,11 +84,17 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         # [BC, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_qg = b_q * exp(b_g - b_gn[None, :]) * scale
+        if USE_EXP2:
+            b_qg = b_q * exp2(b_g - b_gn[None, :]) * scale
+        else:
+            b_qg = b_q * exp(b_g - b_gn[None, :]) * scale
         # [BK, BC]
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        b_kg = b_k * exp(b_gn[:, None] - b_gk)
+        if USE_EXP2:
+            b_kg = b_k * exp2(b_gn[:, None] - b_gk)
+        else:
+            b_kg = b_k * exp(b_gn[:, None] - b_gk)
 
         # [BC, BC] using tf32 to improve precision here.
         b_A += tl.dot(b_qg, b_kg)
@@ -122,6 +130,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     BT: tl.constexpr,
     BC: tl.constexpr,
     BK: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -159,7 +168,10 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
         b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
+        if USE_EXP2:
+            b_A = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
+        else:
+            b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
 
         tl.store(A + o_A + j, b_A, mask=m_A)
         p_k += H*K
@@ -198,6 +210,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     BC: tl.constexpr,
     BK: tl.constexpr,
     NC: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_k, i_tc, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -237,7 +250,10 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
         b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
+        if USE_EXP2:
+            b_A = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
+        else:
+            b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
         tl.store(A + o_A + j, b_A, mask=m_A)
         p_k += H*K
         p_gk += H*K
@@ -422,6 +438,7 @@ def chunk_gla_bwd_kernel_intra(
     BC: tl.constexpr,
     BK: tl.constexpr,
     NC: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -455,12 +472,18 @@ def chunk_gla_bwd_kernel_intra(
             # [BC, BK]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_kg = b_k * exp(b_gn[None, :] - b_gk)
+            if USE_EXP2:
+                b_kg = b_k * exp2(b_gn[None, :] - b_gk)
+            else:
+                b_kg = b_k * exp(b_gn[None, :] - b_gk)
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
 
             b_dq += tl.dot(b_dA, b_kg)
-        b_dq *= exp(b_g - b_gn[None, :])
+        if USE_EXP2:
+            b_dq *= exp2(b_g - b_gn[None, :])
+        else:
+            b_dq *= exp(b_g - b_gn[None, :])
 
     o_i = tl.arange(0, BC)
     m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
@@ -479,7 +502,10 @@ def chunk_gla_bwd_kernel_intra(
         m_i = o_i[:, None] >= j
         # [BC, BK]
         # (SY 09/17) important to not use bf16 here to have a good precision.
-        b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp(b_g - b_gkj[None, :]), 0.)
+        if USE_EXP2:
+            b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.)
+        else:
+            b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp(b_g - b_gkj[None, :]), 0.)
         p_kj += H*K
         p_gkj += H*K
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
@@ -504,13 +530,19 @@ def chunk_gla_bwd_kernel_intra(
             # [BC, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_gq = tl.load(p_gq, boundary_check=(0, 1))
-            b_qg = b_q * tl.where(m_j[:, None], exp(b_gq - b_gn[None, :]), 0)
+            if USE_EXP2:
+                b_qg = b_q * tl.where(m_j[:, None], exp2(b_gq - b_gn[None, :]), 0)
+            else:
+                b_qg = b_q * tl.where(m_j[:, None], exp(b_gq - b_gn[None, :]), 0)
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
             # [BC, BK]
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dk += tl.dot(b_dA, b_qg)
-        b_dk *= exp(b_gn[None, :] - b_g)
+        if USE_EXP2:
+            b_dk *= exp2(b_gn[None, :] - b_g)
+        else:
+            b_dk *= exp(b_gn[None, :] - b_g)
     o_dA = bos*H*BT + (i_t * BT + i_i * BC) * H*BT + i_h * BT + i_i * BC + tl.arange(0, BC)
     p_qj = q + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gqj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
@@ -523,7 +555,10 @@ def chunk_gla_bwd_kernel_intra(
         b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
         # [BC, BK]
         m_i = o_i[:, None] <= j
-        b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_g), 0.)
+        if USE_EXP2:
+            b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.)
+        else:
+            b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_g), 0.)
         p_qj += H*K
         p_gqj += H*K
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
@@ -611,6 +646,7 @@ def chunk_gla_bwd_kernel_dv(
     BT: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -649,7 +685,10 @@ def chunk_gla_bwd_kernel_dv(
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
         b_dh = tl.load(p_dh, boundary_check=(0, 1))
 
-        b_gn = exp(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
+        if USE_EXP2:
+            b_gn = exp2(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
+        else:
+            b_gn = exp(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
         b_k = (b_k * b_gn).to(b_k.dtype)
         # [BT, BV]
         # (SY 09/17) it is ok to have bf16 interchunk gradient contribution here
@@ -696,6 +735,7 @@ def chunk_gla_bwd_kernel_inter(
     BT: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -752,10 +792,16 @@ def chunk_gla_bwd_kernel_inter(
         b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
         b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
 
-    b_dgk *= exp(b_gn)
-    b_dq *= scale
-    b_dq = b_dq * exp(b_gk)
-    b_dk = b_dk * exp(b_gn[None, :] - b_gk)
+    if USE_EXP2:
+        b_dgk *= exp2(b_gn)
+        b_dq *= scale
+        b_dq = b_dq * exp2(b_gk)
+        b_dk = b_dk * exp2(b_gn[None, :] - b_gk)
+    else:
+        b_dgk *= exp(b_gn)
+        b_dq *= scale
+        b_dq = b_dq * exp(b_gk)
+        b_dk = b_dk * exp(b_gn[None, :] - b_gk)
 
     p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
     p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
@@ -788,6 +834,7 @@ def chunk_gla_fwd_intra_gk(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ):
     B, T, H, K = k.shape
     BT = chunk_size
@@ -814,6 +861,7 @@ def chunk_gla_fwd_intra_gk(
         BT=BT,
         BC=BC,
         NC=NC,
+        USE_EXP2=use_exp2,
     )
 
     grid = (NT, NC, B * H)
@@ -834,6 +882,7 @@ def chunk_gla_fwd_intra_gk(
             BT=BT,
             BC=BC,
             BK=BK,
+            USE_EXP2=use_exp2,
         )
     # split then merge
     else:
@@ -858,6 +907,7 @@ def chunk_gla_fwd_intra_gk(
             BC=BC,
             BK=BK,
             NC=NC,
+            USE_EXP2=use_exp2,
         )
 
         grid = (NT, NC, B * H)
@@ -964,6 +1014,7 @@ def chunk_gla_bwd_dv(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, do.shape[-1]
     BT = chunk_size
@@ -988,6 +1039,7 @@ def chunk_gla_bwd_dv(
         K=K,
         V=V,
         BT=BT,
+        USE_EXP2=use_exp2,
     )
     return dv
 
@@ -1000,6 +1052,7 @@ def chunk_gla_bwd_dqk_intra(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ):
     B, T, H, K = q.shape
     BT = chunk_size
@@ -1031,6 +1084,7 @@ def chunk_gla_bwd_dqk_intra(
         BC=BC,
         BK=BK,
         NC=NC,
+        USE_EXP2=use_exp2,
     )
     return dq, dk
 
@@ -1049,6 +1103,7 @@ def chunk_gla_bwd_dqkg(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = chunk_size
@@ -1082,6 +1137,7 @@ def chunk_gla_bwd_dqkg(
         K=K,
         V=V,
         BT=BT,
+        USE_EXP2=use_exp2,
     )
     return dq2, dk2, dg
 
@@ -1098,9 +1154,15 @@ def chunk_gla_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if g_cumsum is None:
-        g_cumsum = chunk_local_cumsum(g, chunk_size, cu_seqlens=cu_seqlens)
+        g_cumsum = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2 if use_exp2 else None,
+            cu_seqlens=cu_seqlens,
+        )
 
     h, ht = chunk_fwd_h(
         k=k,
@@ -1110,9 +1172,10 @@ def chunk_gla_fwd(
         gv=None,
         h0=initial_state,
         output_final_state=output_final_state,
-        states_in_fp32=False,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=use_exp2,
+        states_in_fp32=False,
     )
 
     # the intra A is kept in fp32
@@ -1125,6 +1188,7 @@ def chunk_gla_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
     o = chunk_gla_fwd_o_gk(
         q=q,
@@ -1136,6 +1200,7 @@ def chunk_gla_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
     return g_cumsum, A, h, ht, o
 
@@ -1155,9 +1220,15 @@ def chunk_gla_bwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ):
     if g_cumsum is None:
-        g_cumsum = chunk_local_cumsum(g, chunk_size, cu_seqlens=cu_seqlens)
+        g_cumsum = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2 if use_exp2 else None,
+            cu_seqlens=cu_seqlens,
+        )
 
     if h is None:
         h, _ = chunk_fwd_h(
@@ -1170,6 +1241,7 @@ def chunk_gla_bwd(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
+            use_exp2=use_exp2,
             states_in_fp32=True,
         )
     dh, dh0 = chunk_bwd_dh(
@@ -1185,6 +1257,7 @@ def chunk_gla_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=use_exp2,
         states_in_fp32=True,
     )
 
@@ -1197,6 +1270,7 @@ def chunk_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
 
     # dq dk in fp32
@@ -1216,6 +1290,7 @@ def chunk_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
     dq, dk, dg = chunk_gla_bwd_dqkg(
         q=q,
@@ -1231,6 +1306,7 @@ def chunk_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
     return dq, dk, dv, dg, dh0
 
@@ -1267,6 +1343,7 @@ class ChunkGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
+            use_exp2=True,
         )
         # recompute g_cumsum in bwd pass
         if g.dtype != torch.float:
@@ -1299,6 +1376,7 @@ class ChunkGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
+            use_exp2=True,
         )
         return dq.to(q), dk.to(k), dv.to(v), dg, None, dh0, None, None, None
 

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -14,7 +14,7 @@ from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.cumsum import chunk_local_cumsum
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs, check_shared_mem, input_guard
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
@@ -50,7 +50,6 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
     BC: tl.constexpr,
     BK: tl.constexpr,
     NC: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -84,18 +83,11 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         # [BC, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_g = tl.load(p_g, boundary_check=(0, 1))
-        if USE_EXP2:
-            b_qg = b_q * exp2(b_g - b_gn[None, :]) * scale
-        else:
-            b_qg = b_q * exp(b_g - b_gn[None, :]) * scale
+        b_qg = b_q * exp2(b_g - b_gn[None, :]) * scale
         # [BK, BC]
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        if USE_EXP2:
-            b_kg = b_k * exp2(b_gn[:, None] - b_gk)
-        else:
-            b_kg = b_k * exp(b_gn[:, None] - b_gk)
-
+        b_kg = b_k * exp2(b_gn[:, None] - b_gk)
         # [BC, BC] using tf32 to improve precision here.
         b_A += tl.dot(b_qg, b_kg)
 
@@ -130,7 +122,6 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     BT: tl.constexpr,
     BC: tl.constexpr,
     BK: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -168,11 +159,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
         b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        if USE_EXP2:
-            b_A = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
-        else:
-            b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
-
+        b_A = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
         tl.store(A + o_A + j, b_A, mask=m_A)
         p_k += H*K
         p_gk += H*K
@@ -210,7 +197,6 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     BC: tl.constexpr,
     BK: tl.constexpr,
     NC: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_k, i_tc, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -250,10 +236,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
         b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        if USE_EXP2:
-            b_A = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
-        else:
-            b_A = tl.sum(b_q * b_k[None, :] * exp(b_g - b_gk[None, :]), 1) * scale
+        b_A = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
         tl.store(A + o_A + j, b_A, mask=m_A)
         p_k += H*K
         p_gk += H*K
@@ -345,7 +328,6 @@ def chunk_gla_fwd_kernel_o(
     BT: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -386,10 +368,7 @@ def chunk_gla_fwd_kernel_o(
         # [BT, BK]
         b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
         # [BT, BK]
-        if USE_EXP2:
-            b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
-        else:
-            b_qg = (b_q * exp(b_g)).to(b_q.dtype)
+        b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
         b_h = tl.load(p_h, boundary_check=(0, 1))
         if i_k >= 0:
             if TRANSPOSE_STATE:
@@ -438,7 +417,6 @@ def chunk_gla_bwd_kernel_intra(
     BC: tl.constexpr,
     BK: tl.constexpr,
     NC: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -472,19 +450,12 @@ def chunk_gla_bwd_kernel_intra(
             # [BC, BK]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            if USE_EXP2:
-                b_kg = b_k * exp2(b_gn[None, :] - b_gk)
-            else:
-                b_kg = b_k * exp(b_gn[None, :] - b_gk)
+            b_kg = b_k * exp2(b_gn[None, :] - b_gk)
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
 
             b_dq += tl.dot(b_dA, b_kg)
-        if USE_EXP2:
-            b_dq *= exp2(b_g - b_gn[None, :])
-        else:
-            b_dq *= exp(b_g - b_gn[None, :])
-
+        b_dq *= exp2(b_g - b_gn[None, :])
     o_i = tl.arange(0, BC)
     m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
     o_dA = bos*H*BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_h * BT + i_i * BC
@@ -502,10 +473,7 @@ def chunk_gla_bwd_kernel_intra(
         m_i = o_i[:, None] >= j
         # [BC, BK]
         # (SY 09/17) important to not use bf16 here to have a good precision.
-        if USE_EXP2:
-            b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.)
-        else:
-            b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp(b_g - b_gkj[None, :]), 0.)
+        b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.)
         p_kj += H*K
         p_gkj += H*K
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
@@ -530,19 +498,13 @@ def chunk_gla_bwd_kernel_intra(
             # [BC, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_gq = tl.load(p_gq, boundary_check=(0, 1))
-            if USE_EXP2:
-                b_qg = b_q * tl.where(m_j[:, None], exp2(b_gq - b_gn[None, :]), 0)
-            else:
-                b_qg = b_q * tl.where(m_j[:, None], exp(b_gq - b_gn[None, :]), 0)
+            b_qg = b_q * tl.where(m_j[:, None], exp2(b_gq - b_gn[None, :]), 0)
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
             # [BC, BK]
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dk += tl.dot(b_dA, b_qg)
-        if USE_EXP2:
-            b_dk *= exp2(b_gn[None, :] - b_g)
-        else:
-            b_dk *= exp(b_gn[None, :] - b_g)
+        b_dk *= exp2(b_gn[None, :] - b_g)
     o_dA = bos*H*BT + (i_t * BT + i_i * BC) * H*BT + i_h * BT + i_i * BC + tl.arange(0, BC)
     p_qj = q + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gqj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
@@ -555,10 +517,7 @@ def chunk_gla_bwd_kernel_intra(
         b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
         # [BC, BK]
         m_i = o_i[:, None] <= j
-        if USE_EXP2:
-            b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.)
-        else:
-            b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_g), 0.)
+        b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.)
         p_qj += H*K
         p_gqj += H*K
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
@@ -646,7 +605,6 @@ def chunk_gla_bwd_kernel_dv(
     BT: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -685,10 +643,7 @@ def chunk_gla_bwd_kernel_dv(
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
         b_dh = tl.load(p_dh, boundary_check=(0, 1))
 
-        if USE_EXP2:
-            b_gn = exp2(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
-        else:
-            b_gn = exp(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
+        b_gn = exp2(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
         b_k = (b_k * b_gn).to(b_k.dtype)
         # [BT, BV]
         # (SY 09/17) it is ok to have bf16 interchunk gradient contribution here
@@ -735,7 +690,6 @@ def chunk_gla_bwd_kernel_inter(
     BT: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -792,17 +746,10 @@ def chunk_gla_bwd_kernel_inter(
         b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
         b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
 
-    if USE_EXP2:
-        b_dgk *= exp2(b_gn)
-        b_dq *= scale
-        b_dq = b_dq * exp2(b_gk)
-        b_dk = b_dk * exp2(b_gn[None, :] - b_gk)
-    else:
-        b_dgk *= exp(b_gn)
-        b_dq *= scale
-        b_dq = b_dq * exp(b_gk)
-        b_dk = b_dk * exp(b_gn[None, :] - b_gk)
-
+    b_dgk *= exp2(b_gn)
+    b_dq *= scale
+    b_dq = b_dq * exp2(b_gk)
+    b_dk = b_dk * exp2(b_gn[None, :] - b_gk)
     p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
     p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
     p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
@@ -834,7 +781,6 @@ def chunk_gla_fwd_intra_gk(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ):
     B, T, H, K = k.shape
     BT = chunk_size
@@ -861,7 +807,6 @@ def chunk_gla_fwd_intra_gk(
         BT=BT,
         BC=BC,
         NC=NC,
-        USE_EXP2=use_exp2,
     )
 
     grid = (NT, NC, B * H)
@@ -882,7 +827,6 @@ def chunk_gla_fwd_intra_gk(
             BT=BT,
             BC=BC,
             BK=BK,
-            USE_EXP2=use_exp2,
         )
     # split then merge
     else:
@@ -907,7 +851,6 @@ def chunk_gla_fwd_intra_gk(
             BC=BC,
             BK=BK,
             NC=NC,
-            USE_EXP2=use_exp2,
         )
 
         grid = (NT, NC, B * H)
@@ -936,7 +879,6 @@ def chunk_gla_fwd_o_gk(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
 ):
     B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
@@ -965,7 +907,6 @@ def chunk_gla_fwd_o_gk(
         K=K,
         V=V,
         BT=BT,
-        USE_EXP2=use_exp2,
         TRANSPOSE_STATE=transpose_state_layout,
     )
     return o
@@ -1014,7 +955,6 @@ def chunk_gla_bwd_dv(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, do.shape[-1]
     BT = chunk_size
@@ -1039,7 +979,6 @@ def chunk_gla_bwd_dv(
         K=K,
         V=V,
         BT=BT,
-        USE_EXP2=use_exp2,
     )
     return dv
 
@@ -1052,7 +991,6 @@ def chunk_gla_bwd_dqk_intra(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ):
     B, T, H, K = q.shape
     BT = chunk_size
@@ -1084,7 +1022,6 @@ def chunk_gla_bwd_dqk_intra(
         BC=BC,
         BK=BK,
         NC=NC,
-        USE_EXP2=use_exp2,
     )
     return dq, dk
 
@@ -1103,7 +1040,6 @@ def chunk_gla_bwd_dqkg(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = chunk_size
@@ -1137,7 +1073,6 @@ def chunk_gla_bwd_dqkg(
         K=K,
         V=V,
         BT=BT,
-        USE_EXP2=use_exp2,
     )
     return dq2, dk2, dg
 
@@ -1154,13 +1089,12 @@ def chunk_gla_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if g_cumsum is None:
         g_cumsum = chunk_local_cumsum(
             g,
             chunk_size,
-            scale=RCP_LN2 if use_exp2 else None,
+            scale=RCP_LN2,
             cu_seqlens=cu_seqlens,
         )
 
@@ -1174,7 +1108,7 @@ def chunk_gla_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=use_exp2,
+        use_exp2=True,
         states_in_fp32=False,
     )
 
@@ -1188,7 +1122,6 @@ def chunk_gla_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
     o = chunk_gla_fwd_o_gk(
         q=q,
@@ -1200,7 +1133,6 @@ def chunk_gla_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
     return g_cumsum, A, h, ht, o
 
@@ -1220,13 +1152,12 @@ def chunk_gla_bwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ):
     if g_cumsum is None:
         g_cumsum = chunk_local_cumsum(
             g,
             chunk_size,
-            scale=RCP_LN2 if use_exp2 else None,
+            scale=RCP_LN2,
             cu_seqlens=cu_seqlens,
         )
 
@@ -1241,7 +1172,7 @@ def chunk_gla_bwd(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
-            use_exp2=use_exp2,
+            use_exp2=True,
             states_in_fp32=True,
         )
     dh, dh0 = chunk_bwd_dh(
@@ -1257,7 +1188,7 @@ def chunk_gla_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=use_exp2,
+        use_exp2=True,
         states_in_fp32=True,
     )
 
@@ -1270,7 +1201,6 @@ def chunk_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
 
     # dq dk in fp32
@@ -1290,7 +1220,6 @@ def chunk_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
     dq, dk, dg = chunk_gla_bwd_dqkg(
         q=q,
@@ -1306,7 +1235,6 @@ def chunk_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
     return dq, dk, dv, dg, dh0
 
@@ -1343,7 +1271,6 @@ class ChunkGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
-            use_exp2=True,
         )
         # recompute g_cumsum in bwd pass
         if g.dtype != torch.float:
@@ -1376,7 +1303,6 @@ class ChunkGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
-            use_exp2=True,
         )
         return dq.to(q), dk.to(k), dv.to(v), dg, None, dh0, None, None, None
 

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -1108,7 +1108,6 @@ def chunk_gla_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
         states_in_fp32=False,
     )
 
@@ -1172,7 +1171,6 @@ def chunk_gla_bwd(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
-            use_exp2=True,
             states_in_fp32=True,
         )
     dh, dh0 = chunk_bwd_dh(

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -31,7 +31,7 @@ BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BC"],
+    key=['BC'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -104,7 +104,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3]
     ],
-    key=["BK", "BT"],
+    key=['BK', 'BT'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -1186,7 +1186,6 @@ def chunk_gla_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
         states_in_fp32=True,
     )
 
@@ -1254,8 +1253,14 @@ class ChunkGLAFunction(torch.autograd.Function):
         cu_seqlens_cpu,
     ):
         chunk_size = min(64, max(16, triton.next_power_of_2(q.shape[1])))
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens,
+                chunk_size,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+            )
+        else:
+            chunk_indices = None
 
         g_cumsum, A, _, ht, o = chunk_gla_fwd(
             q=q,
@@ -1391,5 +1396,15 @@ def chunk_gla(
         assert initial_state.dtype == torch.float32, "initial_state must be in float32."
     assert q.shape == k.shape == g.shape, "q, k, g must have the same shape."
     assert v.shape == (*q.shape[:3], v.shape[-1]), "v must be of shape (batch size, seq len, num of head, head dim)."
-    o, final_state = ChunkGLAFunction.apply(q, k, v, g, scale, initial_state, output_final_state, cu_seqlens, cu_seqlens_cpu)
+    o, final_state = ChunkGLAFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        scale,
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+        cu_seqlens_cpu,
+    )
     return o, final_state

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -13,8 +13,9 @@ from einops import reduce
 from fla.ops.common.chunk_h import chunk_bwd_dh, chunk_fwd_h
 from fla.ops.gla.chunk import chunk_gla_bwd, chunk_gla_fwd
 from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.cumsum import chunk_local_cumsum
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.ops.utils.softmax import softmax_bwd, softmax_fwd
 from fla.utils import autotune_cache_kwargs, input_guard
 
@@ -95,7 +96,7 @@ def chunk_gsa_fwd_k_kernel_inter(
     p_A = tl.make_block_ptr(A + (bos * HQ + i_hq) * BT, (T, BT), (HQ*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
     # [BT, BV]
     b_g = tl.load(p_g, boundary_check=(0, 1))
-    b_o = b_o * exp(b_g)
+    b_o = b_o * exp2(b_g)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
     # [BT, BT]
@@ -157,13 +158,13 @@ def chunk_gsa_fwd_k_kernel_intra(
         # [BC, BV]
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_gv = tl.load(p_gv, boundary_check=(0, 1))
-        b_vg = (b_v * exp(b_gn[None, :] - b_gv)).to(b_v.dtype)
+        b_vg = (b_v * exp2(b_gn[None, :] - b_gv)).to(b_v.dtype)
         # [BC, BC]
         b_A = tl.load(p_A, boundary_check=(0, 1))
         b_o += tl.dot(b_A, b_vg)
     # [BC, BV]
     b_g = tl.load(p_g, boundary_check=(0, 1))
-    b_o *= exp(b_g - b_gn[None, :])
+    b_o *= exp2(b_g - b_gn[None, :])
 
     o_A = (bos + i_t * BT + i_i * BC + tl.arange(0, BC)) * HQ*BT + i_hq * BT + i_i * BC
     m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
@@ -176,7 +177,7 @@ def chunk_gsa_fwd_k_kernel_intra(
         b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
         b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
         # [BC, BV]
-        b_vg = b_v[None, :] * exp(b_g - b_gv[None, :])
+        b_vg = b_v[None, :] * exp2(b_g - b_gv[None, :])
         # avoid 0 * inf = inf
         b_o += tl.where(o_i[:, None] >= j, b_A[:, None] * b_vg, 0.)
     p_o = tl.make_block_ptr(o + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
@@ -250,11 +251,11 @@ def chunk_gsa_bwd_k_kernel_dA(
         # [BC, BV]
         b_g = tl.load(p_g, boundary_check=(0, 1))
         b_do = tl.load(p_do, boundary_check=(0, 1))
-        b_do = (b_do * exp(b_g - b_gn[None, :])).to(b_do.dtype)
+        b_do = (b_do * exp2(b_g - b_gn[None, :])).to(b_do.dtype)
         # [BV, BC]
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_gv = tl.load(p_gv, boundary_check=(0, 1))
-        b_vg = (b_v * exp(b_gn[:, None] - b_gv)).to(b_v.dtype)
+        b_vg = (b_v * exp2(b_gn[:, None] - b_gv)).to(b_v.dtype)
         # [BC, BC]
         b_dA = tl.dot(b_do, b_vg) * scale
     elif i_i == i_j:
@@ -275,7 +276,7 @@ def chunk_gsa_bwd_k_kernel_dA(
             b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
             b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
             # [BC,]
-            b_dAj = tl.sum(b_do * b_v[None, :] * exp(b_g - b_gv[None, :]), 1)
+            b_dAj = tl.sum(b_do * b_v[None, :] * exp2(b_g - b_gv[None, :]), 1)
             b_dA = tl.where((o_i == j)[None, :], b_dAj[:, None], b_dA)
 
             p_v += H*V
@@ -379,16 +380,16 @@ def chunk_gsa_bwd_k_kernel_dqkvg(
         # [BT, BV]
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_gv = exp(b_gn[None, :] - b_g)
+        b_gv = exp2(b_gn[None, :] - b_g)
         # [BV, BK]
         b_h = tl.load(p_h, boundary_check=(0, 1))
         # [BT, BV]
         b_do = tl.load(p_do, boundary_check=(0, 1))
-        b_do = (b_do * exp(b_g)).to(b_do.dtype)
+        b_do = (b_do * exp2(b_g)).to(b_do.dtype)
         # [BK, BV]
         b_dh = tl.load(p_dh, boundary_check=(0, 1))
         # [BV]
-        b_dg = tl.sum(tl.trans(b_h) * b_dh, 0) * exp(b_gn)
+        b_dg = tl.sum(tl.trans(b_h) * b_dh, 0) * exp2(b_gn)
 
         b_dh = b_dh.to(b_k.dtype)
         # [BT, BK]
@@ -477,12 +478,12 @@ def chunk_gsa_bwd_k_kernel_intra_dvg(
         m_j = (i_t * BT + i_j * BC + o_i) < T
         # [BC, BV]
         b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)) * tl.where(m_j[:, None], exp(b_g - b_gn[None, :]), 0)
+        b_do = tl.load(p_do, boundary_check=(0, 1)) * tl.where(m_j[:, None], exp2(b_g - b_gn[None, :]), 0)
         # [BC, BC]
         b_A = tl.load(p_A, boundary_check=(0, 1))
         # [BC, BV]
         b_dv += tl.dot(b_A, b_do.to(b_A.dtype))
-    b_dv *= exp(b_gn[None, :] - b_gv)
+    b_dv *= exp2(b_gn[None, :] - b_gv)
 
     p_g = g + (bos + i_t * BT + i_i * BC) * H*V + i_h * V + o_v
     p_A = A + (bos + i_t*BT + i_i*BC) * HQ*BT + i_hq * BT + i_i * BC + o_i
@@ -495,7 +496,7 @@ def chunk_gsa_bwd_k_kernel_intra_dvg(
         b_do = tl.load(p_do, mask=m_v, other=0)
         # [BC, BV]
         m_i = o_i[:, None] <= j
-        b_dv += tl.where(m_i, exp(b_g[None, :] - b_gv) * b_A[:, None] * b_do[None, :], 0.)
+        b_dv += tl.where(m_i, exp2(b_g[None, :] - b_gv) * b_A[:, None] * b_do[None, :], 0.)
 
         p_g += H * V
         p_A += HQ * BT
@@ -539,6 +540,7 @@ def chunk_gsa_fwd_v(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=True,
     )
     return A, h, ht, o
 
@@ -577,6 +579,7 @@ def chunk_gsa_fwd_k(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=BT,
+        use_exp2=True,
         states_in_fp32=False,
     )
     o = v.new_empty(B, T, HQ, V)
@@ -655,6 +658,7 @@ def chunk_gsa_bwd_v(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=True,
     )
     return dq, dk, dv, dg, dh0
 
@@ -701,6 +705,7 @@ def chunk_gsa_bwd_k(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_size=BT,
+            use_exp2=True,
             states_in_fp32=False,
         )
     dh, dh0 = chunk_bwd_dh(
@@ -716,6 +721,7 @@ def chunk_gsa_bwd_k(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=BT,
+        use_exp2=True,
         states_in_fp32=True,
     )
     dA = q.new_empty(NV, B, T, HQ, BT)
@@ -952,7 +958,8 @@ class ChunkGSAFunction(torch.autograd.Function):
         chunk_indices = prepare_chunk_indices(
             cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
 
-        g_org, g = g, chunk_local_cumsum(g, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+        # Pre-scale by RCP_LN2 so downstream kernels can use exp2 directly.
+        g_org, g = g, chunk_local_cumsum(g, chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
         Ak, hk, hkt, ok, p, Av, hv, hvt, ov = chunk_gsa_fwd(
             q=q,
             k=k,
@@ -993,7 +1000,7 @@ class ChunkGSAFunction(torch.autograd.Function):
         chunk_size = ctx.chunk_size
 
         if ctx.checkpoint_level >= 1:
-            g = chunk_local_cumsum(g, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+            g = chunk_local_cumsum(g, chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
         dq, dk, dv, ds, dg, dhk0, dhv0 = chunk_gsa_bwd(
             q=q,
             k=k,

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -540,7 +540,6 @@ def chunk_gsa_fwd_v(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     return A, h, ht, o
 
@@ -658,7 +657,6 @@ def chunk_gsa_bwd_v(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     return dq, dk, dv, dg, dh0
 

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -193,7 +193,7 @@ def chunk_gsa_fwd_k_kernel_intra(
         triton.Config({}, num_warps=num_warps)
         for num_warps in [2, 4, 8]
     ],
-    key=["BT"],
+    key=['BT'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -563,7 +563,10 @@ def chunk_gsa_fwd_k(
     HQ = q.shape[2]
 
     if chunk_indices is None:
-        chunk_indices = prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+        else:
+            chunk_indices = None
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
     NG = HQ // H
@@ -684,7 +687,10 @@ def chunk_gsa_bwd_k(
     HQ = q.shape[2]
 
     if chunk_indices is None:
-        chunk_indices = prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+        else:
+            chunk_indices = None
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
     NK = triton.cdiv(K, BK)
@@ -717,7 +723,6 @@ def chunk_gsa_bwd_k(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=BT,
-        use_exp2=True,
         states_in_fp32=True,
     )
     dA = q.new_empty(NV, B, T, HQ, BT)
@@ -805,7 +810,15 @@ def chunk_gsa_bwd_k(
         num_warps=4,
         num_stages=2,
     )
-    dg = dgv.add_(chunk_local_cumsum(dg, chunk_size=BT, reverse=True, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices))
+    dg = dgv.add_(
+        chunk_local_cumsum(
+            dg,
+            chunk_size=BT,
+            reverse=True,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+    )
 
     return dq, dk, dv, dg, dh0
 
@@ -951,11 +964,24 @@ class ChunkGSAFunction(torch.autograd.Function):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         chunk_size = min(64, max(16, triton.next_power_of_2(q.shape[1])))
 
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens,
+                chunk_size,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+            )
+        else:
+            chunk_indices = None
 
         # Pre-scale by RCP_LN2 so downstream kernels can use exp2 directly.
-        g_org, g = g, chunk_local_cumsum(g, chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+        g_org = g
+        g = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
         Ak, hk, hkt, ok, p, Av, hv, hvt, ov = chunk_gsa_fwd(
             q=q,
             k=k,
@@ -980,7 +1006,21 @@ class ChunkGSAFunction(torch.autograd.Function):
         else:
             hk0, hv0 = None, None
 
-        ctx.save_for_backward(q, k, v, s, g, ok, p, Av, hk0, hv0, hk, hv, chunk_indices)
+        ctx.save_for_backward(
+            q,
+            k,
+            v,
+            s,
+            g,
+            ok,
+            p,
+            Av,
+            hk0,
+            hv0,
+            hk,
+            hv,
+            chunk_indices,
+        )
         ctx.checkpoint_level = checkpoint_level
         ctx.scale = scale
         ctx.cu_seqlens = cu_seqlens
@@ -990,13 +1030,33 @@ class ChunkGSAFunction(torch.autograd.Function):
     @staticmethod
     @input_guard
     def backward(ctx, dov, dhkt=None, dhvt=None):
-        q, k, v, s, g, ok, p, Av, hk0, hv0, hk, hv, chunk_indices = ctx.saved_tensors
+        (
+            q,
+            k,
+            v,
+            s,
+            g,
+            ok,
+            p,
+            Av,
+            hk0,
+            hv0,
+            hk,
+            hv,
+            chunk_indices,
+        ) = ctx.saved_tensors
         scale = ctx.scale
         cu_seqlens = ctx.cu_seqlens
         chunk_size = ctx.chunk_size
 
         if ctx.checkpoint_level >= 1:
-            g = chunk_local_cumsum(g, chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+            g = chunk_local_cumsum(
+                g,
+                chunk_size,
+                scale=RCP_LN2,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+            )
         dq, dk, dv, ds, dg, dhk0, dhv0 = chunk_gsa_bwd(
             q=q,
             k=k,

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -578,7 +578,6 @@ def chunk_gsa_fwd_k(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=BT,
-        use_exp2=True,
         states_in_fp32=False,
     )
     o = v.new_empty(B, T, HQ, V)
@@ -703,7 +702,6 @@ def chunk_gsa_bwd_k(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_size=BT,
-            use_exp2=True,
             states_in_fp32=False,
         )
     dh, dh0 = chunk_bwd_dh(

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -480,7 +480,6 @@ def chunk_kda_bwd(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
-            use_exp2=True,
             transpose_state_layout=transpose_state_layout,
         )
     else:
@@ -518,7 +517,6 @@ def chunk_kda_bwd(
             cu_seqlens=cu_seqlens,
             dht=dht,
             initial_state=initial_state,
-            use_exp2=True,
             context=cp_context,
             transpose_state_layout=transpose_state_layout,
         )
@@ -535,7 +533,6 @@ def chunk_kda_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=True,
         transpose_state_layout=transpose_state_layout,
     )
 

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -122,7 +122,6 @@ def chunk_kda_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=True,
         transpose_state_layout=transpose_state_layout,
     )
     if disable_recompute is False:

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -87,7 +87,6 @@ def chunk_kda_fwd(
             cu_seqlens=cu_seqlens,
             initial_state=initial_state,
             context=cp_context,
-            use_exp2=True,
             transpose_state_layout=transpose_state_layout,
         )
 
@@ -101,7 +100,6 @@ def chunk_kda_fwd(
         cu_seqlens=cu_seqlens,
         cu_seqlens_cpu=cu_seqlens_cpu,
         chunk_indices=chunk_indices,
-        use_exp2=True,
         transpose_state_layout=transpose_state_layout,
     )
 

--- a/fla/ops/mesa_net/chunk.py
+++ b/fla/ops/mesa_net/chunk.py
@@ -15,6 +15,7 @@ from fla.ops.mesa_net.chunk_h_fwd import chunk_mesa_fwd_h
 from fla.ops.mesa_net.chunk_h_kk_intra_bwd import chunk_mesa_net_h_kk_bwd_intra_fn
 from fla.ops.mesa_net.chunk_h_kv_intra_bwd import chunk_mesa_net_h_kv_bwd_intra_fn
 from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
+from fla.ops.utils.constant import RCP_LN2
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
 
@@ -33,8 +34,14 @@ def chunk_fwd_mesa_net_fwd(
     output_final_state: bool = False,
     chunk_indices: torch.LongTensor | None = None,
 ) -> torch.Tensor:
-
-    g = chunk_local_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens) if g is not None else None
+    if g is not None:
+        g = chunk_local_cumsum(
+            g,
+            chunk_size=chunk_size,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
     h_kk, h_kv, h_kk_final, h_kv_final = chunk_mesa_fwd_h(
         k=k,
         v=v,
@@ -165,7 +172,13 @@ def chunk_fwd_mesa_net_bwd(
         chunk_indices=chunk_indices,
     )
     dg.add_(dg2)
-    dg = chunk_local_cumsum(dg, chunk_size=chunk_size, reverse=True, cu_seqlens=cu_seqlens).to(g)
+    dg = chunk_local_cumsum(
+        dg,
+        chunk_size=chunk_size,
+        reverse=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    ).to(g)
     return dq, dk, dv, dg, dbeta, dlamb, -dh0_kk if dh0_kk is not None else None, dh0_kv if dh0_kv is not None else None
 
 
@@ -190,8 +203,14 @@ class ChunkMesaNetFunction(torch.autograd.Function):
         use_qk_l2norm_in_kernel,
     ):
         chunk_size = 64
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens,
+                chunk_size,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+            )
+        else:
+            chunk_indices = None
 
         if use_qk_l2norm_in_kernel:
             q, q_rstd = l2norm_fwd(q, output_dtype=torch.float16)
@@ -220,22 +239,62 @@ class ChunkMesaNetFunction(torch.autograd.Function):
         ctx.chunk_size = chunk_size
         ctx.cu_seqlens = cu_seqlens
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
-        ctx.save_for_backward(q, q_rstd, k, k_rstd, v, g_cumsum, beta, lamb, h_kk_init, h_kv_init, q_star, o, chunk_indices)
+        ctx.save_for_backward(
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            v,
+            g_cumsum,
+            beta,
+            lamb,
+            h_kk_init,
+            h_kv_init,
+            q_star,
+            o,
+            chunk_indices,
+        )
         return o, h_kk_final, h_kv_final
 
     @staticmethod
     @input_guard
     @autocast_custom_bwd
     def backward(ctx, do, dh_kk_final=None, dh_kv_final=None):
-        q, q_rstd, k, k_rstd, v, g, beta, lamb, h_kk_init, h_kv_init, q_star, o, chunk_indices = ctx.saved_tensors
+        (
+            q,
+            q_rstd,
+            k,
+            k_rstd,
+            v,
+            g,
+            beta,
+            lamb,
+            h_kk_init,
+            h_kv_init,
+            q_star,
+            o,
+            chunk_indices,
+        ) = ctx.saved_tensors
 
         max_CG_iteration = ctx.max_CG_iteration
         chunk_size = ctx.chunk_size
         cu_seqlens = ctx.cu_seqlens
         dq, dk, dv, dg, dbeta, dlamb, dh0_kk, dh0_kv = chunk_fwd_mesa_net_bwd(
-            q=q, k=k, v=v, g=g, beta=beta, lamb=lamb, q_star=q_star, do=do,
-            cu_seqlens=cu_seqlens, max_CG_iteration=max_CG_iteration, chunk_size=chunk_size,
-            h_kk_init=h_kk_init, h_kv_init=h_kv_init, dh_kv_final=dh_kv_final, dh_kk_final=dh_kk_final,
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            lamb=lamb,
+            q_star=q_star,
+            do=do,
+            cu_seqlens=cu_seqlens,
+            max_CG_iteration=max_CG_iteration,
+            chunk_size=chunk_size,
+            h_kk_init=h_kk_init,
+            h_kv_init=h_kv_init,
+            dh_kv_final=dh_kv_final,
+            dh_kk_final=dh_kk_final,
             chunk_indices=chunk_indices,
         )
         if ctx.use_qk_l2norm_in_kernel:
@@ -269,7 +328,8 @@ def chunk_mesa_net(
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         g (torch.Tensor):
-            decay factors of shape `[B, T, H]`. Note that `g` should be in log space, that is, `g = log(decay_factor) < 0`.
+            decay factors of shape `[B, T, H]`. Note that `g` should be in log space,
+            that is, `g = log(decay_factor) < 0`.
             Recommended input dtype: `torch.float32`.
         beta (torch.Tensor):
             betas of shape `[B, T, H]`. Recommended input dtype: `torch.float32`.
@@ -346,11 +406,15 @@ def chunk_mesa_net(
     if h_kv_init is not None:
         assert h_kv_init.dtype == torch.float32, "h_kv_init must be in float32."
         if cu_seqlens is None:
-            assert h_kv_init.shape == (B, H, K, K), "h_kv_init must be of shape (batch size, num head, head dim, head dim)."
+            assert h_kv_init.shape == (B, H, K, K), (
+                "h_kv_init must be of shape (batch size, num head, head dim, head dim)."
+            )
     if h_kk_init is not None:
         assert h_kk_init.dtype == torch.float32, "h_kk_init must be in float32."
         if cu_seqlens is None:
-            assert h_kk_init.shape == (B, H, K, K), "h_kk_init must be of shape (batch size, num head, head dim, head dim)."
+            assert h_kk_init.shape == (B, H, K, K), (
+                "h_kk_init must be of shape (batch size, num head, head dim, head dim)."
+            )
 
     if cu_seqlens is not None:
         if q.shape[0] != 1:

--- a/fla/ops/mesa_net/chunk_cg_solver_bwd.py
+++ b/fla/ops/mesa_net/chunk_cg_solver_bwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 
 
 @triton.jit()
@@ -94,9 +94,9 @@ def chunk_fwd_mesa_cg_dim64_kernel(
     p_lamb = tl.make_block_ptr(lamb, (K,), (1,), (0,), (BK,), (0,))
     b_lamb = tl.load(p_lamb, boundary_check=(0,)).to(tl.float32)
 
-    b_m = exp(b_g[:, None] - b_g[None, :]) * b_beta[None, :]
+    b_m = exp2(b_g[:, None] - b_g[None, :]) * b_beta[None, :]
     b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), b_m, 0)
-    b_g_exp_q = tl.exp(b_g)[:, None]
+    b_g_exp_q = exp2(b_g)[:, None]
 
     b_x = tl.zeros([BT, BK], dtype=tl.float32)
     b_p = tl.zeros([BT, BK], dtype=tl.float32)

--- a/fla/ops/mesa_net/chunk_cg_solver_fwd.py
+++ b/fla/ops/mesa_net/chunk_cg_solver_fwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 
 
 @triton.jit()
@@ -101,9 +101,9 @@ def chunk_fwd_mesa_cg_dim64_kernel(
 
     b_lamb = tl.load(p_lamb, boundary_check=(0,)).to(tl.float32)
 
-    b_m = exp(b_g[:, None] - b_g[None, :]) * b_beta[None, :]
+    b_m = exp2(b_g[:, None] - b_g[None, :]) * b_beta[None, :]
     b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), b_m, 0)
-    b_g_exp_q = tl.exp(b_g)[:, None]
+    b_g_exp_q = exp2(b_g)[:, None]
 
     b_x = tl.zeros([BT, BK], dtype=tl.float32)
     b_p = tl.zeros([BT, BK], dtype=tl.float32)

--- a/fla/ops/mesa_net/chunk_h_fwd.py
+++ b/fla/ops/mesa_net/chunk_h_fwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_offsets
-from fla.ops.utils.op import exp2
+from fla.ops.utils.op import exp2, safe_dot
 from fla.utils import autotune_cache_kwargs
 
 
@@ -107,8 +107,8 @@ def chunk_mesa_net_fwd_kernel_h(
         b_h_kv *= exp2(b_g_last)
         b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
         b_k_decay = ((b_k * exp2(b_g_last - b_g)[:, None]) * b_beta[:, None]).to(b_k2.dtype)
-        b_h += tl.dot(tl.trans(b_k_decay), b_k2)
-        b_h_kv += tl.dot(tl.trans(b_k_decay), b_v.to(b_k2.dtype))
+        b_h += safe_dot(tl.trans(b_k_decay), b_k2)
+        b_h_kv += safe_dot(tl.trans(b_k_decay), b_v.to(b_k2.dtype))
 
     if STORE_FINAL_STATE:
         p_ht = tl.make_block_ptr(h_final + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))

--- a/fla/ops/mesa_net/chunk_h_fwd.py
+++ b/fla/ops/mesa_net/chunk_h_fwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_offsets
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs
 
 
@@ -103,10 +103,10 @@ def chunk_mesa_net_fwd_kernel_h(
         # scalar decay
         b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
         p_g = g + bos*H + (i_t * BT + tl.arange(0, BT)) * H + i_h
-        b_h *= exp(b_g_last)
-        b_h_kv *= exp(b_g_last)
+        b_h *= exp2(b_g_last)
+        b_h_kv *= exp2(b_g_last)
         b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.)
-        b_k_decay = ((b_k * exp(b_g_last - b_g)[:, None]) * b_beta[:, None]).to(b_k2.dtype)
+        b_k_decay = ((b_k * exp2(b_g_last - b_g)[:, None]) * b_beta[:, None]).to(b_k2.dtype)
         b_h += tl.dot(tl.trans(b_k_decay), b_k2)
         b_h_kv += tl.dot(tl.trans(b_k_decay), b_v.to(b_k2.dtype))
 

--- a/fla/ops/mesa_net/chunk_h_kk_intra_bwd.py
+++ b/fla/ops/mesa_net/chunk_h_kk_intra_bwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 
 
 @triton.heuristics({
@@ -82,7 +82,7 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
     b_g = tl.load(p_g, boundary_check=(0,))
     b_g_last = tl.load(g + (min(i_t * BT + BT, T) - 1) * H)
-    b_gk = tl.where(m_t, exp(b_g_last - b_g), 0)
+    b_gk = tl.where(m_t, exp2(b_g_last - b_g), 0)
 
     p_q_star = tl.make_block_ptr(q_star, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
     b_q_star = tl.load(p_q_star, boundary_check=(0, 1))
@@ -100,7 +100,7 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     b_v = tl.load(p_k, boundary_check=(0, 1))
     b_k = (b_v * b_beta[:, None]).to(b_v.dtype)
 
-    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp(b_g[:, None] - b_g[None, :]), 0)
+    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp2(b_g[:, None] - b_g[None, :]), 0)
     b_s = tl.dot(b_q_star, tl.trans(b_k)) * b_m
     b_ds = tl.dot(b_dq, tl.trans(b_v))
     b_dv += tl.dot(tl.trans(b_s.to(b_dq.dtype)), b_dq)
@@ -112,7 +112,7 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     b_dk += tl.dot(tl.trans(b_ds.to(b_q_star.dtype)), b_q_star)
 
     b_h = tl.load(p_h, boundary_check=(0, 1))
-    b_dg += tl.sum(tl.dot(b_dq, tl.trans(b_h)) * tl.exp(b_g)[:, None] * b_q_star, axis=1)
+    b_dg += tl.sum(tl.dot(b_dq, tl.trans(b_h)) * exp2(b_g)[:, None] * b_q_star, axis=1)
     b_dh = tl.load(p_dh, boundary_check=(0, 1))
     b_dk2 = tl.dot(b_v, b_dh.to(b_v.dtype)) * b_gk[:, None]
     b_dg -= tl.sum(b_dk2 * b_k, axis=1)
@@ -120,7 +120,7 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     b_dk += b_dk2
     b_dv += tl.dot(b_k, tl.trans(b_dh).to(b_k.dtype)) * b_gk[:, None]
     b_dh = b_dh * b_h
-    b_dg_last += tl.sum(b_dh) * exp(b_g_last)
+    b_dg_last += tl.sum(b_dh) * exp2(b_g_last)
 
     p_dk_beta = tl.make_block_ptr(dk_beta, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
     b_dk -= tl.load(p_dk_beta, boundary_check=(0, 1))

--- a/fla/ops/mesa_net/chunk_h_kv_intra_bwd.py
+++ b/fla/ops/mesa_net/chunk_h_kv_intra_bwd.py
@@ -11,7 +11,7 @@ import triton.language as tl
 
 from fla.ops.mesa_net.chunk_h_kv_intra_bwd_separate import chunk_mesa_net_h_kv_bwd_intra_separate_fn
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
 
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
@@ -113,9 +113,9 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel(
 
     # calculation
     b_dg_last += tl.sum(b_h * b_dh)
-    b_dg_last *= exp(b_g_last)
+    b_dg_last *= exp2(b_g_last)
 
-    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp(b_g[:, None] - b_g[None, :]), 0)
+    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp2(b_g[:, None] - b_g[None, :]), 0)
     b_k = (b_k * b_beta[:, None]).to(b_k.dtype)
     b_s = tl.dot(b_q, tl.trans(b_k)) * b_m
 
@@ -126,8 +126,8 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel(
     b_dg += tl.sum(b_dm, axis=1)
     b_dg -= tl.sum(b_dm, axis=0)
 
-    b_g_exp_q = exp(b_g)
-    b_g_exp_k = tl.where(m_t, exp(-b_g + b_g_last), 0)
+    b_g_exp_q = exp2(b_g)
+    b_g_exp_k = tl.where(m_t, exp2(-b_g + b_g_last), 0)
     b_ds = b_ds * b_m
     b_dq += tl.dot(b_do, b_h.to(b_do.dtype)) * b_g_exp_q[:, None]
     b_dk += tl.dot(b_v, b_dh.to(b_v.dtype)) * b_g_exp_k[:, None]

--- a/fla/ops/mesa_net/chunk_h_kv_intra_bwd_separate.py
+++ b/fla/ops/mesa_net/chunk_h_kv_intra_bwd_separate.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs
 
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
@@ -109,9 +109,9 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dkv(
 
     # calculation
     b_dg_last += tl.sum(b_h * b_dh)
-    b_dg_last *= exp(b_g_last)
+    b_dg_last *= exp2(b_g_last)
 
-    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp(b_g[:, None] - b_g[None, :]), 0)
+    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp2(b_g[:, None] - b_g[None, :]), 0)
     b_k = (b_k * b_beta[:, None]).to(b_k.dtype)
     b_s = tl.dot(b_q, tl.trans(b_k)) * b_m
     b_ds = tl.dot(b_do, tl.trans(b_v))
@@ -119,7 +119,7 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dkv(
     b_dm = tl.where(tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :], b_dm, 0)
     b_dg += tl.sum(b_dm, axis=1)
     b_dg -= tl.sum(b_dm, axis=0)
-    b_g_exp_k = tl.where(m_t, exp(-b_g + b_g_last), 0)
+    b_g_exp_k = tl.where(m_t, exp2(-b_g + b_g_last), 0)
     b_ds = b_ds * b_m
     b_dk += tl.dot(b_v, b_dh.to(b_v.dtype)) * b_g_exp_k[:, None]
     b_dg_last += tl.sum(b_dk * b_k)
@@ -220,11 +220,11 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dq(
     b_do = tl.load(p_do, boundary_check=(0, 1))
     b_h = tl.load(p_h, boundary_check=(0, 1))
 
-    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp(b_g[:, None] - b_g[None, :]), 0)
+    b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp2(b_g[:, None] - b_g[None, :]), 0)
     b_k = (b_k * b_beta[:, None]).to(b_k.dtype)
 
     b_ds = tl.dot(b_do, tl.trans(b_v)) * b_m
-    b_g_exp_q = exp(b_g)
+    b_g_exp_q = exp2(b_g)
     b_dq = tl.dot(b_do, b_h.to(b_do.dtype)) * b_g_exp_q[:, None]
     b_dg = tl.sum(b_dq * b_q, axis=1) + tl.load(p_dg_prev, boundary_check=(0,))
     b_dq += tl.dot(b_ds.to(b_k.dtype), b_k)

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -1024,8 +1024,14 @@ def chunk_rwkv6_fwd(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
     # gi/ge are pre-scaled by RCP_LN2 inside the cumsum kernel; downstream uses exp2.
+    gi, ge = chunk_rwkv6_fwd_cumsum(
+        g,
+        chunk_size=chunk_size,
+        scale=RCP_LN2,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
     h, ht = chunk_fwd_h(
         k=k,
         v=v,
@@ -1081,7 +1087,13 @@ def chunk_rwkv6_bwd(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ):
-    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    gi, ge = chunk_rwkv6_fwd_cumsum(
+        g,
+        chunk_size=chunk_size,
+        scale=RCP_LN2,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
     h, _ = chunk_fwd_h(
         k=k,
         v=v,

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -12,7 +12,8 @@ import triton.language as tl
 from fla.ops.common.chunk_h import chunk_fwd_h
 from fla.ops.gla.chunk import chunk_gla_bwd_dA, chunk_gla_bwd_dv, chunk_gla_fwd_o_gk
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
-from fla.ops.utils.op import exp
+from fla.ops.utils.constant import RCP_LN2
+from fla.ops.utils.op import exp2
 from fla.utils import (
     USE_CUDA_GRAPH,
     autocast_custom_bwd,
@@ -27,6 +28,7 @@ BV_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
 
 @triton.heuristics({
+    'HAS_SCALE': lambda args: args['scale'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.autotune(
@@ -36,7 +38,7 @@ BV_LIST = [32, 64] if check_shared_mem() else [16, 32]
         for num_warps in [4, 8, 16]
         for num_stages in [2, 3, 4]
     ],
-    key=['S', 'BT'],
+    key=['S', 'BT', 'HAS_SCALE'],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -45,6 +47,7 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     s,
     oi,
     oe,
+    scale,
     cu_seqlens,
     chunk_indices,
     T,
@@ -52,6 +55,7 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     S: tl.constexpr,
     BT: tl.constexpr,
     BS: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -74,6 +78,10 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
     b_oi = tl.dot(m_i, b_s)
     b_oe = tl.dot(m_e, b_s)
+    if HAS_SCALE:
+        # Pre-scale by RCP_LN2 so downstream kernels can use exp2 directly.
+        b_oi = b_oi * scale
+        b_oe = b_oe * scale
     tl.store(p_oi, b_oi.to(p_oi.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
     tl.store(p_oe, b_oe.to(p_oe.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
 
@@ -81,6 +89,7 @@ def chunk_rwkv6_fwd_cumsum_kernel(
 def chunk_rwkv6_fwd_cumsum(
     g: torch.Tensor,
     chunk_size: int,
+    scale: float | None = None,
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
 ) -> torch.Tensor:
@@ -97,6 +106,7 @@ def chunk_rwkv6_fwd_cumsum(
         g,
         gi,
         ge,
+        scale,
         cu_seqlens,
         chunk_indices,
         T=T,
@@ -173,11 +183,11 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
         # [BC, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_gq = tl.where(m_i[:, None] & m_k, tl.load(p_gq, boundary_check=(0, 1)), float('-inf'))
-        b_qg = b_q * exp(b_gq - b_gn[None, :]) * scale
+        b_qg = b_q * exp2(b_gq - b_gn[None, :]) * scale
         # [BK, BC]
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        b_kg = b_k * exp(b_gn[:, None] - b_gk)
+        b_kg = b_k * exp2(b_gn[:, None] - b_gk)
         # [BC, BC] using tf32 to improve precision here.
         b_A += tl.dot(b_qg, b_kg)
 
@@ -249,7 +259,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
         b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
         b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
         b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        b_A = tl.sum(b_q * b_kj[None, :] * exp(b_g - b_gk[None, :]), 1)
+        b_A = tl.sum(b_q * b_kj[None, :] * exp2(b_g - b_gk[None, :]), 1)
         b_A = tl.where(o_i > j, b_A * scale, 0.)
         b_A = tl.where(o_i != j, b_A, tl.sum(b_qj * b_kj * b_u * scale))
         tl.store(A + o_A + j, b_A, mask=m_A)
@@ -330,7 +340,7 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
         b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
         b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
         b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
-        b_A = tl.sum(b_q * b_kj[None, :] * exp(b_g - b_gk[None, :]), 1)
+        b_A = tl.sum(b_q * b_kj[None, :] * exp2(b_g - b_gk[None, :]), 1)
         b_A = tl.where(o_i > j, b_A * scale, 0.)
         b_A = tl.where(o_i != j, b_A, tl.sum(b_qj * b_kj * b_u * scale))
         tl.store(A + o_A + j, b_A, mask=m_A)
@@ -465,9 +475,9 @@ def chunk_rwkv6_bwd_kernel_dh(
         p_gk_last = gi + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        b_q = (b_q * exp(b_gk) * scale).to(b_q.dtype)
+        b_q = (b_q * exp2(b_gk) * scale).to(b_q.dtype)
         b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
-        b_dh *= exp(b_gk_last)[:, None]
+        b_dh *= exp2(b_gk_last)[:, None]
         b_dh += tl.dot(b_q, b_do)
 
     if STORE_INITIAL_STATE_GRADIENT:
@@ -537,12 +547,12 @@ def chunk_rwkv6_bwd_kernel_intra(
             # [BC, BK]
             b_k = tl.load(p_k, boundary_check=(0, 1))
             b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_kg = b_k * exp(b_gn[None, :] - b_gk)
+            b_kg = b_k * exp2(b_gn[None, :] - b_gk)
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
             # [BC, BK]
             b_dq += tl.dot(b_dA, b_kg)
-        b_dq *= exp(b_ge - b_gn[None, :])
+        b_dq *= exp2(b_ge - b_gn[None, :])
 
     o_i = tl.arange(0, BC)
     m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
@@ -561,7 +571,7 @@ def chunk_rwkv6_bwd_kernel_intra(
         m_i = o_i[:, None] > j
         # [BC, BK]
         # (SY 09/17) important to not use bf16 here to have a good precision.
-        b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp(b_ge - b_gkj[None, :]), 0.)
+        b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_ge - b_gkj[None, :]), 0.)
         p_kj += H*K
         p_gkj += H*K
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
@@ -589,13 +599,13 @@ def chunk_rwkv6_bwd_kernel_intra(
             # [BC, BK]
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_gq = tl.where(m_j[:, None] & m_k, tl.load(p_gq, boundary_check=(0, 1)), float('-inf'))
-            b_qg = b_q * exp(b_gq - b_gn[None, :])
+            b_qg = b_q * exp2(b_gq - b_gn[None, :])
             # [BC, BC]
             b_dA = tl.load(p_dA, boundary_check=(0, 1))
             # [BC, BK]
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dk += tl.dot(b_dA, b_qg)
-        b_dk *= exp(b_gn[None, :] - b_gk)
+        b_dk *= exp2(b_gn[None, :] - b_gk)
     o_dA = bos*H*BT + (i_t * BT + i_i * BC) * H*BT + i_h * BT + i_i * BC + tl.arange(0, BC)
     p_qj = q + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gqj = ge + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
@@ -608,7 +618,7 @@ def chunk_rwkv6_bwd_kernel_intra(
         b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
         # [BC, BK]
         m_i = o_i[:, None] < j
-        b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp(b_gqj[None, :] - b_gk), 0.)
+        b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_gk), 0.)
         p_qj += H*K
         p_gqj += H*K
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
@@ -698,12 +708,12 @@ def chunk_rwkv6_bwd_kernel_inter(
         # [BT, BK]
         b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
         b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
-    b_dgk *= exp(b_gn)
+    b_dgk *= exp2(b_gn)
     b_dq *= scale
     b_gk = tl.load(p_gk, boundary_check=(0, 1))
     b_gi = tl.load(p_gi, boundary_check=(0, 1))
-    b_dq = b_dq * exp(b_gk)
-    b_dk = b_dk * exp(b_gn[None, :] - b_gi)
+    b_dq = b_dq * exp2(b_gk)
+    b_dk = b_dk * exp2(b_gn[None, :] - b_gi)
 
     o_i = tl.arange(0, BT)
     p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
@@ -1014,7 +1024,8 @@ def chunk_rwkv6_fwd(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    # gi/ge are pre-scaled by RCP_LN2 inside the cumsum kernel; downstream uses exp2.
     h, ht = chunk_fwd_h(
         k=k,
         v=v,
@@ -1025,6 +1036,7 @@ def chunk_rwkv6_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=True,
         states_in_fp32=True,
     )
     A = chunk_rwkv6_fwd_intra(
@@ -1049,6 +1061,7 @@ def chunk_rwkv6_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=True,
     )
     return A, h, ht, o
 
@@ -1068,7 +1081,7 @@ def chunk_rwkv6_bwd(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ):
-    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    gi, ge = chunk_rwkv6_fwd_cumsum(g, chunk_size=chunk_size, scale=RCP_LN2, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
     h, _ = chunk_fwd_h(
         k=k,
         v=v,
@@ -1079,6 +1092,7 @@ def chunk_rwkv6_bwd(
         output_final_state=False,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=True,
         states_in_fp32=True,
     )
     dh, dh0 = chunk_rwkv6_bwd_dh(
@@ -1113,6 +1127,7 @@ def chunk_rwkv6_bwd(
         dh=dh,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=True,
     )
     dq, dk = chunk_rwkv6_bwd_dqk_intra(
         q=q,

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -1067,7 +1067,6 @@ def chunk_rwkv6_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     return A, h, ht, o
 
@@ -1139,7 +1138,6 @@ def chunk_rwkv6_bwd(
         dh=dh,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
     )
     dq, dk = chunk_rwkv6_bwd_dqk_intra(
         q=q,

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -1042,7 +1042,6 @@ def chunk_rwkv6_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
         states_in_fp32=True,
     )
     A = chunk_rwkv6_fwd_intra(
@@ -1103,7 +1102,6 @@ def chunk_rwkv6_bwd(
         output_final_state=False,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
         states_in_fp32=True,
     )
     dh, dh0 = chunk_rwkv6_bwd_dh(

--- a/fla/ops/simple_gla/chunk.py
+++ b/fla/ops/simple_gla/chunk.py
@@ -27,7 +27,6 @@ def chunk_simple_gla_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     h, ht = chunk_fwd_h(
         k=k,
@@ -40,7 +39,7 @@ def chunk_simple_gla_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=use_exp2,
+        use_exp2=True,
         states_in_fp32=False,
     )
     o = chunk_fwd_o(
@@ -54,7 +53,7 @@ def chunk_simple_gla_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
+        use_exp2=True,
     )
     return o, ht
 
@@ -72,7 +71,6 @@ def chunk_simple_gla_bwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # (SY 09/22) states_in_fp32 seems not affecting the error of dg but for safety, set to True
     h, _ = chunk_fwd_h(
@@ -86,7 +84,7 @@ def chunk_simple_gla_bwd(
         output_final_state=False,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=use_exp2,
+        use_exp2=True,
         states_in_fp32=True,
     )
     dh, dh0 = chunk_bwd_dh(
@@ -103,7 +101,7 @@ def chunk_simple_gla_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=use_exp2,
+        use_exp2=True,
         states_in_fp32=True,
     )
     dq, dk, _, dg = chunk_bwd_dqkwg(
@@ -119,7 +117,7 @@ def chunk_simple_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
+        use_exp2=True,
     )
     dv = chunk_bwd_dv(
         q=q,
@@ -132,7 +130,7 @@ def chunk_simple_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
+        use_exp2=True,
     )
     return dq, dk, dv, dg, dh0
 
@@ -184,7 +182,6 @@ class ChunkSimpleGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
-            use_exp2=True,
         )
         ctx.save_for_backward(q, k, v, g, g_gamma, initial_state, chunk_indices)
         ctx.chunk_size = chunk_size
@@ -211,7 +208,6 @@ class ChunkSimpleGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
-            use_exp2=True,
         )
         if g is not None:
             dg = chunk_local_cumsum(

--- a/fla/ops/simple_gla/chunk.py
+++ b/fla/ops/simple_gla/chunk.py
@@ -11,6 +11,7 @@ import triton
 from fla.ops.common.chunk_h import chunk_bwd_dh, chunk_fwd_h
 from fla.ops.common.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv, chunk_fwd_o
 from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
+from fla.ops.utils.constant import RCP_LN2
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
 
@@ -26,6 +27,7 @@ def chunk_simple_gla_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     h, ht = chunk_fwd_h(
         k=k,
@@ -36,9 +38,10 @@ def chunk_simple_gla_fwd(
         gv=None,
         h0=initial_state,
         output_final_state=output_final_state,
-        states_in_fp32=False,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=use_exp2,
+        states_in_fp32=False,
     )
     o = chunk_fwd_o(
         q=q,
@@ -51,6 +54,7 @@ def chunk_simple_gla_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
     return o, ht
 
@@ -68,6 +72,7 @@ def chunk_simple_gla_bwd(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # (SY 09/22) states_in_fp32 seems not affecting the error of dg but for safety, set to True
     h, _ = chunk_fwd_h(
@@ -79,9 +84,10 @@ def chunk_simple_gla_bwd(
         gv=None,
         h0=initial_state,
         output_final_state=False,
-        states_in_fp32=True,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=use_exp2,
+        states_in_fp32=True,
     )
     dh, dh0 = chunk_bwd_dh(
         q=q,
@@ -95,9 +101,10 @@ def chunk_simple_gla_bwd(
         h0=initial_state,
         dht=dht,
         scale=scale,
-        states_in_fp32=True,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        use_exp2=use_exp2,
+        states_in_fp32=True,
     )
     dq, dk, _, dg = chunk_bwd_dqkwg(
         q=q,
@@ -112,6 +119,7 @@ def chunk_simple_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
     dv = chunk_bwd_dv(
         q=q,
@@ -124,6 +132,7 @@ def chunk_simple_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
     )
     return dq, dk, dv, dg, dh0
 
@@ -152,8 +161,17 @@ class ChunkSimpleGLAFunction(torch.autograd.Function):
         chunk_indices = prepare_chunk_indices(
             cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
 
-        g = chunk_local_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens,
-                               chunk_indices=chunk_indices) if g is not None else None
+        # Pre-scale by RCP_LN2 so downstream kernels can use exp2 directly.
+        if g is not None:
+            g = chunk_local_cumsum(
+                g,
+                chunk_size=chunk_size,
+                scale=RCP_LN2,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+            )
+        if g_gamma is not None:
+            g_gamma = g_gamma * RCP_LN2
         o, ht = chunk_simple_gla_fwd(
             q=q,
             k=k,
@@ -166,6 +184,7 @@ class ChunkSimpleGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
+            use_exp2=True,
         )
         ctx.save_for_backward(q, k, v, g, g_gamma, initial_state, chunk_indices)
         ctx.chunk_size = chunk_size
@@ -192,10 +211,16 @@ class ChunkSimpleGLAFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_size=chunk_size,
             chunk_indices=chunk_indices,
+            use_exp2=True,
         )
         if g is not None:
-            dg = chunk_local_cumsum(dg, chunk_size=chunk_size, reverse=True, cu_seqlens=cu_seqlens,
-                                    chunk_indices=chunk_indices).to(g)
+            dg = chunk_local_cumsum(
+                dg,
+                chunk_size=chunk_size,
+                reverse=True,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+            ).to(g)
         else:
             dg = None
         return dq.to(q), dk.to(k), dv.to(v), dg, None, None, dh0, None, None, None

--- a/fla/ops/simple_gla/chunk.py
+++ b/fla/ops/simple_gla/chunk.py
@@ -53,7 +53,6 @@ def chunk_simple_gla_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     return o, ht
 
@@ -117,7 +116,6 @@ def chunk_simple_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     dv = chunk_bwd_dv(
         q=q,
@@ -130,7 +128,6 @@ def chunk_simple_gla_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        use_exp2=True,
     )
     return dq, dk, dv, dg, dh0
 

--- a/fla/ops/simple_gla/chunk.py
+++ b/fla/ops/simple_gla/chunk.py
@@ -39,7 +39,6 @@ def chunk_simple_gla_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
         states_in_fp32=False,
     )
     o = chunk_fwd_o(
@@ -83,7 +82,6 @@ def chunk_simple_gla_bwd(
         output_final_state=False,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
         states_in_fp32=True,
     )
     dh, dh0 = chunk_bwd_dh(

--- a/fla/ops/simple_gla/chunk.py
+++ b/fla/ops/simple_gla/chunk.py
@@ -98,7 +98,6 @@ def chunk_simple_gla_bwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
-        use_exp2=True,
         states_in_fp32=True,
     )
     dq, dk, _, dg = chunk_bwd_dqkwg(
@@ -151,8 +150,14 @@ class ChunkSimpleGLAFunction(torch.autograd.Function):
         T = q.shape[1]
         chunk_size = min(64, max(16, triton.next_power_of_2(T)))
 
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens,
+                chunk_size,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+            )
+        else:
+            chunk_indices = None
 
         # Pre-scale by RCP_LN2 so downstream kernels can use exp2 directly.
         if g is not None:

--- a/fla/ops/simple_gla/parallel.py
+++ b/fla/ops/simple_gla/parallel.py
@@ -12,7 +12,7 @@ import triton.language as tl
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.cumsum import chunk_global_cumsum, chunk_local_cumsum
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import (
     IS_INTEL_ALCHEMIST,
     IS_NVIDIA_HOPPER,
@@ -40,7 +40,7 @@ NUM_WARPS = [2, 4, 8] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
         for num_warps in [2, 4, 8, 16]
         for num_stages in [2, 3, 4]
     ],
-    key=["BT", "BS", "BK", "BV", "USE_G", "USE_EXP2"],
+    key=["BT", "BS", "BK", "BV", "USE_G"],
     **autotune_cache_kwargs,
 )
 @triton.jit
@@ -67,7 +67,6 @@ def parallel_simple_gla_fwd_kernel(
     OUTPUT_ATTENTIONS: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_k, i_v = i_kv // NV, i_kv % NV
@@ -125,10 +124,7 @@ def parallel_simple_gla_fwd_kernel(
         b_s = tl.dot(b_q, b_k)
         if USE_G:
             b_gk = tl.load(g + o_k * H, mask=m_k, other=0)
-            if USE_EXP2:
-                b_s *= exp2(b_gq[:, None] - b_gk[None, :])
-            else:
-                b_s *= exp(b_gq[:, None] - b_gk[None, :])
+            b_s *= exp2(b_gq[:, None] - b_gk[None, :])
         b_s = tl.where(m_s, b_s, 0)
         # [BT, BV]
         if i_s >= 0:
@@ -154,10 +150,7 @@ def parallel_simple_gla_fwd_kernel(
             b_gn = tl.load(g + (min(i_s + BS, T) - 1) * H)
             b_gp = tl.load(g + (i_s-1) * H) if i_s % BT > 0 else 0.
             # No concrete meaning. Just to avoid some layout bugs.
-            if USE_EXP2:
-                b_s *= exp2(b_gq[:, None] + (b_gn - b_g)[None, :])
-            else:
-                b_s *= exp(b_gq[:, None] + (b_gn - b_g)[None, :])
+            b_s *= exp2(b_gq[:, None] + (b_gn - b_g)[None, :])
             b_gq += b_gn - b_gp
         b_s = tl.where(m_s, b_s, 0)
         if OUTPUT_ATTENTIONS:
@@ -191,7 +184,6 @@ def parallel_simple_gla_bwd_kernel_dq(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
     # [BT, BV]
@@ -218,14 +210,9 @@ def parallel_simple_gla_bwd_kernel_dq(
             b_g = tl.load(g + o_k * H, mask=m_k, other=0)
             b_gn = tl.load(g + (min(i_s + BS, T) - 1) * H)
             b_gp = tl.load(g + (i_s - 1) * H) if i_s % BT > 0 else 0.
-            if USE_EXP2:
-                b_ds *= tl.where(m_k, exp2(b_gn - b_g), 0)[None, :]
-                if i_s > 0:
-                    b_dq *= exp2(b_gn - b_gp)
-            else:
-                b_ds *= tl.where(m_k, exp(b_gn - b_g), 0)[None, :]
-                if i_s > 0:
-                    b_dq *= exp(b_gn - b_gp)
+            b_ds *= tl.where(m_k, exp2(b_gn - b_g), 0)[None, :]
+            if i_s > 0:
+                b_dq *= exp2(b_gn - b_gp)
         # [BT, BS] @ [BS, BK] = [BT, BK]
         b_dq += tl.dot(b_ds.to(b_v.dtype), b_k)
 
@@ -233,11 +220,7 @@ def parallel_simple_gla_bwd_kernel_dq(
         # [BT,]
         b_gq = tl.load(g + o_q * H, mask=m_q, other=float('-inf'))
         # [BT, BK]
-        if USE_EXP2:
-            b_dq *= exp2(b_gq)[:, None]
-        else:
-            b_dq *= exp(b_gq)[:, None]
-
+        b_dq *= exp2(b_gq)[:, None]
     # Q block and K block have overlap. masks required
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
         p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_s, i_k * BK), (BS, BK), (1, 0))
@@ -253,10 +236,7 @@ def parallel_simple_gla_bwd_kernel_dq(
         b_ds = tl.dot(b_do, b_v)
         if USE_G:
             b_gk = tl.load(g + o_k * H, mask=m_k, other=0)
-            if USE_EXP2:
-                b_ds *= exp2(b_gq[:, None] - b_gk[None, :])
-            else:
-                b_ds *= exp(b_gq[:, None] - b_gk[None, :])
+            b_ds *= exp2(b_gq[:, None] - b_gk[None, :])
         m_s = (o_q[:, None] >= o_k[None, :]) & (m_q[:, None] & m_k[None, :])
         b_ds = tl.where(m_s, b_ds, 0)
         # [BT, BK]
@@ -296,7 +276,6 @@ def parallel_simple_gla_bwd_kernel_dkv(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     o_k = i_t * BT + tl.arange(0, BT)
     m_k = o_k < T
@@ -330,16 +309,10 @@ def parallel_simple_gla_bwd_kernel_dkv(
             b_gp = tl.load(g + (min(i_s + BS, T) - 1) * H)
             b_gn = tl.load(g + (i_s - 1) * H) if i_s % BT > 0 else 0.
             if i_s >= 0:
-                if USE_EXP2:
-                    b_gpn = exp2(b_gp - b_gn)
-                else:
-                    b_gpn = exp(b_gp - b_gn)
+                b_gpn = exp2(b_gp - b_gn)
                 b_dk *= b_gpn
                 b_dv *= b_gpn
-                if USE_EXP2:
-                    b_gqn = exp2(b_gq - b_gn)
-                else:
-                    b_gqn = exp(b_gq - b_gn)
+                b_gqn = exp2(b_gq - b_gn)
                 b_ds *= b_gqn[None, :]
                 b_s *= b_gqn[None, :]
         # [BT, BK]
@@ -350,10 +323,7 @@ def parallel_simple_gla_bwd_kernel_dkv(
     if USE_G:
         b_gn = tl.load(g + (min(i_t * BT + BT, T) - 1) * H)
         if i_t >= 0:
-            if USE_EXP2:
-                b_gpn = exp2(b_gn - b_gk)[:, None]
-            else:
-                b_gpn = exp(b_gn - b_gk)[:, None]
+            b_gpn = exp2(b_gn - b_gk)[:, None]
             b_dk *= b_gpn
             b_dv *= b_gpn
 
@@ -373,10 +343,7 @@ def parallel_simple_gla_bwd_kernel_dkv(
         if USE_G:
             b_gq = tl.load(g + o_q * H, mask=m_q, other=float('-inf'))
             if i_s >= 0:
-                if USE_EXP2:
-                    b_gkq = exp2(-b_gk[:, None] + b_gq[None, :])
-                else:
-                    b_gkq = exp(-b_gk[:, None] + b_gq[None, :])
+                b_gkq = exp2(-b_gk[:, None] + b_gq[None, :])
                 b_ds *= b_gkq
                 b_s *= b_gkq
         m_s = o_k[:, None] <= o_q[None, :]
@@ -407,7 +374,7 @@ def parallel_simple_gla_bwd_kernel_dkv(
         triton.Config(triton_config, num_warps=num_warps)
         for num_warps in NUM_WARPS
     ],
-    key=['BT', 'BS', 'BK', 'BV', 'USE_G', 'USE_EXP2'],
+    key=['BT', 'BS', 'BK', 'BV', 'USE_G'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -436,7 +403,6 @@ def parallel_simple_gla_bwd_kernel(
     NV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
 ):
     i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_k, i_v = i_kv // NV, i_kv % NV
@@ -486,7 +452,6 @@ def parallel_simple_gla_bwd_kernel(
         BK=BK,
         BV=BV,
         USE_G=USE_G,
-        USE_EXP2=USE_EXP2,
     )
     tl.debug_barrier()
     parallel_simple_gla_bwd_kernel_dkv(
@@ -511,7 +476,6 @@ def parallel_simple_gla_bwd_kernel(
         BK=BK,
         BV=BV,
         USE_G=USE_G,
-        USE_EXP2=USE_EXP2,
     )
 
 
@@ -525,7 +489,6 @@ def parallel_simple_gla_fwd(
     chunk_size: int = 128,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT, BS = chunk_size, 32
@@ -552,7 +515,7 @@ def parallel_simple_gla_fwd(
         g = chunk_local_cumsum(
             g,
             chunk_size,
-            scale=RCP_LN2 if use_exp2 else None,
+            scale=RCP_LN2,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
         )
@@ -579,7 +542,6 @@ def parallel_simple_gla_fwd(
         BS=BS,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     o = o.sum(0)
 
@@ -598,7 +560,6 @@ def parallel_simple_gla_bwd(
     chunk_size: int = 128,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT, BS = chunk_size, 32
@@ -651,7 +612,6 @@ def parallel_simple_gla_bwd(
         BS=BS,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
     dq = dq.sum(0)
     dk = dk.sum(0)
@@ -682,7 +642,6 @@ class ParallelSimpleGLAFunction(torch.autograd.Function):
             chunk_size=chunk_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
-            use_exp2=True,
         )
         ctx.save_for_backward(q, k, v, g, cu_seqlens, chunk_indices)
         ctx.scale = scale
@@ -704,7 +663,6 @@ class ParallelSimpleGLAFunction(torch.autograd.Function):
             chunk_size=ctx.chunk_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
-            use_exp2=True,
         )
         return dq.to(q), dk.to(k), dv.to(v), dg.to(ctx.dtype) if dg is not None else None, None, None, None, None
 

--- a/fla/ops/simple_gla/parallel.py
+++ b/fla/ops/simple_gla/parallel.py
@@ -10,8 +10,9 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.cumsum import chunk_global_cumsum, chunk_local_cumsum
-from fla.ops.utils.op import exp
+from fla.ops.utils.op import exp, exp2
 from fla.utils import (
     IS_INTEL_ALCHEMIST,
     IS_NVIDIA_HOPPER,
@@ -39,7 +40,7 @@ NUM_WARPS = [2, 4, 8] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
         for num_warps in [2, 4, 8, 16]
         for num_stages in [2, 3, 4]
     ],
-    key=["BT", "BS", "BK", "BV", "USE_G"],
+    key=["BT", "BS", "BK", "BV", "USE_G", "USE_EXP2"],
     **autotune_cache_kwargs,
 )
 @triton.jit
@@ -66,6 +67,7 @@ def parallel_simple_gla_fwd_kernel(
     OUTPUT_ATTENTIONS: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_EXP2: tl.constexpr,
 ):
     i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_k, i_v = i_kv // NV, i_kv % NV
@@ -123,7 +125,10 @@ def parallel_simple_gla_fwd_kernel(
         b_s = tl.dot(b_q, b_k)
         if USE_G:
             b_gk = tl.load(g + o_k * H, mask=m_k, other=0)
-            b_s *= exp(b_gq[:, None] - b_gk[None, :])
+            if USE_EXP2:
+                b_s *= exp2(b_gq[:, None] - b_gk[None, :])
+            else:
+                b_s *= exp(b_gq[:, None] - b_gk[None, :])
         b_s = tl.where(m_s, b_s, 0)
         # [BT, BV]
         if i_s >= 0:
@@ -149,7 +154,10 @@ def parallel_simple_gla_fwd_kernel(
             b_gn = tl.load(g + (min(i_s + BS, T) - 1) * H)
             b_gp = tl.load(g + (i_s-1) * H) if i_s % BT > 0 else 0.
             # No concrete meaning. Just to avoid some layout bugs.
-            b_s *= exp(b_gq[:, None] + (b_gn - b_g)[None, :])
+            if USE_EXP2:
+                b_s *= exp2(b_gq[:, None] + (b_gn - b_g)[None, :])
+            else:
+                b_s *= exp(b_gq[:, None] + (b_gn - b_g)[None, :])
             b_gq += b_gn - b_gp
         b_s = tl.where(m_s, b_s, 0)
         if OUTPUT_ATTENTIONS:
@@ -183,6 +191,7 @@ def parallel_simple_gla_bwd_kernel_dq(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_EXP2: tl.constexpr,
 ):
     p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
     # [BT, BV]
@@ -209,9 +218,14 @@ def parallel_simple_gla_bwd_kernel_dq(
             b_g = tl.load(g + o_k * H, mask=m_k, other=0)
             b_gn = tl.load(g + (min(i_s + BS, T) - 1) * H)
             b_gp = tl.load(g + (i_s - 1) * H) if i_s % BT > 0 else 0.
-            b_ds *= tl.where(m_k, exp(b_gn - b_g), 0)[None, :]
-            if i_s > 0:
-                b_dq *= exp(b_gn - b_gp)
+            if USE_EXP2:
+                b_ds *= tl.where(m_k, exp2(b_gn - b_g), 0)[None, :]
+                if i_s > 0:
+                    b_dq *= exp2(b_gn - b_gp)
+            else:
+                b_ds *= tl.where(m_k, exp(b_gn - b_g), 0)[None, :]
+                if i_s > 0:
+                    b_dq *= exp(b_gn - b_gp)
         # [BT, BS] @ [BS, BK] = [BT, BK]
         b_dq += tl.dot(b_ds.to(b_v.dtype), b_k)
 
@@ -219,7 +233,10 @@ def parallel_simple_gla_bwd_kernel_dq(
         # [BT,]
         b_gq = tl.load(g + o_q * H, mask=m_q, other=float('-inf'))
         # [BT, BK]
-        b_dq *= exp(b_gq)[:, None]
+        if USE_EXP2:
+            b_dq *= exp2(b_gq)[:, None]
+        else:
+            b_dq *= exp(b_gq)[:, None]
 
     # Q block and K block have overlap. masks required
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
@@ -236,7 +253,10 @@ def parallel_simple_gla_bwd_kernel_dq(
         b_ds = tl.dot(b_do, b_v)
         if USE_G:
             b_gk = tl.load(g + o_k * H, mask=m_k, other=0)
-            b_ds *= exp(b_gq[:, None] - b_gk[None, :])
+            if USE_EXP2:
+                b_ds *= exp2(b_gq[:, None] - b_gk[None, :])
+            else:
+                b_ds *= exp(b_gq[:, None] - b_gk[None, :])
         m_s = (o_q[:, None] >= o_k[None, :]) & (m_q[:, None] & m_k[None, :])
         b_ds = tl.where(m_s, b_ds, 0)
         # [BT, BK]
@@ -276,6 +296,7 @@ def parallel_simple_gla_bwd_kernel_dkv(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_EXP2: tl.constexpr,
 ):
     o_k = i_t * BT + tl.arange(0, BT)
     m_k = o_k < T
@@ -309,10 +330,16 @@ def parallel_simple_gla_bwd_kernel_dkv(
             b_gp = tl.load(g + (min(i_s + BS, T) - 1) * H)
             b_gn = tl.load(g + (i_s - 1) * H) if i_s % BT > 0 else 0.
             if i_s >= 0:
-                b_gpn = exp(b_gp - b_gn)
+                if USE_EXP2:
+                    b_gpn = exp2(b_gp - b_gn)
+                else:
+                    b_gpn = exp(b_gp - b_gn)
                 b_dk *= b_gpn
                 b_dv *= b_gpn
-                b_gqn = exp(b_gq - b_gn)
+                if USE_EXP2:
+                    b_gqn = exp2(b_gq - b_gn)
+                else:
+                    b_gqn = exp(b_gq - b_gn)
                 b_ds *= b_gqn[None, :]
                 b_s *= b_gqn[None, :]
         # [BT, BK]
@@ -323,7 +350,10 @@ def parallel_simple_gla_bwd_kernel_dkv(
     if USE_G:
         b_gn = tl.load(g + (min(i_t * BT + BT, T) - 1) * H)
         if i_t >= 0:
-            b_gpn = exp(b_gn - b_gk)[:, None]
+            if USE_EXP2:
+                b_gpn = exp2(b_gn - b_gk)[:, None]
+            else:
+                b_gpn = exp(b_gn - b_gk)[:, None]
             b_dk *= b_gpn
             b_dv *= b_gpn
 
@@ -343,7 +373,10 @@ def parallel_simple_gla_bwd_kernel_dkv(
         if USE_G:
             b_gq = tl.load(g + o_q * H, mask=m_q, other=float('-inf'))
             if i_s >= 0:
-                b_gkq = exp(-b_gk[:, None] + b_gq[None, :])
+                if USE_EXP2:
+                    b_gkq = exp2(-b_gk[:, None] + b_gq[None, :])
+                else:
+                    b_gkq = exp(-b_gk[:, None] + b_gq[None, :])
                 b_ds *= b_gkq
                 b_s *= b_gkq
         m_s = o_k[:, None] <= o_q[None, :]
@@ -374,7 +407,7 @@ def parallel_simple_gla_bwd_kernel_dkv(
         triton.Config(triton_config, num_warps=num_warps)
         for num_warps in NUM_WARPS
     ],
-    key=['BT', 'BS', 'BK', 'BV', 'USE_G'],
+    key=['BT', 'BS', 'BK', 'BV', 'USE_G', 'USE_EXP2'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -403,6 +436,7 @@ def parallel_simple_gla_bwd_kernel(
     NV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_EXP2: tl.constexpr,
 ):
     i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_k, i_v = i_kv // NV, i_kv % NV
@@ -452,6 +486,7 @@ def parallel_simple_gla_bwd_kernel(
         BK=BK,
         BV=BV,
         USE_G=USE_G,
+        USE_EXP2=USE_EXP2,
     )
     tl.debug_barrier()
     parallel_simple_gla_bwd_kernel_dkv(
@@ -476,6 +511,7 @@ def parallel_simple_gla_bwd_kernel(
         BK=BK,
         BV=BV,
         USE_G=USE_G,
+        USE_EXP2=USE_EXP2,
     )
 
 
@@ -489,6 +525,7 @@ def parallel_simple_gla_fwd(
     chunk_size: int = 128,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT, BS = chunk_size, 32
@@ -512,7 +549,13 @@ def parallel_simple_gla_fwd(
 
     # local cumulative decay in log space
     if g is not None:
-        g = chunk_local_cumsum(g, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+        g = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2 if use_exp2 else None,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
     grid = (NK * NV, NT, B * H)
     o = torch.empty(NK, *v.shape, dtype=v.dtype if NK == 1 else torch.float, device=q.device)
     attn = q.new_zeros(NK, B, H, T, T) if output_attentions else None
@@ -536,6 +579,7 @@ def parallel_simple_gla_fwd(
         BS=BS,
         BK=BK,
         BV=BV,
+        USE_EXP2=use_exp2,
     )
     o = o.sum(0)
 
@@ -554,6 +598,7 @@ def parallel_simple_gla_bwd(
     chunk_size: int = 128,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = False,
 ):
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT, BS = chunk_size, 32
@@ -606,6 +651,7 @@ def parallel_simple_gla_bwd(
         BS=BS,
         BK=BK,
         BV=BV,
+        USE_EXP2=use_exp2,
     )
     dq = dq.sum(0)
     dk = dk.sum(0)
@@ -636,6 +682,7 @@ class ParallelSimpleGLAFunction(torch.autograd.Function):
             chunk_size=chunk_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
+            use_exp2=True,
         )
         ctx.save_for_backward(q, k, v, g, cu_seqlens, chunk_indices)
         ctx.scale = scale
@@ -657,6 +704,7 @@ class ParallelSimpleGLAFunction(torch.autograd.Function):
             chunk_size=ctx.chunk_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
+            use_exp2=True,
         )
         return dq.to(q), dk.to(k), dv.to(v), dg.to(ctx.dtype) if dg is not None else None, None, None, None, None
 

--- a/fla/ops/utils/op.py
+++ b/fla/ops/utils/op.py
@@ -49,19 +49,19 @@ if IS_NVIDIA_BLACKWELL:
     Track upstream issue at: https://github.com/triton-lang/triton/issues/8695
     """
     @triton.jit
-    def safe_dot(a, b):
+    def safe_dot(a, b, allow_tf32: tl.constexpr = None):
         return tl.inline_asm_elementwise(
             asm="mov.f32 $0, $1;",
             constraints="=r,r",
-            args=[tl.dot(a, b)],
+            args=[tl.dot(a, b, allow_tf32=allow_tf32)],
             dtype=tl.float32,
             is_pure=True,
             pack=1,
         )
 else:
     @triton.jit
-    def safe_dot(a, b):
-        return tl.dot(a, b)
+    def safe_dot(a, b, allow_tf32: tl.constexpr = None):
+        return tl.dot(a, b, allow_tf32=allow_tf32)
 
 
 if not IS_GATHER_SUPPORTED:

--- a/fla/ops/utils/op.py
+++ b/fla/ops/utils/op.py
@@ -11,7 +11,7 @@ import triton
 import triton.language as tl
 import triton.language.extra.libdevice as tldevice
 
-from fla.utils import IS_GATHER_SUPPORTED
+from fla.utils import IS_GATHER_SUPPORTED, IS_NVIDIA_BLACKWELL
 
 if os.environ.get('FLA_USE_FAST_OPS', '0') == '1':
     @triton.jit
@@ -35,6 +35,33 @@ else:
     def log2(x): return tl.log2(x.to(tl.float32))
     @triton.jit
     def tanh(x): return tldevice.tanh(x.to(tl.float32))
+
+
+if IS_NVIDIA_BLACKWELL:
+    """
+    Compute tl.dot with SM100 workaround.
+
+    On SM100 (Blackwell) GPUs, wraps the result in inline assembly to prevent
+    the TritonGPUHoistTMEMAlloc pass from incorrectly fusing add and dot operations.
+    See: https://github.com/fla-org/flash-linear-attention/issues/638
+
+    TODO: Remove this workaround once the Triton compiler bug is fixed.
+    Track upstream issue at: https://github.com/triton-lang/triton/issues/8695
+    """
+    @triton.jit
+    def safe_dot(a, b):
+        return tl.inline_asm_elementwise(
+            asm="mov.f32 $0, $1;",
+            constraints="=r,r",
+            args=[tl.dot(a, b)],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+else:
+    @triton.jit
+    def safe_dot(a, b):
+        return tl.dot(a, b)
 
 
 if not IS_GATHER_SUPPORTED:

--- a/tests/context_parallel/test_cp_bwd_gk_offset.py
+++ b/tests/context_parallel/test_cp_bwd_gk_offset.py
@@ -109,18 +109,48 @@ class TestBwdGkOffset:
         # Run A: all gk = 0
         dhm_a = torch.zeros(H, K, V + K, dtype=torch.float32, device=device)
         pre_process_bwd_kernel_merged[grid](
-            q=q, k=k, w=w, g=None, gk=gk_zero, do=do, dhm=dhm_a, dv=dv,
-            cu_seqlens=cu_seqlens, scale=1.0, T=T, H=H, HV=H, K=K, V=V,
-            BT=BT, BK1=BK, USE_EXP2=True, BLOCK_SIZE=BLOCK_SIZE,
+            q=q,
+            k=k,
+            w=w,
+            g=None,
+            gk=gk_zero,
+            do=do,
+            dhm=dhm_a,
+            dv=dv,
+            cu_seqlens=cu_seqlens,
+            scale=1.0,
+            T=T,
+            H=H,
+            HV=H,
+            K=K,
+            V=V,
+            BT=BT,
+            BK1=BK,
+            BLOCK_SIZE=BLOCK_SIZE,
             USE_BG=False,
         )
 
         # Run B: head 0 = 0, heads 1+ = -10
         dhm_b = torch.zeros(H, K, V + K, dtype=torch.float32, device=device)
         pre_process_bwd_kernel_merged[grid](
-            q=q, k=k, w=w, g=None, gk=gk_diff, do=do, dhm=dhm_b, dv=dv,
-            cu_seqlens=cu_seqlens, scale=1.0, T=T, H=H, HV=H, K=K, V=V,
-            BT=BT, BK1=BK, USE_EXP2=True, BLOCK_SIZE=BLOCK_SIZE,
+            q=q,
+            k=k,
+            w=w,
+            g=None,
+            gk=gk_diff,
+            do=do,
+            dhm=dhm_b,
+            dv=dv,
+            cu_seqlens=cu_seqlens,
+            scale=1.0,
+            T=T,
+            H=H,
+            HV=H,
+            K=K,
+            V=V,
+            BT=BT,
+            BK1=BK,
+            BLOCK_SIZE=BLOCK_SIZE,
             USE_BG=False,
         )
 

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -465,8 +465,7 @@ def test_fused_recurrent_vllm_decode(
         num_accepted_tokens=None,
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
         use_gate_in_kernel=use_gate_in_kernel,
-        use_exp2=False,
-        lower_bound=lower_bound
+        lower_bound=lower_bound,
     )
 
     # Verify results


### PR DESCRIPTION
## Summary

Migrate the chunk forward/backward kernels of the gated linear attention family onto Triton's `exp2` fast path. `exp2` has dedicated hardware on NVIDIA / AMD GPUs and is consistently faster than `exp`. Mirrors the convention established in `fla/ops/gated_delta_rule`.

`exp2(g * RCP_LN2)` is mathematically identical to `exp(g)`, so the user-visible forward output is unchanged. The cumsum kernels already accept a `scale` argument, so we fold `RCP_LN2` into the cumsum step at zero extra cost and emit `exp2` in every downstream kernel.

## Shape of the change

- **`common/chunk_h`** — `chunk_fwd_kernel_h` / `chunk_bwd_kernel_dh` gain a `USE_EXP2` constexpr (default `False`, so `mesa_net` and other consumers stay on `exp`).
- **`common/fused_chunk`** — same kernel-level treatment; `FusedChunkFunction` now hardcodes `use_exp2=True` internally and pre-scales `g` / `g_gamma` by `RCP_LN2`.
- **`gla/chunk`** — every GLA-private intra/inter kernel gains `USE_EXP2`. The helper-level entry points (`chunk_gla_fwd_o_gk`, `chunk_gla_bwd_dA`, `chunk_gla_bwd_dv`, `chunk_gla_bwd_dqkg`, `chunk_gla_fwd_intra_gk`, `chunk_gla_bwd_dqk_intra`) take `use_exp2` so RWKV6 / KDA / GSA can opt in. `ChunkGLAFunction` always runs `use_exp2=True`.
- **`simple_gla/{chunk,parallel}`** — same plumbing; the cumsum step pre-scales by `RCP_LN2` when `use_exp2=True`. `fused_chunk_simple_gla` rides on `common/fused_chunk`'s hardcoded path.
- **`rwkv6/chunk`** — `chunk_rwkv6_fwd_cumsum_kernel` grows a `HAS_SCALE` constexpr (default off so DPLR keeps its current semantics) and applies the scale inside the kernel; all RWKV6-private kernels now emit `exp2` directly. `ChunkRWKV6Function` passes `scale=RCP_LN2` to the cumsum and `use_exp2=True` to `chunk_fwd_h` / `chunk_gla` helpers.
- **`gsa/chunk`** — cumsum gains `scale=RCP_LN2`; all GSA-private kernels emit `exp2`; `chunk_gla_fwd` / `chunk_gla_bwd` / `chunk_fwd_h` / `chunk_bwd_dh` are invoked with `use_exp2=True`.
- **`retention`** — thin wrappers, no signature change. The `exp2` fast path flows in for free via `simple_gla`.

`fused_recurrent` paths are intentionally **left on `exp`**. The kernel is per-step scalar so `g * RCP_LN2 -> exp2(g_scaled)` collapses to identical instruction count without any fast-math benefit.

## Dependent ops not in this PR

| Shared kernel | Caller | Status |
|---|---|---|
| `common/chunk_h` | `mesa_net/chunk` | unchanged (default `USE_EXP2=False`) |
| `common/fused_chunk` | `linear_attn/fused_chunk` | unchanged (passes `g=None`, no gates) |
| `gla/chunk_gla_fwd_o_gk` | `kda/chunk_fwd` | already on `use_exp2=True` (pre-existing) |
| `rwkv6/chunk_rwkv6_fwd_cumsum` | `generalized_delta_rule/dplr` | unchanged (does not pass `scale`) |

## User-facing API

No new kwargs are exposed on `chunk_gla`, `chunk_simple_gla`, `parallel_simple_gla`, `fused_chunk_simple_gla`, `chunk_retention` / `parallel_retention` / `fused_chunk_retention`, `chunk_gsa`, or `chunk_rwkv6`. `use_exp2` is an internal-only knob threaded through helpers; the autograd `Function` boundary always sets it to `True`.

## Test plan

- [ ] `pytest tests/ops/test_gla.py`
- [ ] `pytest tests/ops/test_simple_gla.py`
- [ ] `pytest tests/ops/test_retention.py`
- [ ] `pytest tests/ops/test_gsa.py`
- [ ] `pytest tests/ops/test_rwkv6.py`
- [ ] `pytest tests/ops/test_kda.py` (verify `chunk_gla_fwd_o_gk` consumer still passes)
- [ ] Spot-check `mesa_net` / `linear_attn` / `lightning_attn` / DPLR — these consume the touched shared modules but should be unaffected