### PR TITLE
[Fix] Define FLA package import contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Build packages
       run: |
         python scripts/build_packages.py
-    - name: Smoke test split packages
+    - name: Check packages
       run: |
-        python scripts/smoke_test_split_packages.py dist-packages
+        twine check dist-packages/*
     - name: Publish packages
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install -U pip
-        pip install setuptools wheel twine
-    - name: Build and publish
+        pip install setuptools wheel twine build
+    - name: Build packages
+      run: |
+        python scripts/build_packages.py
+    - name: Smoke test split packages
+      run: |
+        python scripts/smoke_test_split_packages.py dist-packages
+    - name: Publish packages
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        pip install -U build
-        python scripts/build_packages.py
         twine upload dist-packages/*

--- a/fla/__init__.py
+++ b/fla/__init__.py
@@ -5,176 +5,32 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-from fla.layers import (
-    ABCAttention,
-    Attention,
-    BasedLinearAttention,
-    BitAttention,
-    Comba,
-    DeltaFormerAttention,
-    DeltaNet,
-    GatedDeltaNet,
-    GatedDeltaProduct,
-    GatedLinearAttention,
-    GatedSlotAttention,
-    HGRN2Attention,
-    HGRNAttention,
-    LightNetAttention,
-    LinearAttention,
-    LogLinearMamba2,
-    Mamba3,
-    MesaNet,
-    MoBA,
-    MomAttention,
-    MultiheadLatentAttention,
-    MultiScaleRetention,
-    NativeSparseAttention,
-    PaTHAttention,
-    ReBasedLinearAttention,
-    RodimusAttention,
-    RWKV6Attention,
-    RWKV7Attention,
-)
-from fla.models import (
-    ABCForCausalLM,
-    ABCModel,
-    BitNetForCausalLM,
-    BitNetModel,
-    CombaForCausalLM,
-    CombaModel,
-    DeltaFormerForCausalLM,
-    DeltaFormerModel,
-    DeltaNetForCausalLM,
-    DeltaNetModel,
-    GatedDeltaNetForCausalLM,
-    GatedDeltaNetModel,
-    GatedDeltaProductForCausalLM,
-    GatedDeltaProductModel,
-    GLAForCausalLM,
-    GLAModel,
-    GSAForCausalLM,
-    GSAModel,
-    HGRN2ForCausalLM,
-    HGRN2Model,
-    HGRNForCausalLM,
-    HGRNModel,
-    LightNetForCausalLM,
-    LightNetModel,
-    LinearAttentionForCausalLM,
-    LinearAttentionModel,
-    LogLinearMamba2ForCausalLM,
-    LogLinearMamba2Model,
-    Mamba3ForCausalLM,
-    Mamba3Model,
-    MesaNetForCausalLM,
-    MesaNetModel,
-    MLAForCausalLM,
-    MLAModel,
-    MoBAForCausalLM,
-    MoBAModel,
-    MomForCausalLM,
-    MomModel,
-    NSAForCausalLM,
-    NSAModel,
-    PaTHAttentionForCausalLM,
-    PaTHAttentionModel,
-    RetNetForCausalLM,
-    RetNetModel,
-    RodimusForCausalLM,
-    RodimusModel,
-    RWKV6ForCausalLM,
-    RWKV6Model,
-    RWKV7ForCausalLM,
-    RWKV7Model,
-    TransformerForCausalLM,
-    TransformerModel,
-    YOCOForCausalLM,
-    YOCOModel,
-)
+import importlib
+from pkgutil import extend_path
 
-__all__ = [
-    "ABCAttention",
-    "ABCForCausalLM",
-    "ABCModel",
-    "Attention",
-    "BasedLinearAttention",
-    "BitAttention",
-    "BitNetForCausalLM",
-    "BitNetModel",
-    "Comba",
-    "CombaForCausalLM",
-    "CombaModel",
-    "DeltaFormerAttention",
-    "DeltaFormerForCausalLM",
-    "DeltaFormerModel",
-    "DeltaNet",
-    "DeltaNetForCausalLM",
-    "DeltaNetModel",
-    "GLAForCausalLM",
-    "GLAModel",
-    "GSAForCausalLM",
-    "GSAModel",
-    "GatedDeltaNet",
-    "GatedDeltaNetForCausalLM",
-    "GatedDeltaNetModel",
-    "GatedDeltaProduct",
-    "GatedDeltaProductForCausalLM",
-    "GatedDeltaProductModel",
-    "GatedLinearAttention",
-    "GatedSlotAttention",
-    "HGRN2Attention",
-    "HGRN2ForCausalLM",
-    "HGRN2Model",
-    "HGRNAttention",
-    "HGRNForCausalLM",
-    "HGRNModel",
-    "LightNetAttention",
-    "LightNetForCausalLM",
-    "LightNetModel",
-    "LinearAttention",
-    "LinearAttentionForCausalLM",
-    "LinearAttentionModel",
-    "LogLinearMamba2",
-    "LogLinearMamba2ForCausalLM",
-    "LogLinearMamba2Model",
-    "MLAForCausalLM",
-    "MLAModel",
-    "Mamba3",
-    "Mamba3ForCausalLM",
-    "Mamba3Model",
-    "MesaNet",
-    "MesaNetForCausalLM",
-    "MesaNetModel",
-    "MoBA",
-    "MoBAForCausalLM",
-    "MoBAModel",
-    "MomAttention",
-    "MomForCausalLM",
-    "MomModel",
-    "MultiScaleRetention",
-    "MultiheadLatentAttention",
-    "NSAForCausalLM",
-    "NSAModel",
-    "NativeSparseAttention",
-    "PaTHAttention",
-    "PaTHAttentionForCausalLM",
-    "PaTHAttentionModel",
-    "RWKV6Attention",
-    "RWKV6ForCausalLM",
-    "RWKV6Model",
-    "RWKV7Attention",
-    "RWKV7ForCausalLM",
-    "RWKV7Model",
-    "ReBasedLinearAttention",
-    "RetNetForCausalLM",
-    "RetNetModel",
-    "RodimusAttention",
-    "RodimusForCausalLM",
-    "RodimusModel",
-    "TransformerForCausalLM",
-    "TransformerModel",
-    "YOCOForCausalLM",
-    "YOCOModel",
-]
-
+__path__ = extend_path(__path__, __name__)
 __version__ = "0.5.1"
+
+__all__: list[str] = []
+
+
+def _export_optional_public_api(module_name: str) -> None:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name == module_name:
+            return
+        raise
+
+    globals()[module_name.rsplit(".", maxsplit=1)[-1]] = module
+    for name in module.__all__:
+        if name.endswith("Config"):
+            continue
+        globals()[name] = getattr(module, name)
+        __all__.append(name)
+
+
+_export_optional_public_api("fla.layers")
+_export_optional_public_api("fla.models")
+
+del _export_optional_public_api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Repository = "https://github.com/fla-org/flash-linear-attention"
 [build-system]
 requires = ["setuptools>=45", "wheel"]
 
+[tool.setuptools.dynamic]
+version = {attr = "fla.__version__"}
+
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.7.0",
-    "transformers",
+    "triton>=3.3",
+    "transformers>=4.45.0",
     "einops",
 ]
 

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -60,7 +60,7 @@ def categorize_dependencies(deps):
     ext_deps = []
 
     for dep in deps:
-        if any(core in dep for core in ['torch', 'einops']):
+        if any(core in dep for core in ['torch', 'triton', 'einops']):
             core_deps.append(dep)
         else:
             ext_deps.append(dep)
@@ -158,13 +158,11 @@ def build_split_packages():
     shutil.copytree(root_dir / 'fla' / 'modules', fla_core / 'modules')
     shutil.copy(root_dir / 'fla' / 'utils.py', fla_core / 'utils.py')
 
-    # Create fla-core __init__.py
-    with open(fla_core / '__init__.py', 'w') as f:
-        f.write(f"""# -*- coding: utf-8 -*-
-
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
-__version__ = '{version}'
-""")
+    # Keep the source and split-wheel top-level import contract identical.
+    # The source __init__.py is split-package-safe: it always exposes core
+    # metadata, extends the namespace path, and only exports layers/models
+    # when the extension package is installed.
+    shutil.copy(root_dir / 'fla' / '__init__.py', fla_core / '__init__.py')
 
     # Copy ancillary files (README.md, LICENSE) to core package
     for fname in ("README.md", "LICENSE"):

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -5,9 +5,6 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-#!/usr/bin/env python3
-"""Build split packages with proper dependency management and copy them to target directory."""
-
 import ast
 import re
 import shutil
@@ -107,9 +104,9 @@ Repository = "https://github.com/fla-org/flash-linear-attention"
 
     content += extras_content
 
-    # Add setuptools namespace package configuration for extension package
-    if name == 'flash-linear-attention':
-        content += """
+    # both split packages contribute subpackages under the shared `fla`
+    # namespace, so both generated pyproject.toml files need namespace discovery.
+    content += """
 
 [tool.setuptools.packages.find]
 include = ["fla*"]

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -117,7 +117,7 @@ namespaces = true
         f.write(content)
 
 
-def build_split_packages():
+def build_split_packages(output_dir: str | Path | None = None):
     """Build split packages with proper dependency management."""
     # get script directory and find files relative to it
     script_dir = Path(__file__).parent
@@ -140,7 +140,10 @@ def build_split_packages():
     ext_deps.insert(0, f'fla-core=={version}')
 
     # create output directory
-    output_dir = script_dir / 'dist'
+    if output_dir is None:
+        output_dir = script_dir / 'dist'
+    else:
+        output_dir = Path(output_dir)
     output_dir.mkdir(exist_ok=True)
 
     # create fla-core package

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 def extract_dependencies():
     """Extract dependencies from setup.py using AST."""
-    # Get script directory and find setup.py in parent directory
+    # get script directory and find setup.py in parent directory
     script_dir = Path(__file__).parent
     setup_py = script_dir.parent / 'setup.py'
 
@@ -46,7 +46,7 @@ def extract_dependencies():
                                 if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
                             ]
                             extras[key] = values
-            break  # Assume only one setup() call
+            break  # assume only one setup() call
 
     return all_deps, extras
 
@@ -79,7 +79,7 @@ def create_pyproject_toml(package_dir, name, version, dependencies, extras=None)
 
     deps_content = ', '.join(f'"{dep}"' for dep in dependencies)
 
-    # Create description text
+    # create description text
     if name == 'fla-core':
         desc_text = 'Core operations for flash-linear-attention'
     else:
@@ -119,11 +119,11 @@ namespaces = true
 
 def build_split_packages():
     """Build split packages with proper dependency management."""
-    # Get script directory and find files relative to it
+    # get script directory and find files relative to it
     script_dir = Path(__file__).parent
     root_dir = script_dir.parent
 
-    # Get current version
+    # get current version
     init_file = root_dir / 'fla' / '__init__.py'
     with open(init_file, encoding='utf-8') as f:
         content = f.read()
@@ -132,72 +132,72 @@ def build_split_packages():
         raise RuntimeError(f"Could not find __version__ in {init_file}")
     version = version_match.group(1)
 
-    # Extract dependencies
+    # extract dependencies
     all_deps, extras = extract_dependencies()
     core_deps, ext_deps = categorize_dependencies(all_deps)
 
-    # Add version constraint for fla-core in extension package
+    # add version constraint for fla-core in extension package
     ext_deps.insert(0, f'fla-core=={version}')
 
-    # Create output directory
+    # create output directory
     output_dir = script_dir / 'dist'
     output_dir.mkdir(exist_ok=True)
 
-    # Create fla-core package
+    # create fla-core package
     core_dir = output_dir / 'fla-core'
     if core_dir.exists():
         shutil.rmtree(core_dir)
     core_dir.mkdir()
 
-    # Copy core files
+    # copy core files
     fla_core = core_dir / 'fla'
     shutil.copytree(root_dir / 'fla' / 'ops', fla_core / 'ops')
     shutil.copytree(root_dir / 'fla' / 'modules', fla_core / 'modules')
     shutil.copy(root_dir / 'fla' / 'utils.py', fla_core / 'utils.py')
 
-    # Keep the source and split-wheel top-level import contract identical.
-    # The source __init__.py is split-package-safe: it always exposes core
+    # keep the source and split-wheel top-level import contract identical.
+    # the source __init__.py is split-package-safe: it always exposes core
     # metadata, extends the namespace path, and only exports layers/models
     # when the extension package is installed.
     shutil.copy(root_dir / 'fla' / '__init__.py', fla_core / '__init__.py')
 
-    # Copy ancillary files (README.md, LICENSE) to core package
+    # copy ancillary files (README.md, LICENSE) to core package
     for fname in ("README.md", "LICENSE"):
         src = root_dir / fname
         if src.exists():
             shutil.copy(src, core_dir / fname)
 
-    # Create fla-core configs
+    # create fla-core configs
     create_pyproject_toml(core_dir, 'fla-core', version, core_deps)
 
-    # Create flash-linear-attention package
+    # create flash-linear-attention package
     ext_dir = output_dir / 'flash-linear-attention'
     if ext_dir.exists():
         shutil.rmtree(ext_dir)
     ext_dir.mkdir()
 
-    # Copy extension files
+    # copy extension files
     fla_ext = ext_dir / 'fla'
     shutil.copytree(root_dir / 'fla' / 'models', fla_ext / 'models')
     shutil.copytree(root_dir / 'fla' / 'layers', fla_ext / 'layers')
 
-    # Intentionally do NOT create fla/__init__.py in the extension package.
-    # The top-level package is provided by fla-core (namespace via pkgutil).
+    # intentionally do not create fla/__init__.py in the extension package.
+    # the top-level package is provided by fla-core (namespace via pkgutil).
 
-    # Copy ancillary files (README.md, LICENSE) to extension package
+    # copy ancillary files (README.md, LICENSE) to extension package
     for fname in ("README.md", "LICENSE"):
         src = root_dir / fname
         if src.exists():
             shutil.copy(src, ext_dir / fname)
 
-    # Create extension configs
+    # create extension configs
     create_pyproject_toml(ext_dir, 'flash-linear-attention', version, ext_deps, extras)
 
-    # Create build script
+    # create build script
     build_script = output_dir / 'build.sh'
     with open(build_script, 'w') as f:
         f.write("""#!/bin/bash
-# Build both packages
+# build both packages
 
 echo "Building fla-core..."
 cd fla-core
@@ -225,7 +225,7 @@ def build_packages(dist_dir):
     """Build wheels and source distributions for both packages."""
     print("Building packages...")
 
-    # Build fla-core (both wheel and sdist)
+    # build fla-core (both wheel and sdist)
     print("Building fla-core packages...")
     try:
         subprocess.run(
@@ -244,7 +244,7 @@ def build_packages(dist_dir):
         print("Timed out building fla-core packages")
         return False
 
-    # Build flash-linear-attention (both wheel and sdist)
+    # build flash-linear-attention (both wheel and sdist)
     print("Building flash-linear-attention packages...")
     try:
         subprocess.run(
@@ -269,15 +269,15 @@ def build_packages(dist_dir):
 
 def copy_packages_to_output(dist_dir):
     """Copy wheels and source distributions to output directory."""
-    # Get script directory (relative to this file)
+    # get script directory (relative to this file)
     script_dir = Path(__file__).parent
     root_dir = script_dir.parent
 
-    # Create output directory (relative to root)
+    # create output directory (relative to root)
     output_dir = root_dir / 'dist-packages'
     output_dir.mkdir(exist_ok=True)
 
-    # Find wheels and source distributions
+    # find wheels and source distributions
     core_wheels = list((dist_dir / 'fla-core' / 'dist').glob('*.whl'))
     core_sdist = list((dist_dir / 'fla-core' / 'dist').glob('*.tar.gz'))
     ext_wheels = list((dist_dir / 'flash-linear-attention' / 'dist').glob('*.whl'))
@@ -290,7 +290,7 @@ def copy_packages_to_output(dist_dir):
         print("No flash-linear-attention wheel found")
         return False
 
-    # Copy all packages to output directory
+    # copy all packages to output directory
     all_packages = core_wheels + core_sdist + ext_wheels + ext_sdist
     for package in all_packages:
         target = output_dir / package.name
@@ -316,18 +316,18 @@ def main():
 
     print("Building split packages...")
 
-    # Build the split packages
+    # build the split packages
     dist_dir, _ = build_split_packages()
 
     print("\nTo build packages manually:")
     print(f"cd {dist_dir}")
     print("./build.sh")
 
-    # Build packages (wheels and source distributions)
+    # build packages (wheels and source distributions)
     if not build_packages(dist_dir):
         return 1
 
-    # Copy packages to output directory
+    # copy packages to output directory
     if not copy_packages_to_output(dist_dir):
         return 1
 

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -94,6 +94,7 @@ name = "{name}"
 version = "{version}"
 description = "{desc_text}"
 readme = "README.md"
+license = {{file = "LICENSE"}}
 requires-python = ">=3.10"
 dependencies = [{deps_content}]
 
@@ -154,8 +155,9 @@ def build_split_packages(output_dir: str | Path | None = None):
 
     # copy core files
     fla_core = core_dir / 'fla'
-    shutil.copytree(root_dir / 'fla' / 'ops', fla_core / 'ops')
-    shutil.copytree(root_dir / 'fla' / 'modules', fla_core / 'modules')
+    ignore = shutil.ignore_patterns('__pycache__')
+    shutil.copytree(root_dir / 'fla' / 'ops', fla_core / 'ops', ignore=ignore)
+    shutil.copytree(root_dir / 'fla' / 'modules', fla_core / 'modules', ignore=ignore)
     shutil.copy(root_dir / 'fla' / 'utils.py', fla_core / 'utils.py')
 
     # keep the source and split-wheel top-level import contract identical.
@@ -181,8 +183,8 @@ def build_split_packages(output_dir: str | Path | None = None):
 
     # copy extension files
     fla_ext = ext_dir / 'fla'
-    shutil.copytree(root_dir / 'fla' / 'models', fla_ext / 'models')
-    shutil.copytree(root_dir / 'fla' / 'layers', fla_ext / 'layers')
+    shutil.copytree(root_dir / 'fla' / 'models', fla_ext / 'models', ignore=ignore)
+    shutil.copytree(root_dir / 'fla' / 'layers', fla_ext / 'layers', ignore=ignore)
 
     # intentionally do not create fla/__init__.py in the extension package.
     # the top-level package is provided by fla-core (namespace via pkgutil).

--- a/scripts/smoke_test_split_packages.py
+++ b/scripts/smoke_test_split_packages.py
@@ -22,8 +22,9 @@ def run(
     *,
     cwd: str | Path | None = None,
     env: dict[str, str] | None = None,
+    timeout: int = 600,
 ) -> None:
-    subprocess.run(cmd, check=True, cwd=cwd, env=env)
+    subprocess.run(cmd, check=True, cwd=cwd, env=env, timeout=timeout)
 
 
 def venv_python(venv_dir: Path) -> Path:
@@ -93,17 +94,55 @@ def assert_full_import(python: Path, version: str) -> None:
         assert GLAModel is ModelsGLAModel
         assert GatedLinearAttention is fla.layers.GatedLinearAttention
         assert isinstance(AutoConfig.for_model(GLAConfig.model_type), GLAConfig)
-        assert AutoModel._model_mapping[GLAConfig] is ModelsGLAModel
-        assert AutoModelForCausalLM._model_mapping[GLAConfig] is GLAForCausalLM
+        config = GLAConfig(hidden_size=16, hidden_ratio=1, num_hidden_layers=1)
+        assert isinstance(AutoModel.from_config(config), ModelsGLAModel)
+        assert isinstance(AutoModelForCausalLM.from_config(config), GLAForCausalLM)
         """
     )
     run([str(python), "-c", code], cwd=tempfile.gettempdir(), env=python_env())
+
+
+def assert_split_namespace_installed(python: Path) -> None:
+    code = textwrap.dedent(
+        """
+        import importlib.metadata as metadata
+
+        core_files = {str(file) for file in metadata.files("fla-core")}
+        ext_files = {str(file) for file in metadata.files("flash-linear-attention")}
+
+        assert "fla/__init__.py" in core_files
+        assert "fla/ops/__init__.py" in core_files
+        assert "fla/modules/__init__.py" in core_files
+        assert "fla/layers/__init__.py" in ext_files
+        assert "fla/models/__init__.py" in ext_files
+
+        try:
+            import fla
+        except ModuleNotFoundError as exc:
+            assert exc.name not in {"fla.layers", "fla.models"}
+            assert exc.name in {"torch", "triton", "transformers", "einops"}
+        else:
+            assert "GLAModel" in fla.__all__
+            assert "GatedLinearAttention" in fla.__all__
+            assert "GLAConfig" not in fla.__all__
+        """
+    )
+    run([str(python), "-c", code], cwd=tempfile.gettempdir(), env=python_env())
+
+
+def install_wheel(python: Path, wheel: Path, *, with_deps: bool) -> None:
+    cmd = [str(python), "-m", "pip", "install"]
+    if not with_deps:
+        cmd.extend(["--no-index", "--no-deps"])
+    cmd.append(str(wheel))
+    run(cmd, timeout=900)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Smoke test locally built split package wheels.")
     parser.add_argument("dist_dir", type=Path, help="directory containing split package wheels")
     parser.add_argument("--version", help="expected package version")
+    parser.add_argument("--with-deps", action="store_true", help="install runtime dependencies and run full import smoke")
     args = parser.parse_args()
 
     core_wheel = find_wheel(args.dist_dir, "fla_core")
@@ -122,12 +161,14 @@ def main() -> int:
         venv.EnvBuilder(with_pip=True).create(venv_dir)
         python = venv_python(venv_dir)
 
-        run([str(python), "-m", "pip", "install", str(core_wheel)])
+        install_wheel(python, core_wheel, with_deps=args.with_deps)
         assert_core_only_import(python, version)
 
-        run([str(python), "-m", "pip", "install", str(ext_wheel)])
-        run([str(python), "-m", "pip", "check"])
-        assert_full_import(python, version)
+        install_wheel(python, ext_wheel, with_deps=args.with_deps)
+        assert_split_namespace_installed(python)
+        if args.with_deps:
+            run([str(python), "-m", "pip", "check"])
+            assert_full_import(python, version)
 
     return 0
 

--- a/scripts/smoke_test_split_packages.py
+++ b/scripts/smoke_test_split_packages.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import argparse
+import os
+import subprocess
+import tempfile
+import textwrap
+import venv
+import zipfile
+from email.message import Message
+from email.parser import Parser
+from pathlib import Path
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: str | Path | None = None,
+    env: dict[str, str] | None = None,
+) -> None:
+    subprocess.run(cmd, check=True, cwd=cwd, env=env)
+
+
+def venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def find_wheel(dist_dir: Path, prefix: str) -> Path:
+    wheels = sorted(dist_dir.glob(f"{prefix}-*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"Expected one {prefix} wheel in {dist_dir}, found {len(wheels)}")
+    return wheels[0]
+
+
+def read_wheel_metadata(wheel: Path) -> Message:
+    with zipfile.ZipFile(wheel) as zf:
+        metadata_file = next(name for name in zf.namelist() if name.endswith(".dist-info/METADATA"))
+        return Parser().parsestr(zf.read(metadata_file).decode())
+
+
+def python_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env["PYTHONNOUSERSITE"] = "1"
+    return env
+
+
+def assert_core_only_import(python: Path, version: str) -> None:
+    code = textwrap.dedent(
+        f"""
+        import importlib.util
+        import sys
+
+        import fla
+
+        assert fla.__version__ == {version!r}
+        assert fla.__all__ == []
+        assert not hasattr(fla, "layers")
+        assert not hasattr(fla, "models")
+        assert importlib.util.find_spec("fla.ops") is not None
+        assert importlib.util.find_spec("fla.modules") is not None
+        assert importlib.util.find_spec("fla.layers") is None
+        assert importlib.util.find_spec("fla.models") is None
+        assert "fla.layers" not in sys.modules
+        assert "fla.models" not in sys.modules
+        """
+    )
+    run([str(python), "-c", code], cwd=tempfile.gettempdir(), env=python_env())
+
+
+def assert_full_import(python: Path, version: str) -> None:
+    code = textwrap.dedent(
+        f"""
+        import fla
+        import fla.layers
+        import fla.models
+        from fla import GLAModel, GatedLinearAttention
+        from fla.models import GLAConfig, GLAForCausalLM, GLAModel as ModelsGLAModel
+        from transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+
+        assert fla.__version__ == {version!r}
+        assert "GLAModel" in fla.__all__
+        assert "GatedLinearAttention" in fla.__all__
+        assert "GLAConfig" not in fla.__all__
+        assert not hasattr(fla, "GLAConfig")
+        assert GLAModel is ModelsGLAModel
+        assert GatedLinearAttention is fla.layers.GatedLinearAttention
+        assert isinstance(AutoConfig.for_model(GLAConfig.model_type), GLAConfig)
+        assert AutoModel._model_mapping[GLAConfig] is ModelsGLAModel
+        assert AutoModelForCausalLM._model_mapping[GLAConfig] is GLAForCausalLM
+        """
+    )
+    run([str(python), "-c", code], cwd=tempfile.gettempdir(), env=python_env())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Smoke test locally built split package wheels.")
+    parser.add_argument("dist_dir", type=Path, help="directory containing split package wheels")
+    parser.add_argument("--version", help="expected package version")
+    args = parser.parse_args()
+
+    core_wheel = find_wheel(args.dist_dir, "fla_core")
+    ext_wheel = find_wheel(args.dist_dir, "flash_linear_attention")
+    core_metadata = read_wheel_metadata(core_wheel)
+    ext_metadata = read_wheel_metadata(ext_wheel)
+    version = args.version or core_metadata["Version"]
+    if core_metadata["Version"] != version or ext_metadata["Version"] != version:
+        raise RuntimeError(
+            f"Wheel version mismatch: fla-core={core_metadata['Version']}, "
+            f"flash-linear-attention={ext_metadata['Version']}, expected={version}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="fla-release-smoke-") as tmp:
+        venv_dir = Path(tmp) / "venv"
+        venv.EnvBuilder(with_pip=True).create(venv_dir)
+        python = venv_python(venv_dir)
+
+        run([str(python), "-m", "pip", "install", str(core_wheel)])
+        assert_core_only_import(python, version)
+
+        run([str(python), "-m", "pip", "install", str(ext_wheel)])
+        run([str(python), "-m", "pip", "check"])
+        assert_full_import(python, version)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         'torch>=2.7.0',
-        'transformers',
+        'triton>=3.3',
+        'transformers>=4.45.0',
         'einops',
     ],
     extras_require={

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import fla
+import fla.layers as layers
+import fla.models as models
+
+
+def test_top_level_exports_layers_and_non_config_models():
+    expected_exports = [
+        *layers.__all__,
+        *[name for name in models.__all__ if not name.endswith("Config")],
+    ]
+
+    assert fla.__all__ == expected_exports
+
+    for name in expected_exports:
+        source = layers if hasattr(layers, name) else models
+        assert getattr(fla, name) is getattr(source, name)
+
+    config_exports = [name for name in models.__all__ if name.endswith("Config")]
+    assert not set(config_exports).intersection(fla.__all__)
+    assert not any(name in fla.__dict__ for name in config_exports)

--- a/tests/test_split_package_release.py
+++ b/tests/test_split_package_release.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import os
+import subprocess
+import sys
+import textwrap
+import venv
+import zipfile
+from pathlib import Path
+
+import pytest
+from packaging.version import parse as parse_version
+
+from scripts.build_packages import build_split_packages
+from scripts.smoke_test_split_packages import find_wheel, read_wheel_metadata, venv_python
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+    subprocess_env = os.environ.copy()
+    subprocess_env.pop("PYTHONPATH", None)
+    subprocess_env["PYTHONNOUSERSITE"] = "1"
+    if env:
+        subprocess_env.update(env)
+
+    result = subprocess.run(
+        cmd,
+        check=False,
+        cwd=cwd,
+        env=subprocess_env,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def _build_split_wheels(tmp_path: Path) -> tuple[Path, Path, str]:
+    dist_dir, version = build_split_packages(tmp_path / "split")
+    wheel_dir = tmp_path / "wheelhouse"
+    wheel_dir.mkdir()
+
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-index",
+            "--no-deps",
+            "--no-build-isolation",
+            "--wheel-dir",
+            str(wheel_dir),
+            str(dist_dir / "fla-core"),
+            str(dist_dir / "flash-linear-attention"),
+        ],
+        cwd=ROOT,
+    )
+
+    return find_wheel(wheel_dir, "fla_core"), find_wheel(wheel_dir, "flash_linear_attention"), version
+
+
+def _wheel_names(wheel: Path) -> set[str]:
+    with zipfile.ZipFile(wheel) as zf:
+        return set(zf.namelist())
+
+
+def _requires_dist(wheel: Path) -> set[str]:
+    return set(read_wheel_metadata(wheel).get_all("Requires-Dist") or [])
+
+
+def _create_venv(tmp_path: Path, *, system_site_packages: bool = False) -> Path:
+    venv_dir = tmp_path / "venv"
+    venv.EnvBuilder(with_pip=True, system_site_packages=system_site_packages).create(venv_dir)
+    return venv_python(venv_dir)
+
+
+def test_split_wheels_match_release_contract(tmp_path: Path) -> None:
+    core_wheel, ext_wheel, version = _build_split_wheels(tmp_path)
+
+    core_names = _wheel_names(core_wheel)
+    ext_names = _wheel_names(ext_wheel)
+
+    assert "fla/__init__.py" in core_names
+    assert "fla/ops/__init__.py" in core_names
+    assert "fla/modules/__init__.py" in core_names
+    assert "fla/utils.py" in core_names
+    assert not any(name.startswith("fla/layers/") for name in core_names)
+    assert not any(name.startswith("fla/models/") for name in core_names)
+
+    assert "fla/__init__.py" not in ext_names
+    assert "fla/layers/__init__.py" in ext_names
+    assert "fla/models/__init__.py" in ext_names
+    assert not any(name.startswith("fla/ops/") for name in ext_names)
+    assert not any(name.startswith("fla/modules/") for name in ext_names)
+    assert "fla/utils.py" not in ext_names
+
+    assert read_wheel_metadata(core_wheel)["Version"] == version
+    assert read_wheel_metadata(ext_wheel)["Version"] == version
+    assert {"torch >=2.7.0", "triton >=3.3", "einops"}.issubset(_requires_dist(core_wheel))
+    assert {f"fla-core =={version}", "transformers >=4.45.0"}.issubset(_requires_dist(ext_wheel))
+
+
+def test_core_then_extension_install_sequence_without_runtime_deps(tmp_path: Path) -> None:
+    core_wheel, ext_wheel, version = _build_split_wheels(tmp_path)
+    python = _create_venv(tmp_path)
+
+    _run([str(python), "-m", "pip", "install", "--no-index", "--no-deps", str(core_wheel)], cwd=tmp_path)
+    core_check = textwrap.dedent(
+        f"""
+        import importlib.util
+        import sys
+
+        import fla
+
+        assert fla.__version__ == {version!r}
+        assert fla.__all__ == []
+        assert not hasattr(fla, "layers")
+        assert not hasattr(fla, "models")
+        assert importlib.util.find_spec("fla.ops") is not None
+        assert importlib.util.find_spec("fla.modules") is not None
+        assert importlib.util.find_spec("fla.layers") is None
+        assert importlib.util.find_spec("fla.models") is None
+        assert "fla.layers" not in sys.modules
+        assert "fla.models" not in sys.modules
+
+        try:
+            from fla import GLAModel
+        except ImportError:
+            pass
+        else:
+            raise AssertionError("core-only install must not expose model classes")
+        """
+    )
+    _run([str(python), "-c", core_check], cwd=tmp_path)
+
+    _run([str(python), "-m", "pip", "install", "--no-index", "--no-deps", str(ext_wheel)], cwd=tmp_path)
+    extension_check = textwrap.dedent(
+        """
+        import importlib.metadata as metadata
+
+        core_files = {str(file) for file in metadata.files("fla-core")}
+        ext_files = {str(file) for file in metadata.files("flash-linear-attention")}
+
+        assert "fla/__init__.py" in core_files
+        assert "fla/layers/__init__.py" in ext_files
+        assert "fla/models/__init__.py" in ext_files
+
+        try:
+            import fla
+        except ModuleNotFoundError as exc:
+            assert exc.name not in {"fla.layers", "fla.models"}
+            assert exc.name in {"torch", "triton", "transformers", "einops"}
+        else:
+            assert "GLAModel" in fla.__all__
+            assert "GatedLinearAttention" in fla.__all__
+            assert "GLAConfig" not in fla.__all__
+        """
+    )
+    _run([str(python), "-c", extension_check], cwd=tmp_path)
+
+
+def test_full_split_import_contract_when_runtime_dependencies_available(tmp_path: Path) -> None:
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("triton")
+    pytest.importorskip("transformers")
+    pytest.importorskip("einops")
+    if parse_version(torch.__version__.split("+", maxsplit=1)[0]) < parse_version("2.7.0"):
+        pytest.skip("full split import smoke requires torch>=2.7.0")
+
+    core_wheel, ext_wheel, version = _build_split_wheels(tmp_path)
+    python = _create_venv(tmp_path, system_site_packages=True)
+
+    _run([str(python), "-m", "pip", "install", "--no-index", "--no-deps", str(core_wheel)], cwd=tmp_path)
+    _run([str(python), "-m", "pip", "install", "--no-index", "--no-deps", str(ext_wheel)], cwd=tmp_path)
+    full_check = textwrap.dedent(
+        f"""
+        import fla
+        import fla.layers
+        import fla.models
+        from fla import GLAModel, GatedLinearAttention
+        from fla.models import GLAConfig, GLAForCausalLM, GLAModel as ModelsGLAModel
+        from transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+
+        assert fla.__version__ == {version!r}
+        assert "GLAModel" in fla.__all__
+        assert "GatedLinearAttention" in fla.__all__
+        assert "GLAConfig" not in fla.__all__
+        assert not hasattr(fla, "GLAConfig")
+        assert GLAModel is ModelsGLAModel
+        assert GatedLinearAttention is fla.layers.GatedLinearAttention
+        assert isinstance(AutoConfig.for_model(GLAConfig.model_type), GLAConfig)
+        assert AutoModel._model_mapping[GLAConfig] is ModelsGLAModel
+        assert AutoModelForCausalLM._model_mapping[GLAConfig] is GLAForCausalLM
+        """
+    )
+    _run([str(python), "-c", full_check], cwd=tmp_path)

--- a/tests/test_split_package_release.py
+++ b/tests/test_split_package_release.py
@@ -122,6 +122,8 @@ def test_core_then_extension_install_sequence_without_runtime_deps(tmp_path: Pat
     core_wheel, ext_wheel, version = _build_split_wheels(tmp_path)
     python = _create_venv(tmp_path)
 
+    _run([sys.executable, "scripts/smoke_test_split_packages.py", str(core_wheel.parent)], cwd=ROOT)
+
     _run([str(python), "-m", "pip", "install", "--no-index", "--no-deps", str(core_wheel)], cwd=tmp_path)
     core_check = textwrap.dedent(
         f"""
@@ -177,6 +179,41 @@ def test_core_then_extension_install_sequence_without_runtime_deps(tmp_path: Pat
     _run([str(python), "-c", extension_check], cwd=tmp_path)
 
 
+def test_split_namespace_across_sys_path_entries_without_runtime_deps(tmp_path: Path) -> None:
+    core_wheel, ext_wheel, _ = _build_split_wheels(tmp_path)
+    python = _create_venv(tmp_path)
+    core_target = tmp_path / "core-target"
+    ext_target = tmp_path / "ext-target"
+
+    _run(
+        [str(python), "-m", "pip", "install", "--no-index", "--no-deps", "--target", str(core_target), str(core_wheel)],
+        cwd=tmp_path,
+    )
+    _run(
+        [str(python), "-m", "pip", "install", "--no-index", "--no-deps", "--target", str(ext_target), str(ext_wheel)],
+        cwd=tmp_path,
+    )
+
+    for first, second in ((core_target, ext_target), (ext_target, core_target)):
+        check = textwrap.dedent(
+            f"""
+            import sys
+
+            sys.path[:0] = [{str(first)!r}, {str(second)!r}]
+            try:
+                import fla
+            except ModuleNotFoundError as exc:
+                assert exc.name not in {{"fla.layers", "fla.models"}}
+                assert exc.name in {{"torch", "triton", "transformers", "einops"}}
+            else:
+                assert "GLAModel" in fla.__all__
+                assert "GatedLinearAttention" in fla.__all__
+                assert "GLAConfig" not in fla.__all__
+            """
+        )
+        _run([str(python), "-c", check], cwd=tmp_path)
+
+
 def test_full_split_import_contract_when_runtime_dependencies_available(tmp_path: Path) -> None:
     torch = pytest.importorskip("torch")
     pytest.importorskip("triton")
@@ -207,8 +244,9 @@ def test_full_split_import_contract_when_runtime_dependencies_available(tmp_path
         assert GLAModel is ModelsGLAModel
         assert GatedLinearAttention is fla.layers.GatedLinearAttention
         assert isinstance(AutoConfig.for_model(GLAConfig.model_type), GLAConfig)
-        assert AutoModel._model_mapping[GLAConfig] is ModelsGLAModel
-        assert AutoModelForCausalLM._model_mapping[GLAConfig] is GLAForCausalLM
+        config = GLAConfig(hidden_size=16, hidden_ratio=1, num_hidden_layers=1)
+        assert isinstance(AutoModel.from_config(config), ModelsGLAModel)
+        assert isinstance(AutoModelForCausalLM.from_config(config), GLAForCausalLM)
         """
     )
     _run([str(python), "-c", full_check], cwd=tmp_path)

--- a/tests/test_split_package_release.py
+++ b/tests/test_split_package_release.py
@@ -14,6 +14,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from packaging.requirements import Requirement
 from packaging.version import parse as parse_version
 
 from scripts.build_packages import build_split_packages
@@ -71,8 +72,13 @@ def _wheel_names(wheel: Path) -> set[str]:
         return set(zf.namelist())
 
 
-def _requires_dist(wheel: Path) -> set[str]:
-    return set(read_wheel_metadata(wheel).get_all("Requires-Dist") or [])
+def _requires_dist(wheel: Path) -> dict[str, Requirement]:
+    return {
+        requirement.name: requirement
+        for requirement in (
+            Requirement(value) for value in read_wheel_metadata(wheel).get_all("Requires-Dist") or []
+        )
+    }
 
 
 def _create_venv(tmp_path: Path, *, system_site_packages: bool = False) -> Path:
@@ -103,8 +109,13 @@ def test_split_wheels_match_release_contract(tmp_path: Path) -> None:
 
     assert read_wheel_metadata(core_wheel)["Version"] == version
     assert read_wheel_metadata(ext_wheel)["Version"] == version
-    assert {"torch >=2.7.0", "triton >=3.3", "einops"}.issubset(_requires_dist(core_wheel))
-    assert {f"fla-core =={version}", "transformers >=4.45.0"}.issubset(_requires_dist(ext_wheel))
+    core_requires = _requires_dist(core_wheel)
+    ext_requires = _requires_dist(ext_wheel)
+    assert str(core_requires["torch"].specifier) == ">=2.7.0"
+    assert str(core_requires["triton"].specifier) == ">=3.3"
+    assert str(core_requires["einops"].specifier) == ""
+    assert str(ext_requires["fla-core"].specifier) == f"=={version}"
+    assert str(ext_requires["transformers"].specifier) == ">=4.45.0"
 
 
 def test_core_then_extension_install_sequence_without_runtime_deps(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary:
- Make the top-level `fla` package split-package-safe: `import fla` always exposes core metadata and namespace path, and only exports layers/models when the extension package is present.
- Keep model config classes available from `fla.models`, but intentionally out of the top-level `fla` namespace.
- Reuse the source `fla/__init__.py` when building `fla-core`, so source installs and split wheels share one import contract.
- Declare `triton>=3.3` as a core dependency and align the `transformers` lower bound with the README.
- Document the intended import paths in README and add a public API regression test.

Test plan:
- python -m py_compile fla/__init__.py tests/test_public_api.py scripts/build_packages.py
- git diff --check
- Core-only import simulation with only `fla/__init__.py` on PYTHONPATH
- scripts.build_packages dependency categorization check
- build_split_packages() source-generation check for copied core init and split pyproject dependencies

Not run:
- python -m pytest tests/test_public_api.py -q (local environment is missing `triton`; full-source import correctly fails before test collection)

Breaking changes:
- `*Config` classes are not exported from top-level `fla`; they remain available from `fla.models`.