### PR TITLE
[Fix] Correct RWKV7 gate output chunk mask

### DIFF
--- a/fla/ops/rwkv7/gate_output_correction.py
+++ b/fla/ops/rwkv7/gate_output_correction.py
@@ -86,9 +86,9 @@ def gate_output_correction_fwd_kernel(
 ):
     pid_b, pid_t_block = tl.program_id(0), tl.program_id(1)
     pid_h = tl.program_id(2)
-    t_start = pid_t_block * BT + T_OFFSET
-    t_idx = t_start + tl.arange(0, BT)[:, None]
-    mask_t = t_idx < T
+    t_local = pid_t_block * BT + tl.arange(0, BT)[:, None]
+    t_idx = T_OFFSET + t_local
+    mask_t = t_local < T
 
     d_idx = tl.arange(0, BLOCK_SIZE_D)[None, :]
     mask_d = d_idx < head_dim
@@ -137,8 +137,9 @@ def gate_output_correction_bwd_kernel(
     pid_b, pid_t_block = tl.program_id(0), tl.program_id(1)
     pid_h = tl.program_id(2)
 
-    t_idx = pid_t_block * BT + T_OFFSET + tl.arange(0, BT)[:, None]
-    mask_t = t_idx < T
+    t_local = pid_t_block * BT + tl.arange(0, BT)[:, None]
+    t_idx = T_OFFSET + t_local
+    mask_t = t_local < T
 
     d_idx = tl.arange(0, BLOCK_SIZE_D)[None, :]
     mask_d = d_idx < head_dim
@@ -248,4 +249,29 @@ class GateOutputCorrection(torch.autograd.Function):
         return gate_output_correction_backward_triton(grad_output, o, r, k, r_k, v, g)
 
 
-gate_output_correction = GateOutputCorrection.apply
+def gate_output_correction(
+    o: torch.Tensor,
+    r: torch.Tensor,
+    k: torch.Tensor,
+    r_k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Apply the RWKV7 output correction and output gate.
+
+    Computes ``(o + correction) * g``, where
+    ``correction = ((r * k * r_k).sum(-1, keepdim=True) * v).view_as(o)``.
+
+    Args:
+        o: Output tensor before correction, shape `[B, T, H * D]`.
+        r: Receptance tensor, shape `[B, T, H, D]`.
+        k: Key tensor, shape `[B, T, H, D]`.
+        r_k: Per-head correction weight, shape `[H, D]`.
+        v: Value tensor, shape `[B, T, H, D]`.
+        g: Output gate tensor, shape `[B, T, H * D]`.
+
+    Returns:
+        Corrected and gated output tensor with the same shape as `o`.
+    """
+    return GateOutputCorrection.apply(o, r, k, r_k, v, g)

--- a/fla/ops/rwkv7/gate_output_correction.py
+++ b/fla/ops/rwkv7/gate_output_correction.py
@@ -249,6 +249,7 @@ class GateOutputCorrection(torch.autograd.Function):
         return gate_output_correction_backward_triton(grad_output, o, r, k, r_k, v, g)
 
 
+@torch.compiler.disable
 def gate_output_correction(
     o: torch.Tensor,
     r: torch.Tensor,

--- a/tests/ops/test_rwkv7.py
+++ b/tests/ops/test_rwkv7.py
@@ -265,11 +265,13 @@ def test_fused_k_update(
     assert_close("dka", ref_dka, ka.grad, ratio=ratio)
 
 
-@pytest.mark.parametrize("B", [4])
-@pytest.mark.parametrize("T", [4096])
-@pytest.mark.parametrize("H", [64])
-@pytest.mark.parametrize("D", [64])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "dtype"),
+    [
+        pytest.param(4, 4096, 64, 64, torch.bfloat16, id="default"),
+        pytest.param(1, 65537, 8, 64, torch.bfloat16, id="long_ctx"),
+    ],
+)
 def test_gate_output_correction(
     B: int,
     T: int,


### PR DESCRIPTION
Compare chunk-local token indices against the chunk size in the gate_output_correction forward and backward kernels, while keeping absolute token indices for memory offsets. The previous mask compared absolute indices with the local chunk size and skipped tail chunks after the first 65536 tokens.

Add a T=65537 regression case for forward/backward parity with the reference, and expose gate_output_correction through a typed wrapper with shape docs.

Resolved #906 