### PR TITLE
Add Raven model integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 
 - [2026-05] 🚀 Add [YOCO](https://arxiv.org/abs/2405.05254) (You Only Cache Once) implementation to `fla`.
 - [2026-05] ⚡ Add fused [AttnRes](fla/ops/attnres) support to `fla` ([paper](https://arxiv.org/abs/2603.15031)).
+- [2026-05] Add Raven implementation to `fla` ([repo](https://github.com/goombalab/raven)).
 - [2026-04] 🐍 Add Mamba-3 implementation to `fla` ([paper](https://arxiv.org/abs/2603.15569)).
 - [2026-04] 🧱 Add [MoBA](https://arxiv.org/abs/2502.13189) (Mixture of Block Attention) implementation to `fla`, with [FlashMoBA](https://github.com/mit-han-lab/flash-moba) backend support.
 - [2026-04] 🧱 Add [TileLang](https://github.com/tile-ai/tilelang) backend support for selected kernels.
@@ -104,6 +105,7 @@
 | 2025 | KDA                  | [Kimi Linear: An Expressive, Efficient Attention Architecture](https://arxiv.org/abs/2510.26692)                                              |                                                                                                 |            [fla](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/kda)             |
 | 2025 | MoBA                 | [MoBA: Mixture of Block Attention for Long-Context LLMs](https://arxiv.org/abs/2502.13189)                                                    | [official](https://github.com/MoonshotAI/MoBA)                                                  |         [fla](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/moba.py)         |
 | 2026 | Mamba-3              | [Mamba-3: Improved Sequence Modeling using State Space Principles](https://arxiv.org/abs/2603.15569)                                          | [official](https://github.com/state-spaces/mamba)                                               |         [fla](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/mamba3)          |
+| 2026 | Raven                | [Raven: High-Recall Sequence Modeling with Sparse Memory Routing](https://github.com/goombalab/raven/blob/main/raven.pdf)                    | [official](https://github.com/goombalab/raven)                                                  |          [fla](https://github.com/fla-org/flash-linear-attention/tree/main/fla/models/raven)          |
 
 ## Installation
 

--- a/fla/layers/__init__.py
+++ b/fla/layers/__init__.py
@@ -33,6 +33,7 @@ from .mom import MomAttention
 from .multiscale_retention import MultiScaleRetention
 from .nsa import NativeSparseAttention
 from .path_attn import PaTHAttention
+from .raven import Raven
 from .rebased import ReBasedLinearAttention
 from .rodimus import RodimusAttention, SlidingWindowSharedKeyAttention
 from .rwkv6 import RWKV6Attention
@@ -70,6 +71,7 @@ __all__ = [
     'PaTHAttention',
     'RWKV6Attention',
     'RWKV7Attention',
+    'Raven',
     'ReBasedLinearAttention',
     'RodimusAttention',
     'SlidingWindowSharedKeyAttention',

--- a/fla/layers/raven.py
+++ b/fla/layers/raven.py
@@ -1,0 +1,342 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+#
+# Portions of this file are adapted from Raven:
+#   Copyright (c) 2023-2025 Arshia Afzal and Aviv Bick
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange, repeat
+
+from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.modules import FusedRMSNormGated, RMSNorm, RotaryEmbedding
+from fla.modules.activations import ACT2FN
+from fla.modules.feature_map import ReLUFeatureMap, SwishFeatureMap, T2RFeatureMap
+from fla.modules.layernorm import rms_norm_linear
+from fla.ops.gsa import chunk_gsa, fused_recurrent_gsa
+from fla.ops.utils.index import prepare_lens_from_mask
+
+if TYPE_CHECKING:
+    from transformers.processing_utils import Unpack
+
+    from fla.models.utils import Cache
+
+
+def _max_offset(seqlen_offset: int | torch.Tensor) -> int:
+    if isinstance(seqlen_offset, int):
+        return seqlen_offset
+    return int(seqlen_offset.max().item())
+
+
+class Raven(nn.Module):
+
+    def __init__(
+        self,
+        mode: str = 'chunk',
+        hidden_size: int = 1024,
+        expand_k: float = 1.,
+        expand_v: float = 1.,
+        num_heads: int = 4,
+        num_kv_heads: int | None = None,
+        num_slots: int | None = None,
+        elementwise_affine: bool | None = True,
+        norm_eps: float = 1e-5,
+        gate_logit_normalizer: int = 8,
+        feature_map: str = 'swish',
+        use_output_gate: bool = False,
+        use_norm: bool = True,
+        gate_fn: str = 'swish',
+        layer_idx: int | None = None,
+        scale: float | None = 1.,
+        decay_type: str = 'Mamba2',
+        topk: int = 32,
+        bias_rmm: bool = False,
+        add_gumbel_noise: bool = True,
+        router_score: str = 'sigmoid',
+        router_type: str = 'lin',
+        use_rope: bool = False,
+        rope_theta: float = 10000.,
+        max_position_embeddings: int | None = None,
+        use_short_conv: bool = False,
+        fuse_norm: bool = True,
+        **kwargs,
+    ) -> Raven:
+        super().__init__()
+
+        if mode not in ('chunk', 'fused_recurrent'):
+            raise ValueError(f"Unsupported mode `{mode}`.")
+        if decay_type not in ('Mamba2', 'GLA'):
+            raise ValueError(f"Unsupported decay type `{decay_type}`.")
+        if router_score not in ('sigmoid', 'softmax'):
+            raise ValueError(f"Unsupported router score `{router_score}`.")
+        if router_type not in ('lin', 'mlp'):
+            raise ValueError(f"Unsupported router type `{router_type}`.")
+        if use_short_conv:
+            raise NotImplementedError("Raven does not use short convolutional memory.")
+        if gate_fn not in ACT2FN:
+            raise ValueError(f"Unsupported gate function `{gate_fn}`.")
+
+        self.mode = mode
+        self.hidden_size = hidden_size
+        self.expand_k = expand_k
+        self.expand_v = expand_v
+        self.num_heads = num_heads
+        self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
+        if self.num_heads % self.num_kv_heads != 0:
+            raise ValueError(
+                f"`num_heads` must be divisible by `num_kv_heads`, got {self.num_heads} and {self.num_kv_heads}.",
+            )
+
+        self.num_kv_groups = self.num_heads // self.num_kv_heads
+        self.key_dim = int(hidden_size * expand_k)
+        self.value_dim = int(hidden_size * expand_v)
+        self.key_dim_per_group = self.key_dim // self.num_kv_groups
+        self.value_dim_per_group = self.value_dim // self.num_kv_groups
+        self.head_k_dim = self.key_dim // self.num_heads
+        self.head_v_dim = self.value_dim // self.num_heads
+
+        default_num_slots = num_slots is None
+        if num_slots is None:
+            num_slots = self.head_k_dim
+        if default_num_slots and topk > num_slots:
+            topk = num_slots
+        if topk < 1 or topk > num_slots:
+            raise ValueError(f"`topk` must be in [1, num_slots], got topk={topk}, num_slots={num_slots}.")
+
+        self.num_slots = num_slots
+        self.topk = topk
+        self.decay_type = decay_type
+        self.use_output_gate = use_output_gate
+        self.use_rope = use_rope
+        self.gate_logit_normalizer = gate_logit_normalizer
+        self.use_norm = use_norm
+        self.gate_fn_name = gate_fn
+        self.gate_fn = ACT2FN[gate_fn]
+        self.fuse_norm = fuse_norm
+        self.scale = scale
+        self.rope_theta = rope_theta
+        self.max_position_embeddings = max_position_embeddings
+        self.bias_rmm = bias_rmm
+        self.add_gumbel_noise = add_gumbel_noise
+        self.router_score = router_score
+        self.router_type = router_type
+        self.layer_idx = layer_idx
+
+        if layer_idx is None:
+            warnings.warn(
+                f"Instantiating {self.__class__.__name__} without passing `layer_idx` is not recommended and will "
+                "lead to errors during the forward call if caching is used. Please make sure to provide a `layer_idx` "
+                "when creating this class.",
+            )
+
+        self.register_module('feature_map', None)
+        if feature_map == 'swish':
+            self.feature_map = SwishFeatureMap()
+        elif feature_map == 'relu':
+            self.feature_map = ReLUFeatureMap()
+        elif feature_map == 't2r':
+            self.feature_map = T2RFeatureMap(self.head_k_dim, self.head_k_dim)
+        else:
+            raise NotImplementedError(f"Feature map `{feature_map}` is not supported now.")
+
+        self.q_proj = nn.Linear(self.hidden_size, self.key_dim, bias=False)
+        self.k_proj = nn.Linear(self.hidden_size, self.key_dim_per_group, bias=False)
+        self.v_proj = nn.Linear(self.hidden_size, self.value_dim_per_group, bias=False)
+
+        if self.decay_type == 'Mamba2':
+            self.a_proj = nn.Linear(self.hidden_size, self.num_kv_heads, bias=False)
+            A = torch.empty(self.num_kv_heads, dtype=torch.float32).uniform_(1e-4, 16)
+            self.A_log = nn.Parameter(torch.log(A))
+            self.A_log._no_weight_decay = True
+
+            dt_min, dt_max, dt_init_floor = 0.001, 0.1, 1e-4
+            dt = torch.exp(
+                torch.rand(self.num_kv_heads) * (math.log(dt_max) - math.log(dt_min)) + math.log(dt_min),
+            )
+            dt = torch.clamp(dt, min=dt_init_floor)
+            inv_dt = dt + torch.log(-torch.expm1(-dt))
+            self.dt_bias = nn.Parameter(inv_dt)
+            self.dt_bias._no_weight_decay = True
+        else:
+            self.f_proj = nn.Linear(self.hidden_size, self.num_kv_heads * self.num_slots, bias=False)
+
+        if self.bias_rmm:
+            self.r_bias = nn.Parameter(torch.zeros(self.num_kv_heads, self.num_slots, dtype=torch.float32))
+
+        if self.router_type == 'lin':
+            self.r_proj = nn.Linear(self.hidden_size, self.num_kv_heads * self.num_slots, bias=False)
+        else:
+            self.r_proj = nn.Sequential(
+                nn.Linear(self.hidden_size, self.hidden_size, bias=True),
+                nn.GELU(),
+                nn.Linear(self.hidden_size, self.num_kv_heads * self.num_slots, bias=False),
+            )
+
+        if self.use_rope:
+            self.rotary = RotaryEmbedding(dim=self.head_k_dim, base=self.rope_theta)
+
+        norm_cls = RMSNorm if self.fuse_norm else nn.RMSNorm
+        self.q_norm = norm_cls(self.head_k_dim, elementwise_affine=elementwise_affine, eps=norm_eps)
+        self.k_norm = norm_cls(self.head_k_dim, elementwise_affine=elementwise_affine, eps=norm_eps)
+
+        if self.use_output_gate:
+            self.o_gate_proj = nn.Linear(hidden_size, self.value_dim, bias=False)
+            if self.fuse_norm and gate_fn in ('swish', 'silu', 'sigmoid'):
+                self.o_norm = FusedRMSNormGated(self.head_v_dim, eps=norm_eps, activation=gate_fn)
+                self.fuse_norm_and_gate = True
+            else:
+                self.o_norm = norm_cls(self.head_v_dim, eps=norm_eps)
+                self.fuse_norm_and_gate = False
+        else:
+            self.g_norm = norm_cls(self.hidden_size, elementwise_affine=elementwise_affine, eps=norm_eps)
+        self.o_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        output_attentions: bool | None = False,
+        **kwargs: Unpack[dict],
+    ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+        if attention_mask is not None:
+            assert len(attention_mask.shape) == 2, (
+                "Expected attention_mask as a 0-1 matrix with shape [batch_size, seq_len] "
+                "for padding purposes (0 indicating padding). "
+                "Arbitrary attention masks of shape [batch_size, seq_len, seq_len] are not allowed."
+            )
+
+        batch_size, q_len, _ = hidden_states.shape
+        mode = 'fused_recurrent' if hidden_states.shape[1] <= 64 else self.mode
+
+        last_state = get_layer_cache(self, past_key_values)
+        seqlen_offset, max_seqlen = 0, q_len
+        if past_key_values is not None:
+            seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
+            max_seqlen = q_len + _max_offset(seqlen_offset)
+
+        cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
+        if cu_seqlens is None and attention_mask is not None:
+            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+            seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
+            max_seqlen = q_len + _max_offset(seqlen_offset)
+
+        q = rearrange(self.q_proj(hidden_states), '... (h d) -> ... h d', d=self.head_k_dim)
+        k = rearrange(self.k_proj(hidden_states), '... (h d) -> ... h d', d=self.head_k_dim)
+        v = rearrange(self.v_proj(hidden_states), '... (h d) -> ... h d', d=self.head_v_dim)
+        router = rearrange(self.r_proj(hidden_states), '... (h m) -> ... h m', m=self.num_slots)
+
+        if self.decay_type == 'Mamba2':
+            f = (-self.A_log.float().exp() * F.softplus(self.a_proj(hidden_states).float() + self.dt_bias)).unsqueeze(-1)
+        else:
+            f = rearrange(self.f_proj(hidden_states), '... (h m) -> ... h m', m=self.num_slots)
+            f = F.logsigmoid(f) / self.gate_logit_normalizer
+
+        if self.feature_map is not None:
+            q, k = map(lambda x: self.feature_map(x), (q, k))
+        q, k = self.q_norm(q), self.k_norm(k)
+
+        if self.use_rope:
+            if self.max_position_embeddings is not None:
+                max_seqlen = max(max_seqlen, self.max_position_embeddings)
+            q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+
+        v = self.gate_fn(v)
+
+        # Training-time Gumbel routing is RNG-sensitive. Activation checkpointing
+        # must preserve RNG state, otherwise backward recomputes different routes.
+        if self.add_gumbel_noise and self.training:
+            router = router - torch.empty_like(router).exponential_().log()
+        orig_scores = torch.sigmoid(router) if self.router_score == 'sigmoid' else torch.softmax(router, dim=-1)
+        scores = orig_scores + self.r_bias.float() if self.bias_rmm else orig_scores
+
+        route_idx = scores.topk(self.topk, dim=-1).indices
+        topk_weights = torch.gather(orig_scores, dim=-1, index=route_idx)
+        if self.router_score == 'sigmoid':
+            topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-9)
+
+        s_multihot = torch.zeros_like(router).scatter_(-1, route_idx, topk_weights.to(router.dtype))
+        f = (f * s_multihot).to(q.dtype)
+        s = (1 - f.exp()).to(q.dtype)
+
+        recurrent_state = last_state['recurrent_state'] if last_state is not None else None
+        if self.num_kv_groups > 1:
+            k, v, f, s = map(lambda x: repeat(x, '... h d -> ... (h g) d', g=self.num_kv_groups), (k, v, f, s))
+
+        if mode == 'fused_recurrent':
+            o, recurrent_state = fused_recurrent_gsa(
+                q=q,
+                k=k,
+                v=v,
+                s=s,
+                g=f,
+                initial_state=recurrent_state,
+                output_final_state=use_cache,
+                scale=self.scale,
+                cu_seqlens=cu_seqlens,
+            )
+        elif mode == 'chunk':
+            o, recurrent_state = chunk_gsa(
+                q=q,
+                k=k,
+                v=v,
+                s=s,
+                g=f,
+                initial_state=recurrent_state,
+                output_final_state=use_cache,
+                scale=self.scale,
+                cu_seqlens=cu_seqlens,
+            )
+        else:
+            raise NotImplementedError(f"Not supported mode `{mode}`.")
+
+        update_layer_cache(
+            self,
+            past_key_values,
+            recurrent_state=recurrent_state,
+            conv_state=None,
+            offset=q_len,
+        )
+
+        if self.use_output_gate:
+            gate_out = rearrange(self.o_gate_proj(hidden_states), '... (h d) -> ... h d', d=self.head_v_dim)
+            o = self.gate_fn(o)
+            if self.fuse_norm_and_gate:
+                o = self.o_norm(o, gate_out)
+            else:
+                o = self.o_norm(o) * self.gate_fn(gate_out)
+            o = rearrange(o, '... h d -> ... (h d)')
+            o = self.o_proj(o)
+        else:
+            o = rearrange(o, '... h d -> ... (h d)')
+            o = self.gate_fn(o)
+            if self.fuse_norm:
+                o = rms_norm_linear(
+                    o,
+                    self.g_norm.weight,
+                    self.g_norm.bias,
+                    self.o_proj.weight,
+                    self.o_proj.bias,
+                    eps=self.g_norm.eps,
+                )
+            else:
+                o = self.o_proj(self.g_norm(o))
+
+        if indices is not None:
+            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+
+        return o, None, past_key_values

--- a/fla/models/__init__.py
+++ b/fla/models/__init__.py
@@ -34,6 +34,7 @@ from fla.models.moba import MoBAConfig, MoBAForCausalLM, MoBAModel
 from fla.models.mom import MomConfig, MomForCausalLM, MomModel
 from fla.models.nsa import NSAConfig, NSAForCausalLM, NSAModel
 from fla.models.path_attn import PaTHAttentionConfig, PaTHAttentionForCausalLM, PaTHAttentionModel
+from fla.models.raven import RavenConfig, RavenForCausalLM, RavenModel
 from fla.models.retnet import RetNetConfig, RetNetForCausalLM, RetNetModel
 from fla.models.rodimus import RodimusConfig, RodimusForCausalLM, RodimusModel
 from fla.models.rwkv6 import RWKV6Config, RWKV6ForCausalLM, RWKV6Model
@@ -124,6 +125,9 @@ __all__ = [
     'RWKV7Config',
     'RWKV7ForCausalLM',
     'RWKV7Model',
+    'RavenConfig',
+    'RavenForCausalLM',
+    'RavenModel',
     'RetNetConfig',
     'RetNetForCausalLM',
     'RetNetModel',

--- a/fla/models/raven/__init__.py
+++ b/fla/models/raven/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+
+from fla.models.raven.configuration_raven import RavenConfig
+from fla.models.raven.modeling_raven import RavenForCausalLM, RavenModel
+
+AutoConfig.register(RavenConfig.model_type, RavenConfig, exist_ok=True)
+AutoModel.register(RavenConfig, RavenModel, exist_ok=True)
+AutoModelForCausalLM.register(RavenConfig, RavenForCausalLM, exist_ok=True)
+
+
+__all__ = ['RavenConfig', 'RavenForCausalLM', 'RavenModel']

--- a/fla/models/raven/configuration_raven.py
+++ b/fla/models/raven/configuration_raven.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+#
+# Portions of this file are adapted from Raven:
+#   Copyright (c) 2023-2025 Arshia Afzal and Aviv Bick
+
+import warnings
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class RavenConfig(PretrainedConfig):
+
+    model_type = 'raven'
+    keys_to_ignore_at_inference = ['past_key_values']
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        gate_logit_normalizer: int | None = 8,
+        clamp_min: float | None = None,
+        clamp_max: float | None = None,
+        hidden_ratio: int | None = 4,
+        intermediate_size: int | None = None,
+        num_hidden_layers: int = 24,
+        num_heads: int = 4,
+        num_kv_heads: int | None = None,
+        num_slots: int | None = 64,
+        use_short_conv: bool = False,
+        conv_size: int = 4,
+        expand_k: float = 1,
+        expand_v: float = 1,
+        feature_map: str = 'swish',
+        use_output_gate: bool = False,
+        use_norm: bool = True,
+        max_position_embeddings: int = 2048,
+        hidden_act: str = "swish",
+        decay_type: str = 'Mamba2',
+        topk: int = 32,
+        bias_rmm: bool = False,
+        add_gumbel_noise: bool = True,
+        router_score: str = 'sigmoid',
+        router_type: str = 'lin',
+        use_rope: bool = False,
+        rope_theta: float = 10000.,
+        elementwise_affine: bool | None = True,
+        norm_eps: float = 1e-6,
+        attn: dict | None = None,
+        use_cache: bool = True,
+        pad_token_id: int | None = None,
+        bos_token_id: int = 1,
+        eos_token_id: int = 2,
+        initializer_range: float = 0.02,
+        tie_word_embeddings: bool = False,
+        fuse_norm: bool = True,
+        fuse_swiglu: bool = True,
+        fuse_cross_entropy: bool = True,
+        fuse_linear_cross_entropy: bool = False,
+        use_l2warp: bool = False,
+        vocab_size: int = 32000,
+        attnres_block_size: int | None = None,
+        **kwargs,
+    ):
+        self.hidden_size = hidden_size
+        self.gate_logit_normalizer = gate_logit_normalizer
+        self.clamp_min = clamp_min
+        self.clamp_max = clamp_max
+        self.hidden_ratio = hidden_ratio
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.num_slots = num_slots
+        self.use_short_conv = use_short_conv
+        self.conv_size = conv_size
+        self.expand_k = expand_k
+        self.expand_v = expand_v
+        self.feature_map = feature_map
+        self.use_output_gate = use_output_gate
+        self.use_norm = use_norm
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_act = hidden_act
+        self.decay_type = decay_type
+        self.topk = topk
+        self.bias_rmm = bias_rmm
+        self.add_gumbel_noise = add_gumbel_noise
+        self.router_score = router_score
+        self.router_type = router_type
+        self.use_rope = use_rope
+        self.rope_theta = rope_theta
+        self.elementwise_affine = elementwise_affine
+        self.norm_eps = norm_eps
+        self.attn = attn
+        self.use_cache = use_cache
+        self.initializer_range = initializer_range
+
+        self.fuse_norm = fuse_norm
+        self.fuse_swiglu = fuse_swiglu
+        self.fuse_cross_entropy = fuse_cross_entropy
+        self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
+        self.use_l2warp = use_l2warp
+        self.vocab_size = vocab_size
+        self.attnres_block_size = attnres_block_size
+
+        if fuse_cross_entropy and fuse_linear_cross_entropy:
+            raise ValueError(
+                "`fuse_cross_entropy` and `fuse_linear_cross_entropy` cannot be True at the same time.",
+            )
+        if fuse_linear_cross_entropy:
+            warnings.warn(
+                "`fuse_linear_cross_entropy` is enabled, which can improves memory efficiency "
+                "at the potential cost of reduced precision. "
+                "If you observe issues like loss divergence, consider disabling this setting.",
+            )
+
+        if attn is not None:
+            if not isinstance(attn, dict):
+                raise ValueError("attn must be a dictionary")
+            if 'layers' not in attn:
+                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
+            if 'num_heads' not in attn:
+                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
+            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
+            attn['qkv_bias'] = attn.get('qkv_bias', False)
+            attn['window_size'] = attn.get('window_size', None)
+            attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        if attnres_block_size is not None and attnres_block_size != 1:
+            if attnres_block_size < 2 or attnres_block_size % 2 != 0:
+                raise ValueError(
+                    "`attnres_block_size` must be `None`, `1` (full mode), or an even integer (one block "
+                    f"contains `attnres_block_size // 2` transformer layers); got {attnres_block_size}."
+                )
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/fla/models/raven/modeling_raven.py
+++ b/fla/models/raven/modeling_raven.py
@@ -1,0 +1,472 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+#
+# Portions of this file are adapted from Raven:
+#   Copyright (c) 2023-2025 Arshia Afzal and Aviv Bick
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.nn as nn
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import logging
+from transformers.utils.deprecation import deprecate_kwarg
+
+from fla.layers.attn import Attention
+from fla.layers.raven import Raven
+from fla.models.raven.configuration_raven import RavenConfig
+from fla.models.utils import Cache, FLAGenerationMixin
+from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
+from fla.modules import GatedMLP as RavenMLP
+from fla.modules.l2warp import l2_warp
+from fla.ops.attnres import fused_attnres
+
+if TYPE_CHECKING:
+    from transformers.processing_utils import Unpack
+
+
+try:
+    from transformers.modeling_layers import GradientCheckpointingLayer
+except ImportError:
+    from fla.models.modeling_layers import GradientCheckpointingLayer
+
+logger = logging.get_logger(__name__)
+
+
+class RavenBlock(GradientCheckpointingLayer):
+
+    def __init__(self, config: RavenConfig, layer_idx: int):
+        super().__init__()
+
+        self.config = config
+        self.layer_idx = layer_idx
+
+        self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        if config.attn is not None and layer_idx in config.attn['layers']:
+            self.attn = Attention(
+                hidden_size=config.hidden_size,
+                num_heads=config.attn['num_heads'],
+                num_kv_heads=config.attn['num_kv_heads'],
+                qkv_bias=config.attn['qkv_bias'],
+                window_size=config.attn['window_size'],
+                rope_theta=config.attn['rope_theta'],
+                max_position_embeddings=config.max_position_embeddings,
+                layer_idx=layer_idx,
+            )
+        else:
+            self.attn = Raven(
+                hidden_size=config.hidden_size,
+                expand_k=config.expand_k,
+                expand_v=config.expand_v,
+                num_heads=config.num_heads,
+                num_kv_heads=config.num_kv_heads,
+                num_slots=config.num_slots,
+                use_short_conv=config.use_short_conv,
+                conv_size=config.conv_size,
+                feature_map=config.feature_map,
+                use_output_gate=config.use_output_gate,
+                use_norm=config.use_norm,
+                gate_fn=config.hidden_act,
+                decay_type=config.decay_type,
+                topk=config.topk,
+                bias_rmm=config.bias_rmm,
+                add_gumbel_noise=config.add_gumbel_noise,
+                router_score=config.router_score,
+                router_type=config.router_type,
+                use_rope=config.use_rope,
+                rope_theta=config.rope_theta,
+                max_position_embeddings=config.max_position_embeddings,
+                gate_logit_normalizer=config.gate_logit_normalizer,
+                elementwise_affine=config.elementwise_affine,
+                norm_eps=config.norm_eps,
+                fuse_norm=config.fuse_norm,
+                layer_idx=layer_idx,
+            )
+        self.mlp_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        self.mlp = RavenMLP(
+            hidden_size=config.hidden_size,
+            hidden_ratio=config.hidden_ratio,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            fuse_swiglu=config.fuse_swiglu,
+        )
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.attn_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.attn_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.mlp_res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            block_size = config.attnres_block_size
+            self.attnres_is_attn_boundary = (2 * layer_idx) % block_size == 0
+            self.attnres_is_mlp_boundary = (2 * layer_idx + 1) % block_size == 0
+            self.attn_res_proj._is_attnres_proj = True
+            self.mlp_res_proj._is_attnres_proj = True
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        use_cache: bool | None = False,
+        output_attentions: bool | None = False,
+        attnres_states: list[torch.Tensor] | None = None,
+        **kwargs: Unpack[dict],
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
+        if self.use_attnres:
+            prefix_sum = hidden_states
+            if attnres_states is None:
+                # L=1 single-source: attnres is trivially identity (p=1, mix=v[0]);
+                # apply the prenorm directly, matching the L>1 kernel path which
+                # folds it via `output_rms_weight`. Mirrors Megatron-LM's bypass
+                # at the first layer (where `block_residual` is empty).
+                hidden_states = self.attn_norm(prefix_sum)
+                attnres_states = [prefix_sum]
+                prefix_sum = None
+            else:
+                residuals = [*attnres_states, prefix_sum]
+                if self.attnres_is_attn_boundary:
+                    attnres_states = residuals
+                    prefix_sum = None
+                hidden_states = fused_attnres(
+                    query=self.attn_res_proj.weight,
+                    residuals=residuals,
+                    rms_weight=self.attn_res_norm.weight,
+                    output_rms_weight=self.attn_norm.weight,
+                    rms_eps=self.attn_res_norm.eps,
+                )
+        else:
+            residual = hidden_states
+            hidden_states = self.attn_norm(hidden_states)
+        hidden_states, attentions, past_key_values = self.attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            **kwargs,
+        )
+
+        if self.use_attnres:
+            prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+            residuals = [*attnres_states, prefix_sum]
+            if self.attnres_is_mlp_boundary:
+                attnres_states = residuals
+                prefix_sum = None
+            hidden_states = fused_attnres(
+                query=self.mlp_res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.mlp_res_norm.weight,
+                output_rms_weight=self.mlp_norm.weight,
+                rms_eps=self.mlp_res_norm.eps,
+            )
+        elif self.config.fuse_norm:
+            hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
+        else:
+            hidden_states = residual + hidden_states
+            residual = hidden_states
+            hidden_states = self.mlp_norm(hidden_states)
+        hidden_states = self.mlp(hidden_states, **kwargs)
+
+        if self.use_attnres:
+            hidden_states = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        else:
+            hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values, attnres_states)
+
+        return outputs
+
+
+class RavenPreTrainedModel(PreTrainedModel):
+
+    config_class = RavenConfig
+    base_model_prefix = 'model'
+    supports_gradient_checkpointing = True
+    _no_split_modules = ['RavenBlock']
+    _supports_cache_class = True
+
+    def __init__(self, *inputs, **kwargs):
+        super().__init__(*inputs, **kwargs)
+
+    def _init_weights(
+        self,
+        module: nn.Module,
+        prenorm_residual_strategy: str | None = None,
+        num_residuals_per_layer: int = 2,
+    ):
+        if isinstance(module, (nn.Linear, nn.Conv1d)):
+            if getattr(module, '_is_attnres_proj', False):
+                nn.init.zeros_(module.weight)
+            else:
+                # Slightly different from the TF version which uses truncated_normal for initialization
+                # cf https://github.com/pytorch/pytorch/pull/5617
+                nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+        elif hasattr(module, 'reset_parameters'):
+            module.reset_parameters()
+
+        if prenorm_residual_strategy is not None:
+            # Reinitialize selected weights subject to the OpenAI GPT-2 Paper Scheme:
+            #   > A modified initialization which accounts for the accumulation on the residual path with model depth. Scale
+            #   > the weights of residual layers at initialization by a factor of 1/√N where N is the # of residual layers.
+            #   >   -- GPT-2 :: https://openai.com/blog/better-language-models/
+            #
+            # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
+            p = None
+            if hasattr(module, 'o_proj'):
+                p = module.o_proj.weight
+            elif hasattr(module, 'down_proj'):
+                p = module.down_proj.weight
+            if p is not None:
+                # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
+                # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
+                # We need to reinit p since this code could be called multiple times
+                # Having just p *= scale would repeatedly scale it down
+                if prenorm_residual_strategy == 'rescale':
+                    nn.init.kaiming_uniform_(p, a=math.sqrt(5))
+                    with torch.no_grad():
+                        p /= math.sqrt(num_residuals_per_layer * self.config.num_hidden_layers)
+                elif prenorm_residual_strategy == 'zero':
+                    nn.init.zeros_(p)
+                else:
+                    raise ValueError(f"Invalid prenorm_residual_strategy: {prenorm_residual_strategy}")
+
+
+class RavenModel(RavenPreTrainedModel):
+
+    def __init__(self, config: RavenConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([RavenBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
+        self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.use_attnres = config.attnres_block_size is not None
+        if self.use_attnres:
+            self.res_proj = nn.Linear(in_features=config.hidden_size, out_features=1, bias=False)
+            self.res_norm = nn.RMSNorm(normalized_shape=config.hidden_size, eps=config.norm_eps)
+            self.res_proj._is_attnres_proj = True
+
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embeddings
+
+    def set_input_embeddings(self, value):
+        self.embeddings = value
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: Optional[torch.Tensor] = None,  # noqa
+        inputs_embeds: torch.FloatTensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        **kwargs: Unpack[dict],
+    ) -> tuple | BaseModelOutputWithPast:
+        if output_attentions:
+            warnings.warn("`RavenModel` does not `output_attentions` now, setting it to `False`.")
+            output_attentions = False
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        use_cache = use_cache if use_cache is not None else (self.config.use_cache if not self.training else False)
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # retrieve input_ids and inputs_embeds
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embeddings(input_ids)
+        hidden_states = inputs_embeds
+
+        if use_cache and not isinstance(past_key_values, Cache):
+            past_key_values = Cache.from_legacy_cache(past_key_values)
+
+        attnres_states: list[torch.Tensor] | None = None
+
+        all_hidden_states = () if output_hidden_states else None
+        all_attns = () if output_attentions else None
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            hidden_states, attentions, past_key_values, attnres_states = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                attnres_states=attnres_states,
+                **kwargs,
+            )
+
+            if output_attentions:
+                all_attns += (attentions,)
+
+        if self.use_attnres:
+            # top-level attnres aggregation; `self.norm` is folded into the
+            # kernel via `output_rms_weight` so we don't double-norm.
+            residuals = [*attnres_states, hidden_states]
+            hidden_states = fused_attnres(
+                query=self.res_proj.weight,
+                residuals=residuals,
+                rms_weight=self.res_norm.weight,
+                output_rms_weight=self.norm.weight,
+                rms_eps=self.res_norm.eps,
+            )
+        else:
+            hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(i for i in [hidden_states, past_key_values, all_hidden_states, all_attns] if i is not None)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            hidden_states=all_hidden_states,
+            attentions=all_attns,
+        )
+
+
+class RavenForCausalLM(RavenPreTrainedModel, FLAGenerationMixin):
+
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config):
+
+        super().__init__(config)
+        self.model = RavenModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.criterion = None
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embeddings
+
+    def set_input_embeddings(self, value):
+        self.model.embeddings = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def generate(self, *args, **kwargs):
+        try:
+            return super().generate(*args, **kwargs)
+        except AttributeError as exception:
+            if 'past_key_values' in str(exception):
+                raise AttributeError(
+                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
+                    f"which is not supported for {self.__class__.__name__}. "
+                    f"Try another generation strategy instead. "
+                    f"For the available generation strategies, check this doc: "
+                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
+                )
+            else:
+                raise exception
+
+    @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        logits_to_keep: int | None = 0,
+        **kwargs: Unpack[dict],
+    ) -> tuple | CausalLMOutputWithPast:
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs,
+        )
+
+        hidden_states = outputs[0]
+
+        loss, logits = None, None
+        if not self.config.fuse_linear_cross_entropy or labels is None:
+            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+        if labels is not None:
+            if getattr(self, 'criterion', None) is None:
+                if self.config.fuse_linear_cross_entropy:
+                    criterion = FusedLinearCrossEntropyLoss(use_l2warp=self.config.use_l2warp)
+                elif self.config.fuse_cross_entropy:
+                    criterion = FusedCrossEntropyLoss(inplace_backward=True)
+                else:
+                    criterion = nn.CrossEntropyLoss()
+            else:
+                criterion = self.criterion
+            # Enable model parallelism
+            labels = labels.to(hidden_states.device)
+            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            if self.config.fuse_linear_cross_entropy:
+                loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
+            else:
+                loss = criterion(logits.view(labels.numel(), -1), labels.view(-1))
+                loss = l2_warp(loss, logits) if self.config.use_l2warp else loss
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )

--- a/tests/layers/test_layer_cache_layer_idx.py
+++ b/tests/layers/test_layer_cache_layer_idx.py
@@ -26,6 +26,7 @@ from fla.layers.mamba2 import Mamba2
 from fla.layers.mesa_net import MesaNet
 from fla.layers.mom import MomAttention
 from fla.layers.multiscale_retention import MultiScaleRetention
+from fla.layers.raven import Raven
 from fla.layers.rodimus import RodimusAttention
 from fla.layers.rwkv6 import RWKV6Attention
 from fla.layers.rwkv7 import RWKV7Attention
@@ -140,6 +141,11 @@ CACHE_REQUIRES_LAYER_IDX_CASES = [
         lambda: GatedSlotAttention(hidden_size=16, num_heads=4),
         torch.randn(1, 2, 16),
         id="gsa",
+    ),
+    pytest.param(
+        lambda: Raven(hidden_size=16, num_heads=4, num_slots=4, topk=2),
+        torch.randn(1, 2, 16),
+        id="raven",
     ),
     pytest.param(
         lambda: GatedLinearAttention(hidden_size=16, num_heads=4),

--- a/tests/models/test_modeling_raven.py
+++ b/tests/models/test_modeling_raven.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.models import RavenConfig
+
+from .test_modeling_base import run_test_generation, run_test_model_forward_backward
+
+
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'decay_type', 'use_output_gate', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-l2{}-decay{}-og{}-{}".format(*test))
+        for test in [
+            (4, 4, 1024, 4, 64, False, 'Mamba2', False, torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, 'GLA', True, torch.bfloat16),
+        ]
+    ],
+)
+def test_modeling(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    use_l2warp: bool,
+    decay_type: str,
+    use_output_gate: bool,
+    dtype: torch.dtype,
+):
+    run_test_model_forward_backward(
+        L,
+        B,
+        T,
+        H,
+        D,
+        RavenConfig,
+        use_l2warp=use_l2warp,
+        add_gumbel_noise=False,
+        decay_type=decay_type,
+        use_output_gate=use_output_gate,
+        dtype=dtype,
+    )
+
+
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 4, 2000, 8, 64, torch.float16),
+        ]
+    ],
+)
+def test_generation(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    run_test_generation(L, B, T, H, D, RavenConfig, dtype)


### PR DESCRIPTION
## Summary

This PR adds Raven support to FLA.

It includes:
- `Raven` in `fla.layers`
- `RavenConfig`, `RavenModel`, and `RavenForCausalLM` in `fla.models.raven`
- package exports through `fla.layers` and `fla.models`
- README news/model entries, with the paper linked as [Raven: High-Recall Sequence Modeling with Sparse Memory Routing](https://github.com/goombalab/raven/blob/main/raven.pdf)
- Raven coverage in model and cache-layer tests

## Validation

- `git diff --check`
- `python -m compileall -q fla/layers/raven.py fla/models/raven tests/layers/test_layer_cache_layer_idx.py`
- Full Raven training/eval sanity run on SlimPajama through the completed checkpoint/eval flow