### PR TITLE
[Ops] Tidy attnres fused kernels: drop DTYPE, rename BL to L2

### DIFF
--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -22,17 +22,6 @@ from fla.utils import (
     input_guard,
 )
 
-# residual sources are passed as separately allocated tensors and accessed inside kernels via a length-BL tuple of
-# tensor arguments. the caller never has to `torch.stack` / `torch.cat` them. Each kernel selects per-row base pointers
-# from the tuple via a static-range `tl.where`, then broadcasts against inner D offsets to form `[BL, BD]` tiles of
-# independent global addresses. OOB rows (l >= L) are filled with the first tuple entry (a padding copy that is never
-# read or written) and masked by `m_l`.
-_TORCH_TO_TL_DTYPE = {
-    torch.float16: tl.float16,
-    torch.float32: tl.float32,
-    torch.bfloat16: tl.bfloat16,
-}
-
 
 @fla_cache_autotune(
     configs=[
@@ -40,10 +29,10 @@ _TORCH_TO_TL_DTYPE = {
         for BD, num_warps in [(64, 1), (128, 2), (256, 4), (512, 4), (1024, 8)]
         for num_stages in [3, 4]
     ],
-    key=['L', 'D', 'HAS_ONORM'],
+    key=['L2', 'D', 'HAS_ONORM'],
     **autotune_cache_kwargs,
 )
-@triton.jit
+@triton.jit(do_not_specialize=['L'])
 def attnres_fwd_kernel(
     q,
     res,
@@ -55,39 +44,39 @@ def attnres_fwd_kernel(
     ow,
     o_rstd,
     N,
-    L: tl.constexpr,
+    L,
+    L2: tl.constexpr,
     D: tl.constexpr,
     eps: tl.constexpr,
     scale: tl.constexpr,
-    BL: tl.constexpr,
     BD: tl.constexpr,
     HAS_ONORM: tl.constexpr,
 ):
     i_n = tl.program_id(0).to(tl.int64)
 
-    # [BL]
-    o_l = tl.arange(0, BL)
+    # [L2]
+    o_l = tl.arange(0, L2)
     m_l = o_l < L
 
     # one-time construction of source base pointers; reused across all D-loops below.
-    # `BL` is constexpr so the tl.where chain unrolls and folds at compile time.
+    # `L2` is constexpr so the tl.where chain unrolls and folds at compile time.
     p_v = res[0] + o_l * 0
-    for i in tl.static_range(1, BL):
+    for i in tl.static_range(1, L2):
         p_v = tl.where(o_l == i, res[i], p_v)
     # each residual storage is 16-byte aligned (the torch CUDA allocator is 256-byte aligned), so Triton can use wide loads.
     p_v = tl.multiple_of(p_v, 16)
 
-    # [BL]
-    b_var = tl.zeros([BL], dtype=tl.float32)
-    b_logit = tl.zeros([BL], dtype=tl.float32)
+    # [L2]
+    b_var = tl.zeros([L2], dtype=tl.float32)
+    b_logit = tl.zeros([L2], dtype=tl.float32)
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
-        # hint that o_d is a contiguous stride-1 BD tile so Triton coalesces loads over the [BL, BD] pointer tile.
+        # hint that o_d is a contiguous stride-1 BD tile so Triton coalesces loads over the [L2, BD] pointer tile.
         # otherwise, `p_v[:, None] + offs[None, :]` looks opaque and becomes scattered loads.
         o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
-        # [BL, BD] gather: row l from source l's storage at offset i_n*D + o_d
+        # [L2, BD] gather: row l from source l's storage at offset i_n*D + o_d
         b_v = tl.load(p_v[:, None] + (i_n * D + o_d[None, :]), mask=m_l[:, None] & m_d[None, :], other=0.0).to(tl.float32)
         # [BD]
         b_qw = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32) * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
@@ -95,19 +84,19 @@ def attnres_fwd_kernel(
         b_var += tl.sum(b_v * b_v, axis=1)
         b_logit += tl.sum(b_v * b_qw[None, :], axis=1)
 
-    # [BL]
+    # [L2]
     b_rstd = tl.rsqrt(b_var / D + eps)
     # save `score / D` so bwd_dv does not repeat the full LxD dot product for `sum_d (v * rstd) * (w * q)`.
     b_score = b_logit * b_rstd
     b_logit = b_score * scale
     b_logit = tl.where(m_l, b_logit, -float("inf"))
     b_logit = exp(b_logit - tl.max(b_logit, axis=0))
-    # [BL]
+    # [L2]
     b_p = b_logit / tl.sum(b_logit, axis=0)
 
-    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
-    p_score_mean = tl.make_block_ptr(score_mean + i_n, (L,), (N,), (0,), (BL,), (0,))
-    p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
+    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (L2,), (0,))
+    p_score_mean = tl.make_block_ptr(score_mean + i_n, (L,), (N,), (0,), (L2,), (0,))
+    p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (L2,), (0,))
     tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
     tl.store(p_score_mean, (b_score / D).to(p_score_mean.dtype.element_ty), boundary_check=(0,))
     tl.store(p_p, b_p.to(p_p.dtype.element_ty), boundary_check=(0,))
@@ -118,12 +107,10 @@ def attnres_fwd_kernel(
     b_o_var = tl.zeros([], dtype=tl.float32)
     for i_d in range(0, D, BD):
         o_d = i_d + tl.arange(0, BD)
-        # hint that o_d is a contiguous stride-1 BD tile so Triton coalesces loads over the [BL, BD] pointer tile.
-        # otherwise, `p_v[:, None] + offs[None, :]` looks opaque and becomes scattered loads.
         o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         p_o = tl.make_block_ptr(o + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-        # [BL, BD]
+        # [L2, BD]
         b_v = tl.load(p_v[:, None] + (i_n * D + o_d[None, :]), mask=m_l[:, None] & m_d[None, :], other=0.0).to(tl.float32)
         # [BD]
         b_o = tl.sum(b_v * b_p[:, None], axis=0)
@@ -148,7 +135,7 @@ def attnres_fwd_kernel(
 
 
 @fla_cache_autotune(
-    # bwd_dv carries more BL-axis reductions than fwd (b_dp, b_dp_w, b_dp_x, b_o_c1), plus a scattered dv store with no
+    # bwd_dv carries more L2-axis reductions than fwd (b_dp, b_dp_w, b_dp_x, b_o_c1), plus a scattered dv store with no
     # fwd analogue; explore a wider grid along the per-thread = BD/num_warps contour (32, 64, 128).
     configs=[
         triton.Config({'BD': BD}, num_warps=num_warps, num_stages=num_stages)
@@ -161,10 +148,10 @@ def attnres_fwd_kernel(
         ]
         for num_stages in [3, 4]
     ],
-    key=['L', 'D', 'HAS_ONORM'],
+    key=['L2', 'D', 'HAS_ONORM'],
     **autotune_cache_kwargs,
 )
-@triton.jit
+@triton.jit(do_not_specialize=['L'])
 def attnres_bwd_kernel_dv(
     q,
     res,
@@ -180,31 +167,30 @@ def attnres_bwd_kernel_dv(
     dow_partial,
     N,
     scale: tl.constexpr,
-    L: tl.constexpr,
+    L,
+    L2: tl.constexpr,
     D: tl.constexpr,
-    BL: tl.constexpr,
     BD: tl.constexpr,
     HAS_ONORM: tl.constexpr,
-    DTYPE: tl.constexpr,
 ):
     i_n = tl.program_id(0).to(tl.int64)
 
-    o_l = tl.arange(0, BL)
+    o_l = tl.arange(0, L2)
     m_l = o_l < L
     # one-time construction of source / dv base pointers; reused across all D-loops below.
     p_v = res[0] + o_l * 0
     p_dv = dres[0] + o_l * 0
-    for i in tl.static_range(1, BL):
+    for i in tl.static_range(1, L2):
         p_v = tl.where(o_l == i, res[i], p_v)
         p_dv = tl.where(o_l == i, dres[i], p_dv)
     # each residual storage is 16-byte aligned (the torch CUDA allocator is 256-byte aligned), so Triton can use wide loads.
     p_v = tl.multiple_of(p_v, 16)
     p_dv = tl.multiple_of(p_dv, 16)
 
-    p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (BL,), (0,))
-    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (BL,), (0,))
-    p_score_mean = tl.make_block_ptr(score_mean + i_n, (L,), (N,), (0,), (BL,), (0,))
-    # [BL]
+    p_p = tl.make_block_ptr(p + i_n, (L,), (N,), (0,), (L2,), (0,))
+    p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (0,), (L2,), (0,))
+    p_score_mean = tl.make_block_ptr(score_mean + i_n, (L,), (N,), (0,), (L2,), (0,))
+    # [L2]
     b_p = tl.load(p_p, boundary_check=(0,), padding_option="zero").to(tl.float32)
     b_rstd = tl.load(p_rstd, boundary_check=(0,), padding_option="zero").to(tl.float32)
     b_score_mean = tl.load(p_score_mean, boundary_check=(0,), padding_option="zero").to(tl.float32)
@@ -226,22 +212,22 @@ def attnres_bwd_kernel_dv(
     # no separate pre-pass is needed, and `v` is loaded only once across pass 1.
     b_o_rstd = tl.zeros([], dtype=tl.float32)
     b_o_c1 = tl.zeros([], dtype=tl.float32)
-    b_dp_w = tl.zeros([BL], dtype=tl.float32)
-    b_dp_x = tl.zeros([BL], dtype=tl.float32)
+    b_dp_w = tl.zeros([L2], dtype=tl.float32)
+    b_dp_x = tl.zeros([L2], dtype=tl.float32)
     if HAS_ONORM:
         b_o_rstd = tl.load(o_rstd + i_n).to(tl.float32)
 
-    # [BL]
-    b_dp = tl.zeros([BL], dtype=tl.float32)
+    # [L2]
+    b_dp = tl.zeros([L2], dtype=tl.float32)
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
-        # hint that o_d is a contiguous stride-1 BD tile so Triton coalesces loads over the [BL, BD] pointer tile.
+        # hint that o_d is a contiguous stride-1 BD tile so Triton coalesces loads over the [L2, BD] pointer tile.
         # otherwise, `p_v[:, None] + offs[None, :]` looks opaque and becomes scattered loads.
         o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-        # [BL, BD] — pass 2 reloads the same v tile, so hint L2 to retain.
+        # [L2, BD] — pass 2 reloads the same v tile, so evict_last keeps it cached.
         b_v = tl.load(
             p_v[:, None] + (i_n * D + o_d[None, :]),
             mask=m_l[:, None] & m_d[None, :],
@@ -273,20 +259,18 @@ def attnres_bwd_kernel_dv(
     # softmax bwd via the standard delta trick: delta = sum_l p*dp = sum_d do*o.
     # [1]
     b_delta = tl.sum(b_p * b_dp, axis=0)
-    # [BL]
+    # [L2]
     b_ds = b_p * (b_dp - b_delta) * scale
 
     for i_d in range(0, D, BD):
         # [BD]
         o_d = i_d + tl.arange(0, BD)
-        # hint that o_d is a contiguous stride-1 BD tile so Triton coalesces loads over the [BL, BD] pointer tile.
-        # otherwise, `p_v[:, None] + offs[None, :]` looks opaque and becomes scattered loads.
         o_d = tl.max_contiguous(tl.multiple_of(o_d, BD), BD)
         m_d = o_d < D
         m_v = m_l[:, None] & m_d[None, :]
         p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-        # [BL, BD]
-        # last touch of this v tile; release the L2 line.
+        # [L2, BD]
+        # last touch of this v tile; evict_first releases the cache line.
         b_v = tl.load(
             tl.multiple_of(p_v[:, None] + (i_n * D + o_d[None, :]), (1, 16)),
             mask=m_v,
@@ -303,14 +287,18 @@ def attnres_bwd_kernel_dv(
             b_o_xhat = b_o_pre * b_o_rstd
             b_do = (b_ow * b_do - b_o_xhat * b_o_c1) * b_o_rstd
 
-        # [BL, BD]
+        # [L2, BD]
         b_k = b_v * b_rstd[:, None]
         b_dv = b_p[:, None] * b_do[None, :] + b_ds[:, None] * b_rstd[:, None] * (
             b_qw[None, :] - b_k * b_score_mean[:, None]
         )
 
         p_dqw = tl.make_block_ptr(dqw + i_n * D, (D,), (1,), (i_d,), (BD,), (0,))
-        tl.store(tl.multiple_of(p_dv[:, None] + (i_n * D + o_d[None, :]), (1, 16)), b_dv.to(DTYPE), mask=m_v)
+        tl.store(
+            tl.multiple_of(p_dv[:, None] + (i_n * D + o_d[None, :]), (1, 16)),
+            b_dv.to(dres[0].dtype.element_ty),
+            mask=m_v,
+        )
         # [BD]
         tl.store(p_dqw, tl.sum(b_ds[:, None] * b_k, axis=0), boundary_check=(0,))
 
@@ -369,13 +357,13 @@ def attnres_bwd_kernel_dqdw(
 
 
 def _build_ptr_table(tensors: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
-    # pad the per-source tensor tuple to a fixed length so Triton can compile a single kernel per BL bucket.
+    # pad the per-source tensor tuple to a fixed length so Triton can compile a single kernel per L2 bucket.
     # the tuple length is part of the kernel's compile signature; padded slots are address-only (never read/written).
-    BL = max(8, triton.next_power_of_2(len(tensors)))
-    assert 1 <= len(tensors) <= BL
+    L2 = max(8, triton.next_power_of_2(len(tensors)))
+    assert 1 <= len(tensors) <= L2
     for t in tensors:
         assert t.data_ptr() % 16 == 0, "attnres residual sources must be 16-byte aligned"
-    return tuple(tensors) + (tensors[0],) * (BL - len(tensors))
+    return tuple(tensors) + (tensors[0],) * (L2 - len(tensors))
 
 
 def fused_attnres_fwd(
@@ -394,9 +382,6 @@ def fused_attnres_fwd(
     L, N, D = len(residuals), residuals[0].numel() // output_shape[-1], output_shape[-1]
 
     dtype = residuals[0].dtype
-    if dtype not in _TORCH_TO_TL_DTYPE:
-        raise ValueError(f"Unsupported residual dtype for fused_attnres: {dtype}")
-
     stats_shape = (L, *output_shape[:-1])
 
     has_onorm = ow is not None
@@ -409,7 +394,7 @@ def fused_attnres_fwd(
     else:
         o_rstd = None
 
-    BL = max(8, triton.next_power_of_2(L))
+    L2 = max(8, triton.next_power_of_2(L))
     attnres_fwd_kernel[(N,)](
         q=q,
         res=res,
@@ -422,10 +407,10 @@ def fused_attnres_fwd(
         o_rstd=o_rstd,
         N=N,
         L=L,
+        L2=L2,
         D=D,
         eps=eps,
         scale=scale,
-        BL=BL,
         HAS_ONORM=has_onorm,
     )
 
@@ -446,8 +431,6 @@ def fused_attnres_bwd(
     scale: float,
 ) -> tuple[list[torch.Tensor], torch.Tensor, torch.Tensor, torch.Tensor | None]:
     L, N, D = len(residuals), do.numel() // do.shape[-1], do.shape[-1]
-    dtype = residuals[0].dtype
-    DTYPE = _TORCH_TO_TL_DTYPE[dtype]
 
     # output RMSNorm bwd is folded into the attnres kernels. The first D-loop derives `c1_o`, writes `dow_partial`, and
     # rebuilds `o_pre = sum_l p_l * v_l` inline so it is not saved across fwd->bwd.
@@ -467,7 +450,7 @@ def fused_attnres_bwd(
     dq = torch.empty_like(q)
     dw = torch.empty_like(w)
 
-    BL = max(8, triton.next_power_of_2(L))
+    L2 = max(8, triton.next_power_of_2(L))
     attnres_bwd_kernel_dv[(N,)](
         q=q,
         res=res,
@@ -484,10 +467,9 @@ def fused_attnres_bwd(
         N=N,
         scale=scale,
         L=L,
+        L2=L2,
         D=D,
-        BL=BL,
         HAS_ONORM=has_onorm,
-        DTYPE=DTYPE,
     )
 
     def grid(meta): return (triton.cdiv(D, meta['BD']),)


### PR DESCRIPTION
## What

Follow-up cleanup of `fla/ops/attnres/fused.py` after #912 (int64 ptr table → padded tensor tuple). No functional change for valid inputs.

- **Drop the `DTYPE` constexpr from `attnres_bwd_kernel_dv`.** #912 removed the `tl.pointer_type(DTYPE)` cast, leaving the dv store cast `b_dv.to(DTYPE)` as the only consumer. Read the dtype straight from the tuple instead — `dres[0].dtype.element_ty`, the same idiom the fwd kernel already uses for its block-ptr stores — and remove the constexpr plus its host-side plumbing.
- **Drop `_TORCH_TO_TL_DTYPE` and the dtype allowlist.** It only ever fed `DTYPE` and a membership check. With `DTYPE` gone the kernel reads the dtype from its tensor args, so the allowlist no longer maps to any kernel requirement.
- **Rename `BL` → `L2`.** `BL` was misleading: it is `next_power_of_2(L)` — the padded residual-tuple length covered by a single block — not a tunable tile. Along with the rename: make `L` a runtime arg (`do_not_specialize=['L']`), key autotune on `L2` so the `L` values that round to the same power of two share one specialization/autotune entry, and move `L2` next to `L` in both kernel signatures and launch calls.
- **Comments.** Remove the duplicated `tl.max_contiguous` hint repeated across the D-loops; reword the v-tile eviction comments that used "L2" to mean the hardware L2 cache (now collides with the constexpr name).

## Testing

Local: `ruff` clean, module imports. Kernel compilation is lazy, so please rely on CI / a GPU run of `tests/ops/test_attnres.py` to confirm numerics and gradients — the `L`-runtime / `L2`-key change affects specialization (`L` is only used for masks and block-ptr shapes, both valid as runtime values, so behavior should be identical).
