### PR TITLE
[Fix] Fix packed varlen launch

### DIFF
--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -526,7 +526,7 @@ class TokenShift(torch.autograd.Function):
                                          ctx.use_short_kernel, ctx.has_cache, ctx.chunk_indices)
         return dx, None, grad_cache, None, None
 
-
+@torch.compiler.disable
 def token_shift(
     x: torch.Tensor,
     cu_seqlens: torch.LongTensor | None = None,

--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -527,6 +527,7 @@ class TokenShift(torch.autograd.Function):
                                          ctx.use_short_kernel, ctx.has_cache, ctx.chunk_indices)
         return dx, None, grad_cache, None, None
 
+
 @torch.compiler.disable
 def token_shift(
     x: torch.Tensor,

--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -338,6 +338,7 @@ def token_shift_bwd_kernel_long(
         t_start = i_t_blk * BT
         t_end = tl.minimum(t_start + BT, eos - bos)
     else:
+        i_n = i_b
         bos, eos = i_b * T, (i_b + 1) * T
         t_start = i_t_blk * BT
         t_end = tl.minimum(t_start + BT, T)

--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -169,11 +169,13 @@ def token_shift_fwd_kernel_long(
     BD: tl.constexpr,
     BT: tl.constexpr,
     NB: tl.constexpr,
+    ND: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
 ):
-    i_d, i_t, i_b = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_dt, i_b = tl.program_id(0), tl.program_id(1)
+    i_d, i_t = i_dt % ND, i_dt // ND
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), \
@@ -321,11 +323,13 @@ def token_shift_bwd_kernel_long(
     BD: tl.constexpr,
     BT: tl.constexpr,
     NB: tl.constexpr,
+    ND: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     HAS_DCACHE: tl.constexpr,
 ):
-    i_d, i_t_blk, i_b = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_dt, i_b = tl.program_id(0), tl.program_id(1)
+    i_d, i_t_blk = i_dt % ND, i_dt // ND
 
     if IS_VARLEN:
         i_n, i_t_blk = tl.load(chunk_indices + i_t_blk * 2).to(tl.int32), \
@@ -378,13 +382,14 @@ def token_shift_fwd(
 ) -> torch.Tensor:
     B, T, D = x.shape
     y = torch.empty_like(x)
-    use_short_kernel = T <= 4096
 
     if cu_seqlens is not None:
         T = prepare_maxlens(cu_seqlens)
         N = len(cu_seqlens) - 1
     else:
         N = B
+
+    use_short_kernel = T <= 4096
 
     if output_cache:
         cache_out = torch.empty((N, D), device=x.device, dtype=x.dtype)
@@ -418,9 +423,10 @@ def token_shift_fwd(
         NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
 
         BD = triton.next_power_of_2(D)
+        ND = triton.cdiv(D, BD)
         NB = triton.cdiv(B*T, 1024)
 
-        def grid(meta): return (triton.cdiv(D, meta['BD']), NT, N)
+        def grid(meta): return (ND * NT, 1 if cu_seqlens is not None else N)
         token_shift_fwd_kernel_long[grid](
             x,
             y,
@@ -433,6 +439,7 @@ def token_shift_fwd(
             BD=BD,
             BT=BT,
             NB=NB,
+            ND=ND,
             STORE_FINAL_STATE=output_cache,
         )
 
@@ -476,8 +483,9 @@ def token_shift_bwd(
         NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
         NB = triton.cdiv(N * dy.shape[1], 1024)
         BD = triton.next_power_of_2(D)
+        ND = triton.cdiv(D, BD)
 
-        def grid(meta): return (triton.cdiv(D, meta['BD']), NT, N)
+        def grid(meta): return (ND * NT, 1 if cu_seqlens is not None else N)
         token_shift_bwd_kernel_long[grid](
             dx,
             dy,
@@ -490,6 +498,7 @@ def token_shift_bwd(
             BD=BD,
             BT=BT,
             NB=NB,
+            ND=ND,
         )
     return dx, grad_cache_out
 

--- a/fla/modules/token_shift_cp.py
+++ b/fla/modules/token_shift_cp.py
@@ -199,6 +199,7 @@ class TokenShiftCPFunction(torch.autograd.Function):
 
         return dx, None, None, None
 
+
 @torch.compiler.disable
 def token_shift_cp(
     x: torch.Tensor,

--- a/fla/modules/token_shift_cp.py
+++ b/fla/modules/token_shift_cp.py
@@ -199,7 +199,7 @@ class TokenShiftCPFunction(torch.autograd.Function):
 
         return dx, None, None, None
 
-
+@torch.compiler.disable
 def token_shift_cp(
     x: torch.Tensor,
     cp_context: FLACPContext,

--- a/tests/modules/test_token_shift.py
+++ b/tests/modules/test_token_shift.py
@@ -7,6 +7,7 @@
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 from fla.modules.token_shift import token_shift, token_shift_ref
 from fla.utils import assert_close, device
@@ -137,3 +138,43 @@ def test_all_with_and_without_varlen(B, T, H, cu_seqlens, split_at):
     dtype = torch.float
     assert cu_seqlens is None, "This test is for cu_seqlens=None case"
     _check_passing_vs_whole(B, T, H, cu_seqlens, dtype, split_at)
+
+
+def _packed_cu_seqlens(total_tokens: int, doc_len: int) -> torch.Tensor:
+    n_docs = (total_tokens + doc_len - 1) // doc_len
+    lens = torch.full((n_docs,), doc_len, device=device, dtype=torch.long)
+    lens[-1] -= n_docs * doc_len - total_tokens
+    return F.pad(lens.cumsum(0), (1, 0))
+
+
+def test_token_shift_varlen_uses_max_doc_len_for_short_kernel():
+    total_tokens, hidden_size = 262_144, 8
+    torch.manual_seed(42)
+
+    cu_seqlens = _packed_cu_seqlens(total_tokens, doc_len=752)
+    x = torch.randn(1, total_tokens, hidden_size, device=device, dtype=torch.bfloat16)
+
+    ref = token_shift_ref(x, cu_seqlens)
+    tri = token_shift(x, cu_seqlens)
+
+    assert_close(" x", ref, tri, 1e-3)
+
+
+def test_token_shift_varlen_long_kernel_matches_reference():
+    cu_seqlens = torch.tensor([0, 4097, 8200, 12304], dtype=torch.long, device=device)
+    torch.manual_seed(42)
+
+    x = torch.randn(1, cu_seqlens[-1].item(), 32, device=device, dtype=torch.float, requires_grad=True)
+    dy = torch.randn_like(x)
+
+    ref = token_shift_ref(x, cu_seqlens)
+    tri = token_shift(x, cu_seqlens)
+
+    ref.backward(dy)
+    ref_dx, x.grad = x.grad.clone(), None
+
+    tri.backward(dy)
+    tri_dx, x.grad = x.grad.clone(), None
+
+    assert_close(" x", ref, tri, 1e-3)
+    assert_close("dx", ref_dx, tri_dx, 1e-3)


### PR DESCRIPTION
Select the token_shift short/long kernel from max(cu_seqlens.diff()) in varlen mode instead of the flat packed length.

Flatten the long-kernel (D-block, time-chunk) launch onto grid-x and use a single varlen grid-y lane because chunk_indices already carries the document id. This avoids CUDA grid-y overflow at NT >= 65536.

Add regressions for the packed short-document repro and varlen long-kernel forward/backward correctness.

Resolves #903 