### PR TITLE
[Fix] Enable torch.compile on Python 3.10

### DIFF
--- a/fla/ops/rwkv7/fused_addcmul.py
+++ b/fla/ops/rwkv7/fused_addcmul.py
@@ -14,7 +14,7 @@ import triton
 import triton.language as tl
 from packaging.version import Version
 
-from fla.utils import IS_AMD, USE_CUDA_GRAPH, autotune_cache_kwargs, check_pytorch_version, input_guard
+from fla.utils import IS_AMD, IS_ARM, USE_CUDA_GRAPH, autotune_cache_kwargs, check_pytorch_version, input_guard
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +27,14 @@ def identity_decorator(fn):
 
 
 current_python_version = Version(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
-min_torch_compile_version = Version("3.11")
+min_torch_compile_version = Version("3.11" if IS_ARM else "3.10")
 fla_use_compile = os.getenv('FLA_USE_COMPILE', '1').lower() in ('1', 'true', 'yes')
 
 if current_python_version >= min_torch_compile_version and fla_use_compile:
     torch_compile = torch.compile(fullgraph=True)
 else:
-    logger.warning('torch.compile is not available in Python 3.10, using identity decorator instead')
+    if fla_use_compile:
+        logger.warning(f'torch.compile requires Python >= {min_torch_compile_version}, using identity decorator instead')
     torch_compile = identity_decorator
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -10,6 +10,7 @@ import functools
 import inspect
 import logging
 import os
+import platform
 import sys
 import warnings
 from collections.abc import Callable
@@ -460,11 +461,12 @@ device_platform = get_available_device()
 device_name = map_triton_backend_to_torch_device()
 
 IS_AMD = (device_platform == 'hip')
+IS_ARM = platform.machine().lower() in ('aarch64', 'arm64')
 IS_INTEL = (device_platform == 'xpu')
-IS_NVIDIA = (device_platform == 'cuda')
 IS_INTEL_ALCHEMIST = (IS_INTEL and 'Intel(R) Arc(TM) A' in torch.xpu.get_device_name(0))
-IS_NVIDIA_HOPPER = (IS_NVIDIA and ('NVIDIA H' in torch.cuda.get_device_name(0) or torch.cuda.get_device_capability()[0] == 9))
+IS_NVIDIA = (device_platform == 'cuda')
 IS_NVIDIA_BLACKWELL = (IS_NVIDIA and torch.cuda.get_device_capability()[0] == 10)
+IS_NVIDIA_HOPPER = (IS_NVIDIA and ('NVIDIA H' in torch.cuda.get_device_name(0) or torch.cuda.get_device_capability()[0] == 9))
 USE_CUDA_GRAPH = (IS_NVIDIA and os.environ.get('FLA_USE_CUDA_GRAPH', '0') == '1')
 
 # Nvidia Ampere or newer, haven't check AMD and intel yet.
@@ -550,11 +552,12 @@ def _register_aliases():
     current_module = sys.modules[__name__]
     for key in (
         'IS_AMD',
+        'IS_ARM',
         'IS_INTEL',
-        'IS_NVIDIA',
         'IS_INTEL_ALCHEMIST',
-        'IS_NVIDIA_HOPPER',
+        'IS_NVIDIA',
         'IS_NVIDIA_BLACKWELL',
+        'IS_NVIDIA_HOPPER',
         'USE_CUDA_GRAPH',
         'IS_TF32_SUPPORTED',
         'IS_GATHER_SUPPORTED',


### PR DESCRIPTION
## Summary
- Enables `torch.compile` for RWKV7 fused addcmul on Python 3.10 where it is supported.
- Keeps the minimum Python version at 3.11 on ARM platforms.
- Avoids emitting a fallback warning when compilation is explicitly disabled with `FLA_USE_COMPILE=0`.

Fixes #870

## Test plan
- `python -m py_compile fla/ops/rwkv7/fused_addcmul.py`

## Breaking changes
- None