### PR TITLE
[Conv] Fix causal_conv1d backward producing wrong gradients for non-contiguous dy

### DIFF
--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -171,6 +171,9 @@ def causal_conv1d_bwd_kernel(
     stride_dx_n,  # dx batch stride
     stride_dx_t,  # dx time stride
     stride_dx_d,  # dx dim stride
+    stride_dy_n,  # dy batch stride
+    stride_dy_t,  # dy time stride
+    stride_dy_d,  # dy dim stride
     D: tl.constexpr,
     W: tl.constexpr,
     BT: tl.constexpr,
@@ -197,6 +200,11 @@ def causal_conv1d_bwd_kernel(
         bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
         p_x = x + tl.cast(i_b, tl.int64) * stride_x_n
 
+    if IS_VARLEN:
+        p_dy = dy + bos * stride_dy_t
+    else:
+        p_dy = dy + tl.cast(i_b, tl.int64) * stride_dy_n
+
     o_d = i_d * BD + tl.arange(0, BD)
     o_w = tl.arange(0, BW) + W - BW
     m_d = o_d < D
@@ -214,9 +222,10 @@ def causal_conv1d_bwd_kernel(
 
     if not USE_FINAL_STATE and not USE_INITIAL_STATE:
         for i_w in tl.static_range(0, W):
-            p_dy = tl.make_block_ptr(dy + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
+            p_dy_blk = tl.make_block_ptr(p_dy, (T, D), (stride_dy_t, stride_dy_d),
+                                         (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
             # [BT, BD]
-            b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+            b_dy = tl.load(p_dy_blk, boundary_check=(0, 1)).to(tl.float32)
             if ACTIVATION == 'swish' or ACTIVATION == 'silu':
                 p_y = tl.make_block_ptr(y + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
                 b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
@@ -235,9 +244,10 @@ def causal_conv1d_bwd_kernel(
     elif i_t * BT >= W:
         # to make Triton compiler happy, we need to copy codes
         for i_w in tl.static_range(0, W):
-            p_dy = tl.make_block_ptr(dy + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
+            p_dy_blk = tl.make_block_ptr(p_dy, (T, D), (stride_dy_t, stride_dy_d),
+                                         (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
             # [BT, BD]
-            b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+            b_dy = tl.load(p_dy_blk, boundary_check=(0, 1)).to(tl.float32)
             if ACTIVATION == 'swish' or ACTIVATION == 'silu':
                 p_y = tl.make_block_ptr(y + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
                 b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
@@ -257,8 +267,9 @@ def causal_conv1d_bwd_kernel(
         # which may use initial state
         o_t = i_t * BT + tl.arange(0, BT)
         for i_w in tl.static_range(0, W):
-            p_dy = tl.make_block_ptr(dy + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
-            b_dy_shift = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+            p_dy_blk = tl.make_block_ptr(p_dy, (T, D), (stride_dy_t, stride_dy_d),
+                                         (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
+            b_dy_shift = tl.load(p_dy_blk, boundary_check=(0, 1)).to(tl.float32)
             if ACTIVATION == 'swish' or ACTIVATION == 'silu':
                 p_y = tl.make_block_ptr(y + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
                 b_y_shift = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
@@ -271,7 +282,7 @@ def causal_conv1d_bwd_kernel(
                 if USE_INITIAL_STATE:
                     mask_head_rows = (o_t < i_w) & (o_t < T)
                     # dy_head = dy[t]
-                    b_dy_head = tl.load(dy + bos * D + o_t[:, None] * D + o_d, mask=(mask_head_rows[:, None] & m_d[None, :]),
+                    b_dy_head = tl.load(p_dy + o_t[:, None] * stride_dy_t + o_d * stride_dy_d, mask=(mask_head_rows[:, None] & m_d[None, :]),
                                         other=0.0).to(tl.float32)
                     if ACTIVATION == 'swish' or ACTIVATION == 'silu':
                         # use y[t] （not y[t+i_w]）

--- a/fla/modules/conv/triton/ops.py
+++ b/fla/modules/conv/triton/ops.py
@@ -147,11 +147,8 @@ def causal_conv1d_bwd(
     B, T, D = x.shape
     W = weight.shape[1] if weight is not None else None
 
-    # The bwd kernel reads dy with hardcoded stride (D, 1), so dy must be contiguous.
-    # Non-contiguous dy can arise from e.g. torch.cat backward (split produces views).
-    dy = dy.contiguous()
-
     stride_x_n, stride_x_t, stride_x_d = x.stride()
+    stride_dy_n, stride_dy_t, stride_dy_d = dy.stride()
 
     BW = triton.next_power_of_2(W)
     if cu_seqlens is not None and chunk_indices is None:
@@ -206,6 +203,9 @@ def causal_conv1d_bwd(
         stride_dx_n=stride_dx_n,
         stride_dx_t=stride_dx_t,
         stride_dx_d=stride_dx_d,
+        stride_dy_n=stride_dy_n,
+        stride_dy_t=stride_dy_t,
+        stride_dy_d=stride_dy_d,
         ACTIVATION=activation,
     )
     if weight is not None:

--- a/fla/modules/conv/triton/ops.py
+++ b/fla/modules/conv/triton/ops.py
@@ -147,6 +147,10 @@ def causal_conv1d_bwd(
     B, T, D = x.shape
     W = weight.shape[1] if weight is not None else None
 
+    # The bwd kernel reads dy with hardcoded stride (D, 1), so dy must be contiguous.
+    # Non-contiguous dy can arise from e.g. torch.cat backward (split produces views).
+    dy = dy.contiguous()
+
     stride_x_n, stride_x_t, stride_x_d = x.stride()
 
     BW = triton.next_power_of_2(W)

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -1373,3 +1373,47 @@ def test_conv_varlen_non_contiguous_qkv(
 
     assert_close("dx", ref_k_state.grad, k_state.grad, 1e-3)
     assert_close("dh0", ref_initial_state.grad, tri_initial_state.grad, 1e-3)
+
+
+@pytest.mark.parametrize("B", [1, 4])
+@pytest.mark.parametrize("T", [15, 64, 300])
+@pytest.mark.parametrize("D", [32, 64, 128])
+@pytest.mark.parametrize("W", [2, 4])
+@pytest.mark.parametrize("activation", [None, "silu"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_conv_non_contiguous_dy(B, T, D, W, activation, dtype):
+    """Test that backward produces correct gradients when dy is non-contiguous.
+
+    This simulates the split -> conv -> cat pattern used in fused-QKV attention,
+    where torch.cat backward produces non-contiguous dy views via split.
+    """
+    torch.manual_seed(42)
+
+    weight = torch.randn(D, W, device=device, dtype=dtype).requires_grad_(True)
+    weight_ref = weight.detach().clone().requires_grad_(True)
+
+    # --- Reference: contiguous path ---
+    x_ref = torch.randn(B, T, D, device=device, dtype=dtype, requires_grad=True)
+    y_ref, _ = causal_conv1d(x_ref, weight_ref, activation=activation)
+    dy = torch.randn_like(y_ref)
+    y_ref.backward(dy)
+
+    # --- Test: non-contiguous dy via cat/split pattern ---
+    x_test = x_ref.detach().clone().requires_grad_(True)
+    weight_test = weight.detach().clone().requires_grad_(True)
+
+    # Forward through conv
+    y_test, _ = causal_conv1d(x_test, weight_test, activation=activation)
+
+    # Simulate non-contiguous dy: cat into [B, T, 3D] then split back
+    dummy = torch.zeros_like(dy)
+    dy_cat = torch.cat([dy, dummy, dummy], dim=-1)   # [B, T, 3D]
+    dy_nc = dy_cat[:, :, :D]                          # non-contiguous view
+
+    assert not dy_nc.is_contiguous(), "dy should be non-contiguous for this test"
+    assert torch.equal(dy_nc.contiguous(), dy), "dy content should match"
+
+    y_test.backward(dy_nc)
+
+    assert_close(" dx", x_ref.grad, x_test.grad, 1e-3)
+    assert_close(" dw", weight_ref.grad, weight_test.grad, 1e-3)

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -1375,12 +1375,18 @@ def test_conv_varlen_non_contiguous_qkv(
     assert_close("dh0", ref_initial_state.grad, tri_initial_state.grad, 1e-3)
 
 
-@pytest.mark.parametrize("B", [1, 4])
-@pytest.mark.parametrize("T", [15, 64, 300])
-@pytest.mark.parametrize("D", [32, 64, 128])
-@pytest.mark.parametrize("W", [2, 4])
-@pytest.mark.parametrize("activation", [None, "silu"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize(
+    ('B', 'T', 'D', 'W', 'activation', 'dtype'),
+    [
+        pytest.param(*test, id="B{0}_T{1}_D{2}_W{3}_activation{4}_{5}".format(*test))
+        for test in [
+            (2, 64, 128, 4, None, torch.float32),
+            (2, 128, 128, 3, "silu", torch.float32),
+            (1, 15, 64, 2, None, torch.bfloat16),
+            (4, 300, 32, 4, "silu", torch.bfloat16),
+        ]
+    ],
+)
 def test_conv_non_contiguous_dy(B, T, D, W, activation, dtype):
     """Test that backward produces correct gradients when dy is non-contiguous.
 


### PR DESCRIPTION
### Bug

`causal_conv1d_bwd_kernel` reads `dy` using `tl.make_block_ptr` with **hardcoded strides `(D, 1)`**:

```python
# kernels.py, lines 217/238/260 — all three branches of causal_conv1d_bwd_kernel
p_dy = tl.make_block_ptr(dy + bos * D, (T, D), (D, 1), ...)
```

and at line 274 with manual indexing:
```python
b_dy_head = tl.load(dy + bos * D + o_t[:, None] * D + o_d, ...)
```

This **assumes `dy` is contiguous** (`stride == (T*D, D, 1)`). When `dy` is non-contiguous, the kernel reads from wrong memory locations, producing **silently incorrect gradients** — no error is raised.

### When does non-contiguous `dy` occur?

A common pattern in attention layers is to fuse Q/K/V into a single projection, apply per-component convolutions, and concatenate back:

```python
qkv = Wqkv(x)                       # [B, S, 3D], contiguous
q, k, v = qkv.split(D, dim=-1)      # non-contiguous views (stride: (S*3D, 3D, 1))
q = causal_conv1d(q, ...)            # fwd handles non-contiguous x correctly; output is contiguous
k = causal_conv1d(k, ...)
v = causal_conv1d(v, ...)
qkv = torch.cat([q, k, v], dim=-1)  # [B, S, 3D], contiguous
```

Forward works correctly. But in the backward pass, `torch.cat`'s gradient is `torch.split`, which produces **non-contiguous views** of the upstream gradient:

```
dy_qkv: [B, S, 3D], contiguous, strides (S*3D, 3D, 1)
  → split → dy_q, dy_k, dy_v: each [B, S, D], strides (S*3D, 3D, 1)  ← NOT (S*D, D, 1)
```

The kernel reads with stride `(D, 1)`, stepping only `D` elements per timestep instead of `3D`. This causes each conv's backward to read a **cross-mixed** blend of all three gradients.

### Impact

- **Gradient cosine similarity ≈ 0** (essentially random direction).
- `grad_weight` values can even be negative when they shouldn't be.
- In practice this manifests as a **stable ~0.2 loss degradation** and more training spikes. With `activation='silu'`, training diverges entirely.
- The bug is **completely silent** — no shape mismatch, no assertion, no NaN. Only gradient numerics are wrong.

### Why existing usage is unaffected

All current FLA layers (DeltaNet, GLA, Mamba, etc.) use **separate projections** for Q/K/V (`q_proj`, `k_proj`, `v_proj`), so each conv's backward receives an independent contiguous `dy`. The bug only triggers when `causal_conv1d` is used as a building block in architectures that fuse/split QKV tensors.

### Fix

**One-line fix** in `ops.py` — ensure `dy` is contiguous before passing to the kernel:

```python
def causal_conv1d_bwd(...):
    ...
    B, T, D = x.shape
    W = weight.shape[1] if weight is not None else None

    # The bwd kernel reads dy with hardcoded stride (D, 1), so dy must be contiguous.
    # Non-contiguous dy can arise from e.g. torch.cat backward (split produces views).
    dy = dy.contiguous()

    stride_x_n, stride_x_t, stride_x_d = x.stride()
    ...
```

For already-contiguous `dy` (all existing usage), `Tensor.contiguous()` is a **no-op** with zero overhead.

### Test

Add a test that specifically exercises non-contiguous `dy` by simulating the `split → conv → cat` pattern:

```python
@pytest.mark.parametrize(
    ('B', 'T', 'D', 'W', 'activation', 'dtype'),
    [
        pytest.param(*test, id="B{0}_T{1}_D{2}_W{3}_activation{4}_{5}".format(*test))
        for test in [
            (2, 64, 128, 4, None, torch.float32),
            (2, 128, 128, 3, "silu", torch.float32),
            (1, 15, 64, 2, None, torch.bfloat16),
            (4, 300, 32, 4, "silu", torch.bfloat16),
        ]
    ],
)
def test_conv_non_contiguous_dy(B, T, D, W, activation, dtype):
    """Test that backward produces correct gradients when dy is non-contiguous.

    This simulates the split -> conv -> cat pattern used in fused-QKV attention,
    where torch.cat backward produces non-contiguous dy views via split.
    """
    torch.manual_seed(42)

    weight = torch.randn(D, W, device=device, dtype=dtype).requires_grad_(True)
    weight_ref = weight.detach().clone().requires_grad_(True)

    # --- Reference: contiguous path ---
    x_ref = torch.randn(B, T, D, device=device, dtype=dtype, requires_grad=True)
    y_ref, _ = causal_conv1d(x_ref, weight_ref, activation=activation)
    dy = torch.randn_like(y_ref)
    y_ref.backward(dy)

    # --- Test: non-contiguous dy via cat/split pattern ---
    x_test = x_ref.detach().clone().requires_grad_(True)
    weight_test = weight.detach().clone().requires_grad_(True)

    # Forward through conv
    y_test, _ = causal_conv1d(x_test, weight_test, activation=activation)

    # Simulate non-contiguous dy: cat into [B, T, 3D] then split back
    dummy = torch.zeros_like(dy)
    dy_cat = torch.cat([dy, dummy, dummy], dim=-1)   # [B, T, 3D]
    dy_nc = dy_cat[:, :, :D]                          # non-contiguous view

    assert not dy_nc.is_contiguous(), "dy should be non-contiguous for this test"
    assert torch.equal(dy_nc.contiguous(), dy), "dy content should match"

    y_test.backward(dy_nc)

    assert_close(" dx", x_ref.grad, x_test.grad, 1e-3)
    assert_close(" dw", weight_ref.grad, weight_test.grad, 1e-3)
```

### Files changed

| File | Change |
|------|--------|
| `fla/modules/conv/triton/ops.py` | Add `dy = dy.contiguous()` in `causal_conv1d_bwd` |
| `tests/modules/test_conv.py` | Add `test_conv_non_contiguous_dy` |
