### PR TITLE
[KDA] Fix chunk size 32 path

### DIFF
--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -674,7 +674,7 @@ def chunk_gated_delta_rule_bwd_dhu(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V, HV = *q.shape, do.shape[-1], do.shape[2]
     # N: the actual number of sequences in the batch with either equal or variable lengths
-    BT = 64
+    BT = chunk_size
     assert K <= 256, "current kernel does not support head dimension being larger than 256."
 
     if chunk_indices is None and cu_seqlens is not None:

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -831,6 +831,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
     dht: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     context: FLACPContext | None = None,
+    chunk_size: int = 64,
     transpose_state_layout: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if context is None or context.group is None:
@@ -840,7 +841,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
 
     B, T, H, K, V, HV = *q.shape, do.shape[-1], do.shape[2]
     # N: the actual number of sequences in the batch with either equal or variable lengths
-    BT = 64
+    BT = chunk_size
     assert K <= 256, "current kernel does not support head dimension being larger than 256."
     BK = triton.next_power_of_2(K)
 

--- a/fla/ops/generalized_delta_rule/dplr/chunk.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk.py
@@ -349,6 +349,7 @@ class ChunkDPLRDeltaRuleFunction(torch.autograd.Function):
                 dht=dht,
                 initial_state=initial_state,
                 context=cp_context,
+                chunk_size=chunk_size,
             )
 
         dh, dh0, dv_new = chunk_dplr_bwd_dhu(

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -42,13 +42,12 @@ class ChunkKDAFunction(torch.autograd.Function):
         cu_seqlens_cpu: torch.LongTensor | None = None,
         safe_gate: bool = False,
         lower_bound: float | None = None,
+        chunk_size: int = 64,
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         cp_context: FLACPContext | None = None,
         transpose_state_layout: bool = False,
     ):
-        chunk_size = 64
-
         # Apply l2norm
         q_rstd, k_rstd = None, None
         if use_qk_l2norm_in_kernel:
@@ -59,8 +58,13 @@ class ChunkKDAFunction(torch.autograd.Function):
         if use_beta_sigmoid_in_kernel:
             beta = fused_beta_sigmoid(beta_raw)
 
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+        chunk_indices = None
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens,
+                chunk_size,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+            )
 
         g_input = g
 
@@ -81,6 +85,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             use_gate_in_kernel=use_gate_in_kernel,
             A_log=A_log,
             dt_bias=dt_bias,
+            chunk_size=chunk_size,
             disable_recompute=disable_recompute,
             return_intermediate_states=return_intermediate_states,
             cp_context=cp_context,
@@ -154,7 +159,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             db = beta_sigmoid_bwd(beta_raw, db)
 
         return (dq.to(q), dk.to(k), dv.to(v), dg.to(g_input), db.to(beta_raw), dA, dbias, None, dh0,
-                None, None, None, None, None, None, None, None, None, None, None, None)
+                None, None, None, None, None, None, None, None, None, None, None, None, None)
 
 
 @dispatch('kda')
@@ -357,6 +362,10 @@ def chunk_kda(
         assert "A_log" in kwargs, "A_log must be provided when use_gate_in_kernel=True."
         A_log, dt_bias = kwargs["A_log"], kwargs.get("dt_bias")
 
+    chunk_size = kwargs.pop("chunk_size", 64)
+    if chunk_size not in (32, 64):
+        raise ValueError(f"`chunk_size` must be either 32 or 64 for KDA, got {chunk_size}.")
+
     if safe_gate and use_gate_in_kernel:
         if lower_bound is None:
             raise ValueError("`lower_bound` must be specified when `safe_gate=True` and `use_gate_in_kernel=True`.")
@@ -394,6 +403,7 @@ def chunk_kda(
         cu_seqlens_cpu,
         safe_gate,
         lower_bound,
+        chunk_size,
         disable_recompute,
         return_intermediate_states,
         cp_context,

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -480,6 +480,7 @@ def chunk_kda_bwd(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
+            chunk_size=chunk_size,
             transpose_state_layout=transpose_state_layout,
         )
     else:
@@ -518,6 +519,7 @@ def chunk_kda_bwd(
             dht=dht,
             initial_state=initial_state,
             context=cp_context,
+            chunk_size=chunk_size,
             transpose_state_layout=transpose_state_layout,
         )
 
@@ -532,6 +534,7 @@ def chunk_kda_bwd(
         dv=dv,
         scale=scale,
         cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         transpose_state_layout=transpose_state_layout,
     )

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -87,6 +87,7 @@ def chunk_kda_fwd(
             cu_seqlens=cu_seqlens,
             initial_state=initial_state,
             context=cp_context,
+            chunk_size=chunk_size,
             transpose_state_layout=transpose_state_layout,
         )
 
@@ -100,6 +101,7 @@ def chunk_kda_fwd(
         cu_seqlens=cu_seqlens,
         cu_seqlens_cpu=cu_seqlens_cpu,
         chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
         transpose_state_layout=transpose_state_layout,
     )
 

--- a/fla/ops/kda/chunk_intra.py
+++ b/fla/ops/kda/chunk_intra.py
@@ -35,7 +35,7 @@ else:
         for BK in [32, 64]
         for num_warps in [1, 2, 4]
     ],
-    key=["H", "HV", "K", "BC"],
+    key=["H", "HV", "K", "BT", "BC", "NC"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -56,6 +56,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     K: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
+    NC: tl.constexpr,
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_SAFE_GATE: tl.constexpr,
@@ -148,7 +149,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
             b_Aqk10 += tl.dot(b_q1 * b_gqn, b_kgt)
             b_Akk10 += tl.dot(b_k1 * b_gqn, b_kgt)
 
-            if i_tc2 < T:
+            if NC >= 3 and i_tc2 < T:
                 p_q2 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
                 p_k2 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
                 p_g2 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
@@ -172,7 +173,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
                 b_Aqk21 += tl.dot(b_qg2, b_kgt)
                 b_Akk21 += tl.dot(b_kg2, b_kgt)
 
-                if i_tc3 < T:
+                if NC >= 4 and i_tc3 < T:
                     p_q3 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
                     p_k3 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
                     p_g3 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
@@ -212,7 +213,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         p_b1 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,))
         b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
         b_Akk10 = b_Akk10 * b_b1[:, None]
-    if i_tc2 < T:
+    if NC >= 3 and i_tc2 < T:
         p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
         p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
         tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
@@ -222,7 +223,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
         b_Akk20 = b_Akk20 * b_b2[:, None]
         b_Akk21 = b_Akk21 * b_b2[:, None]
-    if i_tc3 < T:
+    if NC >= 4 and i_tc3 < T:
         p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
         p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
         p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
@@ -238,12 +239,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
 
     p_Akk00 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
     p_Akk11 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
     b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
     b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+    if NC >= 3:
+        p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+    if NC >= 4:
+        p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
 
     ################################################################################
     # forward substitution on diagonals
@@ -255,8 +258,10 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
 
         b_Ai00 = -tl.where(m_A, b_Ai00, 0)
         b_Ai11 = -tl.where(m_A, b_Ai11, 0)
-        b_Ai22 = -tl.where(m_A, b_Ai22, 0)
-        b_Ai33 = -tl.where(m_A, b_Ai33, 0)
+        if NC >= 3:
+            b_Ai22 = -tl.where(m_A, b_Ai22, 0)
+        if NC >= 4:
+            b_Ai33 = -tl.where(m_A, b_Ai33, 0)
 
         for i in range(2, min(BC, T - i_tc0)):
             b_a00 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
@@ -268,21 +273,25 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
             b_a11 = tl.where(o_i < i - BC, b_a11, 0.)
             b_a11 += tl.sum(b_a11[:, None] * b_Ai11, 0)
             b_Ai11 = tl.where((o_i == i - BC)[:, None], b_a11, b_Ai11)
-        for i in range(2*BC + 2, min(3*BC, T - i_tc0)):
-            b_a22 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
-            b_a22 = tl.where(o_i < i - 2*BC, b_a22, 0.)
-            b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
-            b_Ai22 = tl.where((o_i == i - 2*BC)[:, None], b_a22, b_Ai22)
-        for i in range(3*BC + 2, min(4*BC, T - i_tc0)):
-            b_a33 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
-            b_a33 = tl.where(o_i < i - 3*BC, b_a33, 0.)
-            b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
-            b_Ai33 = tl.where((o_i == i - 3*BC)[:, None], b_a33, b_Ai33)
+        if NC >= 3:
+            for i in range(2*BC + 2, min(3*BC, T - i_tc0)):
+                b_a22 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
+                b_a22 = tl.where(o_i < i - 2*BC, b_a22, 0.)
+                b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
+                b_Ai22 = tl.where((o_i == i - 2*BC)[:, None], b_a22, b_Ai22)
+        if NC >= 4:
+            for i in range(3*BC + 2, min(4*BC, T - i_tc0)):
+                b_a33 = -tl.load(Akkd + (i_tc0 + i) * HV*BC + o_i)
+                b_a33 = tl.where(o_i < i - 3*BC, b_a33, 0.)
+                b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
+                b_Ai33 = tl.where((o_i == i - 3*BC)[:, None], b_a33, b_Ai33)
 
         b_Ai00 += m_I
         b_Ai11 += m_I
-        b_Ai22 += m_I
-        b_Ai33 += m_I
+        if NC >= 3:
+            b_Ai22 += m_I
+        if NC >= 4:
+            b_Ai33 += m_I
 
     ################################################################################
     # compute merged inverse using off-diagonals
@@ -294,36 +303,38 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         b_Ai00,
         input_precision=SOLVE_TRIL_DOT_PRECISION
     )
-    b_Ai21 = -tl.dot(
-        tl.dot(b_Ai22, b_Akk21, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        b_Ai11,
-        input_precision=SOLVE_TRIL_DOT_PRECISION
-    )
-    b_Ai32 = -tl.dot(
-        tl.dot(b_Ai33, b_Akk32, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        b_Ai22,
-        input_precision=SOLVE_TRIL_DOT_PRECISION
-    )
 
-    b_Ai20 = -tl.dot(
-        b_Ai22,
-        tl.dot(b_Akk20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION) +
-        tl.dot(b_Akk21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        input_precision=SOLVE_TRIL_DOT_PRECISION
-    )
-    b_Ai31 = -tl.dot(
-        b_Ai33,
-        tl.dot(b_Akk31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION) +
-        tl.dot(b_Akk32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        input_precision=SOLVE_TRIL_DOT_PRECISION
-    )
-    b_Ai30 = -tl.dot(
-        b_Ai33,
-        tl.dot(b_Akk30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION) +
-        tl.dot(b_Akk31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION) +
-        tl.dot(b_Akk32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        input_precision=SOLVE_TRIL_DOT_PRECISION
-    )
+    if NC >= 3:
+        b_Ai21 = -tl.dot(
+            tl.dot(b_Ai22, b_Akk21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            b_Ai11,
+            input_precision=SOLVE_TRIL_DOT_PRECISION
+        )
+        b_Ai20 = -tl.dot(
+            b_Ai22,
+            tl.dot(b_Akk20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+            tl.dot(b_Akk21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            input_precision=SOLVE_TRIL_DOT_PRECISION
+        )
+    if NC >= 4:
+        b_Ai32 = -tl.dot(
+            tl.dot(b_Ai33, b_Akk32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            b_Ai22,
+            input_precision=SOLVE_TRIL_DOT_PRECISION
+        )
+        b_Ai31 = -tl.dot(
+            b_Ai33,
+            tl.dot(b_Akk31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+            tl.dot(b_Akk32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            input_precision=SOLVE_TRIL_DOT_PRECISION
+        )
+        b_Ai30 = -tl.dot(
+            b_Ai33,
+            tl.dot(b_Akk30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+            tl.dot(b_Akk31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+            tl.dot(b_Akk32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            input_precision=SOLVE_TRIL_DOT_PRECISION
+        )
 
     ################################################################################
     # store full Akk_inv to Akk
@@ -332,24 +343,26 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
     p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
     p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
-    p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
-    p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-    p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
 
     tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    if NC >= 3:
+        p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+        p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
+        tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    if NC >= 4:
+        p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+        p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
+        p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
+        tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.heuristics({
@@ -763,6 +776,8 @@ def chunk_kda_fwd_intra(
 ):
     B, T, H, K, HV = *k.shape, gk.shape[2]
     BT = chunk_size
+    if BT not in (32, 64):
+        raise ValueError(f"KDA intra chunk kernel only supports chunk_size 32 or 64, got {BT}.")
     BC = 16
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -832,6 +847,7 @@ def chunk_kda_fwd_intra(
         K=K,
         BT=BT,
         BC=BC,
+        NC=NC,
         USE_SAFE_GATE=safe_gate,
     )
     w, u, qg, kg = recompute_w_u_fwd(

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -309,7 +309,7 @@ def prepare_wy_repr_bwd(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     HV = v.shape[2]
-    BT = 64
+    BT = A.shape[-1]
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -492,26 +492,30 @@ def test_fused_recurrent_vllm_decode(
         "dtype",
         "safe_gate",
         "disable_recompute",
+        "chunk_size",
     ),
     [
         pytest.param(
             *test,
-            id=("B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}"
-                "-use_qk_l2norm{}-use_gate{}-{}-safe_gate{}-disable_recompute{}").format(*test),
+            id=(
+                "B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}"
+                "-use_qk_l2norm{}-use_gate{}-{}-safe_gate{}-disable_recompute{}-chunk_size{}"
+            ).format(*test),
         )
         for test in [
-            (1, 63, 1, 1, 64, 1, 1, 0, False, False, torch.float16, True, False),
-            (2, 500, 3, 3, 60, 1, 1, 0, False, False, torch.float16, True, True),
-            (2, 1000, 3, 3, 64, 0.1, 1, 0.5, False, False, torch.float16, False, True),
-            (3, 1024, 4, 4, 100, 1, 0.1, 0, False, False, torch.float16, False, False),
-            (4, 1024, 4, 4, 128, 0.1, 1, 0, False, False, torch.float16, True, True),
-            (4, 1024, 4, 4, 128, 0.1, 1, 0, True, False, torch.float16, True, False),
-            (2, 1500, 4, 4, 128, 0.1, 10, 0, False, True, torch.float16, False, True),
-            (4, 2048, 8, 8, 64, 0.1, 1, 0, False, True, torch.float16, True, True),
+            (1, 63, 1, 1, 64, 1, 1, 0, False, False, torch.float16, True, False, 64),
+            (2, 500, 3, 3, 60, 1, 1, 0, False, False, torch.float16, True, True, 64),
+            (2, 1000, 3, 3, 64, 0.1, 1, 0.5, False, False, torch.float16, False, True, 64),
+            (3, 1024, 4, 4, 100, 1, 0.1, 0, False, False, torch.float16, False, False, 64),
+            (4, 1024, 4, 4, 128, 0.1, 1, 0, False, False, torch.float16, True, True, 64),
+            (4, 1024, 4, 4, 128, 0.1, 1, 0, True, False, torch.float16, True, False, 64),
+            (2, 1500, 4, 4, 128, 0.1, 10, 0, False, True, torch.float16, False, True, 64),
+            (4, 2048, 8, 8, 64, 0.1, 1, 0, False, True, torch.float16, True, True, 64),
 
-            (2, 1024, 2, 4, 64, 0.1, 1, 0, False, False, torch.float16, False, False),
-            (2, 1024, 2, 8, 64, 0.1, 1, 0, False, True, torch.float16, False, False),
-            (2, 1024, 4, 8, 128, 0.1, 1, 0, True, True, torch.float16, False, False),
+            (2, 1024, 2, 4, 64, 0.1, 1, 0, False, False, torch.float16, False, False, 64),
+            (2, 1024, 2, 8, 64, 0.1, 1, 0, False, True, torch.float16, False, False, 64),
+            (2, 1024, 4, 8, 128, 0.1, 1, 0, True, True, torch.float16, False, False, 64),
+            (2, 160, 2, 4, 64, 0.1, 1, 0, False, True, torch.float16, True, True, 32),
         ]
     ],
 )
@@ -529,6 +533,7 @@ def test_chunk(
     dtype: torch.dtype,
     safe_gate: bool,
     disable_recompute: bool,
+    chunk_size: int,
 ):
     torch.manual_seed(42)
     q = torch.rand(B, T, H, D, dtype=dtype)
@@ -591,7 +596,8 @@ def test_chunk(
         use_gate_in_kernel=use_gate_in_kernel,
         safe_gate=safe_gate,
         lower_bound=lower_bound,
-        disable_recompute=disable_recompute
+        disable_recompute=disable_recompute,
+        chunk_size=chunk_size,
     )
     ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
     if use_gate_in_kernel:
@@ -773,15 +779,32 @@ def test_chunk_use_beta_sigmoid_in_kernel(
 
 
 @pytest.mark.parametrize(
-    ("H", "D", "mask_p", "cu_seqlens", "dtype", "use_gate_in_kernel", "safe_gate", "disable_recompute"),
+    (
+        "H",
+        "D",
+        "mask_p",
+        "cu_seqlens",
+        "dtype",
+        "use_gate_in_kernel",
+        "safe_gate",
+        "disable_recompute",
+        "chunk_size",
+    ),
     [
-        pytest.param(*test, id="H{}-D{}-mask_p{}-cu_seqlens{}-{}-gate{}-safe_gate{}-disable_recompute{}".format(*test))
+        pytest.param(
+            *test,
+            id=(
+                "H{}-D{}-mask_p{}-cu_seqlens{}-{}-gate{}"
+                "-safe_gate{}-disable_recompute{}-chunk_size{}"
+            ).format(*test),
+        )
         for test in [
-            (4, 60, 0.1, [0, 15], torch.float16, True, False, False),
-            (4, 64, 0.9, [0, 256, 500, 1000], torch.float16, True, False, False),
-            (4, 128, 0.5, [0, 256, 500, 1000], torch.float16, False, False, False),
-            (4, 100, 0, [0, 15, 100, 300, 1200, 2000], torch.float16, True, False, False),
-            (4, 256, 0, [0, 100, 300, 1200, 3000, 4096], torch.float16, False, True, True),
+            (4, 60, 0.1, [0, 15], torch.float16, True, False, False, 64),
+            (4, 64, 0.9, [0, 256, 500, 1000], torch.float16, True, False, False, 64),
+            (4, 128, 0.5, [0, 256, 500, 1000], torch.float16, False, False, False, 64),
+            (4, 100, 0, [0, 15, 100, 300, 1200, 2000], torch.float16, True, False, False, 64),
+            (4, 256, 0, [0, 100, 300, 1200, 3000, 4096], torch.float16, False, True, True, 64),
+            (4, 60, 0.1, [0, 31, 96, 160], torch.float16, True, False, True, 32),
         ]
     ],
 )
@@ -794,6 +817,7 @@ def test_chunk_varlen(
     use_gate_in_kernel: bool,
     safe_gate: bool,
     disable_recompute: bool,
+    chunk_size: int,
 ):
     if FLA_CACHE_MODE.uses_default_config() and D in (64, 256):
         pytest.skip(reason="Skipping D=64/256 varlen KDA case with default_config")
@@ -844,7 +868,8 @@ def test_chunk_varlen(
         cu_seqlens_cpu=cu_seqlens_cpu,
         use_gate_in_kernel=use_gate_in_kernel,
         safe_gate=safe_gate,
-        disable_recompute=disable_recompute
+        disable_recompute=disable_recompute,
+        chunk_size=chunk_size,
     )
     ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
     tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad


### PR DESCRIPTION
## Summary

- Thread the internal KDA `chunk_size` through chunk forward/backward paths instead of hardcoding 64.
- Guard the fused inter-subchunk solve path so `chunk_size=32` only handles valid 16-token subchunks.
- Add `chunk_size=32` coverage to the existing KDA chunk and varlen chunk tests.

## Test plan

- `python - <<'PY' ... ast.parse(...) ... PY`
- `ruff check fla/ops/common/chunk_delta_h.py fla/ops/cp/chunk_delta_h.py fla/ops/generalized_delta_rule/dplr/chunk.py fla/ops/kda/chunk.py fla/ops/kda/chunk_bwd.py fla/ops/kda/chunk_fwd.py fla/ops/kda/chunk_intra.py fla/ops/kda/wy_fast.py tests/ops/test_kda.py`
- `git diff --check && git diff --cached --check`
- `pytest tests/ops/test_kda.py -k "test_chunk or test_chunk_varlen" --collect-only -q`

CUDA/Triton runtime tests were not run locally because `torch.cuda.is_available()` is `False`.

## Breaking changes

None.
