### PR TITLE
[Ops] Export fused AttnRes from ops [skip test]

### DIFF
--- a/fla/ops/__init__.py
+++ b/fla/ops/__init__.py
@@ -7,6 +7,7 @@
 
 from .abc import chunk_abc
 from .attn import parallel_attn
+from .attnres import fused_attnres
 from .based import fused_chunk_based, parallel_based
 from .comba import chunk_comba, fused_recurrent_comba
 from .delta_rule import chunk_delta_rule, fused_chunk_delta_rule, fused_recurrent_delta_rule
@@ -52,6 +53,7 @@ __all__ = [
     'chunk_rwkv6',
     'chunk_rwkv7',
     'chunk_simple_gla',
+    'fused_attnres',
     'fused_chunk_based',
     'fused_chunk_delta_rule',
     'fused_chunk_gla',


### PR DESCRIPTION
## Summary
- Export `fused_attnres` from the top-level `fla.ops` namespace.

## Tests
- `python - <<PY ... PY` import check for `fla.ops.fused_attnres` and `fla.ops.attnres.naive_attnres`
- `python -m benchmarks.ops.run --list | rg "attnres|Registered ops"`