### PR TITLE
[Lint] Fix benchmark_training_throughput.py [skip test]

### DIFF
--- a/benchmarks/benchmark_training_throughput.py
+++ b/benchmarks/benchmark_training_throughput.py
@@ -13,7 +13,8 @@ import torch
 from accelerate import Accelerator
 from torch.cuda import max_memory_allocated, memory_allocated
 from torch.optim import AdamW
-from torch.profiler import ProfilerActivity, profile as torch_profile, record_function
+from torch.profiler import ProfilerActivity, record_function
+from torch.profiler import profile as torch_profile
 from tqdm import trange
 from transformers import AutoConfig, AutoModelForCausalLM, PretrainedConfig
 from transformers.optimization import get_cosine_schedule_with_warmup
@@ -132,7 +133,7 @@ def profile(
                      f"vocab={config.vocab_size}"),
         'data':     f"B={batch_size} T={seq_len} ctx={context_len} varlen={varlen}",
         'training': f"{dtype} (mixed={mixed_precision}) compile={compile} "
-                    f"warmup={warmup_steps} steps={steps}",
+        f"warmup={warmup_steps} steps={steps}",
         'profile':  profile_str,
         'env':      f"{_git_describe()} | {gpu_name} ({device}) | torch {torch.__version__}",
     })


### PR DESCRIPTION
Apply the auto-fixes from ruff + autopep8 that the \`lint (3.12)\` job in #886 surfaced (and which got merged in spite of the failure).

- **ruff** (I001): split the combined \`from torch.profiler import ProfilerActivity, profile as torch_profile, record_function\` into one regular import + one aliased import on separate lines.
- **autopep8** (E128): reindent the f-string continuation on the \`'training'\` row of \`_print_run_header\` so it matches autopep8's hanging-indent expectation.

Both are mechanical reformat — no behavior change. Locally \`pre-commit run --files benchmarks/benchmark_training_throughput.py\` is now clean.