### PR TITLE
[Ops] Switch attnres to list-input + pointer-table API

### DIFF
--- a/benchmarks/benchmark_training_throughput.py
+++ b/benchmarks/benchmark_training_throughput.py
@@ -104,7 +104,7 @@ def profile(
     mixed_precision: str = 'bf16',
     compile: bool = False,
     enable_profile: bool = False,
-    profile_steps: int = 8,
+    profile_steps: int = 128,
     profile_trace: str | None = None,
 ):
     device = torch.device('cuda')

--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -105,7 +104,7 @@ class ABCBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -116,15 +115,10 @@ class ABCBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -149,12 +143,7 @@ class ABCBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -301,7 +290,7 @@ class ABCModel(ABCPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -325,12 +314,7 @@ class ABCModel(ABCPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -135,7 +134,7 @@ class BitNetBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
@@ -149,15 +148,10 @@ class BitNetBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -184,12 +178,7 @@ class BitNetBlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -343,10 +332,11 @@ class BitNetModel(BitNetPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -371,12 +361,7 @@ class BitNetModel(BitNetPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -102,7 +101,7 @@ class CombaBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -113,15 +112,10 @@ class CombaBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -146,12 +140,7 @@ class CombaBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -312,7 +301,7 @@ class CombaModel(CombaPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -336,12 +325,7 @@ class CombaModel(CombaPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -105,7 +104,7 @@ class DeltaNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -116,15 +115,10 @@ class DeltaNetBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -149,12 +143,7 @@ class DeltaNetBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -301,7 +290,7 @@ class DeltaNetModel(DeltaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -325,12 +314,7 @@ class DeltaNetModel(DeltaNetPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/deltaformer/modeling_deltaformer.py
+++ b/fla/models/deltaformer/modeling_deltaformer.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -84,7 +83,7 @@ class DeltaFormerBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -95,15 +94,10 @@ class DeltaFormerBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -128,12 +122,7 @@ class DeltaFormerBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -253,7 +242,7 @@ class DeltaFormerModel(DeltaFormerPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -277,12 +266,7 @@ class DeltaFormerModel(DeltaFormerPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -94,7 +93,7 @@ class ForgettingTransformerBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
@@ -108,15 +107,10 @@ class ForgettingTransformerBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -143,12 +137,7 @@ class ForgettingTransformerBlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -306,10 +295,11 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -334,12 +324,7 @@ class ForgettingTransformerModel(ForgettingTransformerPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -103,7 +102,7 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -114,15 +113,10 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -147,12 +141,7 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -313,7 +302,7 @@ class GatedDeltaNetModel(GatedDeltaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -337,12 +326,7 @@ class GatedDeltaNetModel(GatedDeltaNetPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -104,7 +103,7 @@ class GatedDeltaProductBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -115,15 +114,10 @@ class GatedDeltaProductBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -148,12 +142,7 @@ class GatedDeltaProductBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -303,7 +292,7 @@ class GatedDeltaProductModel(GatedDeltaProductPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -327,12 +316,7 @@ class GatedDeltaProductModel(GatedDeltaProductPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -107,7 +106,7 @@ class GLABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -118,15 +117,10 @@ class GLABlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -151,12 +145,7 @@ class GLABlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -303,7 +292,7 @@ class GLAModel(GLAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -327,12 +316,7 @@ class GLAModel(GLAPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -108,7 +107,7 @@ class GSABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -119,15 +118,10 @@ class GSABlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -152,12 +146,7 @@ class GSABlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -304,7 +293,7 @@ class GSAModel(GSAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -328,12 +317,7 @@ class GSAModel(GSAPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -100,7 +99,7 @@ class HGRNBlock(GradientCheckpointingLayer):
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
         lower_bound: torch.Tensor | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -111,15 +110,10 @@ class HGRNBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -145,12 +139,7 @@ class HGRNBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -299,7 +288,7 @@ class HGRNModel(HGRNPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -329,12 +318,7 @@ class HGRNModel(HGRNPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -101,7 +100,7 @@ class HGRN2Block(GradientCheckpointingLayer):
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
         lower_bound: torch.Tensor | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -112,15 +111,10 @@ class HGRN2Block(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -146,12 +140,7 @@ class HGRN2Block(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -300,7 +289,7 @@ class HGRN2Model(HGRN2PreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -330,12 +319,7 @@ class HGRN2Model(HGRN2PreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/kda/modeling_kda.py
+++ b/fla/models/kda/modeling_kda.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -110,7 +109,7 @@ class KDABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -123,15 +122,10 @@ class KDABlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -158,12 +152,7 @@ class KDABlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -327,10 +316,11 @@ class KDAModel(KDAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -354,12 +344,7 @@ class KDAModel(KDAPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -100,7 +99,7 @@ class LightNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -111,15 +110,10 @@ class LightNetBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -144,12 +138,7 @@ class LightNetBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -295,7 +284,7 @@ class LightNetModel(LightNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -320,12 +309,7 @@ class LightNetModel(LightNetPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -105,7 +104,7 @@ class LinearAttentionBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs,
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -116,15 +115,10 @@ class LinearAttentionBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -149,12 +143,7 @@ class LinearAttentionBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -303,7 +292,7 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -327,12 +316,7 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
+++ b/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
@@ -9,7 +9,6 @@ import math
 
 import torch
 from torch import nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -81,7 +80,7 @@ class LogLinearMamba2Block(nn.Module):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs,
     ):
         if self.use_attnres:
@@ -92,15 +91,10 @@ class LogLinearMamba2Block(nn.Module):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.mixer_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -125,12 +119,7 @@ class LogLinearMamba2Block(nn.Module):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -355,7 +344,7 @@ class LogLinearMamba2Model(LogLinearMamba2PreTrainedModel):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
         hidden_states = inputs_embeds
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -388,12 +377,7 @@ class LogLinearMamba2Model(LogLinearMamba2PreTrainedModel):
                 all_attns = all_attns + (attentions,)
 
         if self.use_attnres:
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -103,7 +102,7 @@ class MesaNetBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -114,15 +113,10 @@ class MesaNetBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -147,12 +141,7 @@ class MesaNetBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -299,7 +288,7 @@ class MesaNetModel(MesaNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -323,12 +312,7 @@ class MesaNetModel(MesaNetPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/mla/modeling_mla.py
+++ b/fla/models/mla/modeling_mla.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -91,7 +90,7 @@ class MLABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -102,15 +101,10 @@ class MLABlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -135,12 +129,7 @@ class MLABlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -287,7 +276,7 @@ class MLAModel(MLAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -311,12 +300,7 @@ class MLAModel(MLAPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/moba/modeling_moba.py
+++ b/fla/models/moba/modeling_moba.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -91,7 +90,7 @@ class MoBABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -102,15 +101,10 @@ class MoBABlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -135,12 +129,7 @@ class MoBABlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -274,7 +263,7 @@ class MoBAModel(MoBAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -296,12 +285,7 @@ class MoBAModel(MoBAPreTrainedModel):
                 all_attns += (attentions,)
 
         if self.use_attnres:
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -193,7 +192,7 @@ class MomBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -206,15 +205,10 @@ class MomBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -241,12 +235,7 @@ class MomBlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -392,10 +381,11 @@ class MomModel(MomPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -422,12 +412,7 @@ class MomModel(MomPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -96,7 +95,7 @@ class NSABlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         if self.use_attnres:
@@ -109,15 +108,10 @@ class NSABlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -144,12 +138,7 @@ class NSABlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -301,10 +290,11 @@ class NSAModel(NSAPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -328,12 +318,7 @@ class NSAModel(NSAPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -93,7 +92,7 @@ class PaTHAttentionBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
@@ -107,15 +106,10 @@ class PaTHAttentionBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -142,12 +136,7 @@ class PaTHAttentionBlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -305,10 +294,11 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -333,12 +323,7 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -104,7 +103,7 @@ class RetNetBlock(GradientCheckpointingLayer):
         past_key_values: list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
@@ -116,15 +115,10 @@ class RetNetBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     attnres_states = residuals
                     prefix_sum = None
@@ -149,12 +143,7 @@ class RetNetBlock(GradientCheckpointingLayer):
 
         if self.use_attnres:
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -307,7 +296,7 @@ class RetNetModel(RetNetPreTrainedModel):
         if use_cache and not isinstance(past_key_values, Cache):
             past_key_values = Cache.from_legacy_cache(past_key_values)
 
-        attnres_states: torch.Tensor | None = None
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -329,12 +318,7 @@ class RetNetModel(RetNetPreTrainedModel):
                 all_attns += (attentions,)
 
         if self.use_attnres:
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -103,7 +102,7 @@ class SambaBlock(GradientCheckpointingLayer):
         past_key_values: Cache | list[torch.FloatTensor] | None = None,
         use_cache: bool | None = False,
         output_attentions: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[dict],
     ):
         if self.use_attnres:
@@ -116,15 +115,10 @@ class SambaBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.mixer_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -151,12 +145,7 @@ class SambaBlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -310,10 +299,11 @@ class SambaModel(SambaPreTrainedModel):
 
         hidden_states = inputs_embeds
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -337,12 +327,7 @@ class SambaModel(SambaPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm_f` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
@@ -95,7 +94,7 @@ class TransformerBlock(GradientCheckpointingLayer):
         past_key_values: tuple[torch.Tensor] | None = None,
         output_attentions: bool | None = False,
         use_cache: bool | None = False,
-        attnres_states: torch.Tensor | None = None,
+        attnres_states: list[torch.Tensor] | None = None,
         **kwargs: Unpack[Any],
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
 
@@ -109,15 +108,10 @@ class TransformerBlock(GradientCheckpointingLayer):
                 # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
                 # at the first layer (where `block_residual` is empty).
                 hidden_states = self.attn_norm(prefix_sum)
-                attnres_states = prefix_sum.unsqueeze(0)
+                attnres_states = [prefix_sum]
                 prefix_sum = None
             else:
-                residuals = checkpoint(
-                    lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                    attnres_states,
-                    prefix_sum,
-                    use_reentrant=False,
-                )
+                residuals = [*attnres_states, prefix_sum]
                 if self.attnres_is_attn_boundary:
                     # prev block's sum becomes a new residual entry
                     attnres_states = residuals
@@ -144,12 +138,7 @@ class TransformerBlock(GradientCheckpointingLayer):
         if self.use_attnres:
             # accumulate attn output into the running `prefix_sum`
             prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                prefix_sum,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, prefix_sum]
             if self.attnres_is_mlp_boundary:
                 attnres_states = residuals
                 prefix_sum = None
@@ -300,10 +289,11 @@ class TransformerModel(TransformerPreTrainedModel):
         # embed positions
         hidden_states = inputs_embeds
 
-        # block-residual stack of shape `[L, B, T, D]` (only completed block
-        # summaries; the running `prefix_sum` rides on `hidden_states` itself,
-        # so pp transmits a single tensor + a stacked block-residual tensor)
-        attnres_states: torch.Tensor | None = None
+        # list of completed block summaries (kept as separate tensors so
+        # `fused_attnres` can ingest them via its pointer-table API
+        # without an upstream `torch.cat`); the running `prefix_sum`
+        # rides on `hidden_states` itself.
+        attnres_states: list[torch.Tensor] | None = None
 
         all_hidden_states = () if output_hidden_states else None
         all_attns = () if output_attentions else None
@@ -327,12 +317,7 @@ class TransformerModel(TransformerPreTrainedModel):
         if self.use_attnres:
             # top-level attnres aggregation; `self.norm` is folded into the
             # kernel via `output_rms_weight` so we don't double-norm.
-            residuals = checkpoint(
-                lambda s, p: torch.cat([s, p.unsqueeze(0)], 0),
-                attnres_states,
-                hidden_states,
-                use_reentrant=False,
-            )
+            residuals = [*attnres_states, hidden_states]
             hidden_states = fused_attnres(
                 query=self.res_proj.weight,
                 residuals=residuals,

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -82,6 +82,9 @@ def attnres_fwd_kernel(
 
     # one-time gather of source base pointers; reused across all D-loops below.
     p_v = tl.load(res + o_l, mask=m_l, other=0).to(tl.pointer_type(DTYPE))
+    # each residual storage is 16-byte aligned (torch CUDA allocator is
+    # 256-byte aligned), so tell Triton it can use wide vector loads.
+    p_v = tl.multiple_of(p_v, 16)
 
     # [BL]
     b_var = tl.zeros([BL], dtype=tl.float32)
@@ -89,6 +92,11 @@ def attnres_fwd_kernel(
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
+        # tell Triton that o_d has BD contiguous elements with stride 1 — this
+        # is the hint the compiler needs to coalesce the inner-D load across
+        # the [BL, BD] pointer tile (without it, Triton sees `p_v[:, None] +
+        # offs[None, :]` as opaque and emits per-element scattered loads).
+        o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         # [BL, BD] gather: row l from source l's storage at offset i_n*D + o_d
         b_v = tl.load(
@@ -125,6 +133,11 @@ def attnres_fwd_kernel(
     b_o_var = tl.zeros([], dtype=tl.float32)
     for i_d in range(0, D, BD):
         o_d = i_d + tl.arange(0, BD)
+        # tell Triton that o_d has BD contiguous elements with stride 1 — this
+        # is the hint the compiler needs to coalesce the inner-D load across
+        # the [BL, BD] pointer tile (without it, Triton sees `p_v[:, None] +
+        # offs[None, :]` as opaque and emits per-element scattered loads).
+        o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         p_o = tl.make_block_ptr(o + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
@@ -187,7 +200,11 @@ def attnres_bwd_kernel_dv(
     o_l = tl.arange(0, BL)
     m_l = o_l < L
     p_v = tl.load(res + o_l, mask=m_l, other=0).to(tl.pointer_type(DTYPE))
+    # each residual storage is 16-byte aligned (torch CUDA allocator is
+    # 256-byte aligned), so tell Triton it can use wide vector loads.
+    p_v = tl.multiple_of(p_v, 16)
     p_dv = tl.load(dres + o_l, mask=m_l, other=0).to(tl.pointer_type(DTYPE))
+    p_dv = tl.multiple_of(p_dv, 16)
 
     p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
     p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
@@ -221,6 +238,11 @@ def attnres_bwd_kernel_dv(
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
+        # tell Triton that o_d has BD contiguous elements with stride 1 — this
+        # is the hint the compiler needs to coalesce the inner-D load across
+        # the [BL, BD] pointer tile (without it, Triton sees `p_v[:, None] +
+        # offs[None, :]` as opaque and emits per-element scattered loads).
+        o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
@@ -269,6 +291,11 @@ def attnres_bwd_kernel_dv(
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
+        # tell Triton that o_d has BD contiguous elements with stride 1 — this
+        # is the hint the compiler needs to coalesce the inner-D load across
+        # the [BL, BD] pointer tile (without it, Triton sees `p_v[:, None] +
+        # offs[None, :]` as opaque and emits per-element scattered loads).
+        o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         m_v = m_l[:, None] & m_d[None, :]
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -22,18 +22,6 @@ from fla.utils import (
     input_guard,
 )
 
-ATTNRES_FWD_BWD_CONFIGS = [
-    triton.Config({'BD': BD}, num_warps=num_warps, num_stages=num_stages)
-    for BD, num_warps in [(64, 1), (128, 2), (256, 4), (512, 4), (1024, 8)]
-    for num_stages in [3, 4]
-]
-
-ATTNRES_DW_CONFIGS = [
-    triton.Config({'BN': BN, 'BD': BD}, num_warps=num_warps, num_stages=num_stages)
-    for BN, BD, num_warps in [(1024, 16, 4), (2048, 32, 4), (2048, 32, 8), (4096, 32, 8), (4096, 64, 8)]
-    for num_stages in [3, 4]
-]
-
 # residual sources are passed as a list of separately-allocated tensors and
 # accessed inside the kernels via int64 pointer tables — the upstream caller
 # never has to `torch.stack` / `torch.cat` them. each source is read with a
@@ -50,7 +38,11 @@ _TORCH_TO_TL_DTYPE = {
 
 
 @fla_cache_autotune(
-    configs=ATTNRES_FWD_BWD_CONFIGS,
+    configs=[
+        triton.Config({'BD': BD}, num_warps=num_warps, num_stages=num_stages)
+        for BD, num_warps in [(64, 1), (128, 2), (256, 4), (512, 4), (1024, 8)]
+        for num_stages in [3, 4]
+    ],
     key=['L', 'D', 'HAS_ONORM'],
     **autotune_cache_kwargs,
 )
@@ -169,7 +161,20 @@ def attnres_fwd_kernel(
 
 
 @fla_cache_autotune(
-    configs=ATTNRES_FWD_BWD_CONFIGS,
+    # bwd_dv carries more BL-axis reductions (b_dp, b_dp_w, b_dp_x, b_z, b_o_c1)
+    # than fwd plus a scattered dv store with no fwd analogue, so explore a
+    # wider grid along the per-thread = BD/num_warps contour (32, 64, 128).
+    configs=[
+        triton.Config({'BD': BD}, num_warps=num_warps, num_stages=num_stages)
+        for BD, num_warps in [
+            (64, 1),   (64, 2),
+            (128, 1),  (128, 2),  (128, 4),
+            (256, 2),  (256, 4),  (256, 8),
+            (512, 4),  (512, 8),  (512, 16),
+            (1024, 8), (1024, 16),
+        ]
+        for num_stages in [3, 4]
+    ],
     key=['L', 'D', 'HAS_ONORM'],
     **autotune_cache_kwargs,
 )
@@ -245,11 +250,12 @@ def attnres_bwd_kernel_dv(
         o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-        # [BL, BD]
+        # [BL, BD] — pass 2 reloads the same v tile, so hint L2 to retain.
         b_v = tl.load(
             p_v[:, None] + (i_n * D + o_d[None, :]),
             mask=m_l[:, None] & m_d[None, :],
             other=0.0,
+            eviction_policy="evict_last",
         ).to(tl.float32)
         # [BD]
         b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
@@ -300,7 +306,13 @@ def attnres_bwd_kernel_dv(
         m_v = m_l[:, None] & m_d[None, :]
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
-        b_v = tl.load(tl.multiple_of(p_v[:, None] + (i_n * D + o_d[None, :]), (1, 16)), mask=m_v, other=0.0).to(tl.float32)
+        # last touch of this v tile — release the L2 line.
+        b_v = tl.load(
+            tl.multiple_of(p_v[:, None] + (i_n * D + o_d[None, :]), (1, 16)),
+            mask=m_v,
+            other=0.0,
+            eviction_policy="evict_first",
+        ).to(tl.float32)
         # [BD]
         b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
@@ -325,7 +337,11 @@ def attnres_bwd_kernel_dv(
 
 
 @fla_cache_autotune(
-    configs=ATTNRES_DW_CONFIGS,
+    configs=[
+        triton.Config({'BN': BN, 'BD': BD}, num_warps=num_warps, num_stages=num_stages)
+        for BN, BD, num_warps in [(1024, 16, 4), (2048, 32, 4), (2048, 32, 8), (4096, 32, 8), (4096, 64, 8)]
+        for num_stages in [3, 4]
+    ],
     key=['N', 'D', 'HAS_ONORM'],
     **autotune_cache_kwargs,
 )

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -34,6 +34,20 @@ ATTNRES_DW_CONFIGS = [
     for num_stages in [3, 4]
 ]
 
+# residual sources are passed as a list of separately-allocated tensors and
+# accessed inside the kernels via int64 pointer tables — the upstream caller
+# never has to `torch.stack` / `torch.cat` them. each source is read with a
+# 2D pointer-tile gather: BL int64 base addresses are loaded once, cast to
+# `tl.pointer_type(DTYPE)`, then broadcast against the inner D-tile to form
+# `[BL, BD]` of independent global addresses. OOB rows (l >= L) load the
+# dummy address 0 but are masked off by `m_l`, so the zero pointer is never
+# dereferenced.
+_TORCH_TO_TL_DTYPE = {
+    torch.float16: tl.float16,
+    torch.float32: tl.float32,
+    torch.bfloat16: tl.bfloat16,
+}
+
 
 @fla_cache_autotune(
     configs=ATTNRES_FWD_BWD_CONFIGS,
@@ -43,7 +57,7 @@ ATTNRES_DW_CONFIGS = [
 @triton.jit
 def attnres_fwd_kernel(
     q,
-    v,
+    res,
     w,
     o,
     rstd,
@@ -58,11 +72,16 @@ def attnres_fwd_kernel(
     BL: tl.constexpr,
     BD: tl.constexpr,
     HAS_ONORM: tl.constexpr,
+    DTYPE: tl.constexpr,
 ):
     i_n = tl.program_id(0).to(tl.int64)
 
     # [BL]
-    m_l = tl.arange(0, BL) < L
+    o_l = tl.arange(0, BL)
+    m_l = o_l < L
+
+    # one-time gather of source base pointers; reused across all D-loops below.
+    p_v = tl.load(res + o_l, mask=m_l, other=0).to(tl.pointer_type(DTYPE))
 
     # [BL]
     b_var = tl.zeros([BL], dtype=tl.float32)
@@ -71,9 +90,12 @@ def attnres_fwd_kernel(
         # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
-        # [BL, BD]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        # [BL, BD] gather: row l from source l's storage at offset i_n*D + o_d
+        b_v = tl.load(
+            p_v[:, None] + (i_n * D + o_d[None, :]),
+            mask=m_l[:, None] & m_d[None, :],
+            other=0.0,
+        ).to(tl.float32)
         # [BD]
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
         b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
@@ -94,29 +116,32 @@ def attnres_fwd_kernel(
     tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
     tl.store(p_p, b_p.to(p_p.dtype.element_ty), boundary_check=(0,))
 
-    # second pass: compute mix `b_o = sum_l p_l * v_l` and write to `o`.
-    # under HAS_ONORM we also accumulate `b_var_o` for the output rstd. `o`
-    # is allocated as fp32 by the python wrapper when HAS_ONORM=True so the
+    # second pass: compute mix `b_o = sum_l p_l * v_l` and write to `o`. under
+    # HAS_ONORM we also accumulate `b_o_var` for the output rstd. `o` is
+    # allocated as fp32 by the python wrapper when HAS_ONORM=True so the
     # un-normed mix round-trips losslessly through gmem before pass 3
-    # normalizes and overwrites it in place; the final cast to `v.dtype`
-    # happens once at the wrapper boundary.
-    b_var_o = tl.zeros([], dtype=tl.float32)
+    # normalizes and overwrites it in place; the final cast to the residual
+    # dtype happens once at the wrapper boundary.
+    b_o_var = tl.zeros([], dtype=tl.float32)
     for i_d in range(0, D, BD):
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
         p_o = tl.make_block_ptr(o + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_v = tl.load(
+            p_v[:, None] + (i_n * D + o_d[None, :]),
+            mask=m_l[:, None] & m_d[None, :],
+            other=0.0,
+        ).to(tl.float32)
         # [BD]
         b_o = tl.sum(b_v * b_p[:, None], axis=0)
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
         if HAS_ONORM:
-            b_var_o += tl.sum(tl.where(m_d, b_o * b_o, 0.0), axis=0)
+            b_o_var += tl.sum(tl.where(m_d, b_o * b_o, 0.0), axis=0)
 
     if HAS_ONORM:
-        b_rstd_o = tl.rsqrt(b_var_o / D + eps)
-        tl.store(o_rstd + i_n, b_rstd_o)
+        b_o_rstd = tl.rsqrt(b_o_var / D + eps)
+        tl.store(o_rstd + i_n, b_o_rstd)
         # ensure pass-2 stores to `o` are visible before pass 3 reads them back.
         tl.debug_barrier()
         # third pass: load staged `o`, apply RMSNorm with `ow`, write back to `o`.
@@ -127,7 +152,7 @@ def attnres_fwd_kernel(
             # [BD]
             b_o = tl.load(p_o, boundary_check=(0,)).to(tl.float32)
             b_ow = tl.load(ow + o_d, mask=m_d, other=0.).to(tl.float32)
-            tl.store(p_o, (b_o * b_rstd_o * b_ow).to(p_o.dtype.element_ty), boundary_check=(0,))
+            tl.store(p_o, (b_o * b_o_rstd * b_ow).to(p_o.dtype.element_ty), boundary_check=(0,))
 
 
 @fla_cache_autotune(
@@ -138,14 +163,14 @@ def attnres_fwd_kernel(
 @triton.jit
 def attnres_bwd_kernel_dv(
     q,
-    v,
+    res,     # int64 [L]
     w,
     ow,
     p,
     rstd,
     o_rstd,
     do,
-    dv,
+    dres,    # int64 [L]; data_ptr() of each per-source dv allocation
     dqw,
     dow_partial,
     N,
@@ -155,8 +180,14 @@ def attnres_bwd_kernel_dv(
     BL: tl.constexpr,
     BD: tl.constexpr,
     HAS_ONORM: tl.constexpr,
+    DTYPE: tl.constexpr,
 ):
     i_n = tl.program_id(0).to(tl.int64)
+
+    o_l = tl.arange(0, BL)
+    m_l = o_l < L
+    p_v = tl.load(res + o_l, mask=m_l, other=0).to(tl.pointer_type(DTYPE))
+    p_dv = tl.load(dres + o_l, mask=m_l, other=0).to(tl.pointer_type(DTYPE))
 
     p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
     p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
@@ -178,7 +209,7 @@ def attnres_bwd_kernel_dv(
     # over the same D-loop that already loads `v` for `b_dp` / `b_z`, so we
     # don't need a separate pre-pass and only load `v` once across pass 1.
     b_o_rstd = tl.zeros([], dtype=tl.float32)
-    b_c1_o = tl.zeros([], dtype=tl.float32)
+    b_o_c1 = tl.zeros([], dtype=tl.float32)
     b_dp_w = tl.zeros([BL], dtype=tl.float32)
     b_dp_x = tl.zeros([BL], dtype=tl.float32)
     if HAS_ONORM:
@@ -191,10 +222,13 @@ def attnres_bwd_kernel_dv(
         # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_v = tl.load(
+            p_v[:, None] + (i_n * D + o_d[None, :]),
+            mask=m_l[:, None] & m_d[None, :],
+            other=0.0,
+        ).to(tl.float32)
         # [BD]
         b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
@@ -205,13 +239,13 @@ def attnres_bwd_kernel_dv(
             # rebuild `o_pre` and `xhat_o` from the just-loaded `b_v` and
             # the saved softmax probs `b_p` — no extra v load.
             b_o_pre = tl.sum(b_v * b_p[:, None], axis=0)
-            b_xhat_o = b_o_pre * b_o_rstd
-            b_wdy_o = b_ow * b_do
-            b_c1_o += tl.sum(tl.where(m_d, b_xhat_o * b_wdy_o, 0.0), axis=0)
-            b_dp_w += tl.sum(b_v * b_wdy_o[None, :], axis=1)
-            b_dp_x += tl.sum(b_v * b_xhat_o[None, :], axis=1)
+            b_o_xhat = b_o_pre * b_o_rstd
+            b_o_wdy = b_ow * b_do
+            b_o_c1 += tl.sum(tl.where(m_d, b_o_xhat * b_o_wdy, 0.0), axis=0)
+            b_dp_w += tl.sum(b_v * b_o_wdy[None, :], axis=1)
+            b_dp_x += tl.sum(b_v * b_o_xhat[None, :], axis=1)
             p_dow = tl.make_block_ptr(dow_partial + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-            tl.store(p_dow, (b_xhat_o * b_do).to(p_dow.dtype.element_ty), boundary_check=(0,))
+            tl.store(p_dow, (b_o_xhat * b_do).to(p_dow.dtype.element_ty), boundary_check=(0,))
         else:
             b_dp += tl.sum(b_v * b_do[None, :], axis=1)
 
@@ -220,8 +254,8 @@ def attnres_bwd_kernel_dv(
         b_z += tl.sum(b_xhat * (b_w * b_q)[None, :], axis=1)
 
     if HAS_ONORM:
-        b_c1_o = b_c1_o / D
-        b_dp = b_o_rstd * (b_dp_w - b_c1_o * b_dp_x)
+        b_o_c1 = b_o_c1 / D
+        b_dp = b_o_rstd * (b_dp_w - b_o_c1 * b_dp_x)
 
     # softmax bwd via the standard delta trick: delta = sum_l p*dp = sum_d do*o
     # [1]
@@ -236,10 +270,10 @@ def attnres_bwd_kernel_dv(
         # [BD]
         o_d = i_d + tl.arange(0, BD)
         m_d = o_d < D
-        p_v = tl.make_block_ptr(v + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
+        m_v = m_l[:, None] & m_d[None, :]
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_v = tl.load(p_v[:, None] + (i_n * D + o_d[None, :]), mask=m_v, other=0.0).to(tl.float32)
         # [BD]
         b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
@@ -248,8 +282,8 @@ def attnres_bwd_kernel_dv(
         if HAS_ONORM:
             b_o_pre = tl.sum(b_v * b_p[:, None], axis=0)
             b_ow = tl.load(ow + o_d, mask=m_d, other=0.).to(tl.float32)
-            b_xhat_o = b_o_pre * b_o_rstd
-            b_do = (b_ow * b_do - b_xhat_o * b_c1_o) * b_o_rstd
+            b_o_xhat = b_o_pre * b_o_rstd
+            b_do = (b_ow * b_do - b_o_xhat * b_o_c1) * b_o_rstd
 
         # [BL, BD]
         b_xhat = b_v * b_rstd[:, None]
@@ -257,9 +291,8 @@ def attnres_bwd_kernel_dv(
             (b_w * b_q)[None, :] - b_xhat * b_c1[:, None]
         )
 
-        p_dv = tl.make_block_ptr(dv + i_n * D, (L, D), (N * D, 1), (0, i_d), (BL, BD), (1, 0))
         p_dqw = tl.make_block_ptr(dqw + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-        tl.store(p_dv, b_dv.to(dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv[:, None] + (i_n * D + o_d[None, :]), b_dv.to(DTYPE), mask=m_v)
         # [BD]
         tl.store(p_dqw, tl.sum(b_ds[:, None] * b_xhat, axis=0), boundary_check=(0,))
 
@@ -292,7 +325,7 @@ def attnres_bwd_kernel_dqdw(
 
     # [BD]
     b_acc = tl.zeros([BD], dtype=tl.float32)
-    b_acc_o = tl.zeros([BD], dtype=tl.float32)
+    b_o_acc = tl.zeros([BD], dtype=tl.float32)
     for i_n in range(0, N, BN):
         p_dqw = tl.make_block_ptr(dqw, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
         # [BN, BD]
@@ -301,7 +334,7 @@ def attnres_bwd_kernel_dqdw(
         if HAS_ONORM:
             p_dow = tl.make_block_ptr(dow_partial, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
             b_dow = tl.load(p_dow, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
-            b_acc_o += tl.sum(b_dow, axis=0)
+            b_o_acc += tl.sum(b_dow, axis=0)
 
     # [BD]
     b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
@@ -310,46 +343,64 @@ def attnres_bwd_kernel_dqdw(
     tl.store(dq + o_d, b_acc * b_w, mask=m_d)
     tl.store(dw + o_d, b_acc * b_q, mask=m_d)
     if HAS_ONORM:
-        tl.store(dow + o_d, b_acc_o, mask=m_d)
+        tl.store(dow + o_d, b_o_acc, mask=m_d)
+
+
+def _build_ptr_table(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
+    # build the int64 ptr table on **pinned** CPU memory, then issue a
+    # `non_blocking=True` H2D. with this combo PyTorch knows the source
+    # storage outlives the async copy and skips the implicit
+    # `cudaStreamSynchronize` that `torch.tensor([...], device='cuda')`
+    # otherwise inserts to keep the pageable staging buffer alive
+    # (~600µs of CPU stall per call, observed via `torch.profiler`).
+    cpu_t = torch.tensor(
+        [t.data_ptr() for t in tensors],
+        dtype=torch.int64,
+        pin_memory=True,
+    )
+    return cpu_t.to(tensors[0].device, non_blocking=True)
 
 
 def fused_attnres_fwd(
     q: torch.Tensor,
-    v: torch.Tensor,
+    residuals: Sequence[torch.Tensor],
+    res: torch.Tensor,
     w: torch.Tensor,
     ow: torch.Tensor | None,
     eps: float,
     scale: float,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
-    if not v.is_cuda:
+    if not residuals[0].is_cuda:
         raise ValueError("Triton attnres requires CUDA tensors")
-    if v.shape[0] < 1:
-        raise ValueError("Triton attnres requires at least one residual source")
 
-    L, N, D = v.shape[0], v[0].numel() // v.shape[-1], v.shape[-1]
-    output_shape = v.shape[1:]
+    output_shape = residuals[0].shape
+    L, N, D = len(residuals), residuals[0].numel() // output_shape[-1], output_shape[-1]
+
+    dtype = residuals[0].dtype
+    if dtype not in _TORCH_TO_TL_DTYPE:
+        raise ValueError(f"Unsupported residual dtype for fused_attnres: {dtype}")
+    DTYPE = _TORCH_TO_TL_DTYPE[dtype]
+
     stats_shape = (L, *output_shape[:-1])
 
     # under HAS_ONORM the kernel needs `o` to round-trip across pass 2 → pass 3
     # without precision loss, so we keep it in fp32 inside the kernel and cast
-    # to `v.dtype` once at the end. bwd recomputes `o_pre = sum_l p_l * v_l`
-    # inline from saved `p` and `v`, so we don't keep an [N, D] activation
-    # across fwd→bwd.
+    # to the residual dtype once at the end. bwd recomputes
+    # `o_pre = sum_l p_l * v_l` inline from saved `p` and `res`, so we
+    # don't keep an [N, D] activation across fwd→bwd.
     has_onorm = ow is not None
-    o = torch.empty(output_shape, device=v.device, dtype=torch.float32 if has_onorm else v.dtype)
-    p = torch.empty(stats_shape, device=v.device, dtype=torch.float32)
+    o = torch.empty(output_shape, device=residuals[0].device, dtype=torch.float32 if has_onorm else dtype)
+    p = torch.empty(stats_shape, device=residuals[0].device, dtype=torch.float32)
     rstd = torch.empty_like(p)
     if has_onorm:
-        o_rstd = torch.empty(output_shape[:-1], device=v.device, dtype=torch.float32)
+        o_rstd = torch.empty(output_shape[:-1], device=residuals[0].device, dtype=torch.float32)
     else:
         o_rstd = None
 
     BL = max(8, triton.next_power_of_2(L))
-    grid = (N,)
-
-    attnres_fwd_kernel[grid](
+    attnres_fwd_kernel[(N,)](
         q=q,
-        v=v,
+        res=res,
         w=w,
         o=o,
         rstd=rstd,
@@ -363,10 +414,11 @@ def fused_attnres_fwd(
         scale=scale,
         BL=BL,
         HAS_ONORM=has_onorm,
+        DTYPE=DTYPE,
     )
 
     if has_onorm:
-        o = o.to(v.dtype)
+        o = o.to(dtype)
 
     return o, p, rstd, o_rstd
 
@@ -374,15 +426,18 @@ def fused_attnres_fwd(
 def fused_attnres_bwd(
     do: torch.Tensor,
     q: torch.Tensor,
-    v: torch.Tensor,
+    residuals: Sequence[torch.Tensor],
+    res: torch.Tensor,
     w: torch.Tensor,
     ow: torch.Tensor | None,
     p: torch.Tensor,
     rstd: torch.Tensor,
     o_rstd: torch.Tensor | None,
     scale: float,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
-    L, N, D = v.shape[0], do.numel() // do.shape[-1], do.shape[-1]
+) -> tuple[list[torch.Tensor], torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    L, N, D = len(residuals), do.numel() // do.shape[-1], do.shape[-1]
+    dtype = residuals[0].dtype
+    DTYPE = _TORCH_TO_TL_DTYPE[dtype]
 
     # optional output RMSNorm bwd is folded into the attnres kernels:
     # `attnres_bwd_kernel_dv` derives `c1_o` and `dow_partial` in a pre-pass,
@@ -398,7 +453,8 @@ def fused_attnres_bwd(
     else:
         dow_partial = dow = None
 
-    dv = torch.empty_like(v)
+    dvs = [torch.empty_like(r) for r in residuals]
+    dres = _build_ptr_table(dvs)
     dqw = torch.empty_like(do, dtype=torch.float32)
     dq = torch.empty_like(q)
     dw = torch.empty_like(w)
@@ -406,14 +462,14 @@ def fused_attnres_bwd(
     BL = max(8, triton.next_power_of_2(L))
     attnres_bwd_kernel_dv[(N,)](
         q=q,
-        v=v,
+        res=res,
         w=w,
         ow=ow,
         p=p,
         rstd=rstd,
         o_rstd=o_rstd,
         do=do,
-        dv=dv,
+        dres=dres,
         dqw=dqw,
         dow_partial=dow_partial,
         N=N,
@@ -422,6 +478,7 @@ def fused_attnres_bwd(
         D=D,
         BL=BL,
         HAS_ONORM=has_onorm,
+        DTYPE=DTYPE,
     )
 
     def grid(meta): return (triton.cdiv(D, meta['BD']),)
@@ -438,7 +495,7 @@ def fused_attnres_bwd(
         HAS_ONORM=has_onorm,
     )
 
-    return dv, dq, dw, dow
+    return dvs, dq, dw, dow
 
 
 class FusedAttnresFunction(torch.autograd.Function):
@@ -449,22 +506,28 @@ class FusedAttnresFunction(torch.autograd.Function):
     def forward(
         ctx,
         query: torch.Tensor,
-        residuals: torch.Tensor,
         rms_weight: torch.Tensor,
         output_rms_weight: torch.Tensor | None,
         rms_eps: float,
         scale: float,
+        *residuals: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        # `res` is built once here and threaded through fwd/bwd so neither
+        # internal wrapper has to rebuild it (the H2D copy + cudaMemcpy
+        # launch is ~tens of µs, comparable to the kernel itself for small N).
+        res = _build_ptr_table(residuals)
         o, p, rstd, o_rstd = fused_attnres_fwd(
             q=query,
-            v=residuals,
+            residuals=residuals,
+            res=res,
             w=rms_weight,
             ow=output_rms_weight,
             eps=rms_eps,
             scale=scale,
         )
-        ctx.save_for_backward(query, residuals, rms_weight, output_rms_weight, p, rstd, o_rstd)
+        ctx.save_for_backward(query, rms_weight, output_rms_weight, p, rstd, o_rstd, *residuals)
         ctx.scale = scale
+        ctx.res = res
         ctx.mark_non_differentiable(p)
         return o, p
 
@@ -475,13 +538,14 @@ class FusedAttnresFunction(torch.autograd.Function):
         ctx,
         do: torch.Tensor,
         dp: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None, None, None]:
+    ):
         del dp
-        query, residuals, rms_weight, output_rms_weight, p, rstd, o_rstd = ctx.saved_tensors
-        dv, dq, dw, dow = fused_attnres_bwd(
+        query, rms_weight, output_rms_weight, p, rstd, o_rstd, *residuals = ctx.saved_tensors
+        dvs, dq, dw, dow = fused_attnres_bwd(
             do=do,
             q=query,
-            v=residuals,
+            residuals=residuals,
+            res=ctx.res,
             w=rms_weight,
             ow=output_rms_weight,
             p=p,
@@ -489,18 +553,19 @@ class FusedAttnresFunction(torch.autograd.Function):
             o_rstd=o_rstd,
             scale=ctx.scale,
         )
-        return dq, dv, dw, dow, None, None
+        # gradient order matches forward signature:
+        # query, rms_weight, output_rms_weight, rms_eps (None), scale (None), *residuals.
+        return (dq, dw, dow, None, None, *dvs)
 
 
 def fused_attnres(
     query: torch.Tensor,
-    residuals: torch.Tensor | Sequence[torch.Tensor],
+    residuals: Sequence[torch.Tensor],
     rms_weight: torch.Tensor,
     output_rms_weight: torch.Tensor | None = None,
     rms_eps: float = 1e-6,
     scale: float = 1.0,
     return_weights: bool = False,
-    return_residuals: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     r"""
     Apply AttnRes residual aggregation.
@@ -510,14 +575,19 @@ def fused_attnres(
     the weighted sum of residual sources.
     See `Attention Residuals <https://arxiv.org/abs/2603.15031>`_.
 
+    Residual sources are passed as a sequence of independently allocated
+    tensors and accessed inside the kernel via a pointer table — there is no
+    upstream `torch.stack` / `torch.cat`, and per-source `dv` is written back
+    into separately allocated tensors so autograd routes each gradient to its
+    own leaf.
+
     Args:
         query (torch.Tensor):
             Per-layer pseudo-query of shape `[D]` or `[D, 1]`, where `D` is
             the hidden size.
-        residuals (torch.Tensor or Sequence[torch.Tensor]):
-            Residual sources of shape `[L, ..., D]`, or a sequence of tensors
-            each with shape `[..., D]`, where `L` is the number of residual
-            sources.
+        residuals (Sequence[torch.Tensor]):
+            Non-empty sequence of same-dtype, same-`D` residual sources, each
+            of shape `[..., D]`.
         rms_weight (torch.Tensor):
             RMSNorm scale for key normalization of shape `[D]`.
         output_rms_weight (torch.Tensor, optional):
@@ -532,10 +602,6 @@ def fused_attnres(
             Scale factor applied to AttnRes logits before softmax. Default: `1.0`.
         return_weights (bool):
             Whether to return depth softmax probabilities. Default: `False`.
-        return_residuals (bool):
-            Whether to return the stacked residual tensor. Useful when the
-            input was a list and the caller wants the materialized
-            `[L, ..., D]` tensor without re-stacking. Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -543,32 +609,23 @@ def fused_attnres(
         p (torch.Tensor):
             Depth softmax probabilities of shape `[L, ...]` if
             `return_weights=True`, otherwise not returned.
-        residuals (torch.Tensor):
-            Stacked residuals of shape `[L, ..., D]` if `return_residuals=True`,
-            otherwise not returned.
     """
-    output_shape = None
-    if isinstance(residuals, Sequence) and not isinstance(residuals, torch.Tensor):
-        if len(residuals) == 0:
-            raise ValueError("residuals must contain at least one source")
-        output_shape = residuals[0].shape
-        D = output_shape[-1]
-        residuals = torch.stack(tuple(residual.view(-1, D) for residual in residuals), dim=0)
+    if len(residuals) == 0:
+        raise ValueError("residuals must contain at least one source")
 
-    o, p = FusedAttnresFunction.apply(query, residuals, rms_weight, output_rms_weight, rms_eps, scale)
-    if output_shape is not None:
-        o = o.view(output_shape)
+    output_shape = residuals[0].shape
+    D = output_shape[-1]
+    flat_residuals = tuple(r.reshape(-1, D).contiguous() for r in residuals)
 
-    outputs = [o]
+    o, p = FusedAttnresFunction.apply(
+        query, rms_weight, output_rms_weight, rms_eps, scale, *flat_residuals,
+    )
+    o = o.view(output_shape)
+
     if return_weights:
-        if output_shape is not None:
-            p = p.view(residuals.shape[0], *output_shape[:-1])
-        outputs.append(p)
-    if return_residuals:
-        if output_shape is not None:
-            residuals = residuals.view(residuals.shape[0], *output_shape)
-        outputs.append(residuals)
-    return tuple(outputs) if len(outputs) > 1 else o
+        p = p.view(len(residuals), *output_shape[:-1])
+        return o, p
+    return o
 
 
 __all__ = ["fused_attnres"]

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -300,7 +300,7 @@ def attnres_bwd_kernel_dv(
         m_v = m_l[:, None] & m_d[None, :]
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
         # [BL, BD]
-        b_v = tl.load(p_v[:, None] + (i_n * D + o_d[None, :]), mask=m_v, other=0.0).to(tl.float32)
+        b_v = tl.load(tl.multiple_of(p_v[:, None] + (i_n * D + o_d[None, :]), (1, 16)), mask=m_v, other=0.0).to(tl.float32)
         # [BD]
         b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
         b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
@@ -319,7 +319,7 @@ def attnres_bwd_kernel_dv(
         )
 
         p_dqw = tl.make_block_ptr(dqw + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-        tl.store(p_dv[:, None] + (i_n * D + o_d[None, :]), b_dv.to(DTYPE), mask=m_v)
+        tl.store(tl.multiple_of(p_dv[:, None] + (i_n * D + o_d[None, :]), (1, 16)), b_dv.to(DTYPE), mask=m_v)
         # [BD]
         tl.store(p_dqw, tl.sum(b_ds[:, None] * b_xhat, axis=0), boundary_check=(0,))
 

--- a/fla/ops/attnres/naive.py
+++ b/fla/ops/attnres/naive.py
@@ -16,13 +16,12 @@ from einops import einsum
 
 def naive_attnres(
     query: torch.Tensor,
-    residuals: torch.Tensor | Sequence[torch.Tensor],
+    residuals: Sequence[torch.Tensor],
     rms_weight: torch.Tensor,
     output_rms_weight: torch.Tensor | None = None,
     rms_eps: float = 1e-6,
     scale: float = 1.0,
     return_weights: bool = False,
-    return_residuals: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     r"""
     Apply AttnRes residual aggregation.
@@ -36,10 +35,9 @@ def naive_attnres(
         query (torch.Tensor):
             Per-layer pseudo-query of shape `[D]` or `[D, 1]`, where `D` is
             the hidden size.
-        residuals (torch.Tensor or Sequence[torch.Tensor]):
-            Residual sources of shape `[L, ..., D]`, or a sequence of tensors
-            each with shape `[..., D]`, where `L` is the number of residual
-            sources.
+        residuals (Sequence[torch.Tensor]):
+            Non-empty sequence of same-dtype, same-`D` residual sources, each
+            of shape `[..., D]`.
         rms_weight (torch.Tensor):
             RMSNorm scale for key normalization of shape `[D]`.
         output_rms_weight (torch.Tensor, optional):
@@ -54,10 +52,6 @@ def naive_attnres(
             Scale factor applied to AttnRes logits before softmax. Default: `1.0`.
         return_weights (bool):
             Whether to return depth softmax probabilities. Default: `False`.
-        return_residuals (bool):
-            Whether to return the stacked residual tensor. Useful when the
-            input was a list and the caller wants the materialized
-            `[L, ..., D]` tensor without re-stacking. Default: `False`.
 
     Returns:
         o (torch.Tensor):
@@ -65,42 +59,34 @@ def naive_attnres(
         p (torch.Tensor):
             Depth softmax probabilities of shape `[L, ...]` if
             `return_weights=True`, otherwise not returned.
-        residuals (torch.Tensor):
-            Stacked residuals of shape `[L, ..., D]` if `return_residuals=True`,
-            otherwise not returned.
     """
-    output_shape = None
-    if isinstance(residuals, Sequence) and not isinstance(residuals, torch.Tensor):
-        if len(residuals) == 0:
-            raise ValueError("residuals must contain at least one source")
-        output_shape = residuals[0].shape
-        D = output_shape[-1]
-        residuals = torch.stack(tuple(residual.view(-1, D) for residual in residuals), dim=0)
+    if len(residuals) == 0:
+        raise ValueError("residuals must contain at least one source")
 
-    # all math runs in fp32 end-to-end; the final downcast back to
-    # `residuals.dtype` happens once, just before returning.
-    v = residuals.float()
-    k = F.rms_norm(v, (residuals.shape[-1],), rms_weight.flatten().float(), rms_eps)
+    output_shape = residuals[0].shape
+    D = output_shape[-1]
+    # the stack here is part of the *reference* impl, not the API — it lets
+    # einsum-style math run on a single tensor while the autograd graph still
+    # routes per-source gradients back to each leaf via the inner views.
+    stacked = torch.stack(tuple(residual.view(-1, D) for residual in residuals), dim=0)
+
+    # all math runs in fp32 end-to-end; the final downcast back to the
+    # residual dtype happens once, just before returning.
+    v = stacked.float()
+    k = F.rms_norm(v, (D,), rms_weight.flatten().float(), rms_eps)
     p = (einsum(k, query.flatten().float() * scale, "l ... d, d -> l ...")).softmax(dim=0)
     o = einsum(p, v, "l ..., l ... d -> ... d")
-    if output_shape is not None:
-        o = o.view(output_shape)
+    o = o.view(output_shape)
 
     if output_rms_weight is not None:
-        o = F.rms_norm(o, (o.shape[-1],), output_rms_weight.float(), rms_eps)
+        o = F.rms_norm(o, (D,), output_rms_weight.float(), rms_eps)
 
-    o = o.to(residuals.dtype)
+    o = o.to(stacked.dtype)
 
-    outputs = [o]
     if return_weights:
-        if output_shape is not None:
-            p = p.view(residuals.shape[0], *output_shape[:-1])
-        outputs.append(p)
-    if return_residuals:
-        if output_shape is not None:
-            residuals = residuals.view(residuals.shape[0], *output_shape)
-        outputs.append(residuals)
-    return tuple(outputs) if len(outputs) > 1 else o
+        p = p.view(len(residuals), *output_shape[:-1])
+        return o, p
+    return o
 
 
 __all__ = ["naive_attnres"]

--- a/tests/ops/test_attnres.py
+++ b/tests/ops/test_attnres.py
@@ -55,7 +55,11 @@ def test_attnres(
     torch.backends.cuda.matmul.allow_tf32 = False
     rms_eps = 1e-6
 
-    residuals = torch.randn(L, B, T, D, dtype=dtype, device=device).requires_grad_(True)
+    # list of L independently allocated `[B, T, D]` tensors — true zero-cat input.
+    residuals = [
+        torch.randn(B, T, D, dtype=dtype, device=device).requires_grad_(True)
+        for _ in range(L)
+    ]
     query = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
     rms_weight = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
     output_rms_weight = (
@@ -74,11 +78,11 @@ def test_attnres(
     )
     do = torch.randn_like(tri)
     (tri * do).sum().backward()
-    tri_dv = residuals.grad
+    tri_dvs = [r.grad for r in residuals]
     tri_dq, tri_dw = query.grad, rms_weight.grad
     tri_dow = output_rms_weight.grad if fuse_output_norm else None
 
-    residuals_ref = residuals.detach().clone().requires_grad_(True)
+    residuals_ref = [r.detach().clone().requires_grad_(True) for r in residuals]
     query_ref = query.detach().clone().requires_grad_(True)
     rms_weight_ref = rms_weight.detach().clone().requires_grad_(True)
     output_rms_weight_ref = (
@@ -100,7 +104,7 @@ def test_attnres(
     assert_close(' o', ref, tri, 0.005)
     assert_close(' p', ref_p, tri_p, 0.005)
     assert_close('dq', query_ref.grad, tri_dq, 0.005)
-    assert_close('dv', residuals_ref.grad, tri_dv, 0.005)
     assert_close('dw', rms_weight_ref.grad, tri_dw, 0.005)
+    assert_close('dv', torch.stack([r.grad for r in residuals_ref]), torch.stack(tri_dvs), 0.005)
     if fuse_output_norm:
         assert_close('dow', output_rms_weight_ref.grad, tri_dow, 0.005)


### PR DESCRIPTION
## Summary

- Replace stacked-tensor `fused_attnres(residuals: Tensor)` API with list-input `fused_attnres(residuals: Sequence[Tensor])`. Each residual stays in its own storage; the kernel reads them via an int64 pointer table (`tl.load(...).to(tl.pointer_type(DTYPE))` for the gather, mirrored with a `dres` table for per-source `dv` writes).
- The pointer table is built on **pinned** CPU memory and shipped with `non_blocking=True`. Without this, `torch.tensor([...], device='cuda')` triggers an implicit `cudaStreamSynchronize` to keep the pageable staging buffer alive (~600 µs of CPU stall per call, observed via `torch.profiler`).
- All 25 modeling files that wire AttnRes have their per-layer `checkpoint(lambda s, p: torch.cat([s, p.unsqueeze(0)], 0), ...)` collapsed to a Python list concat `[*attnres_states, prefix_sum]` — no tensor allocation, no autograd graph node.

## Why

Old design forced each layer to `torch.cat(running_stack, prefix_sum)`. With autograd holding each cat'd `[L+1, ..., D]` copy across fwd→bwd, total residual activation memory grew quadratically in attnres depth. List-input keeps each source as one reference; activation memory is now linear.

## Perf

`bench_attnres.py` (B=4, T=2048, D=4096, L=24, bf16, H100) before/after the pinned + non_blocking switch:

| | before | after |
|---|---|---|
| `cudaStreamSynchronize` | 12.45ms / 20 calls / 622µs each | not in top 20 |
| `aten::to` per-call | 471µs | 29µs |
| Self CPU / step | 5.59ms | 4.83ms |
| Self CUDA / step | 3.45ms | 3.45ms (unchanged) |
| **wall-clock / step** | CPU-bound | **3.51ms (≈ GPU kernel time)** |

We're now GPU-bound. Memory drop is the primary win; speed is parity with the previous stacked path (which itself was already kernel-bound).

## Test plan

- [ ] `pytest tests/ops/test_attnres.py -x -q` — list-input correctness vs. `naive_attnres` across L=1/3/15/29, B/T/D edge cases, fp16/fp32, with and without `output_rms_weight`. dv asserted per-source via `torch.stack`.
- [ ] One end-to-end model fwd+bwd on a representative config (e.g. transformer or kda with `attnres_block_size` set) to confirm modeling migration is correct.