### PR TITLE
[Ops] Skip None args in autotune restore_value to avoid clone crash

### DIFF
--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -334,7 +334,7 @@ def causal_conv1d_bwd_kernel(
     'HAS_BIAS': lambda args: args['bias'] is not None,
     'HAS_RESIDUAL': lambda args: args['residual'] is not None,
 })
-@triton.autotune(
+@fla_cache_autotune(
     configs=[
         triton.Config({'BD': BD}, num_warps=num_warps)
         for BD in [8, 16, 32, 64, 128, 256]

--- a/fla/ops/utils/cache.py
+++ b/fla/ops/utils/cache.py
@@ -346,11 +346,10 @@ class CachedAutotuner(Autotuner):
         super().__init__(fn, arg_names, configs, key, reset_to_zero, restore_value, **kwargs)
         self.kernel_name = fn.fn.__name__ if hasattr(fn, 'fn') else fn.__name__
 
-        # Replace Triton's default pre/post hooks with None-safe versions. The defaults
-        # unconditionally call .clone()/.copy_()/.zero_() on every restore_value /
-        # reset_to_zero name, which crashes when a kernel arg is None (idiomatic for
-        # optional pointers gated by a tl.constexpr flag). User-supplied hooks are
-        # left alone.
+        # None-safe pre/post hooks: Triton's defaults crash when a restore_value /
+        # reset_to_zero arg is None (idiomatic for optional pointers gated by a
+        # tl.constexpr flag). Fixed upstream in triton-lang/triton#10295 — remove
+        # this override once FLA's minimum Triton version contains the fix.
         if not self.user_defined_pre_hook and (self.reset_to_zero or self.restore_value):
             def _pre_hook(kw, reset_only=False):
                 for n in self.reset_to_zero:

--- a/fla/ops/utils/cache.py
+++ b/fla/ops/utils/cache.py
@@ -346,6 +346,26 @@ class CachedAutotuner(Autotuner):
         super().__init__(fn, arg_names, configs, key, reset_to_zero, restore_value, **kwargs)
         self.kernel_name = fn.fn.__name__ if hasattr(fn, 'fn') else fn.__name__
 
+        # Replace Triton's default pre/post hooks with None-safe versions. The defaults
+        # unconditionally call .clone()/.copy_()/.zero_() on every restore_value /
+        # reset_to_zero name, which crashes when a kernel arg is None (idiomatic for
+        # optional pointers gated by a tl.constexpr flag). User-supplied hooks are
+        # left alone.
+        if not self.user_defined_pre_hook and (self.reset_to_zero or self.restore_value):
+            def _pre_hook(kw, reset_only=False):
+                for n in self.reset_to_zero:
+                    if kw[n] is not None:
+                        kw[n].zero_()
+                if not reset_only:
+                    self.restore_copies = {n: kw[n].clone() for n in self.restore_value if kw[n] is not None}
+            self.pre_hook = _pre_hook
+        if not self.user_defined_post_hook and self.restore_value:
+            def _post_hook(kw, exception):
+                for n, copy in self.restore_copies.items():
+                    kw[n].copy_(copy)
+                self.restore_copies = {}
+            self.post_hook = _post_hook
+
     def should_check_fla_cache(self, key: AutotuneKey) -> bool:
         if FLA_CACHE_MODE is FlaCacheMode.DISABLED:
             return False

--- a/fla/ops/utils/cache.py
+++ b/fla/ops/utils/cache.py
@@ -346,10 +346,9 @@ class CachedAutotuner(Autotuner):
         super().__init__(fn, arg_names, configs, key, reset_to_zero, restore_value, **kwargs)
         self.kernel_name = fn.fn.__name__ if hasattr(fn, 'fn') else fn.__name__
 
-        # None-safe pre/post hooks: Triton's defaults crash when a restore_value /
-        # reset_to_zero arg is None (idiomatic for optional pointers gated by a
-        # tl.constexpr flag). Fixed upstream in triton-lang/triton#10295 — remove
-        # this override once FLA's minimum Triton version contains the fix.
+        # None-safe pre/post hooks: Triton's defaults crash when a restore_value / reset_to_zero arg
+        # is None (idiomatic for optional pointers gated by a tl.constexpr flag).
+        # Fixed upstream in triton-lang/triton#10295 — remove this override once FLA's minimum Triton version has it.
         if not self.user_defined_pre_hook and (self.reset_to_zero or self.restore_value):
             def _pre_hook(kw, reset_only=False):
                 for n in self.reset_to_zero:

--- a/tests/ops/test_cache.py
+++ b/tests/ops/test_cache.py
@@ -14,9 +14,8 @@ from fla.ops.utils.cache import fla_cache_autotune
 from fla.utils import device
 
 
-# Multiple configs are required to actually exercise the autotune benchmark
-# path, which is where Triton's default pre_hook clones each `restore_value`
-# argument and previously crashed when the argument was None.
+# Multiple configs are required to actually exercise the autotune benchmark path, which is where Triton's default pre_hook
+# clones each `restore_value` argument and previously crashed when the argument was None.
 @fla_cache_autotune(
     configs=[
         triton.Config({'BLOCK_SIZE': 128}, num_warps=4),
@@ -40,12 +39,10 @@ def _optional_restore_kernel(x, y, N, BLOCK_SIZE: tl.constexpr):
 def test_fla_cache_autotune_handles_none_restore_value():
     """A None argument listed in restore_value must not crash autotuning.
 
-    Triton's default pre_hook clones every ``restore_value`` argument during
-    benchmarking; if the argument is None this raises
-    ``AttributeError: 'NoneType' object has no attribute 'clone'``.
-    CachedAutotuner filters None entries from restore_value at call time to
-    avoid this; the test exercises the multi-config (benchmark) path so the
-    pre_hook is actually invoked.
+    Triton's default pre_hook clones every ``restore_value`` argument during benchmarking;
+    if the argument is None this raises ``AttributeError: 'NoneType' object has no attribute 'clone'``.
+    CachedAutotuner installs None-safe pre/post hooks to avoid this;
+    the test exercises the multi-config (benchmark) path so the pre_hook is actually invoked.
     """
     N = 1024
     y = torch.zeros(N, dtype=torch.int32, device=device)
@@ -55,9 +52,8 @@ def test_fla_cache_autotune_handles_none_restore_value():
     _optional_restore_kernel[(triton.cdiv(N, 128),)](x, y, N)
     assert torch.equal(y, torch.ones(N, dtype=torch.int32, device=device))
 
-    # Use a different key so the benchmark path runs again, this time with
-    # the restore_value arg set to None. Pre-fix this raised
-    # AttributeError: 'NoneType' object has no attribute 'clone'.
+    # Use a different key so the benchmark path runs again, this time with the restore_value arg set to None.
+    # Pre-fix this raised AttributeError: 'NoneType' object has no attribute 'clone'.
     M = 2048
     y2 = torch.full((M,), 7, dtype=torch.int32, device=device)
     _optional_restore_kernel[(triton.cdiv(M, 128),)](None, y2, M)

--- a/tests/ops/test_cache.py
+++ b/tests/ops/test_cache.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.cache import fla_cache_autotune
+from fla.utils import device
+
+
+# Multiple configs are required to actually exercise the autotune benchmark
+# path, which is where Triton's default pre_hook clones each `restore_value`
+# argument and previously crashed when the argument was None.
+@fla_cache_autotune(
+    configs=[
+        triton.Config({'BLOCK_SIZE': 128}, num_warps=4),
+        triton.Config({'BLOCK_SIZE': 256}, num_warps=4),
+        triton.Config({'BLOCK_SIZE': 512}, num_warps=8),
+    ],
+    key=['N'],
+    restore_value=['x'],
+)
+@triton.jit
+def _optional_restore_kernel(x, y, N, BLOCK_SIZE: tl.constexpr):
+    idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = idx < N
+    if x is not None:
+        tl.store(y + idx, tl.load(x + idx, mask=mask), mask=mask)
+    else:
+        tl.store(y + idx, tl.zeros_like(idx), mask=mask)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fla_cache_autotune_handles_none_restore_value():
+    """A None argument listed in restore_value must not crash autotuning.
+
+    Triton's default pre_hook clones every ``restore_value`` argument during
+    benchmarking; if the argument is None this raises
+    ``AttributeError: 'NoneType' object has no attribute 'clone'``.
+    CachedAutotuner filters None entries from restore_value at call time to
+    avoid this; the test exercises the multi-config (benchmark) path so the
+    pre_hook is actually invoked.
+    """
+    N = 1024
+    y = torch.zeros(N, dtype=torch.int32, device=device)
+
+    # Baseline: restore-value arg is a real tensor — should produce ones.
+    x = torch.ones(N, dtype=torch.int32, device=device)
+    _optional_restore_kernel[(triton.cdiv(N, 128),)](x, y, N)
+    assert torch.equal(y, torch.ones(N, dtype=torch.int32, device=device))
+
+    # Use a different key so the benchmark path runs again, this time with
+    # the restore_value arg set to None. Pre-fix this raised
+    # AttributeError: 'NoneType' object has no attribute 'clone'.
+    M = 2048
+    y2 = torch.full((M,), 7, dtype=torch.int32, device=device)
+    _optional_restore_kernel[(triton.cdiv(M, 128),)](None, y2, M)
+    assert torch.equal(y2, torch.zeros(M, dtype=torch.int32, device=device))


### PR DESCRIPTION
Triton's `Autotuner` installs default pre/post hooks that unconditionally call `kwargs[name].clone()` (and `.copy_()` / `.zero_()`) for every name in `restore_value` / `reset_to_zero`. When such an argument is `None` at call time (e.g. `causal_conv1d_update_kernel` called with `cache=None` for the no-initial-state path), the hook crashes:

    AttributeError: 'NoneType' object has no attribute 'clone'

This surfaced on torch 2.11+cu130 / triton 3.6.0.

`CachedAutotuner.__init__` now installs None-safe replacements for those default hooks. The pre-hook skips `None` entries when zeroing and only clones non-None args; the post-hook iterates the saved copies directly, so anything that was None at pre-hook time is silently skipped. User-supplied hooks (`user_defined_pre_hook` / `user_defined_post_hook`) are left untouched.

Triton's stock `@triton.autotune` has the same bug and can't be patched here, so `causal_conv1d_update_kernel` is switched to `@fla_cache_autotune` to route through `CachedAutotuner` and pick up the fix.

Test: `tests/ops/test_cache.py` reproduces the original crash without the fix (uses >=2 configs so the benchmark path runs, then calls with the `restore_value` arg set to None) and passes with it.

The bug is fixed upstream in Triton too (https://github.com/triton-lang/triton/pull/10295); this workaround stays until FLA's minimum Triton version ships the fix.
