### PR TITLE
[Fix] Fix dk in normalized linear attention

### DIFF
--- a/fla/ops/linear_attn/utils.py
+++ b/fla/ops/linear_attn/utils.py
@@ -10,6 +10,85 @@ import torch
 from fla.ops.utils.cumsum import chunk_global_cumsum
 
 
+class NormalizeWithZState(torch.autograd.Function):
+    """Normalized linear-attention divide step with a hand-written backward.
+
+    Forward computes the running key-cumsum z_t and divides ``o`` by ``<q_t, z_t>``.
+    Backward mirrors the pattern used by simple_gla / gla / gated_delta_rule
+    """
+
+    @staticmethod
+    def forward(ctx, o, q, k, scale, z_init, reverse, cu_seqlens):
+        k_cum = chunk_global_cumsum(k, reverse=reverse, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
+        if z_init is not None:
+            if cu_seqlens is not None:
+                seq_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.long)
+                z_init_b = z_init.squeeze(1).repeat_interleave(seq_lens, dim=0).unsqueeze(0)
+            else:
+                z_init_b = z_init
+            k_cum = k_cum + z_init_b
+        denom = (q * scale * k_cum).sum(-1, keepdim=True) + 1e-10
+        o_out = o / denom
+        if cu_seqlens is not None:
+            idx = (cu_seqlens[:-1] if reverse else cu_seqlens[1:] - 1).to(torch.long)
+            z_state_out = k_cum[0, idx].unsqueeze(1).contiguous()
+        else:
+            z_state_out = (k_cum[:, :1] if reverse else k_cum[:, -1:]).contiguous()
+
+        ctx.save_for_backward(o, q, k_cum, denom)
+        ctx.scale = scale
+        ctx.reverse = reverse
+        ctx.cu_seqlens = cu_seqlens
+        ctx.has_z_init = z_init is not None
+        ctx.k_dtype = k.dtype
+        return o_out, z_state_out
+
+    @staticmethod
+    def backward(ctx, do, dz_state):
+        o, q, k_cum, denom = ctx.saved_tensors
+        scale = ctx.scale
+        reverse = ctx.reverse
+        cu_seqlens = ctx.cu_seqlens
+
+        d_o_in = do / denom
+        ddenom = -(do * o).sum(-1, keepdim=True) / (denom * denom)
+
+        dq = ddenom * scale * k_cum
+        dk_cum = ddenom * scale * q
+
+        if dz_state is not None:
+            dk_cum = dk_cum.clone()
+            if cu_seqlens is not None:
+                idx = (cu_seqlens[:-1] if reverse else cu_seqlens[1:] - 1).to(torch.long)
+                dk_cum[0].index_add_(0, idx, dz_state.squeeze(1).to(dk_cum.dtype))
+            elif reverse:
+                dk_cum[:, :1] = dk_cum[:, :1] + dz_state.to(dk_cum.dtype)
+            else:
+                dk_cum[:, -1:] = dk_cum[:, -1:] + dz_state.to(dk_cum.dtype)
+
+        dz_init = None
+        if ctx.has_z_init:
+            if cu_seqlens is not None:
+                seq_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.long)
+                seg_id = torch.repeat_interleave(
+                    torch.arange(seq_lens.numel(), device=dk_cum.device), seq_lens,
+                )
+                flat = dk_cum[0]
+                dz_init = torch.zeros(
+                    seq_lens.numel(), flat.shape[1], flat.shape[2],
+                    device=flat.device, dtype=flat.dtype,
+                )
+                dz_init.index_add_(0, seg_id, flat)
+                dz_init = dz_init.unsqueeze(1)
+            else:
+                dz_init = dk_cum.sum(dim=1, keepdim=True)
+
+        dk = chunk_global_cumsum(
+            dk_cum, reverse=not reverse, cu_seqlens=cu_seqlens, output_dtype=ctx.k_dtype,
+        )
+        return d_o_in, dq, dk, None, dz_init, None, None
+
+
 def normalize_with_z_state(
     o: torch.Tensor,
     q: torch.Tensor,
@@ -25,16 +104,4 @@ def normalize_with_z_state(
     boundary needed to chain into the next chunk. Varlen path broadcasts z_init and
     extracts the boundary per-sequence.
     """
-    k_cum = chunk_global_cumsum(k, reverse=reverse, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
-    if z_init is not None:
-        if cu_seqlens is not None:
-            seq_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.long)
-            z_init = z_init.squeeze(1).repeat_interleave(seq_lens, dim=0).unsqueeze(0)
-        k_cum = k_cum + z_init
-    o = o / ((q * scale * k_cum).sum(-1, keepdim=True) + 1e-10)
-    if cu_seqlens is not None:
-        idx = (cu_seqlens[:-1] if reverse else cu_seqlens[1:] - 1).to(torch.long)
-        z_state_out = k_cum[0, idx].unsqueeze(1).contiguous()
-    else:
-        z_state_out = k_cum[:, :1] if reverse else k_cum[:, -1:]
-    return o, z_state_out
+    return NormalizeWithZState.apply(o, q, k, scale, z_init, reverse, cu_seqlens)

--- a/fla/ops/linear_attn/utils.py
+++ b/fla/ops/linear_attn/utils.py
@@ -57,14 +57,13 @@ class NormalizeWithZState(torch.autograd.Function):
         dk_cum = ddenom * scale * q
 
         if dz_state is not None:
-            dk_cum = dk_cum.clone()
             if cu_seqlens is not None:
                 idx = (cu_seqlens[:-1] if reverse else cu_seqlens[1:] - 1).to(torch.long)
                 dk_cum[0].index_add_(0, idx, dz_state.squeeze(1).to(dk_cum.dtype))
             elif reverse:
-                dk_cum[:, :1] = dk_cum[:, :1] + dz_state.to(dk_cum.dtype)
+                dk_cum[:, :1].add_(dz_state.to(dk_cum.dtype))
             else:
-                dk_cum[:, -1:] = dk_cum[:, -1:] + dz_state.to(dk_cum.dtype)
+                dk_cum[:, -1:].add_(dz_state.to(dk_cum.dtype))
 
         dz_init = None
         if ctx.has_z_init:

--- a/fla/ops/linear_attn/utils.py
+++ b/fla/ops/linear_attn/utils.py
@@ -10,7 +10,7 @@ import torch
 from fla.ops.utils.cumsum import chunk_global_cumsum
 
 
-class NormalizeWithZState(torch.autograd.Function):
+class StatefulNormalizeFunction(torch.autograd.Function):
     """Normalized linear-attention divide step with a hand-written backward.
 
     Forward computes the running key-cumsum z_t and divides ``o`` by ``<q_t, z_t>``.
@@ -103,4 +103,4 @@ def normalize_with_z_state(
     boundary needed to chain into the next chunk. Varlen path broadcasts z_init and
     extracts the boundary per-sequence.
     """
-    return NormalizeWithZState.apply(o, q, k, scale, z_init, reverse, cu_seqlens)
+    return StatefulNormalizeFunction.apply(o, q, k, scale, z_init, reverse, cu_seqlens)

--- a/tests/ops/test_linear_attn.py
+++ b/tests/ops/test_linear_attn.py
@@ -280,7 +280,7 @@ def test_normalize_grad(fn, B: int, T: int, H: int, D: int):
     Uses strictly-positive q, k ( normalize=True is designed for);
     """
     torch.manual_seed(42)
-    eps = 0.1
+    eps = 0.01
     q = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
     k = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
     v = torch.randn((B, T, H, D), dtype=torch.float32, device=device).requires_grad_()
@@ -320,7 +320,7 @@ def test_normalize_zinit_grad(fn, B: int, T: int, split: int, H: int, D: int):
     `split` and resuming with the prior `z_state` as `z_init` must produce the
     same q/k/v gradients as a single-call run."""
     torch.manual_seed(42)
-    eps = 0.1
+    eps = 0.01
     q = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
     k = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
     v = torch.randn((B, T, H, D), dtype=torch.float32, device=device).requires_grad_()

--- a/tests/ops/test_linear_attn.py
+++ b/tests/ops/test_linear_attn.py
@@ -257,3 +257,96 @@ def test_normalize_split_resume(fn, B: int, T: int, split: int, H: int, D: int):
     o_split = torch.cat([o_a, o_b], dim=1)
 
     assert_close('o', o_full, o_split, 0.002)
+
+
+@pytest.mark.parametrize(
+    ('fn', 'B', 'T', 'H', 'D'),
+    [
+        pytest.param(fn, 2, 256, 4, 64, id=f"{name}-normgrad")
+        for fn, name in [
+            (fused_recurrent_linear_attn, 'fused_recurrent'),
+            (fused_chunk_linear_attn, 'fused_chunk'),
+            (chunk_linear_attn, 'chunk'),
+        ]
+    ],
+)
+def test_normalize_grad(fn, B: int, T: int, H: int, D: int):
+    """Gradient parity for `normalize=True` against the naive recurrent reference.
+
+    Regression test for the missing `dk` denominator-path contribution: pre-fix,
+    `chunk_global_cumsum` had no autograd so the chain `k -> k_cum -> denom` was
+    severed and `dk` collapsed to the numerator-only contribution.
+
+    Uses strictly-positive q, k ( normalize=True is designed for);
+    """
+    torch.manual_seed(42)
+    eps = 0.1
+    q = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
+    k = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
+    v = torch.randn((B, T, H, D), dtype=torch.float32, device=device).requires_grad_()
+    do = torch.randn_like(v)
+
+    ref, _ = naive_recurrent_linear_attn(q, k, v, normalize=True)
+    (ref * do).sum().backward()
+    ref_dq, q.grad = q.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dv, v.grad = v.grad.clone(), None
+
+    tri, _ = fn(q=q, k=k, v=v, normalize=True)
+    (tri * do).sum().backward()
+    tri_dq, q.grad = q.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dv, v.grad = v.grad.clone(), None
+
+    assert_close('o', ref, tri, 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.005)
+    assert_close('dk', ref_dk, tri_dk, 0.005)
+    assert_close('dv', ref_dv, tri_dv, 0.005)
+
+
+@pytest.mark.parametrize(
+    ('fn', 'B', 'T', 'split', 'H', 'D'),
+    [
+        pytest.param(fn, 2, 256, 128, 4, 64, id=f"{name}-zinitgrad")
+        for fn, name in [
+            (fused_recurrent_linear_attn, 'fused_recurrent'),
+            (fused_chunk_linear_attn, 'fused_chunk'),
+            (chunk_linear_attn, 'chunk'),
+        ]
+    ],
+)
+def test_normalize_zinit_grad(fn, B: int, T: int, split: int, H: int, D: int):
+    """Gradient parity when chaining via `(kv_state, z_state)`: splitting at
+    `split` and resuming with the prior `z_state` as `z_init` must produce the
+    same q/k/v gradients as a single-call run."""
+    torch.manual_seed(42)
+    eps = 0.1
+    q = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
+    k = (torch.randn((B, T, H, D), dtype=torch.float32, device=device).abs() + eps).requires_grad_()
+    v = torch.randn((B, T, H, D), dtype=torch.float32, device=device).requires_grad_()
+    do = torch.randn_like(v)
+
+    o_full, _ = fn(q=q, k=k, v=v, normalize=True)
+    (o_full * do).sum().backward()
+    full_dq, q.grad = q.grad.clone(), None
+    full_dk, k.grad = k.grad.clone(), None
+    full_dv, v.grad = v.grad.clone(), None
+
+    o_a, state_a = fn(
+        q=q[:, :split], k=k[:, :split], v=v[:, :split],
+        output_final_state=True, normalize=True,
+    )
+    o_b, _ = fn(
+        q=q[:, split:], k=k[:, split:], v=v[:, split:],
+        initial_state=state_a, normalize=True,
+    )
+    o_split = torch.cat([o_a, o_b], dim=1)
+    (o_split * do).sum().backward()
+    split_dq, q.grad = q.grad.clone(), None
+    split_dk, k.grad = k.grad.clone(), None
+    split_dv, v.grad = v.grad.clone(), None
+
+    assert_close('o', o_full, o_split, 0.002)
+    assert_close('dq', full_dq, split_dq, 0.005)
+    assert_close('dk', full_dk, split_dk, 0.005)
+    assert_close('dv', full_dv, split_dv, 0.005)


### PR DESCRIPTION

`chunk_linear_attn(normalize=True)` and the matching `fused_{chunk,recurrent}` produced wrong gradients w.r.t. `k`. Forward, dq, dv were fine.

**Cause**: `normalize_with_z_state` calls `chunk_global_cumsum(k)` from plain Python:

```python
k_cum = chunk_global_cumsum(k, ...)              # grad_fn = None
o = o / ((q * scale * k_cum).sum(-1, keepdim=True) + 1e-10)
```
`normalize_with_z_state` was the only caller using it bare, so the chain `k → k_cum → denom` was severed.

## Reproduce

```python
import torch
from fla.ops.linear_attn import chunk_linear_attn

torch.manual_seed(0)
B, T, H, D = 2, 64, 2, 8
q = (torch.rand(B,T,H,D, device='cuda').abs() + 0.1).requires_grad_()
k = (torch.rand(B,T,H,D, device='cuda').abs() + 0.1).requires_grad_()
v = torch.randn(B,T,H,D, device='cuda', requires_grad=True)

o, _ = chunk_linear_attn(q, k, v, scale=1.0, normalize=True)
o.sum().backward()

# naive O(L^2) reference
q2,k2,v2 = (t.detach().clone().requires_grad_() for t in (q,k,v))
mask = torch.tril(torch.ones(T,T, device='cuda'))
s = torch.einsum('bthd,bshd->bhts', q2, k2) * mask
num = torch.einsum('bhts,bshd->bthd', s, v2)
denom = (q2 * k2.cumsum(1)).sum(-1, keepdim=True)
(num/denom).sum().backward()

print((k.grad - k2.grad).abs().max())  # ~1.73 before fix, ~5e-3 after
```

## Fix

`fla/ops/linear_attn/utils.py`: wrap the divide step in `NormalizeWithZState(torch.autograd.Function)`, the same pattern other ops already use. Also handles `dz_state` (scatter to the boundary index) and `dz_init` (sum over the broadcast axis, per-segment for varlen).

## Tests

`tests/ops/test_linear_attn.py` adds two parametrized tests across all three
impls:

- `test_normalize_grad`: dq/dk/dv parity with `naive_recurrent_linear_attn`.
- `test_normalize_zinit_grad`: chained-chunk path  `(kv_state, z_state)`
  threaded across a split must reproduce the single-call gradients.

I confirmed the new tests fail on `main` 
