### PR TITLE
[Fix] Add functools.cache for op dispatch to reduce CPU overhead

### DIFF
--- a/fla/ops/backends/__init__.py
+++ b/fla/ops/backends/__init__.py
@@ -14,7 +14,7 @@ import logging
 import os
 import threading
 from collections.abc import Callable
-from functools import wraps
+from functools import wraps, cache
 from importlib.util import find_spec
 from typing import Any, ClassVar, TypeVar
 
@@ -60,6 +60,7 @@ class BaseBackend:
         return os.environ.get(cls.env_var, default_value) != "0"
 
     @classmethod
+    @cache
     def can_use(cls) -> bool:
         return cls.is_available() and cls.is_enabled()
 

--- a/fla/ops/backends/__init__.py
+++ b/fla/ops/backends/__init__.py
@@ -14,7 +14,7 @@ import logging
 import os
 import threading
 from collections.abc import Callable
-from functools import wraps, cache
+from functools import cache, wraps
 from importlib.util import find_spec
 from typing import Any, ClassVar, TypeVar
 

--- a/fla/ops/backends/__init__.py
+++ b/fla/ops/backends/__init__.py
@@ -31,12 +31,20 @@ class BaseBackend:
     """Base class for operation-specific backends.
 
     Attributes:
-        backend_type: Identifier for the backend type, used to distinguish different backend implementations.
-        package_name: Name of the external package required by the backend. None indicates no external dependency.
-        env_var: Environment variable name that controls whether the backend is enabled. None means always enabled.
-        default_enable: Controls whether the backend is enabled by default when env_var is not set.
-                       Defaults to True (enabled). Set to False to require explicit user opt-in.
-        priority: Backend priority, lower values indicate higher priority (default is 5).
+        backend_type (str, Optional):
+            Identifier for the backend type, used to distinguish different backend implementations.
+            Default: `"base"`.
+        package_name (str, Optional):
+            Name of the external package required by the backend.
+            `None` indicates no external dependency. Default: `None`.
+        env_var (str, Optional):
+            Environment variable name that controls whether the backend is enabled.
+            `None` means always enabled. Default: `None`.
+        default_enable (bool, Optional):
+            Whether the backend is enabled by default when `env_var` is not set.
+            Set to `False` to require explicit user opt-in. Default: `True`.
+        priority (int, Optional):
+            Backend priority. Lower values indicate higher priority. Default: 5.
     """
 
     backend_type: ClassVar[str] = "base"


### PR DESCRIPTION
## Bug: Per-call import probing in `@dispatch` backend selection

FLA introduced a generic `@dispatch` decorator that wraps operations like `chunk_kda`
to dynamically select the best available backend at runtime. On every call, the dispatch loop
iterates over all registered backends and calls `backend.can_use()` to filter usable ones.
`can_use()` delegates to `is_available()`, which performs expensive checks each time:

- `FlashKDABackend.is_available()` → `importlib.find_spec('flash_kda')` — walks `sys.path` to probe filesystem (~40 µs)
- `KDATileLangBackend.is_available()` → `try: import tilelang` — triggers Python's import machinery (~40 µs)

Combined, this adds ~80 µs of pure overhead per forward pass. For short sequences (T ≤ 1024)
where the actual kernel runs in ~500 µs, this is a >15% regression. The issue went unnoticed
because long-sequence benchmarks (T ≥ 8192, ~1.4 ms kernel) are minimally affected.

## Fix

Add `@classmethod @cache` to `BaseBackend.can_use()` in `fla/ops/backends/__init__.py`.
`functools.cache` keys on `cls`, so each backend subclass pays the `is_available()` cost
exactly once per process — subsequent calls return the cached `bool` in nanoseconds.
The fix is two lines and requires no structural changes to the dispatch system.

```python
@classmethod
@cache
def can_use(cls) -> bool:
    return cls.is_available() and cls.is_enabled()
```

## Performance

perf increase on small sequences with reduced CPU overhead

```python
python -m benchmarks.ops.run --op chunk_kda --base 0ce1d581cd5ac6185d6e9051460c82915c06c6a2
```

```
===========================================================================================================================
  Machine: NVIDIA H200 | CUDA 12.9 | PyTorch 2.9.1+cu129
===========================================================================================================================
  fwd        B      T    H    D  op                                   HEAD[0ce1d581](ms) fix/op-d...[45cf2ae8](ms)  speedup
          -----------------------------------------------------------------------------------------------------------------
             1   8192   96  128  chunk_kda                                         2.569                     2.566    1.00x
          -----------------------------------------------------------------------------------------------------------------
             2  16384   16  128  chunk_kda                                         1.843                     1.845    1.00x
          -----------------------------------------------------------------------------------------------------------------
             4   2048   16  128  chunk_kda                                         0.871                     0.601    1.45x
          -----------------------------------------------------------------------------------------------------------------
             4   4096   64  128  chunk_kda                                         3.297                     3.295    1.00x
          -----------------------------------------------------------------------------------------------------------------
             8   1024    8   64  chunk_kda                                         0.871                     0.600    1.45x
          -----------------------------------------------------------------------------------------------------------------
             8   2048   32  256  chunk_kda                                         3.850                     3.853    1.00x
===========================================================================================================================
  fwdbwd     B      T    H    D  op                                   HEAD[0ce1d581](ms) fix/op-d...[45cf2ae8](ms)  speedup
          -----------------------------------------------------------------------------------------------------------------
             1   8192   96  128  chunk_kda                                        11.901                    11.899    1.00x
          -----------------------------------------------------------------------------------------------------------------
             2  16384   16  128  chunk_kda                                         8.144                     8.140    1.00x
          -----------------------------------------------------------------------------------------------------------------
             4   2048   16  128  chunk_kda                                         2.239                     2.134    1.05x
          -----------------------------------------------------------------------------------------------------------------
             4   4096   64  128  chunk_kda                                        15.405                    15.410    1.00x
          -----------------------------------------------------------------------------------------------------------------
             8   1024    8   64  chunk_kda                                         2.266                     1.631    1.39x
          -----------------------------------------------------------------------------------------------------------------
             8   2048   32  256  chunk_kda                                        17.407                    17.430    1.00x
===========================================================================================================================
```

NOTE: most contents are AI-generated