### PR TITLE
[Fix] Zero-init chunk-mode backward gradient buffers to prevent NaN propagation

### DIFF
--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -625,13 +625,13 @@ def chunk_gated_delta_rule_fwd_h(
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
     if transpose_state_layout:
-        h = k.new_empty(B, NT, HV, V, K)
+        h = k.new_zeros(B, NT, HV, V, K)
         final_state = k.new_zeros(N, HV, V, K, dtype=torch.float32) if output_final_state else None
     else:
-        h = k.new_empty(B, NT, HV, K, V)
+        h = k.new_zeros(B, NT, HV, K, V)
         final_state = k.new_zeros(N, HV, K, V, dtype=torch.float32) if output_final_state else None
 
-    v_new = torch.empty_like(u) if save_new_value else None
+    v_new = torch.zeros_like(u) if save_new_value else None
     def grid(meta): return (triton.cdiv(V, meta['BV']), N*HV)
     chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
         k=k,
@@ -685,11 +685,11 @@ def chunk_gated_delta_rule_bwd_dhu(
         N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
 
     if transpose_state_layout:
-        dh = q.new_empty(B, NT, HV, V, K)
+        dh = q.new_zeros(B, NT, HV, V, K)
     else:
-        dh = q.new_empty(B, NT, HV, K, V)
-    dh0 = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
-    dv2 = torch.empty_like(dv)
+        dh = q.new_zeros(B, NT, HV, K, V)
+    dh0 = torch.zeros_like(h0, dtype=torch.float32) if h0 is not None else None
+    dv2 = torch.zeros_like(dv)
 
     def grid(meta): return (triton.cdiv(V, meta['BV']), N*HV)
     chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64[grid](

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -518,7 +518,7 @@ def chunk_fwd_o(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    o = torch.empty_like(v)
+    o = torch.zeros_like(v)
     def grid(meta): return (triton.cdiv(V, meta['BV']), NT, B * HV)
     chunk_fwd_kernel_o[grid](
         q=q,
@@ -572,7 +572,7 @@ def chunk_bwd_dv(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    dv = torch.empty_like(do)
+    dv = torch.zeros_like(do)
     grid = (NV, NT, B * HV)
     chunk_bwd_kernel_dv[grid](
         q=q,
@@ -624,7 +624,7 @@ def chunk_bwd_dv_local(
     BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    dv = torch.empty_like(do)
+    dv = torch.zeros_like(do)
     grid = (NT, B * HV)
     chunk_bwd_kernel_dv_local[grid](
         q=q,
@@ -689,10 +689,10 @@ def chunk_bwd_dqkwg(
     BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
     BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
     NK = triton.cdiv(K, BK)
-    dq = q.new_empty(B, T, HV, K)
-    dk = k.new_empty(B, T, HV, K)
-    dg = torch.empty(NK, *g.shape, dtype=torch.float32, device=g.device) if g is not None else None
-    dw = torch.empty_like(w) if w is not None else None
+    dq = q.new_zeros(B, T, HV, K)
+    dk = k.new_zeros(B, T, HV, K)
+    dg = torch.zeros(NK, *g.shape, dtype=torch.float32, device=g.device) if g is not None else None
+    dw = torch.zeros_like(w) if w is not None else None
 
     grid = (NK, NT, B * HV)
     chunk_bwd_kernel_dqkwg[grid](

--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -242,8 +242,8 @@ def recompute_w_u_fwd(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    w = k.new_empty(B, T, HV, K)
-    u = torch.empty_like(v)
+    w = k.new_zeros(B, T, HV, K)
+    u = torch.zeros_like(v)
     recompute_w_u_fwd_kernel[(NT, B*HV)](
         k=k,
         v=v,
@@ -286,10 +286,10 @@ def prepare_wy_repr_bwd(
     BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
     BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
 
-    dk = k.new_empty(B, T, HV, K)
-    dv = torch.empty_like(v)
-    dg = torch.empty_like(g) if g is not None else None
-    db = torch.empty_like(beta)
+    dk = k.new_zeros(B, T, HV, K)
+    dv = torch.zeros_like(v)
+    dg = torch.zeros_like(g) if g is not None else None
+    db = torch.zeros_like(beta)
     prepare_wy_repr_bwd_kernel[(NT, B * HV)](
         k=k,
         v=v,


### PR DESCRIPTION

## Summary

Swap `empty_like` / `new_empty` → `zeros_like` / `new_zeros` for every chunk-mode output / gradient buffer that downstream Triton kernels write with `boundary_check`. Under packed sequences where `T = k.shape[1] > cu_seqlens[-1]`
(common with SP > 1), the trailing OOB rows are never written and inherit whatever the CUDA caching allocator hands back — often NaN from a prior intermediate. The next autograd op (e.g. `dW = dk.T @ x`) reduces over the full `T` axis and corrupts weight gradients.

Same root cause diagnosed for FA2 in [Dao-AILab/flash-attention#41](https://github.com/Dao-AILab/flash-attention/issues/41).

## Minimal repro

```python
import torch; torch.cuda.init()
# A previous op leaves NaN on a page, then frees it
prev = torch.softmax(torch.full((1024,), float('-inf'), device='cuda'), dim=0)
addr = prev.data_ptr(); del prev
# The next `empty` gets the SAME page back, NaN bits intact
new_buf = torch.empty(1024, dtype=torch.float32, device='cuda')
assert new_buf.data_ptr() == addr
print(new_buf.isnan().sum().item())  # → 1024
```

## Changes

20 1:1 substitutions across 3 files (`+20 / -20`, no logic changes):

- `fla/ops/gated_delta_rule/wy_fast.py` — `w, u, dk, dv, dg, db`
- `fla/ops/common/chunk_o.py` — `o, dv (×2), dq, dk, dg, dw`
- `fla/ops/common/chunk_delta_h.py` — `h (×2), v_new, dh (×2), dh0, dv2`

Overhead: one `cudaMemsetAsync` per allocation (~µs, dwarfed by the kernel it precedes).

## Verification

Qwen3.5-9B SFT on 4×B200, Ulysses SP=4, packed bf16, smoke config:

| Configuration                                  | iter 0    | iter 1    | iter 2    |
|------------------------------------------------|-----------|-----------|-----------|
| `fla-core==0.5.0` (unpatched)                  | ~390/427  | ~400/427  | crash     |
| **This PR**                                    | **0/427** | **0/427** | **0/427** |

`bad/427` = params with any NaN/inf in `.grad`. Loss converges normally (5.22 → 5.05 → 5.05).

SP=1 is latent — per-rank shards rarely have trailing padding. SP > 1 exposes it deterministically.

## Risk

None. `zeros_like` is a strict superset of `empty_like` behavior — every cell the kernel writes is identical; only unused / OOB cells change from indeterminate to deterministic zero.
