### PR TITLE
[Models] Apply AttnRes to model definitions

### DIFF
--- a/fla/models/abc/configuration_abc.py
+++ b/fla/models/abc/configuration_abc.py
@@ -48,6 +48,7 @@ class ABCConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -78,6 +79,7 @@ class ABCConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -101,6 +103,13 @@ class ABCConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as ABCMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 try:
     from transformers.modeling_layers import GradientCheckpointingLayer
@@ -84,6 +86,18 @@ class ABCBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -91,11 +105,33 @@ class ABCBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-
-        residual = hidden_states
-
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -105,16 +141,39 @@ class ABCBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -137,9 +196,12 @@ class ABCPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -185,6 +247,12 @@ class ABCModel(ABCPreTrainedModel):
         self.layers = nn.ModuleList([ABCBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -228,24 +296,40 @@ class ABCModel(ABCPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
-                attention_mask,
+                attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/bitnet/configuration_bitnet.py
+++ b/fla/models/bitnet/configuration_bitnet.py
@@ -41,6 +41,7 @@ class BitNetConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -66,6 +67,7 @@ class BitNetConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -77,6 +79,13 @@ class BitNetConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSN
 from fla.modules.activations import swiglu
 from fla.modules.fused_bitlinear import FusedBitLinear
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -107,6 +109,25 @@ class BitNetBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -114,10 +135,39 @@ class BitNetBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
-        residual = hidden_states
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -127,22 +177,42 @@ class BitNetBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states,)
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
 
-        if output_attentions:
-            outputs += (attentions,)
-
-        if use_cache:
-            outputs += (past_key_values,)
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -165,9 +235,14 @@ class BitNetPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, FusedBitLinear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -210,6 +285,13 @@ class BitNetModel(BitNetPreTrainedModel):
         self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
         self.layers = nn.ModuleList([BitNetBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -258,30 +340,45 @@ class BitNetModel(BitNetPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
-        next_cache = None
 
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            layer_outputs = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
-            hidden_states = layer_outputs[0]
-
-            if use_cache:
-                next_cache = layer_outputs[2 if output_attentions else 1]
-
             if output_attentions:
-                all_attns += (layer_outputs[1],)
+                all_attns += (attentions,)
+
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
 
         hidden_states = self.norm(hidden_states)
 
@@ -290,11 +387,11 @@ class BitNetModel(BitNetPreTrainedModel):
             all_hidden_states += (hidden_states,)
 
         if not return_dict:
-            return tuple(v for v in [hidden_states, next_cache, all_hidden_states, all_attns] if v is not None)
+            return tuple(v for v in [hidden_states, past_key_values, all_hidden_states, all_attns] if v is not None)
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=next_cache,
+            past_key_values=past_key_values,
             hidden_states=all_hidden_states,
             attentions=all_attns,
         )

--- a/fla/models/comba/configuration_comba.py
+++ b/fla/models/comba/configuration_comba.py
@@ -47,6 +47,7 @@ class CombaConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -78,6 +79,7 @@ class CombaConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -101,6 +103,13 @@ class CombaConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as CombaMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -81,6 +83,18 @@ class CombaBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -88,9 +102,33 @@ class CombaBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -100,16 +138,39 @@ class CombaBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -146,9 +207,12 @@ class CombaPreTrainedModel(PreTrainedModel):
                 module.dt_bias._no_weight_decay = True
 
         elif isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -194,6 +258,12 @@ class CombaModel(CombaPreTrainedModel):
         self.layers = nn.ModuleList([CombaBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -237,24 +307,40 @@ class CombaModel(CombaPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/delta_net/configuration_delta_net.py
+++ b/fla/models/delta_net/configuration_delta_net.py
@@ -49,6 +49,7 @@ class DeltaNetConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -80,6 +81,7 @@ class DeltaNetConfig(PretrainedConfig):
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
         self.allow_neg_eigval = allow_neg_eigval
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -103,6 +105,13 @@ class DeltaNetConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as DeltaNetMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 try:
     from transformers.modeling_layers import GradientCheckpointingLayer
@@ -84,6 +86,18 @@ class DeltaNetBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -91,9 +105,33 @@ class DeltaNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -103,16 +141,39 @@ class DeltaNetBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -135,9 +196,12 @@ class DeltaNetPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -183,6 +247,12 @@ class DeltaNetModel(DeltaNetPreTrainedModel):
         self.layers = nn.ModuleList([DeltaNetBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -226,24 +296,40 @@ class DeltaNetModel(DeltaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/deltaformer/configuration_deltaformer.py
+++ b/fla/models/deltaformer/configuration_deltaformer.py
@@ -48,6 +48,7 @@ class DeltaFormerConfig(PretrainedConfig):
         vocab_size: int = 32000,
         output_attentions: bool = False,
         output_hidden_states: bool = False,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -78,6 +79,7 @@ class DeltaFormerConfig(PretrainedConfig):
 
         self.output_attentions = output_attentions
         self.output_hidden_states = output_hidden_states
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -101,6 +103,13 @@ class DeltaFormerConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/deltaformer/modeling_deltaformer.py
+++ b/fla/models/deltaformer/modeling_deltaformer.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -23,6 +24,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as DeltaFormerMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 try:
     from transformers.modeling_layers import GradientCheckpointingLayer
@@ -63,6 +65,18 @@ class DeltaFormerBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -70,9 +84,33 @@ class DeltaFormerBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, _, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -82,15 +120,39 @@ class DeltaFormerBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
-        outputs = (hidden_states, None, past_key_values)
+
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, None, past_key_values, attnres_states)
         return outputs
 
 
@@ -112,7 +174,10 @@ class DeltaFormerPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -131,6 +196,12 @@ class DeltaFormerModel(DeltaFormerPreTrainedModel):
         self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
         self.layers = nn.ModuleList([DeltaFormerBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -177,24 +248,40 @@ class DeltaFormerModel(DeltaFormerPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         if output_hidden_states:

--- a/fla/models/forgetting_transformer/configuration_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/configuration_forgetting_transformer.py
@@ -42,6 +42,7 @@ class ForgettingTransformerConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -67,6 +68,7 @@ class ForgettingTransformerConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -78,6 +80,13 @@ class ForgettingTransformerConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as ForgettingTransformerMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -66,6 +68,25 @@ class ForgettingTransformerBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -73,10 +94,39 @@ class ForgettingTransformerBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
-        residual = hidden_states
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -86,22 +136,42 @@ class ForgettingTransformerBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states,)
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
 
-        if output_attentions:
-            outputs += (attentions,)
-
-        if use_cache:
-            outputs += (past_key_values,)
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -124,9 +194,14 @@ class ForgettingTransformerPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -172,6 +247,13 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
             for layer_idx in range(config.num_hidden_layers)
         ])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -221,30 +303,45 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
-        next_cache = None
 
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            layer_outputs = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
-            hidden_states = layer_outputs[0]
-
-            if use_cache:
-                next_cache = layer_outputs[2 if output_attentions else 1]
-
             if output_attentions:
-                all_attns += (layer_outputs[1],)
+                all_attns += (attentions,)
+
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
 
         hidden_states = self.norm(hidden_states)
 
@@ -253,11 +350,11 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
             all_hidden_states += (hidden_states,)
 
         if not return_dict:
-            return tuple(v for v in [hidden_states, next_cache, all_hidden_states, all_attns] if v is not None)
+            return tuple(v for v in [hidden_states, past_key_values, all_hidden_states, all_attns] if v is not None)
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=next_cache,
+            past_key_values=past_key_values,
             hidden_states=all_hidden_states,
             attentions=all_attns,
         )

--- a/fla/models/gated_deltanet/configuration_gated_deltanet.py
+++ b/fla/models/gated_deltanet/configuration_gated_deltanet.py
@@ -45,6 +45,7 @@ class GatedDeltaNetConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -74,6 +75,7 @@ class GatedDeltaNetConfig(PretrainedConfig):
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
         self.allow_neg_eigval = allow_neg_eigval
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -97,6 +99,13 @@ class GatedDeltaNetConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaNetMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -82,6 +84,18 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -89,9 +103,33 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -101,16 +139,39 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -147,9 +208,12 @@ class GatedDeltaNetPreTrainedModel(PreTrainedModel):
                 module.dt_bias._no_weight_decay = True
 
         elif isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -195,6 +259,12 @@ class GatedDeltaNetModel(GatedDeltaNetPreTrainedModel):
         self.layers = nn.ModuleList([GatedDeltaNetBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -238,24 +308,40 @@ class GatedDeltaNetModel(GatedDeltaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/gated_deltaproduct/configuration_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/configuration_gated_deltaproduct.py
@@ -46,6 +46,7 @@ class GatedDeltaProductConfig(PretrainedConfig):
         use_forget_gate: bool = False,
         allow_neg_eigval: bool = False,
         num_householder: int = 1,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -89,6 +90,7 @@ class GatedDeltaProductConfig(PretrainedConfig):
         self.allow_neg_eigval = allow_neg_eigval
         self.num_householder = num_householder
         self.use_forget_gate = use_forget_gate
+        self.attnres_block_size = attnres_block_size
 
         if attn is not None:
             if not isinstance(attn, dict):
@@ -101,6 +103,13 @@ class GatedDeltaProductConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaProductMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -83,6 +85,18 @@ class GatedDeltaProductBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -90,9 +104,33 @@ class GatedDeltaProductBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -102,16 +140,39 @@ class GatedDeltaProductBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -134,9 +195,12 @@ class GatedDeltaProductPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -185,6 +249,12 @@ class GatedDeltaProductModel(GatedDeltaProductPreTrainedModel):
         ])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -228,24 +298,40 @@ class GatedDeltaProductModel(GatedDeltaProductPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/gla/configuration_gla.py
+++ b/fla/models/gla/configuration_gla.py
@@ -50,6 +50,7 @@ class GLAConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -82,6 +83,7 @@ class GLAConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -105,6 +107,13 @@ class GLAConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GLAMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -86,6 +88,18 @@ class GLABlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -93,9 +107,33 @@ class GLABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -105,16 +143,39 @@ class GLABlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -137,9 +198,12 @@ class GLAPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -185,6 +249,12 @@ class GLAModel(GLAPreTrainedModel):
         self.layers = nn.ModuleList([GLABlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -228,24 +298,40 @@ class GLAModel(GLAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/gsa/configuration_gsa.py
+++ b/fla/models/gsa/configuration_gsa.py
@@ -51,6 +51,7 @@ class GSAConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -84,6 +85,7 @@ class GSAConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -107,6 +109,13 @@ class GSAConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GSAMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -87,6 +89,18 @@ class GSABlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -94,9 +108,33 @@ class GSABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -106,16 +144,39 @@ class GSABlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -138,9 +199,12 @@ class GSAPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -186,6 +250,12 @@ class GSAModel(GSAPreTrainedModel):
         self.layers = nn.ModuleList([GSABlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -229,24 +299,40 @@ class GSAModel(GSAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/hgrn/configuration_hgrn.py
+++ b/fla/models/hgrn/configuration_hgrn.py
@@ -43,6 +43,7 @@ class HGRNConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -68,6 +69,7 @@ class HGRNConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -91,6 +93,13 @@ class HGRNConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRNMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -78,6 +80,18 @@ class HGRNBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -86,9 +100,33 @@ class HGRNBlock(GradientCheckpointingLayer):
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
         lower_bound: torch.Tensor | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -99,16 +137,39 @@ class HGRNBlock(GradientCheckpointingLayer):
             lower_bound=lower_bound,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -131,9 +192,12 @@ class HGRNPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -181,6 +245,12 @@ class HGRNModel(HGRNPreTrainedModel):
         self.layers = nn.ModuleList([HGRNBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -224,6 +294,8 @@ class HGRNModel(HGRNPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 
@@ -235,19 +307,33 @@ class HGRNModel(HGRNPreTrainedModel):
                 all_hidden_states += (hidden_states,)
 
             lower_bound = lower_bounds[i] if self.config.use_lower_bound else None
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
                 lower_bound=lower_bound,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/hgrn2/configuration_hgrn2.py
+++ b/fla/models/hgrn2/configuration_hgrn2.py
@@ -44,6 +44,7 @@ class HGRN2Config(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -78,6 +79,7 @@ class HGRN2Config(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -101,6 +103,13 @@ class HGRN2Config(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRN2MLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -79,6 +81,18 @@ class HGRN2Block(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -87,9 +101,33 @@ class HGRN2Block(GradientCheckpointingLayer):
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
         lower_bound: torch.Tensor | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -100,16 +138,39 @@ class HGRN2Block(GradientCheckpointingLayer):
             lower_bound=lower_bound,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -132,9 +193,12 @@ class HGRN2PreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -182,6 +246,12 @@ class HGRN2Model(HGRN2PreTrainedModel):
         self.layers = nn.ModuleList([HGRN2Block(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -225,6 +295,8 @@ class HGRN2Model(HGRN2PreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 
@@ -236,19 +308,33 @@ class HGRN2Model(HGRN2PreTrainedModel):
                 all_hidden_states += (hidden_states,)
 
             lower_bound = lower_bounds[i] if self.config.use_lower_bound else None
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
                 lower_bound=lower_bound,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/kda/configuration_kda.py
+++ b/fla/models/kda/configuration_kda.py
@@ -43,6 +43,7 @@ class KDAConfig(PretrainedConfig):
         fuse_cross_entropy: bool = True,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -72,6 +73,8 @@ class KDAConfig(PretrainedConfig):
         self.allow_neg_eigval = allow_neg_eigval
         self.safe_gate = safe_gate
         self.lower_bound = lower_bound
+        self.attnres_block_size = attnres_block_size
+
         if safe_gate and lower_bound is None:
             raise ValueError("`lower_bound` must be specified when `safe_gate=True` (recommended: -5).")
 
@@ -86,6 +89,13 @@ class KDAConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/kda/modeling_kda.py
+++ b/fla/models/kda/modeling_kda.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as KDAMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -82,6 +84,25 @@ class KDABlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -89,9 +110,38 @@ class KDABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -101,16 +151,42 @@ class KDABlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -146,9 +222,14 @@ class KDAPreTrainedModel(PreTrainedModel):
                     module.dt_bias.copy_(inv_dt)
                 module.dt_bias._is_hf_initialized = True
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None and not getattr(module.bias, "_is_hf_initialized", False):
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -193,6 +274,13 @@ class KDAModel(KDAPreTrainedModel):
         self.layers = nn.ModuleList([KDABlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -236,24 +324,44 @@ class KDAModel(KDAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/lightnet/configuration_lightnet.py
+++ b/fla/models/lightnet/configuration_lightnet.py
@@ -44,6 +44,7 @@ class LightNetConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -70,6 +71,7 @@ class LightNetConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -93,6 +95,13 @@ class LightNetConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as LightNetMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -79,6 +81,18 @@ class LightNetBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -86,9 +100,33 @@ class LightNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -98,16 +136,39 @@ class LightNetBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -129,9 +190,12 @@ class LightNetPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -177,6 +241,12 @@ class LightNetModel(LightNetPreTrainedModel):
         self.layers = nn.ModuleList([LightNetBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -220,6 +290,8 @@ class LightNetModel(LightNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 
@@ -227,18 +299,32 @@ class LightNetModel(LightNetPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/linear_attn/configuration_linear_attn.py
+++ b/fla/models/linear_attn/configuration_linear_attn.py
@@ -48,6 +48,7 @@ class LinearAttentionConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -78,6 +79,7 @@ class LinearAttentionConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -101,6 +103,13 @@ class LinearAttentionConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as LinearAttentionMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -84,6 +86,18 @@ class LinearAttentionBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -91,9 +105,33 @@ class LinearAttentionBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs,
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -103,16 +141,39 @@ class LinearAttentionBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -135,9 +196,12 @@ class LinearAttentionPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -182,6 +246,12 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
         self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
         self.layers = nn.ModuleList([LinearAttentionBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -228,6 +298,8 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
 
@@ -235,17 +307,31 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/log_linear_mamba2/configuration_log_linear_mamba2.py
+++ b/fla/models/log_linear_mamba2/configuration_log_linear_mamba2.py
@@ -16,8 +16,18 @@ class LogLinearMamba2Config(Mamba2Config):
         self,
         residual_in_fp32: bool = False,
         chunk_size: int = 64,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
+        self.attnres_block_size = attnres_block_size
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
+
         super().__init__(
             residual_in_fp32=residual_in_fp32,
             chunk_size=chunk_size,

--- a/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
+++ b/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
@@ -9,6 +9,7 @@ import math
 
 import torch
 from torch import nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -18,6 +19,7 @@ from fla.layers.log_linear_mamba2 import LogLinearMamba2
 from fla.models.log_linear_mamba2.configuration_log_linear_mamba2 import LogLinearMamba2Config
 from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, GatedMLP, RMSNorm
+from fla.ops.attnres import fused_attnres
 
 logger = logging.get_logger(__name__)
 
@@ -60,6 +62,18 @@ class LogLinearMamba2Block(nn.Module):
             fuse_swiglu=True,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -67,9 +81,33 @@ class LogLinearMamba2Block(nn.Module):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs,
     ):
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.mixer_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.mixer(
             hidden_states=hidden_states,
@@ -79,7 +117,26 @@ class LogLinearMamba2Block(nn.Module):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(
                 hidden_states, residual=residual, prenorm=True,
             )
@@ -88,8 +145,12 @@ class LogLinearMamba2Block(nn.Module):
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-        return hidden_states, attentions, past_key_values
+
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+        return hidden_states, attentions, past_key_values, attnres_states
 
 
 class LogLinearMamba2PreTrainedModel(PreTrainedModel, FLAGenerationMixin):
@@ -159,9 +220,14 @@ class LogLinearMamba2PreTrainedModel(PreTrainedModel, FLAGenerationMixin):
             module.dt_bias._no_reinit = True
 
         elif isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
                 # guard against deprecated behavior
@@ -214,6 +280,13 @@ class LogLinearMamba2Model(LogLinearMamba2PreTrainedModel):
 
         self.gradient_checkpointing = False
         self.norm_f = RMSNorm(config.hidden_size, eps=config.norm_eps, dtype=torch.float32)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         # Initialize weights and apply final processing
         self._register_load_state_dict_pre_hook(self.load_hook)
         self.post_init()
@@ -277,6 +350,8 @@ class LogLinearMamba2Model(LogLinearMamba2PreTrainedModel):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
         hidden_states = inputs_embeds
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for mixer_block in self.layers:
@@ -284,26 +359,42 @@ class LogLinearMamba2Model(LogLinearMamba2PreTrainedModel):
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
             if self.gradient_checkpointing and self.training:
-                hidden_states, attentions, past_key_values = self._gradient_checkpointing_func(
+                hidden_states, attentions, past_key_values, attnres_states = self._gradient_checkpointing_func(
                     mixer_block.__call__,
                     hidden_states,
                     attention_mask,
                     past_key_values,
                     use_cache,
                     output_attentions,
+                    attnres_states,
                 )
             else:
-                hidden_states, attentions, past_key_values = mixer_block(
+                hidden_states, attentions, past_key_values, attnres_states = mixer_block(
                     hidden_states,
                     attention_mask=attention_mask,
                     past_key_values=past_key_values,
                     use_cache=use_cache,
                     output_attentions=output_attentions,
+                    attnres_states=attnres_states,
                     **kwargs,
                 )
 
             if output_attentions and attentions is not None:
                 all_attns = all_attns + (attentions,)
+
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
 
         hidden_states = self.norm_f(hidden_states)
 

--- a/fla/models/mesa_net/configuration_mesa_net.py
+++ b/fla/models/mesa_net/configuration_mesa_net.py
@@ -45,6 +45,7 @@ class MesaNetConfig(PretrainedConfig):
         vocab_size: int = 32000,
         max_cg_step_training: int = 30,
         max_cg_step_decoding: int = 30,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -74,6 +75,7 @@ class MesaNetConfig(PretrainedConfig):
         self.vocab_size = vocab_size
         self.max_cg_step_training = max_cg_step_training
         self.max_cg_step_decoding = max_cg_step_decoding
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -97,6 +99,13 @@ class MesaNetConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MesaNetMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -82,6 +84,18 @@ class MesaNetBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -89,9 +103,33 @@ class MesaNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -101,16 +139,39 @@ class MesaNetBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -133,9 +194,12 @@ class MesaNetPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -181,6 +245,12 @@ class MesaNetModel(MesaNetPreTrainedModel):
         self.layers = nn.ModuleList([MesaNetBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -224,24 +294,40 @@ class MesaNetModel(MesaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/mla/configuration_mla.py
+++ b/fla/models/mla/configuration_mla.py
@@ -47,6 +47,7 @@ class MLAConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -81,6 +82,7 @@ class MLAConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -92,6 +94,13 @@ class MLAConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/mla/modeling_mla.py
+++ b/fla/models/mla/modeling_mla.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MLAMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -70,6 +72,18 @@ class MLABlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -77,9 +91,33 @@ class MLABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -89,16 +127,39 @@ class MLABlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -121,9 +182,12 @@ class MLAPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -169,6 +233,12 @@ class MLAModel(MLAPreTrainedModel):
         self.layers = nn.ModuleList([MLABlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -212,24 +282,40 @@ class MLAModel(MLAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/moba/configuration_moba.py
+++ b/fla/models/moba/configuration_moba.py
@@ -47,6 +47,7 @@ class MoBAConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -78,6 +79,7 @@ class MoBAConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -89,6 +91,13 @@ class MoBAConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/moba/modeling_moba.py
+++ b/fla/models/moba/modeling_moba.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MoBAMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -70,6 +72,18 @@ class MoBABlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -77,9 +91,33 @@ class MoBABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -89,16 +127,39 @@ class MoBABlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -121,7 +182,10 @@ class MoBAPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -156,6 +220,12 @@ class MoBAModel(MoBAPreTrainedModel):
         self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
         self.layers = nn.ModuleList([MoBABlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -199,24 +269,40 @@ class MoBAModel(MoBAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         if output_hidden_states:

--- a/fla/models/mom/configuration_mom.py
+++ b/fla/models/mom/configuration_mom.py
@@ -47,6 +47,7 @@ class MomConfig(PretrainedConfig):
         fuse_swiglu: bool = True,
         fuse_cross_entropy: bool = True,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -81,6 +82,7 @@ class MomConfig(PretrainedConfig):
         self.fuse_swiglu = fuse_swiglu
         self.fuse_cross_entropy = fuse_cross_entropy
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if self.mom_backend not in ['gated_deltanet']:
             raise NotImplementedError(f"The MoM backend {mom_backend} is not currently supported.")
@@ -94,6 +96,13 @@ class MomConfig(PretrainedConfig):
                 raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
             attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
             attn['window_size'] = attn.get('window_size', None)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.mom.configuration_mom import MomConfig
 from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MomMLP
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -165,6 +167,25 @@ class MomBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -172,11 +193,39 @@ class MomBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
-        if hasattr(self, 'attn_norm'):
-            hidden_states = self.attn_norm(hidden_states)
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
+        hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values, router_logits = self.attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
@@ -185,15 +234,41 @@ class MomBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if hasattr(self, 'mlp_norm'):
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif hasattr(self, 'mlp_norm'):
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values, router_logits)
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, router_logits, attnres_states)
 
         return outputs
 
@@ -214,9 +289,14 @@ class MomPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -258,6 +338,13 @@ class MomModel(MomPreTrainedModel):
         self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
         self.layers = nn.ModuleList([MomBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = RMSNorm(config.hidden_size, eps=config.norm_eps, dtype=torch.float32)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -302,6 +389,11 @@ class MomModel(MomPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         all_router_logits = ()
@@ -310,12 +402,13 @@ class MomModel(MomPreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values, router_logits = layer(
+            hidden_states, attentions, past_key_values, router_logits, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
@@ -323,6 +416,20 @@ class MomModel(MomPreTrainedModel):
                 all_attns += (attentions,)
             all_router_logits += (router_logits,)
 
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/nsa/configuration_nsa.py
+++ b/fla/models/nsa/configuration_nsa.py
@@ -45,6 +45,7 @@ class NSAConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -74,6 +75,7 @@ class NSAConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -85,6 +87,13 @@ class NSAConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as NSAMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -68,6 +70,25 @@ class NSABlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -75,9 +96,38 @@ class NSABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
-        residual = hidden_states
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -87,16 +137,42 @@ class NSABlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -119,9 +195,14 @@ class NSAPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -167,6 +248,13 @@ class NSAModel(NSAPreTrainedModel):
         self.layers = nn.ModuleList([NSABlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         self.gradient_checkpointing = False
 
         self.post_init()
@@ -210,24 +298,44 @@ class NSAModel(NSAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/path_attn/configuration_path_attention.py
+++ b/fla/models/path_attn/configuration_path_attention.py
@@ -41,6 +41,7 @@ class PaTHAttentionConfig(PretrainedConfig):
         use_forget_gate: bool = False,
         use_w_shortconv: bool = True,
         use_low_rank_w: bool = True,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -77,6 +78,14 @@ class PaTHAttentionConfig(PretrainedConfig):
         self.use_forget_gate = use_forget_gate
         self.use_w_shortconv = use_w_shortconv
         self.use_low_rank_w = use_low_rank_w
+        self.attnres_block_size = attnres_block_size
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as PaTHAttentionMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -65,6 +67,25 @@ class PaTHAttentionBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -72,10 +93,39 @@ class PaTHAttentionBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
-        residual = hidden_states
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -85,22 +135,42 @@ class PaTHAttentionBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states,)
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
 
-        if output_attentions:
-            outputs += (attentions,)
-
-        if use_cache:
-            outputs += (past_key_values,)
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -123,9 +193,14 @@ class PaTHAttentionPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -171,6 +246,13 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
             for layer_idx in range(config.num_hidden_layers)
         ])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -220,30 +302,45 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
-        next_cache = None
 
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            layer_outputs = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
-            hidden_states = layer_outputs[0]
-
-            if use_cache:
-                next_cache = layer_outputs[2 if output_attentions else 1]
-
             if output_attentions:
-                all_attns += (layer_outputs[1],)
+                all_attns += (attentions,)
+
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
 
         hidden_states = self.norm(hidden_states)
 
@@ -252,11 +349,11 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
             all_hidden_states += (hidden_states,)
 
         if not return_dict:
-            return tuple(v for v in [hidden_states, next_cache, all_hidden_states, all_attns] if v is not None)
+            return tuple(v for v in [hidden_states, past_key_values, all_hidden_states, all_attns] if v is not None)
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=next_cache,
+            past_key_values=past_key_values,
             hidden_states=all_hidden_states,
             attentions=all_attns,
         )

--- a/fla/models/retnet/configuration_retnet.py
+++ b/fla/models/retnet/configuration_retnet.py
@@ -49,6 +49,7 @@ class RetNetConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ) -> RetNetConfig:
         self.attn_mode = attn_mode
@@ -79,6 +80,7 @@ class RetNetConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -102,6 +104,13 @@ class RetNetConfig(PretrainedConfig):
             attn['qkv_bias'] = attn.get('qkv_bias', False)
             attn['window_size'] = attn.get('window_size', None)
             attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -25,6 +26,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as RetNetMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -83,6 +85,18 @@ class RetNetBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -90,10 +104,34 @@ class RetNetBlock(GradientCheckpointingLayer):
         past_key_values: list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
-        residual = hidden_states
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
 
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
@@ -104,16 +142,39 @@ class RetNetBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
 
-        outputs = (hidden_states, attentions, past_key_values)
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -136,9 +197,12 @@ class RetNetPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -185,6 +249,12 @@ class RetNetModel(RetNetPreTrainedModel):
             [RetNetBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)],
         )
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -233,24 +303,40 @@ class RetNetModel(RetNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            hidden_states, attentions, past_key_values = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions:
                 all_attns += (attentions,)
 
+        if self.use_attnres:
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
         hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer

--- a/fla/models/samba/configuration_samba.py
+++ b/fla/models/samba/configuration_samba.py
@@ -56,6 +56,7 @@ class SambaConfig(PretrainedConfig):
         use_l2warp: bool = False,
         vocab_size: int = 32000,
         tie_word_embeddings: bool = False,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -91,6 +92,7 @@ class SambaConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -102,6 +104,13 @@ class SambaConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             bos_token_id=bos_token_id,

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as SambaMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -75,6 +77,25 @@ class SambaBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -82,9 +103,38 @@ class SambaBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[dict],
     ):
-        residual = hidden_states
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.mixer_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.mixer(
             hidden_states=hidden_states,
@@ -94,15 +144,41 @@ class SambaBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
-        return hidden_states, attentions, past_key_values
+
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+        return hidden_states, attentions, past_key_values, attnres_states
 
 
 class SambaPreTrainedModel(PreTrainedModel):
@@ -119,7 +195,12 @@ class SambaPreTrainedModel(PreTrainedModel):
     def _init_weights(self, module):
         """Initialize the weights."""
         if isinstance(module, nn.Linear):
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 if not getattr(module.bias, "_no_reinit", False):
                     nn.init.zeros_(module.bias)
@@ -175,6 +256,14 @@ class SambaModel(SambaPreTrainedModel):
 
         self.gradient_checkpointing = False
         self.norm_f = RMSNorm(config.hidden_size, eps=config.norm_eps, dtype=torch.float32)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm_f` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -217,23 +306,45 @@ class SambaModel(SambaPreTrainedModel):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
         hidden_states = inputs_embeds
+
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
         for mixer_block in self.layers:
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
-            hidden_states, attentions, past_key_values = mixer_block(
+            hidden_states, attentions, past_key_values, attnres_states = mixer_block(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
             if output_attentions and attentions is not None:
                 all_attns = all_attns + (attentions,)
+
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm_f` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
 
         hidden_states = self.norm_f(hidden_states)
 

--- a/fla/models/transformer/configuration_transformer.py
+++ b/fla/models/transformer/configuration_transformer.py
@@ -43,6 +43,7 @@ class TransformerConfig(PretrainedConfig):
         fuse_linear_cross_entropy: bool = False,
         use_l2warp: bool = False,
         vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
         **kwargs,
     ):
         self.hidden_size = hidden_size
@@ -70,6 +71,7 @@ class TransformerConfig(PretrainedConfig):
         self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
         self.use_l2warp = use_l2warp
         self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(
@@ -81,6 +83,13 @@ class TransformerConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -24,6 +25,7 @@ from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as TransformerMLP
 from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -67,6 +69,25 @@ class TransformerBlock(GradientCheckpointingLayer):
             fuse_swiglu=config.fuse_swiglu,
         )
 
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            # a sub-layer "starts a new block" if its global index
+            # (`2*layer_idx` for attn, `2*layer_idx+1` for mlp) is a multiple
+            # of `attnres_block_size`. when `True`, the incoming `prefix_sum`
+            # represents the previous block's complete sum (or the token
+            # embedding for the very first sub-layer) and gets cat'd into
+            # `attnres_states` before this sub-layer's attnres call.
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            # tag so `_init_weights` keeps the zero init (paper §5)
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -74,10 +95,39 @@ class TransformerBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
+        attnres_states: torch.Tensor | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
-        residual = hidden_states
+        if self.use_attnres:
+            # incoming `hidden_states` is the running `prefix_sum`
+            # (= previous layer's `output = prefix_sum + mlp_out`)
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L0 attn single-source path: softmax over 1 entry has weight 1,
+                # so attnres reduces to `attn_res_norm(emb)` (no kernel call)
+                hidden_states = self.attn_res_norm(prefix_sum)
+                attnres_states = prefix_sum.unsqueeze(0)
+                prefix_sum = None
+            else:
+                residuals = checkpoint(
+                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                    attnres_states,
+                    prefix_sum,
+                    use_reentrant=False,
+                )
+                if self.attnres_is_attn_boundary:
+                    # prev block's sum becomes a new residual entry
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
         hidden_states = self.attn_norm(hidden_states)
         hidden_states, attentions, past_key_values = self.attn(
             hidden_states=hidden_states,
@@ -87,14 +137,40 @@ class TransformerBlock(GradientCheckpointingLayer):
             output_attentions=output_attentions,
             **kwargs,
         )
-        if self.config.fuse_norm:
+
+        if self.use_attnres:
+            # accumulate attn output into the running `prefix_sum`
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                prefix_sum,
+                use_reentrant=False,
+            )
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+            hidden_states = self.mlp_norm(hidden_states)
+        elif self.config.fuse_norm:
             hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
         else:
             hidden_states = residual + hidden_states
             residual = hidden_states
             hidden_states = self.mlp_norm(hidden_states)
         hidden_states = self.mlp(hidden_states, **kwargs)
-        hidden_states = residual + hidden_states
+
+        if self.use_attnres:
+            # returned `hidden_states` carries the running `prefix_sum` to
+            # the next layer (single-tensor pp transmission, no separate carry)
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
 
         outputs = (hidden_states,)
 
@@ -103,6 +179,9 @@ class TransformerBlock(GradientCheckpointingLayer):
 
         if use_cache:
             outputs += (past_key_values,)
+
+        if self.use_attnres:
+            outputs += (attnres_states,)
 
         return outputs
 
@@ -125,9 +204,14 @@ class TransformerPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, (nn.Linear, nn.Conv1d)):
-            # Slightly different from the TF version which uses truncated_normal for initialization
-            # cf https://github.com/pytorch/pytorch/pull/5617
-            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if getattr(module, '_is_attnres_proj', False):
+                # attnres pseudo-query (per-layer projection): zero init keeps
+                # the initial softmax uniform (paper §5)
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
@@ -170,6 +254,13 @@ class TransformerModel(TransformerPreTrainedModel):
         self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
         self.layers = nn.ModuleList([TransformerBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
         self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            # top-level attnres aggregation params; `self.norm` still applies afterward
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
 
         self.gradient_checkpointing = False
 
@@ -222,6 +313,11 @@ class TransformerModel(TransformerPreTrainedModel):
         all_attns = () if output_attentions else None
         next_cache = None
 
+        # block-residual stack of shape `[L, B, T, D]` (only completed block
+        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
+        # so pp transmits a single tensor + a stacked block-residual tensor)
+        attnres_states: torch.Tensor | None = None
+
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
@@ -232,6 +328,7 @@ class TransformerModel(TransformerPreTrainedModel):
                 past_key_values=past_key_values,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
+                attnres_states=attnres_states,
                 **kwargs,
             )
 
@@ -242,6 +339,24 @@ class TransformerModel(TransformerPreTrainedModel):
 
             if output_attentions:
                 all_attns += (layer_outputs[1],)
+
+            if self.use_attnres:
+                attnres_states = layer_outputs[-1]
+
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` still applies afterward
+            residuals = checkpoint(
+                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
+                attnres_states,
+                hidden_states,
+                use_reentrant=False,
+            )
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
 
         hidden_states = self.norm(hidden_states)
 

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -172,16 +172,7 @@ class TransformerBlock(GradientCheckpointingLayer):
         else:
             hidden_states = residual + hidden_states
 
-        outputs = (hidden_states,)
-
-        if output_attentions:
-            outputs += (attentions,)
-
-        if use_cache:
-            outputs += (past_key_values,)
-
-        if self.use_attnres:
-            outputs += (attnres_states,)
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
 
         return outputs
 
@@ -243,10 +234,7 @@ class TransformerPreTrainedModel(PreTrainedModel):
 
 class TransformerModel(TransformerPreTrainedModel):
 
-    def __init__(
-        self,
-        config: TransformerConfig,
-    ) -> TransformerModel:
+    def __init__(self, config: TransformerConfig):
         super().__init__(config)
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
@@ -283,7 +271,7 @@ class TransformerModel(TransformerPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs: Unpack[Any],
-    ) -> tuple | CausalLMOutputWithPast:
+    ) -> tuple | BaseModelOutputWithPast:
         if output_attentions:
             warnings.warn(
                 "`TransformerModel` does not support output attention weights now, so `output_attentions` is set to `False`.",
@@ -297,7 +285,7 @@ class TransformerModel(TransformerPreTrainedModel):
         # retrieve input_ids and inputs_embeds
         if input_ids is not None and inputs_embeds is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
-        elif input_ids is None and inputs_embeds is None:
+        if input_ids is None and inputs_embeds is None:
             raise ValueError("You have to specify either input_ids or inputs_embeds")
 
         if use_cache and not isinstance(past_key_values, Cache):
@@ -309,20 +297,18 @@ class TransformerModel(TransformerPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        all_hidden_states = () if output_hidden_states else None
-        all_attns = () if output_attentions else None
-        next_cache = None
-
         # block-residual stack of shape `[L, B, T, D]` (only completed block
         # summaries; the running `prefix_sum` rides on `hidden_states` itself,
         # so pp transmits a single tensor + a stacked block-residual tensor)
         attnres_states: torch.Tensor | None = None
 
+        all_hidden_states = () if output_hidden_states else None
+        all_attns = () if output_attentions else None
         for layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            layer_outputs = layer(
+            hidden_states, attentions, past_key_values, attnres_states = layer(
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_values=past_key_values,
@@ -332,16 +318,8 @@ class TransformerModel(TransformerPreTrainedModel):
                 **kwargs,
             )
 
-            hidden_states = layer_outputs[0]
-
-            if use_cache:
-                next_cache = layer_outputs[2 if output_attentions else 1]
-
             if output_attentions:
-                all_attns += (layer_outputs[1],)
-
-            if self.use_attnres:
-                attnres_states = layer_outputs[-1]
+                all_attns += (attentions,)
 
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` still applies afterward
@@ -365,11 +343,11 @@ class TransformerModel(TransformerPreTrainedModel):
             all_hidden_states += (hidden_states,)
 
         if not return_dict:
-            return tuple(v for v in [hidden_states, next_cache, all_hidden_states, all_attns] if v is not None)
+            return tuple(v for v in [hidden_states, past_key_values, all_hidden_states, all_attns] if v is not None)
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=next_cache,
+            past_key_values=past_key_values,
             hidden_states=all_hidden_states,
             attentions=all_attns,
         )
@@ -442,9 +420,9 @@ class TransformerForCausalLM(TransformerPreTrainedModel, FLAGenerationMixin):
 
         hidden_states = outputs[0]
 
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
-
-        loss = None
+        loss, logits = None, None
+        if not self.config.fuse_linear_cross_entropy or labels is None:
+            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/ops/__init__.py
+++ b/fla/ops/__init__.py
@@ -7,6 +7,7 @@
 
 from .abc import chunk_abc
 from .attn import parallel_attn
+from .attnres import fused_attnres
 from .based import fused_chunk_based, parallel_based
 from .comba import chunk_comba, fused_recurrent_comba
 from .delta_rule import chunk_delta_rule, fused_chunk_delta_rule, fused_recurrent_delta_rule
@@ -52,6 +53,7 @@ __all__ = [
     'chunk_rwkv6',
     'chunk_rwkv7',
     'chunk_simple_gla',
+    'fused_attnres',
     'fused_chunk_based',
     'fused_chunk_delta_rule',
     'fused_chunk_gla',

--- a/tests/models/test_modeling_abc.py
+++ b/tests/models/test_modeling_abc.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, ABCConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        ABCConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_bitnet.py
+++ b/tests/models/test_modeling_bitnet.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, BitNetConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        BitNetConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_comba.py
+++ b/tests/models/test_modeling_comba.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, CombaConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        CombaConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_deltaformer.py
+++ b/tests/models/test_modeling_deltaformer.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, DeltaFormerConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        DeltaFormerConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_deltanet.py
+++ b/tests/models/test_modeling_deltanet.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, DeltaNetConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        DeltaNetConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_forgetting_transformer.py
+++ b/tests/models/test_modeling_forgetting_transformer.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, ForgettingTransformerConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        ForgettingTransformerConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_gated_deltanet.py
+++ b/tests/models/test_modeling_gated_deltanet.py
@@ -17,12 +17,14 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64, True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -33,9 +35,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, GatedDeltaNetConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        GatedDeltaNetConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_gated_deltaproduct.py
+++ b/tests/models/test_modeling_gated_deltaproduct.py
@@ -20,13 +20,15 @@ from .test_modeling_utils import init_weights_recursively
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -37,9 +39,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, GatedDeltaProductConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        GatedDeltaProductConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_gla.py
+++ b/tests/models/test_modeling_gla.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, GLAConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        GLAConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_gsa.py
+++ b/tests/models/test_modeling_gsa.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, GSAConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        GSAConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_hgrn.py
+++ b/tests/models/test_modeling_hgrn.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, HGRNConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        HGRNConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_hgrn2.py
+++ b/tests/models/test_modeling_hgrn2.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_hgrn2_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, HGRN2Config, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        HGRN2Config,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_kda.py
+++ b/tests/models/test_modeling_kda.py
@@ -17,12 +17,14 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64, True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -33,9 +35,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, KDAConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        KDAConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_lightnet.py
+++ b/tests/models/test_modeling_lightnet.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, LightNetConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        LightNetConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_linear_attn.py
+++ b/tests/models/test_modeling_linear_attn.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, LinearAttentionConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        LinearAttentionConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_log_linear_mamba2.py
+++ b/tests/models/test_modeling_log_linear_mamba2.py
@@ -18,13 +18,15 @@ from fla.utils import device
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'dtype', 'conv_backend'],
+    ['L', 'B', 'T', 'H', 'D', 'attnres_block_size', 'dtype', 'conv_backend'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-{}-conv-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-bs{}-{}-conv-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, torch.bfloat16, 'cuda'),
-            (4, 4, 1024, 4, 64, torch.bfloat16, 'triton'),
-            (4, 4, 1024, 4, 128, torch.bfloat16, 'cuda'),
+            (4, 4, 1024, 4, 64,  None, torch.bfloat16, 'cuda'),
+            (4, 4, 1024, 4, 64,  None, torch.bfloat16, 'triton'),
+            (4, 4, 1024, 4, 128, None, torch.bfloat16, 'cuda'),
+            (4, 4, 1024, 4, 64,  1,    torch.bfloat16, 'cuda'),
+            (4, 4, 1024, 4, 64,  4,    torch.bfloat16, 'cuda'),
         ]
     ],
 )
@@ -34,6 +36,7 @@ def test_modeling(
     T: int,
     H: int,
     D: int,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
     conv_backend: str,
 ):
@@ -55,6 +58,7 @@ def test_modeling(
         expand=expand,
         num_heads=H,
         head_dim=D,
+        attnres_block_size=attnres_block_size,
         vocab_size=1000,  # dummy vocab size
     )
 

--- a/tests/models/test_modeling_mesanet.py
+++ b/tests/models/test_modeling_mesanet.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, MesaNetConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        MesaNetConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_mla.py
+++ b/tests/models/test_modeling_mla.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, MLAConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        MLAConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_moba.py
+++ b/tests/models/test_modeling_moba.py
@@ -17,18 +17,21 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'qk_norm', 'use_output_gate', 'moba_topk', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'qk_norm', 'use_output_gate', 'moba_topk', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-qkn{}-og{}-k{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-qkn{}-og{}-k{}-bs{}-{}".format(*test))
         for test in [
             # baseline
-            (4, 4, 1024, 4, 64, False, False, True, 3, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, False, True,  3, None, torch.bfloat16),
             # D=128 + l2warp (exercises Hopper head-dim and the l2warp branch)
-            (4, 4, 1024, 4, 128, True, False, True, 3, torch.bfloat16),
+            (4, 4, 1024, 4, 128, True,  False, True,  3, None, torch.bfloat16),
             # qk_norm + no output gate (covers both layer variants in one case)
-            (2, 4, 1024, 4, 64, False, True, False, 3, torch.bfloat16),
+            (2, 4, 1024, 4, 64,  False, True,  False, 3, None, torch.bfloat16),
             # topk=1 triggers the full-attn short-circuit inside `parallel_moba`
-            (2, 4, 1024, 4, 64, False, False, True, 1, torch.bfloat16),
+            (2, 4, 1024, 4, 64,  False, False, True,  1, None, torch.bfloat16),
+            # attnres rows
+            (4, 4, 1024, 4, 64,  False, False, True,  3, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, False, True,  3, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -42,6 +45,7 @@ def test_modeling(
     qk_norm: bool,
     use_output_gate: bool,
     moba_topk: int,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
     run_test_model_forward_backward(
@@ -51,6 +55,7 @@ def test_modeling(
         use_output_gate=use_output_gate,
         moba_chunk_size=128,
         moba_topk=moba_topk,
+        attnres_block_size=attnres_block_size,
     )
 
 

--- a/tests/models/test_modeling_mom.py
+++ b/tests/models/test_modeling_mom.py
@@ -18,13 +18,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # ===================================================================================
 @pytest.mark.skip(reason="Bug not fixed yet")
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -35,9 +37,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, MomConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        MomConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_nsa.py
+++ b/tests/models/test_modeling_nsa.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, NSAConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        NSAConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_path_attn.py
+++ b/tests/models/test_modeling_path_attn.py
@@ -17,12 +17,14 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, False, torch.float16),
-            (4, 4, 1024, 4, 128, False, torch.float16),
+            (4, 4, 1024, 4, 64,  False, None, torch.float16),
+            (4, 4, 1024, 4, 128, False, None, torch.float16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.float16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.float16),
         ]
     ],
 )
@@ -33,9 +35,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, PaTHAttentionConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        PaTHAttentionConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 # ===================================================================================
 # Test for Generation

--- a/tests/models/test_modeling_retnet.py
+++ b/tests/models/test_modeling_retnet.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, RetNetConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        RetNetConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_samba.py
+++ b/tests/models/test_modeling_samba.py
@@ -17,13 +17,15 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 18, 64, True, torch.bfloat16),
-            (4, 4, 1024, 18, 64, False, torch.bfloat16),
-            (4, 4, 1024, 9, 128, False, torch.bfloat16),
+            (4, 4, 1024, 18, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 18, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 9,  128, False, None, torch.bfloat16),
+            (4, 4, 1024, 18, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 18, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +36,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, SambaConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        SambaConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================

--- a/tests/models/test_modeling_transformer.py
+++ b/tests/models/test_modeling_transformer.py
@@ -17,13 +17,16 @@ from .test_modeling_base import run_test_generation, run_test_model_forward_back
 # Test for Modeling (Forward/Backward Pass)
 # ===================================================================================
 @pytest.mark.parametrize(
-    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'attnres_block_size', 'dtype'],
     [
-        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-bs{}-{}".format(*test))
         for test in [
-            (4, 4, 1024, 4, 64, True, torch.bfloat16),
-            (4, 4, 1024, 4, 64, False, torch.bfloat16),
-            (4, 4, 1024, 4, 128, False, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  True,  None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 128, False, None, torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 1,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 2,    torch.bfloat16),
+            (4, 4, 1024, 4, 64,  False, 4,    torch.bfloat16),
         ]
     ],
 )
@@ -34,9 +37,20 @@ def test_modeling(
     H: int,
     D: int,
     use_l2warp: bool,
+    attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
-    run_test_model_forward_backward(L, B, T, H, D, TransformerConfig, use_l2warp=use_l2warp, dtype=dtype)
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        TransformerConfig,
+        use_l2warp=use_l2warp,
+        attnres_block_size=attnres_block_size,
+        dtype=dtype,
+    )
 
 
 # ===================================================================================


### PR DESCRIPTION
## Summary

Initial scaffold for rolling out AttnRes across all `fla.models.*`. This PR wires `fused_attnres` into the model definitions and exposes a single `attnres_block_size` config flag; subsequent PRs (or follow-up commits to this branch) will extend coverage to the remaining models.

So far covered: **KDA**, **Transformer**.

## Design

- `attnres_block_size=None` disables AttnRes (default, no behavior change).
- `attnres_block_size=1` is full mode — every sub-layer is a boundary; there is **no** residual accumulation, every sub-layer's input is `attnres(stack of all previous outputs + emb)`.
- Even `attnres_block_size>=2` groups `block_size//2` transformer layers per block. Inside a block, normal pre-norm residual accumulation; at block boundaries (always at attn sub-layers) the running `prefix_sum` is committed into `attnres_states` and the next sub-layer's input is `attnres(completed-block representations)` only.
- `attnres_states` is carried as a stacked `[L, B, T, D]` tensor; the running `prefix_sum` rides on `hidden_states` itself so pp transmits a single tensor.
- Pseudo-query projections (`attn_res_proj`, `mlp_res_proj`, top-level `res_proj`) are tagged `_is_attnres_proj` and zero-initialized in `_init_weights` so the initial softmax stays uniform (paper §5).
- L0 attn single-source path bypasses the `fused_attnres` kernel (softmax over one entry reduces to `attn_res_norm(emb)`).
- Config validation rejects anything other than `None`, `1`, or even integers.

## Test plan
- [ ] `pytest tests/models/test_modeling_kda.py` (covers `attnres_block_size ∈ {None, 1, 2, 4}`)
- [ ] `pytest tests/models/test_modeling_transformer.py` (same parametrization)
- [ ] Roll out to remaining models in `fla.models.*` in follow-up commits