### PR TITLE
[Ops] Add AttnRes operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,13 +597,22 @@ If you find this repository helpful, please cite our work:
   year   = {2024}
 }
 
+@misc{chen2026attnres,
+  title         = {Attention Residuals},
+  author        = {Chen, Guangyu  and Zhang, Yu  and Su, Jianlin  and Xu, Weixin  and Pan, Siyuan  and Wang, Yaoyu  and Wang, Yucheng  and Chen, Guanduo  and Yin, Bohong  and Chen, Yutian  and Yan, Junjie  and Wei, Ming  and Zhang, Y.  and Meng, Fanqing  and Hong, Chao  and Xie, Xiaotong  and Liu, Shaowei  and Lu, Enzhe  and Tai, Yunpeng  and Chen, Yanru  and Men, Xin  and Guo, Haiqing  and Charles, Y.  and Lu, Haoyu  and Sui, Lin  and Zhu, Jinguo  and Zhou, Zaida  and He, Weiran  and Huang, Weixiao  and Xu, Xinran  and Wang, Yuzhi  and Lai, Guokun  and Du, Yulun  and Wu, Yuxin  and Yang, Zhilin  and Zhou, Xinyu},
+  year          = {2026},
+  archiveprefix = {arXiv},
+  eprint        = {2603.15031},
+  primaryclass  = {cs.CL}
+}
+
 @misc{zhang2025kda,
-    title         = {Kimi Linear: An Expressive, Efficient Attention Architecture},
-    author        = {Zhang, Yu  and Lin, Zongyu  and Yao, Xingcheng  and Hu, Jiaxi  and Meng, Fanqing  and Liu, Chengyin  and Men, Xin  and Yang, Songlin  and Li, Zhiyuan  and Li, Wentao  and Lu, Enzhe  and Liu, Weizhou  and Chen, Yanru  and Xu, Weixin  and Yu, Longhui  and Wang, Yejie  and Fan, Yu  and Zhong, Longguang  and Yuan, Enming  and Zhang, Dehao  and Zhang, Yizhi  and T. Liu, Y.  and Wang, Haiming  and Fang, Shengjun  and He, Weiran  and Liu, Shaowei  and Li, Yiwei  and Su, Jianlin  and Qiu, Jiezhong  and Pang, Bo  and Yan, Junjie  and Jiang, Zhejun  and Huang, Weixiao  and Yin, Bohong  and You, Jiacheng  and Wei, Chu  and Wang, Zhengtao  and Hong, Chao  and Chen, Yutian  and Chen, Guanduo  and Wang, Yucheng  and Zheng, Huabin  and Wang, Feng  and Liu, Yibo  and Dong, Mengnan  and Zhang, Zheng  and Pan, Siyuan  and Wu, Wenhao  and Wu, Yuhao  and Guan, Longyu  and Tao, Jiawen  and Fu, Guohong  and Xu, Xinran  and Wang, Yuzhi  and Lai, Guokun  and Wu, Yuxin  and Zhou, Xinyu  and Yang, Zhilin  and Du, Yulun},
-    year          = {2025},
-    eprint        = {2510.26692},
-    archivePrefix = {arXiv},
-    primaryClass  = {cs.CL}
+  title         = {Kimi Linear: An Expressive, Efficient Attention Architecture},
+  author        = {Zhang, Yu  and Lin, Zongyu  and Yao, Xingcheng  and Hu, Jiaxi  and Meng, Fanqing  and Liu, Chengyin  and Men, Xin  and Yang, Songlin  and Li, Zhiyuan  and Li, Wentao  and Lu, Enzhe  and Liu, Weizhou  and Chen, Yanru  and Xu, Weixin  and Yu, Longhui  and Wang, Yejie  and Fan, Yu  and Zhong, Longguang  and Yuan, Enming  and Zhang, Dehao  and Zhang, Yizhi  and T. Liu, Y.  and Wang, Haiming  and Fang, Shengjun  and He, Weiran  and Liu, Shaowei  and Li, Yiwei  and Su, Jianlin  and Qiu, Jiezhong  and Pang, Bo  and Yan, Junjie  and Jiang, Zhejun  and Huang, Weixiao  and Yin, Bohong  and You, Jiacheng  and Wei, Chu  and Wang, Zhengtao  and Hong, Chao  and Chen, Yutian  and Chen, Guanduo  and Wang, Yucheng  and Zheng, Huabin  and Wang, Feng  and Liu, Yibo  and Dong, Mengnan  and Zhang, Zheng  and Pan, Siyuan  and Wu, Wenhao  and Wu, Yuhao  and Guan, Longyu  and Tao, Jiawen  and Fu, Guohong  and Xu, Xinran  and Wang, Yuzhi  and Lai, Guokun  and Wu, Yuxin  and Zhou, Xinyu  and Yang, Zhilin  and Du, Yulun},
+  year          = {2025},
+  eprint        = {2510.26692},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.CL}
 }
 
 @inproceedings{yang2025path,

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 ## News
 
+- [2026-04] ⚡ Add fused [AttnRes](fla/ops/attnres) support to `fla` ([paper](https://arxiv.org/abs/2603.15031)).
 - [2026-04] 🐍 Add Mamba-3 implementation to `fla` ([paper](https://arxiv.org/abs/2603.15569)).
 - [2026-04] 🧱 Add [MoBA](https://arxiv.org/abs/2502.13189) (Mixture of Block Attention) implementation to `fla`, with [FlashMoBA](https://github.com/mit-han-lab/flash-moba) backend support.
 - [2026-04] 🧱 Add [TileLang](https://github.com/tile-ai/tilelang) backend support for selected kernels.
@@ -43,11 +44,11 @@
 - [2025-07] 🛣️ Add PaTH Attention implementation to `fla` ([paper](https://arxiv.org/abs/2505.16381)).
 - [2025-06] 🎉 Add MesaNet implementation to `fla` ([paper](https://arxiv.org/abs/2506.05233)).
 - [2025-06] 🐍 Add Comba implementation to `fla` ([paper](https://arxiv.org/abs/2506.02475)).
-- [2025-05] 🎉 Add Rodimus&ast; implementation to `fla` ([paper](https://arxiv.org/abs/2410.06577)).
 
 <details>
 <summary>Older news</summary>
 
+- [2025-05] 🎉 Add Rodimus&ast; implementation to `fla` ([paper](https://arxiv.org/abs/2410.06577)).
 - [2025-04] 🎉 Add DeltaProduct implementation to `fla` ([paper](https://arxiv.org/abs/2502.10297)).
 - [2025-04] 🎉 Add FoX implementation to `fla` ([paper](https://arxiv.org/abs/2503.02130)).
 - [2025-03] ~~We have changed the default `initializer_range` to the magic 🐳 0.006~~ The `initializer_range` was rolled back to the default value of 0.02. For actual training, we recommend trying both.

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -48,6 +48,17 @@ def shape_HD(B, T, H, D, **kw):
     return (H, D)
 
 
+def shape_D(B, T, H, D, **kw):
+    return (D,)
+
+
+def shape_LBTD(B, T, H, D, L=None, **kw):
+    """AttnRes-style residuals stack: [L, B, T, D] where L is the number of residual sources."""
+    if L is None:
+        raise ValueError("shape_LBTD requires the 'L' shape config key")
+    return (L, B, T, D)
+
+
 # ---------------------------------------------------------------------------
 # Transform helpers
 # ---------------------------------------------------------------------------
@@ -102,16 +113,35 @@ class OpConfig:
     """Registry entry describing how to benchmark a single op.
 
     Args:
-        name:           display/registry name, e.g. 'chunk_gla'
-        import_path:    Python module path, e.g. 'fla.ops.gla'
-        inputs:         param_name -> TensorSpec mapping
-        func_name:      actual function attribute name if different from *name*
-        extra_kwargs:   constant keyword args passed to the op
-        output_is_tuple: True if output[0] is the tensor to .backward()
-        skip_backward:  True to skip fwdbwd mode
-        post_init:      callable(inputs_dict, B, T, H, D, **kw) for custom mutation
-        category:       grouping label
-        dim_constraints: e.g. {'D': [64, 128]} — skip shapes that don't match
+        name (str):
+            Display and registry name, such as `chunk_gla`.
+        import_path (str):
+            Python module path, such as `fla.ops.gla`.
+        inputs (dict[str, TensorSpec]):
+            Mapping from function argument names to tensor specs.
+        func_name (str, Optional):
+            Function attribute name to import when it differs from `name`.
+            Default: None.
+        extra_kwargs (dict[str, Any], Optional):
+            Constant keyword arguments passed to the op. Default: `{}`.
+        output_is_tuple (bool):
+            Whether the op returns a tuple whose first item is the tensor used
+            for `.backward()`. Default: `True`.
+        skip_backward (bool):
+            Whether to skip forward-backward benchmark mode. Default: `False`.
+        post_init (Callable, Optional):
+            Callback invoked as `post_init(inputs, B=B, T=T, H=H, D=D, **kw)`
+            for custom input mutation. Default: None.
+        category (str):
+            Grouping label used in reports. Default: `''`.
+        dim_constraints (dict, Optional):
+            Shape constraints, such as `{'D': [64, 128]}`. Shapes that do not
+            match are skipped. Default: None.
+        default_shapes (dict[str, dict[str, int]], Optional):
+            Per-op shape configs used instead of the global `SHAPE_CONFIGS`.
+            This is useful when the op's shape semantics differ from `B/T/H/D`,
+            for example when AttnRes uses an extra `L` residual-source axis.
+            Default: None.
     """
     name: str
     import_path: str
@@ -123,6 +153,7 @@ class OpConfig:
     post_init: Callable | None = None
     category: str = ''
     dim_constraints: dict | None = None
+    default_shapes: dict[str, dict[str, int]] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -419,4 +450,28 @@ register_op(OpConfig(
     extra_kwargs={'causal': True},
     output_is_tuple=False,
     category='flash_attn',
+))
+
+# --- M: AttnRes (per-layer pseudo-query attends over L stacked residual sources) ---
+# Uses an extra `L` shape key (number of residual sources, paper §3.1/3.2)
+# so it doesn't share dims with q/k/v ops.
+
+register_op(OpConfig(
+    name='fused_attnres',
+    import_path='fla.ops.attnres',
+    inputs={
+        'query': TensorSpec(shape_D),
+        'residuals': TensorSpec(shape_LBTD),
+        'rms_weight': TensorSpec(shape_D),
+    },
+    output_is_tuple=False,
+    default_shapes={
+        'L8_B1_T8K_D2K':   {'L': 8,  'B': 1, 'T': 8192,  'H': 1, 'D': 2048},
+        'L10_B1_T8K_D4K':  {'L': 10, 'B': 1, 'T': 8192,  'H': 1, 'D': 4096},
+        'L8_B1_T32K_D2K':  {'L': 8,  'B': 1, 'T': 32768, 'H': 1, 'D': 2048},
+        'L10_B1_T32K_D4K': {'L': 10, 'B': 1, 'T': 32768, 'H': 1, 'D': 4096},
+        'L32_B1_T8K_D2K':  {'L': 32, 'B': 1, 'T': 8192,  'H': 1, 'D': 2048},
+        'L64_B1_T8K_D2K':  {'L': 64, 'B': 1, 'T': 8192,  'H': 1, 'D': 2048},
+    },
+    category='attnres',
 ))

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -452,26 +452,39 @@ register_op(OpConfig(
     category='flash_attn',
 ))
 
-# --- M: AttnRes (per-layer pseudo-query attends over L stacked residual sources) ---
-# Uses an extra `L` shape key (number of residual sources, paper §3.1/3.2)
-# so it doesn't share dims with q/k/v ops.
+# --- M: layer-axis residual aggregation (AttnRes, mHC, ...) ---
+# These ops attend / aggregate over an `L` axis of stacked residual sources.
+# Inputs and shape sweeps are shared so future ops (mHC etc.) can reuse them.
+
+_layer_default_shapes = {
+    'L8_B1_T8K_D2K':   {'L': 8,  'B': 1, 'T': 8192,  'H': 1, 'D': 2048},
+    'L8_B1_T32K_D2K':  {'L': 8,  'B': 1, 'T': 32768, 'H': 1, 'D': 2048},
+    'L10_B1_T8K_D4K':  {'L': 10, 'B': 1, 'T': 8192,  'H': 1, 'D': 4096},
+    'L10_B1_T32K_D4K': {'L': 10, 'B': 1, 'T': 32768, 'H': 1, 'D': 4096},
+    'L32_B1_T8K_D2K':  {'L': 64, 'B': 1, 'T': 8192,  'H': 1, 'D': 8192},
+}
+
+
+_attnres_inputs = {
+    'query': TensorSpec(shape_D),
+    'residuals': TensorSpec(shape_LBTD),
+    'rms_weight': TensorSpec(shape_D),
+}
 
 register_op(OpConfig(
     name='fused_attnres',
     import_path='fla.ops.attnres',
-    inputs={
-        'query': TensorSpec(shape_D),
-        'residuals': TensorSpec(shape_LBTD),
-        'rms_weight': TensorSpec(shape_D),
-    },
+    inputs=_attnres_inputs,
     output_is_tuple=False,
-    default_shapes={
-        'L8_B1_T8K_D2K':   {'L': 8,  'B': 1, 'T': 8192,  'H': 1, 'D': 2048},
-        'L10_B1_T8K_D4K':  {'L': 10, 'B': 1, 'T': 8192,  'H': 1, 'D': 4096},
-        'L8_B1_T32K_D2K':  {'L': 8,  'B': 1, 'T': 32768, 'H': 1, 'D': 2048},
-        'L10_B1_T32K_D4K': {'L': 10, 'B': 1, 'T': 32768, 'H': 1, 'D': 4096},
-        'L32_B1_T8K_D2K':  {'L': 32, 'B': 1, 'T': 8192,  'H': 1, 'D': 2048},
-        'L64_B1_T8K_D2K':  {'L': 64, 'B': 1, 'T': 8192,  'H': 1, 'D': 2048},
-    },
-    category='attnres',
+    default_shapes=_layer_default_shapes,
+    category='fused_attnres',
+))
+
+register_op(OpConfig(
+    name='naive_attnres',
+    import_path='fla.ops.attnres',
+    inputs=_attnres_inputs,
+    output_is_tuple=False,
+    default_shapes=_layer_default_shapes,
+    category='naive_attnres',
 ))

--- a/benchmarks/ops/run.py
+++ b/benchmarks/ops/run.py
@@ -407,23 +407,29 @@ def print_results_table(results: list[dict], machine_info: dict | None = None,
 
     new_git = machine_info.get('git_label', 'new') if machine_info else 'new'
 
-    # mode_w = 2 (indent) + 7 (mode field) + 1 (space) = 10 chars before B column
+    # mode_w = 2 (indent) + 7 (mode field) + 1 (space) = 10 chars before first dim column
     mode_pad = ' ' * 10
+
+    # Show L column only when every row has an L axis (e.g., a pure
+    # AttnRes / mHC / layer-attn run). Mixed runs hide L for clarity.
+    has_l = bool(results) and all('L' in r for r in results)
+    l_col = f"{'L':>4s} " if has_l else ''
+    l_extra_w = 5 if has_l else 0
 
     if has_baseline:
         old_git = baseline_info.get('git_label', 'main') if baseline_info else 'main'
         old_hdr, new_hdr = _make_col_headers(old_git, new_git)
         col_w = max(len(old_hdr), len(new_hdr), 10)
-        inner_w = 4 + 1 + 6 + 1 + 4 + 1 + 4 + 2 + 28 + 2 + col_w + 1 + col_w + 1 + 8
-        inner_hdr = (f"{'B':>4s} {'T':>6s} {'H':>4s} {'D':>4s}  {'op':<28s}"
+        inner_w = l_extra_w + 4 + 1 + 6 + 1 + 4 + 1 + 4 + 2 + 28 + 2 + col_w + 1 + col_w + 1 + 8
+        inner_hdr = (f"{l_col}{'B':>4s} {'T':>6s} {'H':>4s} {'D':>4s}  {'op':<28s}"
                      f"  {old_hdr:>{col_w}s} {new_hdr:>{col_w}s} {'speedup':>8s}")
     else:
         new_hdr = _truncate_branch(new_git.split('[')[0]) if '[' in new_git else new_git
         suffix = '[' + new_git.split('[', 1)[1] + '(ms)' if '[' in new_git else '(ms)'
         new_hdr = new_hdr + suffix
         col_w = max(len(new_hdr), 10)
-        inner_w = 4 + 1 + 6 + 1 + 4 + 1 + 4 + 2 + 28 + 2 + col_w
-        inner_hdr = (f"{'B':>4s} {'T':>6s} {'H':>4s} {'D':>4s}  {'op':<28s}"
+        inner_w = l_extra_w + 4 + 1 + 6 + 1 + 4 + 1 + 4 + 2 + 28 + 2 + col_w
+        inner_hdr = (f"{l_col}{'B':>4s} {'T':>6s} {'H':>4s} {'D':>4s}  {'op':<28s}"
                      f"  {new_hdr:>{col_w}s}")
 
     width = 10 + inner_w
@@ -437,10 +443,18 @@ def print_results_table(results: list[dict], machine_info: dict | None = None,
         pytorch = machine_info.get('pytorch_version', 'N/A')
         print(f"  Machine: {gpu} | CUDA {cuda} | PyTorch {pytorch}")
 
+    def _l_cell(r, blank=False):
+        if not has_l:
+            return ''
+        if blank:
+            return f"{'':>4s} "
+        v = r.get('L')
+        return f"{v:>4d} " if v is not None else f"{'-':>4s} "
+
     prev_shape = None
     prev_mode = None
     for r in results:
-        cur_shape = (r['B'], r['T'], r['H'], r['D'])
+        cur_shape = (r.get('L'), r['B'], r['T'], r['H'], r['D'])
         cur_mode = r['mode']
 
         # Show mode label + column header when mode changes; just a dash line between shapes
@@ -451,11 +465,11 @@ def print_results_table(results: list[dict], machine_info: dict | None = None,
         elif cur_shape != prev_shape:
             print(dash_line)
 
-        # Show B/T/H/D on first row of each shape group
+        # Show shape columns on first row of each shape group
         if cur_mode != prev_mode or cur_shape != prev_shape:
-            shape_str = f"{r['B']:>4d} {r['T']:>6d} {r['H']:>4d} {r['D']:>4d}"
+            shape_str = f"{_l_cell(r)}{r['B']:>4d} {r['T']:>6d} {r['H']:>4d} {r['D']:>4d}"
         else:
-            shape_str = f"{'':>4s} {'':>6s} {'':>4s} {'':>4s}"
+            shape_str = f"{_l_cell(r, blank=True)}{'':>4s} {'':>6s} {'':>4s} {'':>4s}"
 
         prev_shape = cur_shape
         prev_mode = cur_mode
@@ -642,9 +656,14 @@ def main():
         baseline, baseline_info = _bench_at_ref(
             base_ref, op_names, shape_configs, args.modes)
 
-    # Sort by (mode, B, T, H, D, op) so the table groups by mode first
+    # Sort by (mode, L, B, T, H, D, op) so the table groups by mode first
+    # and (when present) by L so different residual-source counts cluster.
     mode_order = {'fwd': 0, 'fwdbwd': 1}
-    all_results.sort(key=lambda r: (mode_order.get(r['mode'], 9), r['B'], r['T'], r['H'], r['D'], r['op']))
+    all_results.sort(key=lambda r: (
+        mode_order.get(r['mode'], 9),
+        r.get('L', 0),
+        r['B'], r['T'], r['H'], r['D'], r['op'],
+    ))
 
     print_results_table(all_results, machine_info, baseline=baseline, baseline_info=baseline_info)
 

--- a/benchmarks/ops/run.py
+++ b/benchmarks/ops/run.py
@@ -249,6 +249,10 @@ def benchmark_op(
     if config.skip_backward and 'fwdbwd' in modes:
         modes = [m for m in modes if m != 'fwdbwd']
 
+    # Per-op shape override (e.g., AttnRes uses an `L` axis not in B/T/H/D)
+    if config.default_shapes is not None:
+        shapes = config.default_shapes
+
     # Filter shapes by dim_constraints
     valid_shapes = {}
     for shape_name, shape_dict in shapes.items():
@@ -278,8 +282,9 @@ def benchmark_op(
     failed_shapes = set()
     for shape_name, shape_dict in valid_shapes.items():
         B, T, H, D = shape_dict['B'], shape_dict['T'], shape_dict['H'], shape_dict['D']
+        extra_shape_kw = {k: v for k, v in shape_dict.items() if k not in ('B', 'T', 'H', 'D')}
         try:
-            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device)
+            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device, **extra_shape_kw)
             out = op_fn(**inputs, **config.extra_kwargs)
             out_tensor = out[0] if config.output_is_tuple else out
             do = torch.randn_like(out_tensor)
@@ -302,8 +307,9 @@ def benchmark_op(
     results = []
     for shape_name, shape_dict in list(valid_shapes.items()):
         B, T, H, D = shape_dict['B'], shape_dict['T'], shape_dict['H'], shape_dict['D']
+        extra_shape_kw = {k: v for k, v in shape_dict.items() if k not in ('B', 'T', 'H', 'D')}
         try:
-            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device)
+            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device, **extra_shape_kw)
         except Exception as e:
             logger.warning(f"Input generation failed for {op_name} @ {shape_name}: {e}")
             continue
@@ -334,6 +340,7 @@ def benchmark_op(
                 'op': op_name,
                 'mode': mode,
                 'B': B, 'T': T, 'H': H, 'D': D,
+                **extra_shape_kw,
                 'median_ms': ms[0],
                 'p20_ms': ms[1],
                 'p80_ms': ms[2],
@@ -342,8 +349,15 @@ def benchmark_op(
     return results
 
 
+_RESULT_RESERVED_KEYS = {'op', 'mode', 'B', 'T', 'H', 'D', 'median_ms', 'p20_ms', 'p80_ms'}
+
+
 def _make_result_key(r):
-    return (r['op'], r['mode'], r['B'], r['T'], r['H'], r['D'])
+    """Identify a result row. Include any extra shape dims (e.g., AttnRes `L`)
+    so per-op shape configs that share B/T/H/D but vary in extras don't collide.
+    """
+    extras = tuple(sorted((k, v) for k, v in r.items() if k not in _RESULT_RESERVED_KEYS))
+    return (r['op'], r['mode'], r['B'], r['T'], r['H'], r['D'], extras)
 
 
 def _truncate_branch(name: str, max_len: int = 8) -> str:

--- a/fla/ops/attnres/__init__.py
+++ b/fla/ops/attnres/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from fla.ops.attnres.fused import fused_attnres
+from fla.ops.attnres.naive import naive_attnres
+
+__all__ = [
+    'fused_attnres',
+    'naive_attnres',
+]

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.op import exp
+from fla.utils import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    autotune_cache_kwargs,
+    input_guard,
+)
+
+ATTNRES_FWD_BWD_CONFIGS = [
+    triton.Config({'BD': BD}, num_warps=num_warps, num_stages=num_stages)
+    for BD, num_warps in [(64, 1), (128, 2), (256, 4), (512, 4), (1024, 8)]
+    for num_stages in [3, 4]
+]
+
+ATTNRES_DW_CONFIGS = [
+    triton.Config({'BN': BN, 'BD': BD}, num_warps=num_warps, num_stages=num_stages)
+    for BN, BD, num_warps in [(1024, 16, 4), (2048, 32, 4), (2048, 32, 8), (4096, 32, 8), (4096, 64, 8)]
+    for num_stages in [3, 4]
+]
+
+
+@triton.autotune(
+    configs=ATTNRES_FWD_BWD_CONFIGS,
+    key=['L', 'D'],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def attnres_fwd_kernel(
+    q,
+    res,
+    w,
+    o,
+    rstd,
+    p,
+    N,
+    L: tl.constexpr,
+    D: tl.constexpr,
+    eps: tl.constexpr,
+    scale: tl.constexpr,
+    BL: tl.constexpr,
+    BD: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64)
+
+    o_l = tl.arange(0, BL)
+    m_l = o_l < L
+
+    b_var = tl.zeros([BL], dtype=tl.float32)
+    for i_d in range(0, D, BD):
+        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_var += tl.sum(b_v * b_v, axis=1)
+    b_var = b_var / D
+    b_rstd = tl.rsqrt(b_var + eps)
+
+    b_logits = tl.zeros([BL], dtype=tl.float32)
+    for i_d in range(0, D, BD):
+        o_d = i_d + tl.arange(0, BD)
+        m_d = o_d < D
+        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+        b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+
+        b_xhat = b_v * b_rstd[:, None]
+        b_logits += tl.sum(b_xhat * (b_w * b_q)[None, :], axis=1)
+
+    b_logits *= scale
+    b_logits = tl.where(m_l, b_logits, -float("inf"))
+    b_logits = exp(b_logits - tl.max(b_logits, axis=0))
+    b_p = b_logits / tl.sum(b_logits, axis=0)
+
+    o_stats = o_l * N + i_n
+    tl.store(rstd + o_stats, b_rstd, mask=m_l)
+    tl.store(p + o_stats, b_p, mask=m_l)
+
+    p_o = o + i_n * D
+    for i_d in range(0, D, BD):
+        o_d = i_d + tl.arange(0, BD)
+        m_d = o_d < D
+        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_o = tl.sum(b_v * b_p[:, None], axis=0)
+        tl.store(p_o + o_d, b_o.to(o.dtype.element_ty), mask=m_d)
+
+
+@triton.autotune(
+    configs=ATTNRES_FWD_BWD_CONFIGS,
+    key=['L', 'D'],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def attnres_bwd_kernel_dx(
+    dv,
+    base,
+    do,
+    q,
+    w,
+    res,
+    rstd,
+    p,
+    N,
+    scale: tl.constexpr,
+    L: tl.constexpr,
+    D: tl.constexpr,
+    BL: tl.constexpr,
+    BD: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64)
+
+    o_l = tl.arange(0, BL)
+    m_l = o_l < L
+
+    p_do = do + i_n * D
+    p_base = base + i_n * D
+
+    o_stats = o_l * N + i_n
+    b_rstd = tl.load(rstd + o_stats, mask=m_l, other=0.).to(tl.float32)
+    b_p = tl.load(p + o_stats, mask=m_l, other=0.).to(tl.float32)
+
+    b_dp = tl.zeros([BL], dtype=tl.float32)
+    b_logits = tl.zeros([BL], dtype=tl.float32)
+    for i_d in range(0, D, BD):
+        o_d = i_d + tl.arange(0, BD)
+        m_d = o_d < D
+        b_do = tl.load(p_do + o_d, mask=m_d, other=0.).to(tl.float32)
+        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+        b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+
+        b_xhat = b_v * b_rstd[:, None]
+        b_dp += tl.sum(b_v * b_do[None, :], axis=1)
+        b_logits += tl.sum(b_xhat * (b_w * b_q)[None, :], axis=1)
+
+    b_pp = tl.sum(b_p * b_dp, axis=0)
+    b_ds = b_p * (b_dp - b_pp) * scale
+    b_c = b_logits / D
+
+    for i_d in range(0, D, BD):
+        o_d = i_d + tl.arange(0, BD)
+        m_d = o_d < D
+        b_do = tl.load(p_do + o_d, mask=m_d, other=0.).to(tl.float32)
+        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+        b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+
+        b_xhat = b_v * b_rstd[:, None]
+        b_dv = b_p[:, None] * b_do[None, :] + b_ds[:, None] * b_rstd[:, None] * (
+            (b_w * b_q)[None, :] - b_xhat * b_c[:, None]
+        )
+
+        p_dv = tl.make_block_ptr(dv + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        tl.store(p_dv, b_dv.to(dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_base + o_d, tl.sum(b_ds[:, None] * b_xhat, axis=0), mask=m_d)
+
+
+@triton.autotune(
+    configs=ATTNRES_DW_CONFIGS,
+    key=['N', 'D'],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def attnres_bwd_kernel_dw(
+    dq,
+    dw,
+    q,
+    w,
+    base,
+    N,
+    D: tl.constexpr,
+    BN: tl.constexpr,
+    BD: tl.constexpr,
+):
+    i_d = tl.program_id(0).to(tl.int32)
+
+    o_d = i_d * BD + tl.arange(0, BD)
+    m_d = o_d < D
+
+    b_acc = tl.zeros([BD], dtype=tl.float32)
+    for i_n in range(0, N, BN):
+        p_base = tl.make_block_ptr(base, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
+        b_base = tl.load(p_base, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_acc += tl.sum(b_base, axis=0)
+
+    b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+    b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+
+    tl.store(dq + o_d, b_acc * b_w, mask=m_d)
+    tl.store(dw + o_d, b_acc * b_q, mask=m_d)
+
+
+def fused_attnres_fwd(
+    query: torch.Tensor,
+    residuals: torch.Tensor,
+    rms_weight: torch.Tensor,
+    rms_eps: float,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if not residuals.is_cuda:
+        raise ValueError("Triton attnres requires CUDA tensors")
+    if residuals.shape[0] < 1:
+        raise ValueError("Triton attnres requires at least one residual source")
+
+    output_shape = residuals.shape[1:]
+    L, N, D = residuals.shape[0], residuals[0].numel() // residuals.shape[-1], residuals.shape[-1]
+    q, res, w = query.view(-1), residuals.view(L, N, D), rms_weight.view(-1)
+
+    o = torch.empty((N, D), device=residuals.device, dtype=residuals.dtype)
+    stats_shape = (L, *output_shape[:-1])
+    rstd = torch.empty((L, N), device=residuals.device, dtype=torch.float32)
+    p = torch.empty_like(rstd)
+
+    BL = max(8, triton.next_power_of_2(L))
+    grid = (N,)
+
+    attnres_fwd_kernel[grid](
+        q,
+        res,
+        w,
+        o,
+        rstd,
+        p,
+        N,
+        L,
+        D,
+        rms_eps,
+        scale,
+        BL=BL,
+    )
+    return o.view(output_shape), rstd.view(stats_shape), p.view(stats_shape)
+
+
+def fused_attnres_bwd(
+    do: torch.Tensor,
+    rstd: torch.Tensor,
+    p: torch.Tensor,
+    query: torch.Tensor,
+    residuals: torch.Tensor,
+    rms_weight: torch.Tensor,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    L, N, D = residuals.shape[0], do.numel() // do.shape[-1], do.shape[-1]
+    residuals_shape = residuals.shape
+    query_shape = query.shape
+    rms_weight_shape = rms_weight.shape
+
+    do = do.view(N, D)
+    res = residuals.view(L, N, D)
+    rstd = rstd.view(L, N)
+    p = p.view(L, N)
+    q = query.view(-1)
+    w = rms_weight.view(-1)
+
+    dv = torch.empty((L, N, D), dtype=do.dtype, device=do.device)
+    base = torch.empty((N, D), dtype=torch.float32, device=do.device)
+    dq = torch.empty_like(q)
+    dw = torch.empty_like(w)
+
+    BL = max(8, triton.next_power_of_2(L))
+    attnres_bwd_kernel_dx[(N,)](
+        dv,
+        base,
+        do,
+        q,
+        w,
+        res,
+        rstd,
+        p,
+        N,
+        scale,
+        L,
+        D,
+        BL=BL,
+    )
+
+    def grid(meta): return (triton.cdiv(D, meta['BD']),)
+    attnres_bwd_kernel_dw[grid](
+        dq,
+        dw,
+        q,
+        w,
+        base,
+        N,
+        D,
+    )
+
+    return dv.view(residuals_shape), dq.view(query_shape), dw.view(rms_weight_shape)
+
+
+class FusedAttnresFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        query: torch.Tensor,
+        residuals: torch.Tensor,
+        rms_weight: torch.Tensor,
+        rms_eps: float,
+        scale: float,
+        return_weights: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        o, rstd, p = fused_attnres_fwd(query, residuals, rms_weight, rms_eps, scale)
+        ctx.save_for_backward(rstd, p, query, residuals, rms_weight)
+        ctx.scale = scale
+        if return_weights:
+            ctx.mark_non_differentiable(p)
+            return o, p
+        return o
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(
+        ctx,
+        do: torch.Tensor,
+        dp: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None, None]:
+        del dp
+        rstd, p, query, residuals, rms_weight = ctx.saved_tensors
+        dv, dq, dw = fused_attnres_bwd(
+            do,
+            rstd,
+            p,
+            query,
+            residuals,
+            rms_weight,
+            ctx.scale,
+        )
+        return dq, dv, dw, None, None, None
+
+
+def fused_attnres(
+    query: torch.Tensor,
+    residuals: torch.Tensor | Sequence[torch.Tensor],
+    rms_weight: torch.Tensor,
+    rms_eps: float = 1e-6,
+    scale: float = 1.0,
+    return_weights: bool = False,
+    return_residuals: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    r"""
+    Apply AttnRes residual aggregation.
+
+    AttnRes normalizes each residual source with RMSNorm, scores it against
+    `query`, applies softmax over the residual-source dimension, and returns
+    the weighted sum of residual sources.
+    See `Attention Residuals <https://arxiv.org/abs/2603.15031>`_.
+
+    Args:
+        query (torch.Tensor):
+            Per-layer pseudo-query of shape `[D]` or `[D, 1]`, where `D` is
+            the hidden size.
+        residuals (torch.Tensor or Sequence[torch.Tensor]):
+            Residual sources of shape `[L, ..., D]`, or a sequence of tensors
+            each with shape `[..., D]`, where `L` is the number of residual
+            sources.
+        rms_weight (torch.Tensor):
+            RMSNorm scale for key normalization of shape `[D]`.
+        rms_eps (float):
+            RMSNorm epsilon. Default: `1e-6`.
+        scale (float):
+            Scale factor applied to AttnRes logits before softmax. Default: `1.0`.
+        return_weights (bool):
+            Whether to return depth softmax probabilities. Default: `False`.
+        return_residuals (bool):
+            Whether to return tensor-form residual sources. Default: `False`.
+
+    Returns:
+        o (torch.Tensor):
+            Mixed residual of shape `[..., D]`.
+        p (torch.Tensor):
+            Depth softmax probabilities of shape `[L, ...]` if
+            `return_weights=True`, otherwise not returned.
+        residuals (torch.Tensor):
+            Tensor-form residual sources if `return_residuals=True`. List inputs
+            are returned after stacking as shape `[L, N, D]`, where `N` is the
+            flattened size of the `...` dimensions.
+    """
+    output_shape = None
+    if isinstance(residuals, Sequence) and not isinstance(residuals, torch.Tensor):
+        if len(residuals) == 0:
+            raise ValueError("residuals must contain at least one source")
+        output_shape = residuals[0].shape
+        D = output_shape[-1]
+        residuals = torch.stack(tuple(residual.view(-1, D) for residual in residuals), dim=0)
+
+    o = FusedAttnresFunction.apply(query, residuals, rms_weight, rms_eps, scale, return_weights)
+    p = None
+    if return_weights:
+        o, p = o
+    if output_shape is not None:
+        o = o.view(output_shape)
+        if p is not None:
+            p = p.view(len(residuals), *output_shape[:-1])
+
+    outputs = [o]
+    if return_weights:
+        outputs.append(p)
+    if return_residuals:
+        outputs.append(residuals)
+    return tuple(outputs) if len(outputs) > 1 else o
+
+
+__all__ = ["fused_attnres"]

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -57,46 +57,48 @@ def attnres_fwd_kernel(
 ):
     i_n = tl.program_id(0).to(tl.int64)
 
+    # [BL]
     o_l = tl.arange(0, BL)
     m_l = o_l < L
 
+    # [BL]
     b_var = tl.zeros([BL], dtype=tl.float32)
-    for i_d in range(0, D, BD):
-        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
-        b_var += tl.sum(b_v * b_v, axis=1)
-    b_var = b_var / D
-    b_rstd = tl.rsqrt(b_var + eps)
-
     b_logits = tl.zeros([BL], dtype=tl.float32)
     for i_d in range(0, D, BD):
+        # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
         p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        # [BD]
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
         b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
 
-        b_xhat = b_v * b_rstd[:, None]
-        b_logits += tl.sum(b_xhat * (b_w * b_q)[None, :], axis=1)
+        b_var += tl.sum(b_v * b_v, axis=1)
+        b_logits += tl.sum(b_v * (b_w * b_q)[None, :], axis=1)
 
-    b_logits *= scale
+    # [BL]
+    b_rstd = tl.rsqrt(b_var / D + eps)
+    b_logits *= b_rstd * scale
     b_logits = tl.where(m_l, b_logits, -float("inf"))
     b_logits = exp(b_logits - tl.max(b_logits, axis=0))
+    # [BL]
     b_p = b_logits / tl.sum(b_logits, axis=0)
 
-    o_stats = o_l * N + i_n
-    tl.store(rstd + o_stats, b_rstd, mask=m_l)
-    tl.store(p + o_stats, b_p, mask=m_l)
+    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
+    p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_p, b_p.to(p_p.dtype.element_ty), boundary_check=(0,))
 
-    p_o = o + i_n * D
     for i_d in range(0, D, BD):
-        o_d = i_d + tl.arange(0, BD)
-        m_d = o_d < D
         p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_o = tl.make_block_ptr(o + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
+        # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        # [BD]
         b_o = tl.sum(b_v * b_p[:, None], axis=0)
-        tl.store(p_o + o_d, b_o.to(o.dtype.element_ty), mask=m_d)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
 
 
 @triton.autotune(
@@ -123,52 +125,67 @@ def attnres_bwd_kernel_dx(
 ):
     i_n = tl.program_id(0).to(tl.int64)
 
+    # [BL]
     o_l = tl.arange(0, BL)
     m_l = o_l < L
 
-    p_do = do + i_n * D
-    p_base = base + i_n * D
+    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
+    p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
+    # [BL]
+    b_rstd = tl.load(p_rstd, boundary_check=(0,), padding_option="zero").to(tl.float32)
+    b_p = tl.load(p_p, boundary_check=(0,), padding_option="zero").to(tl.float32)
 
-    o_stats = o_l * N + i_n
-    b_rstd = tl.load(rstd + o_stats, mask=m_l, other=0.).to(tl.float32)
-    b_p = tl.load(p + o_stats, mask=m_l, other=0.).to(tl.float32)
-
+    # [BL]
     b_dp = tl.zeros([BL], dtype=tl.float32)
     b_logits = tl.zeros([BL], dtype=tl.float32)
     for i_d in range(0, D, BD):
+        # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        b_do = tl.load(p_do + o_d, mask=m_d, other=0.).to(tl.float32)
         p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
+        # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        # [BD]
+        b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
         b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
 
+        # [BL, BD]
         b_xhat = b_v * b_rstd[:, None]
         b_dp += tl.sum(b_v * b_do[None, :], axis=1)
         b_logits += tl.sum(b_xhat * (b_w * b_q)[None, :], axis=1)
 
-    b_pp = tl.sum(b_p * b_dp, axis=0)
-    b_ds = b_p * (b_dp - b_pp) * scale
+    # [1]
+    b_dpp = tl.sum(b_p * b_dp, axis=0)
+    # [BL]
+    b_ds = b_p * (b_dp - b_dpp) * scale
     b_c = b_logits / D
 
     for i_d in range(0, D, BD):
+        # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        b_do = tl.load(p_do + o_d, mask=m_d, other=0.).to(tl.float32)
         p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
+        # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        # [BD]
+        b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
         b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
 
+        # [BL, BD]
         b_xhat = b_v * b_rstd[:, None]
         b_dv = b_p[:, None] * b_do[None, :] + b_ds[:, None] * b_rstd[:, None] * (
             (b_w * b_q)[None, :] - b_xhat * b_c[:, None]
         )
 
         p_dv = tl.make_block_ptr(dv + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_base = tl.make_block_ptr(base + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         tl.store(p_dv, b_dv.to(dv.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_base + o_d, tl.sum(b_ds[:, None] * b_xhat, axis=0), mask=m_d)
+        # [BD]
+        tl.store(p_base, tl.sum(b_ds[:, None] * b_xhat, axis=0), boundary_check=(0,))
 
 
 @triton.autotune(
@@ -190,15 +207,19 @@ def attnres_bwd_kernel_dw(
 ):
     i_d = tl.program_id(0).to(tl.int32)
 
+    # [BD]
     o_d = i_d * BD + tl.arange(0, BD)
     m_d = o_d < D
 
+    # [BD]
     b_acc = tl.zeros([BD], dtype=tl.float32)
     for i_n in range(0, N, BN):
         p_base = tl.make_block_ptr(base, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
+        # [BN, BD]
         b_base = tl.load(p_base, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
         b_acc += tl.sum(b_base, axis=0)
 
+    # [BD]
     b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
     b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
 

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -42,7 +42,7 @@ ATTNRES_DW_CONFIGS = [
 @triton.jit
 def attnres_fwd_kernel(
     q,
-    res,
+    v,
     w,
     o,
     rstd,
@@ -58,8 +58,7 @@ def attnres_fwd_kernel(
     i_n = tl.program_id(0).to(tl.int64)
 
     # [BL]
-    o_l = tl.arange(0, BL)
-    m_l = o_l < L
+    m_l = tl.arange(0, BL) < L
 
     # [BL]
     b_var = tl.zeros([BL], dtype=tl.float32)
@@ -68,7 +67,7 @@ def attnres_fwd_kernel(
         # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
         # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
         # [BD]
@@ -92,7 +91,7 @@ def attnres_fwd_kernel(
     tl.store(p_p, b_p.to(p_p.dtype.element_ty), boundary_check=(0,))
 
     for i_d in range(0, D, BD):
-        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
         p_o = tl.make_block_ptr(o + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
@@ -107,13 +106,13 @@ def attnres_fwd_kernel(
     **autotune_cache_kwargs,
 )
 @triton.jit
-def attnres_bwd_kernel_dx(
+def attnres_bwd_kernel_dv(
     dv,
     base,
     do,
     q,
     w,
-    res,
+    v,
     rstd,
     p,
     N,
@@ -125,10 +124,6 @@ def attnres_bwd_kernel_dx(
 ):
     i_n = tl.program_id(0).to(tl.int64)
 
-    # [BL]
-    o_l = tl.arange(0, BL)
-    m_l = o_l < L
-
     p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
     p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
     # [BL]
@@ -137,12 +132,12 @@ def attnres_bwd_kernel_dx(
 
     # [BL]
     b_dp = tl.zeros([BL], dtype=tl.float32)
-    b_logits = tl.zeros([BL], dtype=tl.float32)
+    b_z = tl.zeros([BL], dtype=tl.float32)
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
@@ -154,19 +149,22 @@ def attnres_bwd_kernel_dx(
         # [BL, BD]
         b_xhat = b_v * b_rstd[:, None]
         b_dp += tl.sum(b_v * b_do[None, :], axis=1)
-        b_logits += tl.sum(b_xhat * (b_w * b_q)[None, :], axis=1)
+        b_z += tl.sum(b_xhat * (b_w * b_q)[None, :], axis=1)
 
+    # softmax bwd via the standard delta trick: delta = sum_l p*dp = sum_d do*o
     # [1]
-    b_dpp = tl.sum(b_p * b_dp, axis=0)
+    b_delta = tl.sum(b_p * b_dp, axis=0)
     # [BL]
-    b_ds = b_p * (b_dp - b_dpp) * scale
-    b_c = b_logits / D
+    b_ds = b_p * (b_dp - b_delta) * scale
+    # rstd-coupling correction (same role as `c1` in layernorm bwd)
+    # [BL]
+    b_c1 = b_z / D
 
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        p_v = tl.make_block_ptr(res + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
         b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
@@ -178,7 +176,7 @@ def attnres_bwd_kernel_dx(
         # [BL, BD]
         b_xhat = b_v * b_rstd[:, None]
         b_dv = b_p[:, None] * b_do[None, :] + b_ds[:, None] * b_rstd[:, None] * (
-            (b_w * b_q)[None, :] - b_xhat * b_c[:, None]
+            (b_w * b_q)[None, :] - b_xhat * b_c1[:, None]
         )
 
         p_dv = tl.make_block_ptr(dv + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
@@ -194,7 +192,7 @@ def attnres_bwd_kernel_dx(
     **autotune_cache_kwargs,
 )
 @triton.jit
-def attnres_bwd_kernel_dw(
+def attnres_bwd_kernel_dqdw(
     dq,
     dw,
     q,
@@ -241,7 +239,7 @@ def fused_attnres_fwd(
 
     output_shape = residuals.shape[1:]
     L, N, D = residuals.shape[0], residuals[0].numel() // residuals.shape[-1], residuals.shape[-1]
-    q, res, w = query.view(-1), residuals.view(L, N, D), rms_weight.view(-1)
+    q, v, w = query.view(-1), residuals.view(L, N, D), rms_weight.view(-1)
 
     o = torch.empty((N, D), device=residuals.device, dtype=residuals.dtype)
     stats_shape = (L, *output_shape[:-1])
@@ -252,17 +250,17 @@ def fused_attnres_fwd(
     grid = (N,)
 
     attnres_fwd_kernel[grid](
-        q,
-        res,
-        w,
-        o,
-        rstd,
-        p,
-        N,
-        L,
-        D,
-        rms_eps,
-        scale,
+        q=q,
+        v=v,
+        w=w,
+        o=o,
+        rstd=rstd,
+        p=p,
+        N=N,
+        L=L,
+        D=D,
+        eps=rms_eps,
+        scale=scale,
         BL=BL,
     )
     return o.view(output_shape), rstd.view(stats_shape), p.view(stats_shape)
@@ -282,44 +280,44 @@ def fused_attnres_bwd(
     query_shape = query.shape
     rms_weight_shape = rms_weight.shape
 
-    do = do.view(N, D)
-    res = residuals.view(L, N, D)
-    rstd = rstd.view(L, N)
-    p = p.view(L, N)
     q = query.view(-1)
+    v = residuals.view(L, N, D)
+    p = p.view(L, N)
     w = rms_weight.view(-1)
+    rstd = rstd.view(L, N)
 
+    do = do.view(N, D)
     dv = torch.empty((L, N, D), dtype=do.dtype, device=do.device)
     base = torch.empty((N, D), dtype=torch.float32, device=do.device)
     dq = torch.empty_like(q)
     dw = torch.empty_like(w)
 
     BL = max(8, triton.next_power_of_2(L))
-    attnres_bwd_kernel_dx[(N,)](
-        dv,
-        base,
-        do,
-        q,
-        w,
-        res,
-        rstd,
-        p,
-        N,
-        scale,
-        L,
-        D,
+    attnres_bwd_kernel_dv[(N,)](
+        dv=dv,
+        base=base,
+        do=do,
+        q=q,
+        w=w,
+        v=v,
+        rstd=rstd,
+        p=p,
+        N=N,
+        scale=scale,
+        L=L,
+        D=D,
         BL=BL,
     )
 
     def grid(meta): return (triton.cdiv(D, meta['BD']),)
-    attnres_bwd_kernel_dw[grid](
-        dq,
-        dw,
-        q,
-        w,
-        base,
-        N,
-        D,
+    attnres_bwd_kernel_dqdw[grid](
+        dq=dq,
+        dw=dw,
+        q=q,
+        w=w,
+        base=base,
+        N=N,
+        D=D,
     )
 
     return dv.view(residuals_shape), dq.view(query_shape), dw.view(rms_weight_shape)
@@ -337,15 +335,12 @@ class FusedAttnresFunction(torch.autograd.Function):
         rms_weight: torch.Tensor,
         rms_eps: float,
         scale: float,
-        return_weights: bool,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         o, rstd, p = fused_attnres_fwd(query, residuals, rms_weight, rms_eps, scale)
         ctx.save_for_backward(rstd, p, query, residuals, rms_weight)
         ctx.scale = scale
-        if return_weights:
-            ctx.mark_non_differentiable(p)
-            return o, p
-        return o
+        ctx.mark_non_differentiable(p)
+        return o, p
 
     @staticmethod
     @input_guard
@@ -354,7 +349,7 @@ class FusedAttnresFunction(torch.autograd.Function):
         ctx,
         do: torch.Tensor,
         dp: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None, None]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None]:
         del dp
         rstd, p, query, residuals, rms_weight = ctx.saved_tensors
         dv, dq, dw = fused_attnres_bwd(
@@ -366,7 +361,7 @@ class FusedAttnresFunction(torch.autograd.Function):
             rms_weight,
             ctx.scale,
         )
-        return dq, dv, dw, None, None, None
+        return dq, dv, dw, None, None
 
 
 def fused_attnres(
@@ -403,7 +398,9 @@ def fused_attnres(
         return_weights (bool):
             Whether to return depth softmax probabilities. Default: `False`.
         return_residuals (bool):
-            Whether to return tensor-form residual sources. Default: `False`.
+            Whether to return the stacked residual tensor. Useful when the
+            input was a list and the caller wants the materialized
+            `[L, ..., D]` tensor without re-stacking. Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -412,9 +409,8 @@ def fused_attnres(
             Depth softmax probabilities of shape `[L, ...]` if
             `return_weights=True`, otherwise not returned.
         residuals (torch.Tensor):
-            Tensor-form residual sources if `return_residuals=True`. List inputs
-            are returned after stacking as shape `[L, N, D]`, where `N` is the
-            flattened size of the `...` dimensions.
+            Stacked residuals of shape `[L, ..., D]` if `return_residuals=True`,
+            otherwise not returned.
     """
     output_shape = None
     if isinstance(residuals, Sequence) and not isinstance(residuals, torch.Tensor):
@@ -424,19 +420,18 @@ def fused_attnres(
         D = output_shape[-1]
         residuals = torch.stack(tuple(residual.view(-1, D) for residual in residuals), dim=0)
 
-    o = FusedAttnresFunction.apply(query, residuals, rms_weight, rms_eps, scale, return_weights)
-    p = None
-    if return_weights:
-        o, p = o
+    o, p = FusedAttnresFunction.apply(query, residuals, rms_weight, rms_eps, scale)
     if output_shape is not None:
         o = o.view(output_shape)
-        if p is not None:
-            p = p.view(len(residuals), *output_shape[:-1])
 
     outputs = [o]
     if return_weights:
+        if output_shape is not None:
+            p = p.view(residuals.shape[0], *output_shape[:-1])
         outputs.append(p)
     if return_residuals:
+        if output_shape is not None:
+            residuals = residuals.view(residuals.shape[0], *output_shape)
         outputs.append(residuals)
     return tuple(outputs) if len(outputs) > 1 else o
 

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -13,6 +13,7 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp
 from fla.utils import (
     autocast_custom_bwd,
@@ -34,7 +35,7 @@ ATTNRES_DW_CONFIGS = [
 ]
 
 
-@triton.autotune(
+@fla_cache_autotune(
     configs=ATTNRES_FWD_BWD_CONFIGS,
     key=['L', 'D'],
     **autotune_cache_kwargs,
@@ -100,21 +101,21 @@ def attnres_fwd_kernel(
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
 
 
-@triton.autotune(
+@fla_cache_autotune(
     configs=ATTNRES_FWD_BWD_CONFIGS,
     key=['L', 'D'],
     **autotune_cache_kwargs,
 )
 @triton.jit
 def attnres_bwd_kernel_dv(
-    dv,
-    base,
-    do,
     q,
-    w,
     v,
+    w,
     rstd,
     p,
+    do,
+    dv,
+    dqw,
     N,
     scale: tl.constexpr,
     L: tl.constexpr,
@@ -124,11 +125,11 @@ def attnres_bwd_kernel_dv(
 ):
     i_n = tl.program_id(0).to(tl.int64)
 
-    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
     p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
+    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
     # [BL]
-    b_rstd = tl.load(p_rstd, boundary_check=(0,), padding_option="zero").to(tl.float32)
     b_p = tl.load(p_p, boundary_check=(0,), padding_option="zero").to(tl.float32)
+    b_rstd = tl.load(p_rstd, boundary_check=(0,), padding_option="zero").to(tl.float32)
 
     # [BL]
     b_dp = tl.zeros([BL], dtype=tl.float32)
@@ -180,24 +181,24 @@ def attnres_bwd_kernel_dv(
         )
 
         p_dv = tl.make_block_ptr(dv + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
-        p_base = tl.make_block_ptr(base + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
+        p_base = tl.make_block_ptr(dqw + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         tl.store(p_dv, b_dv.to(dv.dtype.element_ty), boundary_check=(0, 1))
         # [BD]
         tl.store(p_base, tl.sum(b_ds[:, None] * b_xhat, axis=0), boundary_check=(0,))
 
 
-@triton.autotune(
+@fla_cache_autotune(
     configs=ATTNRES_DW_CONFIGS,
     key=['N', 'D'],
     **autotune_cache_kwargs,
 )
 @triton.jit
 def attnres_bwd_kernel_dqdw(
-    dq,
-    dw,
     q,
     w,
-    base,
+    dqw,
+    dq,
+    dw,
     N,
     D: tl.constexpr,
     BN: tl.constexpr,
@@ -212,7 +213,7 @@ def attnres_bwd_kernel_dqdw(
     # [BD]
     b_acc = tl.zeros([BD], dtype=tl.float32)
     for i_n in range(0, N, BN):
-        p_base = tl.make_block_ptr(base, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
+        p_base = tl.make_block_ptr(dqw, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
         # [BN, BD]
         b_base = tl.load(p_base, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
         b_acc += tl.sum(b_base, axis=0)
@@ -288,20 +289,20 @@ def fused_attnres_bwd(
 
     do = do.view(N, D)
     dv = torch.empty((L, N, D), dtype=do.dtype, device=do.device)
-    base = torch.empty((N, D), dtype=torch.float32, device=do.device)
+    dqw = torch.empty((N, D), dtype=torch.float32, device=do.device)
     dq = torch.empty_like(q)
     dw = torch.empty_like(w)
 
     BL = max(8, triton.next_power_of_2(L))
     attnres_bwd_kernel_dv[(N,)](
-        dv=dv,
-        base=base,
-        do=do,
         q=q,
-        w=w,
         v=v,
+        w=w,
         rstd=rstd,
         p=p,
+        do=do,
+        dv=dv,
+        dqw=dqw,
         N=N,
         scale=scale,
         L=L,
@@ -311,11 +312,11 @@ def fused_attnres_bwd(
 
     def grid(meta): return (triton.cdiv(D, meta['BD']),)
     attnres_bwd_kernel_dqdw[grid](
-        dq=dq,
-        dw=dw,
         q=q,
         w=w,
-        base=base,
+        dqw=dqw,
+        dq=dq,
+        dw=dw,
         N=N,
         D=D,
     )

--- a/fla/ops/attnres/naive.py
+++ b/fla/ops/attnres/naive.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import torch.nn.functional as F
+from einops import einsum
+
+
+def naive_attnres(
+    query: torch.Tensor,
+    residuals: torch.Tensor | Sequence[torch.Tensor],
+    rms_weight: torch.Tensor,
+    rms_eps: float = 1e-6,
+    scale: float = 1.0,
+    return_weights: bool = False,
+    return_residuals: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    r"""
+    Apply AttnRes residual aggregation.
+
+    AttnRes normalizes each residual source with RMSNorm, scores it against
+    `query`, applies softmax over the residual-source dimension, and returns
+    the weighted sum of residual sources.
+    See `Attention Residuals <https://arxiv.org/abs/2603.15031>`_.
+
+    Args:
+        query (torch.Tensor):
+            Per-layer pseudo-query of shape `[D]` or `[D, 1]`, where `D` is
+            the hidden size.
+        residuals (torch.Tensor or Sequence[torch.Tensor]):
+            Residual sources of shape `[L, ..., D]`, or a sequence of tensors
+            each with shape `[..., D]`, where `L` is the number of residual
+            sources.
+        rms_weight (torch.Tensor):
+            RMSNorm scale for key normalization of shape `[D]`.
+        rms_eps (float):
+            RMSNorm epsilon. Default: `1e-6`.
+        scale (float):
+            Scale factor applied to AttnRes logits before softmax. Default: `1.0`.
+        return_weights (bool):
+            Whether to return depth softmax probabilities. Default: `False`.
+        return_residuals (bool):
+            Whether to return tensor-form residual sources. Default: `False`.
+
+    Returns:
+        o (torch.Tensor):
+            Mixed residual of shape `[..., D]`.
+        p (torch.Tensor):
+            Depth softmax probabilities of shape `[L, ...]` if
+            `return_weights=True`, otherwise not returned.
+        residuals (torch.Tensor):
+            Tensor-form residual sources if `return_residuals=True`. List inputs
+            are returned after stacking as shape `[L, N, D]`, where `N` is the
+            flattened size of the `...` dimensions.
+    """
+    output_shape = None
+    if isinstance(residuals, Sequence) and not isinstance(residuals, torch.Tensor):
+        if len(residuals) == 0:
+            raise ValueError("residuals must contain at least one source")
+        output_shape = residuals[0].shape
+        D = output_shape[-1]
+        residuals = torch.stack(tuple(residual.view(-1, D) for residual in residuals), dim=0)
+
+    v_float = residuals.float()
+    k = F.rms_norm(v_float, (residuals.shape[-1],), rms_weight.flatten().float(), rms_eps)
+    p = (einsum(k, query.flatten().float() * scale, "l ... d, d -> l ...")).softmax(dim=0)
+    o = einsum(p, v_float, "l ..., l ... d -> ... d").to(residuals.dtype)
+    if output_shape is not None:
+        o = o.view(output_shape)
+        p = p.view(len(residuals), *output_shape[:-1])
+
+    outputs = [o]
+    if return_weights:
+        outputs.append(p)
+    if return_residuals:
+        outputs.append(residuals)
+    return tuple(outputs) if len(outputs) > 1 else o
+
+
+__all__ = ["naive_attnres"]

--- a/fla/ops/attnres/naive.py
+++ b/fla/ops/attnres/naive.py
@@ -48,7 +48,9 @@ def naive_attnres(
         return_weights (bool):
             Whether to return depth softmax probabilities. Default: `False`.
         return_residuals (bool):
-            Whether to return tensor-form residual sources. Default: `False`.
+            Whether to return the stacked residual tensor. Useful when the
+            input was a list and the caller wants the materialized
+            `[L, ..., D]` tensor without re-stacking. Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -57,9 +59,8 @@ def naive_attnres(
             Depth softmax probabilities of shape `[L, ...]` if
             `return_weights=True`, otherwise not returned.
         residuals (torch.Tensor):
-            Tensor-form residual sources if `return_residuals=True`. List inputs
-            are returned after stacking as shape `[L, N, D]`, where `N` is the
-            flattened size of the `...` dimensions.
+            Stacked residuals of shape `[L, ..., D]` if `return_residuals=True`,
+            otherwise not returned.
     """
     output_shape = None
     if isinstance(residuals, Sequence) and not isinstance(residuals, torch.Tensor):
@@ -75,12 +76,15 @@ def naive_attnres(
     o = einsum(p, v, "l ..., l ... d -> ... d").to(residuals.dtype)
     if output_shape is not None:
         o = o.view(output_shape)
-        p = p.view(len(residuals), *output_shape[:-1])
 
     outputs = [o]
     if return_weights:
+        if output_shape is not None:
+            p = p.view(residuals.shape[0], *output_shape[:-1])
         outputs.append(p)
     if return_residuals:
+        if output_shape is not None:
+            residuals = residuals.view(residuals.shape[0], *output_shape)
         outputs.append(residuals)
     return tuple(outputs) if len(outputs) > 1 else o
 

--- a/fla/ops/attnres/naive.py
+++ b/fla/ops/attnres/naive.py
@@ -69,10 +69,10 @@ def naive_attnres(
         D = output_shape[-1]
         residuals = torch.stack(tuple(residual.view(-1, D) for residual in residuals), dim=0)
 
-    v_float = residuals.float()
-    k = F.rms_norm(v_float, (residuals.shape[-1],), rms_weight.flatten().float(), rms_eps)
+    v = residuals.float()
+    k = F.rms_norm(v, (residuals.shape[-1],), rms_weight.flatten().float(), rms_eps)
     p = (einsum(k, query.flatten().float() * scale, "l ... d, d -> l ...")).softmax(dim=0)
-    o = einsum(p, v_float, "l ..., l ... d -> ... d").to(residuals.dtype)
+    o = einsum(p, v, "l ..., l ... d -> ... d").to(residuals.dtype)
     if output_shape is not None:
         o = o.view(output_shape)
         p = p.view(len(residuals), *output_shape[:-1])

--- a/tests/ops/test_attnres.py
+++ b/tests/ops/test_attnres.py
@@ -43,6 +43,10 @@ def test_attnres(
     dtype: torch.dtype,
 ):
     torch.manual_seed(42)
+    # disable TF32 in the PyTorch reference path so the fp32 sanity case
+    # actually compares fp32 vs fp32 (otherwise einsum bwd uses cuBLAS TF32
+    # which only has 10-bit mantissa and inflates the diff)
+    torch.backends.cuda.matmul.allow_tf32 = False
     rms_eps = 1e-6
 
     residuals = torch.randn(L, B, T, D, dtype=dtype, device=device).requires_grad_(True)

--- a/tests/ops/test_attnres.py
+++ b/tests/ops/test_attnres.py
@@ -9,59 +9,52 @@ import pytest
 import torch
 
 from fla.ops.attnres import fused_attnres, naive_attnres
-from fla.utils import assert_close, device, device_platform
-
-TEST_CASES = [
-    (1, 1, 128, 1024, torch.float32, 1, 1.0),
-    (3, 1, 128, 1024, torch.float32, 1, 1.0),
-    (7, 1, 128, 1024, torch.float32, 1, 1024 ** -0.5),
-    (3, 1, 1024, 1024, torch.float32, 2, 1024 ** -0.5),
-    (7, 1, 1024, 1024, torch.float32, 1, 1024 ** -0.5),
-    (7, 1, 1024, 1024, torch.bfloat16, 1, 1024 ** -0.5),
-]
+from fla.utils import assert_close, device
 
 
-@pytest.mark.skipif(device_platform == 'cpu', reason='Triton attnres requires a GPU backend')
 @pytest.mark.parametrize(
-    ('L', 'B', 'T', 'D', 'dtype', 'query_ndim', 'scale'),
+    ('L', 'B', 'T', 'D', 'scale', 'dtype'),
     [
-        pytest.param(
-            L,
-            B,
-            T,
-            D,
-            dtype,
-            query_ndim,
-            scale,
-            id=f"L{L}-B{B}-T{T}-D{D}-{dtype}-Q{query_ndim}-scale{scale}",
-        )
-        for L, B, T, D, dtype, query_ndim, scale in TEST_CASES
+        pytest.param(*test, id="L{}-B{}-T{}-D{}-scale{}-{}".format(*test))
+        for test in [
+            # single-axis stress
+            (1,  1, 1000, 4096, 1.0,             torch.float16),  # L=1
+            (3,  1, 1000, 4096, 4096 ** -0.5,    torch.float16),  # L=3
+            (15, 1, 15,   4096, 1.0,             torch.float16),  # T=15
+            (7,  1, 1000, 1000, 1000 ** -0.5,    torch.float16),  # D=1000
+            (7,  1, 1000, 2000, 2000 ** -0.5,    torch.float16),  # D=2000
+            # multi-axis stress (extremes stacked)
+            (29, 5, 1000, 4096, 4096 ** -0.5,    torch.float16),  # L=29 + B=5
+            (29, 1, 8000, 4096, 4096 ** -0.5,    torch.float16),  # L=29 + T=8000
+            (15, 5, 1000, 7186, 7186 ** -0.5,    torch.float16),  # B=5  + D=7186
+            (15, 1, 8000, 7186, 1.0,             torch.float16),  # T=8000 + D=7186
+            (29, 3, 63,   7186, 7186 ** -0.5,    torch.float16),  # L=29 + D=7186 + T=63
+            # fp32 sanity at a larger size
+            (10, 2, 8000, 4096, 4096 ** -0.5,    torch.float32),
+        ]
     ],
 )
-def test_fused_attnres(
+def test_attnres(
     L: int,
     B: int,
     T: int,
     D: int,
-    dtype: torch.dtype,
-    query_ndim: int,
     scale: float,
+    dtype: torch.dtype,
 ):
     torch.manual_seed(42)
     rms_eps = 1e-6
 
     residuals = torch.randn(L, B, T, D, dtype=dtype, device=device).requires_grad_(True)
     query = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
-    if query_ndim == 2:
-        query = query.detach().clone().unsqueeze(-1).requires_grad_(True)
     rms_weight = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
 
     tri, tri_p = fused_attnres(
-        query,
-        residuals,
-        rms_weight,
-        rms_eps,
-        scale,
+        query=query,
+        residuals=residuals,
+        rms_weight=rms_weight,
+        rms_eps=rms_eps,
+        scale=scale,
         return_weights=True,
     )
     do = torch.randn_like(tri)
@@ -74,18 +67,17 @@ def test_fused_attnres(
     rms_weight_ref = rms_weight.detach().clone().requires_grad_(True)
 
     ref, ref_p = naive_attnres(
-        query_ref,
-        residuals_ref,
-        rms_weight_ref,
-        rms_eps,
-        scale,
+        query=query_ref,
+        residuals=residuals_ref,
+        rms_weight=rms_weight_ref,
+        rms_eps=rms_eps,
+        scale=scale,
         return_weights=True,
     )
     (ref * do).sum().backward()
 
-    tol = 0.02 if dtype is torch.bfloat16 else 0.005
-    assert_close('o', ref, tri, tol)
-    assert_close('p', ref_p, tri_p, tol)
-    assert_close('dv', residuals_ref.grad, tri_dv, tol)
-    assert_close('dq', query_ref.grad, tri_dq, tol)
-    assert_close('dw', rms_weight_ref.grad, tri_dw, tol)
+    assert_close(' o', ref, tri, 0.005)
+    assert_close(' p', ref_p, tri_p, 0.005)
+    assert_close('dq', query_ref.grad, tri_dq, 0.005)
+    assert_close('dv', residuals_ref.grad, tri_dv, 0.005)
+    assert_close('dw', rms_weight_ref.grad, tri_dw, 0.005)

--- a/tests/ops/test_attnres.py
+++ b/tests/ops/test_attnres.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.ops.attnres import fused_attnres, naive_attnres
+from fla.utils import assert_close, device, device_platform
+
+TEST_CASES = [
+    (1, 1, 128, 1024, torch.float32, 1, 1.0),
+    (3, 1, 128, 1024, torch.float32, 1, 1.0),
+    (7, 1, 128, 1024, torch.float32, 1, 1024 ** -0.5),
+    (3, 1, 1024, 1024, torch.float32, 2, 1024 ** -0.5),
+    (7, 1, 1024, 1024, torch.float32, 1, 1024 ** -0.5),
+    (7, 1, 1024, 1024, torch.bfloat16, 1, 1024 ** -0.5),
+]
+
+
+@pytest.mark.skipif(device_platform == 'cpu', reason='Triton attnres requires a GPU backend')
+@pytest.mark.parametrize(
+    ('L', 'B', 'T', 'D', 'dtype', 'query_ndim', 'scale'),
+    [
+        pytest.param(
+            L,
+            B,
+            T,
+            D,
+            dtype,
+            query_ndim,
+            scale,
+            id=f"L{L}-B{B}-T{T}-D{D}-{dtype}-Q{query_ndim}-scale{scale}",
+        )
+        for L, B, T, D, dtype, query_ndim, scale in TEST_CASES
+    ],
+)
+def test_fused_attnres(
+    L: int,
+    B: int,
+    T: int,
+    D: int,
+    dtype: torch.dtype,
+    query_ndim: int,
+    scale: float,
+):
+    torch.manual_seed(42)
+    rms_eps = 1e-6
+
+    residuals = torch.randn(L, B, T, D, dtype=dtype, device=device).requires_grad_(True)
+    query = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
+    if query_ndim == 2:
+        query = query.detach().clone().unsqueeze(-1).requires_grad_(True)
+    rms_weight = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
+
+    tri, tri_p = fused_attnres(
+        query,
+        residuals,
+        rms_weight,
+        rms_eps,
+        scale,
+        return_weights=True,
+    )
+    do = torch.randn_like(tri)
+    (tri * do).sum().backward()
+    tri_dv = residuals.grad
+    tri_dq, tri_dw = query.grad, rms_weight.grad
+
+    residuals_ref = residuals.detach().clone().requires_grad_(True)
+    query_ref = query.detach().clone().requires_grad_(True)
+    rms_weight_ref = rms_weight.detach().clone().requires_grad_(True)
+
+    ref, ref_p = naive_attnres(
+        query_ref,
+        residuals_ref,
+        rms_weight_ref,
+        rms_eps,
+        scale,
+        return_weights=True,
+    )
+    (ref * do).sum().backward()
+
+    tol = 0.02 if dtype is torch.bfloat16 else 0.005
+    assert_close('o', ref, tri, tol)
+    assert_close('p', ref_p, tri_p, tol)
+    assert_close('dv', residuals_ref.grad, tri_dv, tol)
+    assert_close('dq', query_ref.grad, tri_dq, tol)
+    assert_close('dw', rms_weight_ref.grad, tri_dw, tol)


### PR DESCRIPTION
Summary:
- Add AttnRes naive reference and fused Triton operator under `fla.ops.attnres`.
- Reference paper: Attention Residuals (https://arxiv.org/abs/2603.15031).
- Support dense residual tensors or residual tensor lists, optional return of weights/residuals, RMSNorm epsilon, and logits scale.
- Add operator tests comparing fused forward/backward against the naive implementation.
- Add the Attention Residuals citation to README.

AttnRes formula:
For residual sources `v_l` over residual-source dimension `L`, query `q`, RMSNorm scale `w`, and hidden size `D`:

```text
k_l = RMSNorm(v_l; w, rms_eps)
p_l = softmax_l(scale * <k_l, q>)
o = sum_l p_l * v_l
```

The implementation flattens non-hidden dimensions into `N`, computes softmax over `L`, and returns `o` with the original `[..., D]` shape.

Test plan:
- `python -m ruff check fla/ops/attnres tests/ops/test_attnres.py`
- `PYTHONPYCACHEPREFIX=/tmp/fla-pycache python -m compileall -q fla/ops/attnres tests/ops/test_attnres.py`
- `git diff --check -- README.md fla/ops/attnres tests/ops/test_attnres.py`
- `pre-commit run --files README.md fla/ops/attnres/__init__.py fla/ops/attnres/fused.py fla/ops/attnres/naive.py tests/ops/test_attnres.py`
- `pytest tests/ops/test_attnres.py -q` (local environment has no Triton GPU backend, so fused cases are skipped)

Breaking changes:
- None.