### PR TITLE
[Fix] Improve fused loss gradient accumulation

### DIFF
--- a/fla/modules/fused_kl_div.py
+++ b/fla/modules/fused_kl_div.py
@@ -125,6 +125,7 @@ def fused_kl_div_forward(
     weight: torch.Tensor,
     target_weight: torch.Tensor,
     reduction: str = 'batchmean',
+    accumulate_grad_in_fp32: bool = True,
 ):
     device = x.device
 
@@ -141,8 +142,10 @@ def fused_kl_div_forward(
     C = triton.next_power_of_2(triton.cdiv(N, NC))
     NC = triton.cdiv(N, C)
 
+    grad_dtype = torch.float32 if accumulate_grad_in_fp32 else weight.dtype
+
     dx = torch.zeros_like(x, device=device)
-    dw = torch.zeros_like(weight, device=device) if weight is not None else None
+    dw = torch.zeros_like(weight, device=device, dtype=grad_dtype) if weight is not None else None
     # we use fp32 for loss accumulator
     loss = torch.zeros(N, dtype=torch.float32, device=device)
 
@@ -155,6 +158,8 @@ def fused_kl_div_forward(
         # [C, V]
         c_sl = F.linear(c_sx, weight)
         c_tl = F.linear(c_tx, target_weight)
+        if weight is not None and c_sx.dtype != grad_dtype:
+            c_sx = c_sx.to(dtype=grad_dtype)
 
         # unreduced loss
         c_loss = loss[start:end]
@@ -183,9 +188,16 @@ def fused_kl_div_forward(
         dx[start:end] = torch.mm(c_sl, weight)
 
         if weight is not None:
-            torch.addmm(input=dw, mat1=c_sl.t(), mat2=c_sx, out=dw)
+            torch.addmm(
+                input=dw,
+                mat1=c_sl.t().to(dtype=grad_dtype),
+                mat2=c_sx,
+                out=dw,
+            )
 
     loss = loss.sum()
+    if dw is not None:
+        dw = dw.to(weight)
     return loss, dx, dw
 
 
@@ -234,6 +246,7 @@ class FusedKLDivLossFunction(torch.autograd.Function):
         weight: torch.Tensor,
         target_weight: torch.Tensor,
         reduction: str,
+        accumulate_grad_in_fp32: bool,
     ):
         loss, dx, dw = fused_kl_div_forward(
             x=x,
@@ -241,6 +254,7 @@ class FusedKLDivLossFunction(torch.autograd.Function):
             weight=weight,
             target_weight=target_weight,
             reduction=reduction,
+            accumulate_grad_in_fp32=accumulate_grad_in_fp32,
         )
         ctx.save_for_backward(dx, dw)
         return loss
@@ -250,7 +264,7 @@ class FusedKLDivLossFunction(torch.autograd.Function):
     def backward(ctx, do):
         dx, dw = ctx.saved_tensors
         dx, dw = fused_kl_div_backward(do, dx, dw)
-        return dx, None, dw, None, None
+        return dx, None, dw, None, None, None
 
 
 def fused_kl_div_loss(
@@ -259,26 +273,41 @@ def fused_kl_div_loss(
     weight: torch.Tensor,
     target_weight: torch.Tensor,
     reduction: str = 'batchmean',
+    accumulate_grad_in_fp32: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Args:
-        x (torch.Tensor): [batch_size * seq_len, hidden_size]
-        target_x (torch.Tensor): [batch_size * seq_len, hidden_size]
-        weight (torch.Tensor): [vocab_size, hidden_size]
-            where `vocab_size` is the number of classes.
-        target_weight (torch.Tensor): [vocab_size, hidden_size]
-            where `vocab_size` is the number of classes.
-        reduction:
+        x (`torch.Tensor`):
+            Tensor of shape `[batch_size * seq_len, hidden_size]`.
+        target_x (`torch.Tensor`):
+            Frozen teacher input tensor of shape `[batch_size * seq_len, hidden_size]`.
+            Must not require gradients.
+        weight (`torch.Tensor`):
+            Tensor of shape `[vocab_size, hidden_size]`.
+        target_weight (`torch.Tensor`):
+            Frozen teacher weight tensor of shape `[vocab_size, hidden_size]`.
+            Must not require gradients.
+        reduction (`str`):
             Specifies the reduction to apply to the output: 'batchmean'. Default: 'batchmean'.
+        accumulate_grad_in_fp32 (`bool`):
+            Whether to accumulate the student weight gradient in fp32 before casting it back
+            to `weight.dtype`. Default: `True`.
     Returns:
         loss
     """
+    if target_x.requires_grad or target_weight.requires_grad:
+        raise RuntimeError(
+            "FusedKLDivLoss treats target_x and target_weight as a frozen teacher and does not compute "
+            "gradients for them. Detach target_x/target_weight before calling FusedKLDivLoss, or use "
+            "torch.nn.functional.kl_div if teacher gradients are required."
+        )
     return FusedKLDivLossFunction.apply(
         x,
         target_x,
         weight,
         target_weight,
         reduction,
+        accumulate_grad_in_fp32,
     )
 
 
@@ -287,17 +316,25 @@ class FusedKLDivLoss(nn.Module):
     def __init__(
         self,
         reduction: str = 'batchmean',
+        accumulate_grad_in_fp32: bool = True,
     ):
         """
         Args:
-            reduction:
+            reduction (`str`):
                 Specifies the reduction to apply to the output: 'batchmean'. Default: 'batchmean'.
+            accumulate_grad_in_fp32 (`bool`):
+                Whether to accumulate the student weight gradient in fp32 before casting it back
+                to `weight.dtype`. Default: `True`.
+        Note:
+            FusedKLDivLoss only computes gradients for `x` and `weight`; `target_x` and
+            `target_weight` are treated as frozen teacher tensors and must not require gradients.
         """
         super().__init__()
 
         assert reduction in ['batchmean'], f"reduction: {reduction} is not supported"
 
         self.reduction = reduction
+        self.accumulate_grad_in_fp32 = accumulate_grad_in_fp32
 
     def forward(
         self,
@@ -308,12 +345,16 @@ class FusedKLDivLoss(nn.Module):
     ):
         """
         Args:
-            x (torch.Tensor): [batch_size * seq_len, hidden_size]
-            target_x (torch.Tensor): [batch_size * seq_len, hidden_size]
-            weight (torch.Tensor): [vocab_size, hidden_size]
-                where `vocab_size` is the number of classes.
-            target_weight (torch.Tensor): [vocab_size, hidden_size]
-                where `vocab_size` is the number of classes.
+            x (`torch.Tensor`):
+                Tensor of shape `[batch_size * seq_len, hidden_size]`.
+            target_x (`torch.Tensor`):
+                Frozen teacher input tensor of shape `[batch_size * seq_len, hidden_size]`.
+                Must not require gradients.
+            weight (`torch.Tensor`):
+                Tensor of shape `[vocab_size, hidden_size]`.
+            target_weight (`torch.Tensor`):
+                Frozen teacher weight tensor of shape `[vocab_size, hidden_size]`.
+                Must not require gradients.
         Returns:
             loss
         """
@@ -323,5 +364,6 @@ class FusedKLDivLoss(nn.Module):
             weight=weight,
             target_weight=target_weight,
             reduction=self.reduction,
+            accumulate_grad_in_fp32=self.accumulate_grad_in_fp32,
         )
         return loss

--- a/fla/modules/fused_linear_cross_entropy.py
+++ b/fla/modules/fused_linear_cross_entropy.py
@@ -284,6 +284,7 @@ def fused_linear_cross_entropy_forward(
     reduction: str = "mean",
     use_l2warp: bool = False,
     l2_penalty_factor: float = 1e-4,
+    accumulate_grad_in_fp32: bool = True,
 ):
     device = x.device
     # inputs have shape: [N, H]
@@ -306,10 +307,15 @@ def fused_linear_cross_entropy_forward(
 
     # [N, H]
     dx = torch.zeros_like(x, device=device)
+    grad_dtype = torch.float32 if accumulate_grad_in_fp32 else weight.dtype
+    bias_grad_dtype = None
+    if bias is not None:
+        bias_grad_dtype = torch.float32 if accumulate_grad_in_fp32 else bias.dtype
+
     # [V, H]
-    dw = torch.zeros_like(weight, device=device, dtype=torch.float) if weight is not None else None
+    dw = torch.zeros_like(weight, device=device, dtype=grad_dtype) if weight is not None else None
     # [V]
-    db = torch.zeros_like(bias, device=device, dtype=torch.float) if bias is not None else None
+    db = torch.zeros_like(bias, device=device, dtype=bias_grad_dtype) if bias is not None else None
     # [N]
     loss = torch.zeros(N, device=device, dtype=torch.float)
 
@@ -322,6 +328,8 @@ def fused_linear_cross_entropy_forward(
         # when doing matmul, use the original precision
         # [C, V]
         c_logits = F.linear(c_x, weight, bias)
+        if weight is not None and c_x.dtype != grad_dtype:
+            c_x = c_x.to(dtype=grad_dtype)
         c_target = target[start:end]
         # [C]
         # keep lse in fp32 to maintain precision
@@ -352,8 +360,8 @@ def fused_linear_cross_entropy_forward(
             # a. Calculate the L2 gradient w.r.t logits (g_logits_l2)
             g_logits_l2 = torch.zeros_like(c_logits)
 
-            # Normalize factor by B*T, which is the 'total' variable here
-            l2_factor = l2_penalty_factor / total if reduction == 'mean' else l2_penalty_factor
+            # Match L2Wrap: normalize by the full number of input tokens, not by non-ignored labels.
+            l2_factor = l2_penalty_factor / N
             penalty_grad = c_maxx * l2_factor
             g_logits_l2.scatter_(-1, c_ids, penalty_grad)
 
@@ -363,9 +371,14 @@ def fused_linear_cross_entropy_forward(
             # Total_dw = CE_dw + L2_dw
             # Total_db = CE_db + L2_db
             if weight is not None:
-                dw.add_(g_logits_l2.t() @ c_x)
+                torch.addmm(
+                    input=dw,
+                    mat1=g_logits_l2.t().to(dtype=grad_dtype),
+                    mat2=c_x,
+                    out=dw,
+                )
             if bias is not None:
-                db.add_(g_logits_l2.sum(0))
+                torch.add(input=db, other=g_logits_l2.sum(0, dtype=bias_grad_dtype), out=db)
             # The dx contribution must be added to the final dx calculation
             dx_l2_contribution = torch.mm(g_logits_l2, weight)
         else:
@@ -375,12 +388,16 @@ def fused_linear_cross_entropy_forward(
         # thus dx should be of shape: C x H
         dx[start:end] = torch.mm(c_logits, weight) + dx_l2_contribution
 
-        # keep dw in fp32 to maintain precision
         if weight is not None:
-            dw += c_logits.t() @ c_x
+            torch.addmm(
+                input=dw,
+                mat1=c_logits.t().to(dtype=grad_dtype),
+                mat2=c_x,
+                out=dw,
+            )
 
         if bias is not None:
-            torch.add(input=db, other=c_logits.sum(0), out=db)
+            torch.add(input=db, other=c_logits.sum(0, dtype=bias_grad_dtype), out=db)
 
     loss = loss.sum()
     if dw is not None:
@@ -452,6 +469,7 @@ class FusedLinearCrossEntropyFunction(torch.autograd.Function):
         reduction: str = "mean",
         use_l2warp: bool = False,
         l2_penalty_factor: float = 1e-4,
+        accumulate_grad_in_fp32: bool = True,
     ):
         """
         Fusing the last linear layer with cross-entropy loss
@@ -491,6 +509,10 @@ class FusedLinearCrossEntropyFunction(torch.autograd.Function):
             Whether to use L2 regularization on the logits to prevent overconfidence.
             Default: False
         l2_penalty_factor: float = 1e-4,
+            The L2Warp penalty factor. Default: 1e-4
+        accumulate_grad_in_fp32: bool = True,
+            Whether to accumulate weight and bias gradients in fp32 before casting them
+            back to the parameter dtype. Default: True
         """
         loss, dx, dw, db = fused_linear_cross_entropy_forward(
             x,
@@ -505,6 +527,7 @@ class FusedLinearCrossEntropyFunction(torch.autograd.Function):
             reduction,
             use_l2warp,
             l2_penalty_factor,
+            accumulate_grad_in_fp32,
         )
         # downcast to dtype and store for backward
         ctx.save_for_backward(
@@ -519,7 +542,7 @@ class FusedLinearCrossEntropyFunction(torch.autograd.Function):
     def backward(ctx, do):
         dx, dw, db = ctx.saved_tensors
         dx, dw, db = fused_linear_cross_entropy_backward(do, dx, dw, db)
-        return dx, None, dw, db, None, None, None, None, None, None, None, None
+        return dx, None, dw, db, None, None, None, None, None, None, None, None, None
 
 
 def fused_linear_cross_entropy_loss(
@@ -535,6 +558,7 @@ def fused_linear_cross_entropy_loss(
     reduction: str = "mean",
     use_l2warp: bool = False,
     l2_penalty_factor: float = 1e-4,
+    accumulate_grad_in_fp32: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Args:
@@ -562,6 +586,15 @@ def fused_linear_cross_entropy_loss(
             'mean': the weighted mean of the output is taken,
             'sum': the output will be summed.
             Default: 'mean'.
+        use_l2warp:
+            Whether to add the L2Warp logit regularization gradient. The penalty is normalized by
+            the full number of input tokens, matching `fla.modules.l2warp.l2_warp`.
+            Default: `False`.
+        l2_penalty_factor:
+            The L2Warp penalty factor. Default: `1e-4`.
+        accumulate_grad_in_fp32:
+            Whether to accumulate weight and bias gradients in fp32 before casting them
+            back to the parameter dtype. Default: `True`.
     Returns:
         losses: [batch,], float
     """
@@ -578,6 +611,7 @@ def fused_linear_cross_entropy_loss(
         reduction,
         use_l2warp,
         l2_penalty_factor,
+        accumulate_grad_in_fp32,
     )
 
 
@@ -593,6 +627,7 @@ class FusedLinearCrossEntropyLoss(nn.Module):
         reduction: str = "mean",
         use_l2warp: bool = False,
         l2_penalty_factor: float = 1e-4,
+        accumulate_grad_in_fp32: bool = True,
     ):
         """
         Args:
@@ -613,6 +648,15 @@ class FusedLinearCrossEntropyLoss(nn.Module):
                 'mean': the weighted mean of the output is taken,
                 'sum': the output will be summed.
                 Default: 'mean'.
+            use_l2warp:
+                Whether to add the L2Warp logit regularization gradient. The penalty is normalized by
+                the full number of input tokens, matching `fla.modules.l2warp.l2_warp`.
+                Default: `False`.
+            l2_penalty_factor:
+                The L2Warp penalty factor. Default: `1e-4`.
+            accumulate_grad_in_fp32:
+                Whether to accumulate weight and bias gradients in fp32 before casting them
+                back to the parameter dtype. Default: `True`.
         """
         super().__init__()
 
@@ -626,6 +670,7 @@ class FusedLinearCrossEntropyLoss(nn.Module):
         self.reduction = reduction
         self.use_l2warp = use_l2warp
         self.l2_penalty_factor = l2_penalty_factor
+        self.accumulate_grad_in_fp32 = accumulate_grad_in_fp32
 
     @torch.compiler.disable
     def forward(
@@ -660,6 +705,7 @@ class FusedLinearCrossEntropyLoss(nn.Module):
             reduction=self.reduction,
             use_l2warp=self.use_l2warp,
             l2_penalty_factor=self.l2_penalty_factor,
+            accumulate_grad_in_fp32=self.accumulate_grad_in_fp32,
         )
         return loss
 

--- a/tests/modules/test_cross_entropy.py
+++ b/tests/modules/test_cross_entropy.py
@@ -100,6 +100,7 @@ def test_fused_cross_entropy_softcap(
 @pytest.mark.parametrize("V", [32000, 100000])
 @pytest.mark.parametrize("scale", [1., 0.5])
 @pytest.mark.parametrize("reduction", ['mean'])
+@pytest.mark.parametrize("accumulate_grad_in_fp32", [False, True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.skipif(
     device_platform == 'intel',
@@ -112,6 +113,7 @@ def test_fused_linear_cross_entropy(
     V: int,
     scale: float,
     reduction: str,
+    accumulate_grad_in_fp32: bool,
     dtype: torch.dtype
 ):
     torch.manual_seed(42)
@@ -132,7 +134,11 @@ def test_fused_linear_cross_entropy(
     ref_dw, weight.grad = weight.grad.clone(), None
     ref_db, bias.grad = bias.grad.clone(), None
 
-    tri = FusedLinearCrossEntropyLoss(logit_scale=scale, reduction=reduction)(x, target, weight, bias)
+    tri = FusedLinearCrossEntropyLoss(
+        logit_scale=scale,
+        reduction=reduction,
+        accumulate_grad_in_fp32=accumulate_grad_in_fp32,
+    )(x, target, weight, bias)
     tri.backward(do)
     tri_dx, x.grad = x.grad.clone(), None
     tri_dw, weight.grad = weight.grad.clone(), None

--- a/tests/modules/test_kl_div.py
+++ b/tests/modules/test_kl_div.py
@@ -18,12 +18,21 @@ from fla.utils import assert_close, device, device_platform
 @pytest.mark.parametrize("D", [1024, 2048])
 @pytest.mark.parametrize("V", [32000, 100000])
 @pytest.mark.parametrize("reduction", ["batchmean"])
+@pytest.mark.parametrize("accumulate_grad_in_fp32", [False, True])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 @pytest.mark.skipif(
     device_platform == 'intel',
     reason="Intel Triton Failure",
 )
-def test_fused(B: int, T: int, D: int, V: int, reduction: str, dtype: torch.dtype):
+def test_fused(
+    B: int,
+    T: int,
+    D: int,
+    V: int,
+    reduction: str,
+    accumulate_grad_in_fp32: bool,
+    dtype: torch.dtype,
+):
     torch.manual_seed(42)
     x = torch.randn(B * T, D).to(device).to(dtype=dtype).requires_grad_()
     x_weight = torch.randn(V, D).to(device).to(dtype=dtype).requires_grad_()
@@ -40,7 +49,10 @@ def test_fused(B: int, T: int, D: int, V: int, reduction: str, dtype: torch.dtyp
     ref_dx, x.grad = x.grad.clone(), None
     ref_dw, x_weight.grad = x_weight.grad.clone(), None
 
-    tri = FusedKLDivLoss(reduction)(x, target_x, x_weight, target_weight).to(dtype=dtype)
+    tri = FusedKLDivLoss(
+        reduction=reduction,
+        accumulate_grad_in_fp32=accumulate_grad_in_fp32,
+    )(x, target_x, x_weight, target_weight).to(dtype=dtype)
     tri.backward(do)
     tri_dx, x.grad = x.grad.clone(), None
     tri_dw, x_weight.grad = x_weight.grad.clone(), None
@@ -48,3 +60,19 @@ def test_fused(B: int, T: int, D: int, V: int, reduction: str, dtype: torch.dtyp
     assert_close("  o", ref, tri, 1e-2)
     assert_close(" dx", ref_dx, tri_dx, 1e-2)
     assert_close(" dw", ref_dw, tri_dw, 1e-2)
+
+
+def test_fused_rejects_trainable_teacher():
+    torch.manual_seed(42)
+    x = torch.randn(2, 4)
+    weight = torch.randn(8, 4)
+    target_x = torch.randn(2, 4, requires_grad=True)
+    target_weight = torch.randn(8, 4)
+
+    with pytest.raises(RuntimeError, match="frozen teacher"):
+        FusedKLDivLoss()(x, target_x, weight, target_weight)
+
+    target_x = target_x.detach()
+    target_weight = target_weight.requires_grad_()
+    with pytest.raises(RuntimeError, match="frozen teacher"):
+        FusedKLDivLoss()(x, target_x, weight, target_weight)

--- a/tests/modules/test_l2warp.py
+++ b/tests/modules/test_l2warp.py
@@ -41,6 +41,7 @@ def test_fused_linear_cross_entropy_l2_warp(
 
     ignore_index = -100
     shift_labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], ignore_index)), 1)
+    shift_labels[:, ::2] = ignore_index
 
     ref_criterion = nn.CrossEntropyLoss()
 


### PR DESCRIPTION
## Summary
- add an explicit `accumulate_grad_in_fp32` option to fused linear cross entropy and fused KL divergence
- accumulate fused loss weight/bias gradients with in-place `addmm(..., out=...)` and optional fp32 inputs/accumulators
- reject trainable KL teacher tensors and document the frozen-teacher contract
- align fused L2Warp normalization with standalone `l2_warp`

## Test plan
- `pre-commit run --files fla/modules/fused_linear_cross_entropy.py fla/modules/fused_kl_div.py tests/modules/test_cross_entropy.py tests/modules/test_kl_div.py tests/modules/test_l2warp.py`
- `pytest -q tests/modules/test_kl_div.py::test_fused_rejects_trainable_teacher`
- `git diff --check -- fla/modules/fused_linear_cross_entropy.py fla/modules/fused_kl_div.py tests/modules/test_cross_entropy.py tests/modules/test_kl_div.py tests/modules/test_l2warp.py`

## Breaking changes
- None