### PR TITLE
Add reference higher-order linear attention

### DIFF
--- a/fla/layers/__init__.py
+++ b/fla/layers/__init__.py
@@ -19,6 +19,7 @@ from .gla import GatedLinearAttention
 from .gsa import GatedSlotAttention
 from .hgrn import HGRNAttention
 from .hgrn2 import HGRN2Attention
+from .hla import HigherOrderLinearAttention
 from .kda import KimiDeltaAttention
 from .lightnet import LightNetAttention
 from .linear_attn import LinearAttention
@@ -55,6 +56,7 @@ __all__ = [
     'GatedSlotAttention',
     'HGRN2Attention',
     'HGRNAttention',
+    'HigherOrderLinearAttention',
     'KimiDeltaAttention',
     'LightNetAttention',
     'LinearAttention',

--- a/fla/layers/hla.py
+++ b/fla/layers/hla.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+from einops import rearrange, repeat
+
+from fla.layers.utils import get_layer_cache, update_layer_cache
+from fla.modules import RMSNorm
+from fla.ops.hla import recurrent_hla
+
+if TYPE_CHECKING:
+    from fla.models.utils import Cache
+
+
+class HigherOrderLinearAttention(nn.Module):
+    """
+    Second-order Higher-order Linear Attention (HLA).
+
+    This is a reference FLA layer for the masked second-order operator from
+    "Higher-order Linear Attention" (arXiv:2510.27258). It exposes a standard
+    FLA recurrent-layer interface and uses the exact streaming identity with
+    state tuple ``(S, C, m, G, h)``. The implementation is intentionally kept as
+    a PyTorch baseline; chunk/Triton kernels can replace ``recurrent_hla`` while
+    preserving this API.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 1024,
+        expand_v: float = 1.0,
+        head_dim: int = 64,
+        num_heads: int = 8,
+        num_v_heads: int | None = None,
+        mode: str = "recurrent",
+        normalize: bool = False,
+        eps: float = 1e-6,
+        ridge: float = 0.0,
+        output_norm: str = "rmsnorm",
+        elementwise_affine: bool = True,
+        norm_eps: float = 1e-5,
+        layer_idx: int | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+
+        if mode not in {"recurrent", "fused_recurrent"}:
+            raise ValueError(f"Unsupported mode `{mode}`.")
+        self.hidden_size = hidden_size
+        self.expand_v = expand_v
+        self.head_dim = head_dim
+        self.head_v_dim = int(head_dim * expand_v)
+        self.num_heads = num_heads
+        self.num_v_heads = num_heads if num_v_heads is None else num_v_heads
+        self.mode = mode
+        self.normalize = normalize
+        self.eps = eps
+        self.ridge = ridge
+        self.layer_idx = layer_idx
+
+        if hidden_size <= 0:
+            raise ValueError("`hidden_size` must be positive.")
+        if head_dim <= 0:
+            raise ValueError("`head_dim` must be positive.")
+        if num_heads <= 0 or self.num_v_heads <= 0:
+            raise ValueError("`num_heads` and `num_v_heads` must be positive.")
+        if self.num_v_heads % self.num_heads != 0:
+            raise ValueError(
+                f"`num_v_heads` must be divisible by `num_heads`, got {self.num_v_heads} and {self.num_heads}."
+            )
+        if self.head_v_dim <= 0:
+            raise ValueError("`head_dim * expand_v` must be positive.")
+
+        self.key_dim = self.num_heads * self.head_dim
+        self.value_dim = self.num_v_heads * self.head_v_dim
+        self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, self.value_dim, bias=False)
+
+        if output_norm == "rmsnorm":
+            self.norm = RMSNorm(
+                hidden_size=self.head_v_dim,
+                elementwise_affine=elementwise_affine,
+                eps=norm_eps,
+                dtype=torch.float32,
+            )
+        elif output_norm == "identity":
+            self.norm = nn.Identity()
+        else:
+            raise ValueError(f"Unsupported output_norm `{output_norm}`.")
+        self.o_proj = nn.Linear(self.value_dim, hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        output_attentions: bool | None = False,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+        if attention_mask is not None and attention_mask.ndim != 2:
+            raise ValueError("HigherOrderLinearAttention expects a 2D padding attention_mask.")
+
+        q = rearrange(self.q_proj(hidden_states), "... (h d) -> ... h d", d=self.head_dim)
+        k = rearrange(self.k_proj(hidden_states), "... (h d) -> ... h d", d=self.head_dim)
+        v = rearrange(self.v_proj(hidden_states), "... (h d) -> ... h d", d=self.head_v_dim)
+        if attention_mask is not None:
+            v = v.mul(attention_mask[:, -v.shape[1]:, None, None])
+
+        if self.num_v_heads != self.num_heads:
+            groups = self.num_v_heads // self.num_heads
+            q = repeat(q, "b t h d -> b t (h g) d", g=groups)
+            k = repeat(k, "b t h d -> b t (h g) d", g=groups)
+
+        last_state = get_layer_cache(self, past_key_values)
+        recurrent_state = last_state["recurrent_state"] if last_state is not None else None
+        o, recurrent_state = recurrent_hla(
+            q=q,
+            k=k,
+            v=v,
+            initial_state=recurrent_state,
+            output_final_state=use_cache,
+            normalize=self.normalize,
+            eps=self.eps,
+            ridge=self.ridge,
+        )
+        update_layer_cache(
+            self,
+            past_key_values,
+            recurrent_state=recurrent_state,
+            offset=q.shape[1],
+        )
+        o = self.norm(o)
+        o = rearrange(o, "b t h d -> b t (h d)")
+        o = self.o_proj(o)
+        return o, None, past_key_values

--- a/fla/layers/hla.py
+++ b/fla/layers/hla.py
@@ -52,8 +52,8 @@ class HigherOrderLinearAttention(nn.Module):
     ) -> None:
         super().__init__()
 
-        if mode not in {"recurrent", "fused_recurrent"}:
-            raise ValueError(f"Unsupported mode `{mode}`.")
+        if mode != "recurrent":
+            raise ValueError("HigherOrderLinearAttention currently supports only `mode='recurrent'`.")
         self.hidden_size = hidden_size
         self.expand_v = expand_v
         self.head_dim = head_dim
@@ -114,7 +114,10 @@ class HigherOrderLinearAttention(nn.Module):
         k = rearrange(self.k_proj(hidden_states), "... (h d) -> ... h d", d=self.head_dim)
         v = rearrange(self.v_proj(hidden_states), "... (h d) -> ... h d", d=self.head_v_dim)
         if attention_mask is not None:
-            v = v.mul(attention_mask[:, -v.shape[1]:, None, None])
+            mask = attention_mask[:, -v.shape[1]:, None, None]
+            q = q.mul(mask)
+            k = k.mul(mask)
+            v = v.mul(mask)
 
         if self.num_v_heads != self.num_heads:
             groups = self.num_v_heads // self.num_heads

--- a/fla/ops/hla/__init__.py
+++ b/fla/ops/hla/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from .recurrent import recurrent_hla
+
+__all__ = [
+    "recurrent_hla",
+]

--- a/fla/ops/hla/recurrent.py
+++ b/fla/ops/hla/recurrent.py
@@ -30,7 +30,11 @@ def _init_state(
     return S, C, m, G, h
 
 
-@torch.compiler.disable
+def _signed_clamp_min(x: torch.Tensor, eps: float) -> torch.Tensor:
+    sign = torch.where(x < 0, -torch.ones_like(x), torch.ones_like(x))
+    return sign * x.abs().clamp_min(eps)
+
+
 def recurrent_hla(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -45,6 +49,14 @@ def recurrent_hla(
 ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None]:
     r"""
     Reference recurrent implementation of masked second-order Higher-order Linear Attention.
+
+    This implements the second-order masked streaming identity from
+    "Higher-order Linear Attention" (arXiv:2510.27258):
+    ``S_t = sum_{i<=t} k_i k_i^T``, ``C_t = sum_{i<=t} q_i v_i^T``,
+    ``m_t = sum_{i<=t} q_i``, ``G_t = sum_{i<=t} k_i k_i^T C_{i-1}``,
+    and ``h_t = sum_{i<=t} k_i k_i^T m_{i-1}``. The unnormalized output is
+    ``o_t = q_t^T (S_t C_t - G_t)``; the optional normalized variant divides
+    by ``q_t^T (S_t m_t - h_t)`` with a signed epsilon floor.
 
     Args:
         q:
@@ -125,7 +137,7 @@ def recurrent_hla(
         o = torch.einsum("bhk,bhkv->bhv", u, C) - torch.einsum("bhk,bhkv->bhv", q_t, G)
         if normalize:
             den = torch.einsum("bhk,bhk->bh", u, m) - torch.einsum("bhk,bhk->bh", q_t, h)
-            o = o / den.unsqueeze(-1).clamp_min(eps)
+            o = o / _signed_clamp_min(den, eps).unsqueeze(-1)
         outputs.append(o)
 
     output = torch.stack(outputs, dim=1).to(dtype)

--- a/fla/ops/hla/recurrent.py
+++ b/fla/ops/hla/recurrent.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+import torch
+from einops import repeat
+
+
+def _init_state(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    initial_state: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    batch, _, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+    if initial_state is not None:
+        return initial_state
+    state_dtype = torch.float32 if q.dtype in {torch.float16, torch.bfloat16} else q.dtype
+    state_shape = (batch, heads)
+    S = q.new_zeros((*state_shape, key_dim, key_dim), dtype=state_dtype)
+    C = q.new_zeros((*state_shape, key_dim, value_dim), dtype=state_dtype)
+    m = q.new_zeros((*state_shape, key_dim), dtype=state_dtype)
+    G = q.new_zeros((*state_shape, key_dim, value_dim), dtype=state_dtype)
+    h = q.new_zeros((*state_shape, key_dim), dtype=state_dtype)
+    return S, C, m, G, h
+
+
+@torch.compiler.disable
+def recurrent_hla(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    initial_state: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    output_final_state: bool = False,
+    normalize: bool = False,
+    eps: float = 1e-6,
+    ridge: float = 0.0,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None]:
+    r"""
+    Reference recurrent implementation of masked second-order Higher-order Linear Attention.
+
+    Args:
+        q:
+            Queries of shape ``[B, T, H, K]``.
+        k:
+            Keys of shape ``[B, T, H, K]``.
+        v:
+            Values of shape ``[B, T, HV, V]``. ``HV`` must be divisible by ``H``.
+        initial_state:
+            Optional tuple ``(S, C, m, G, h)`` with shapes ``[B, HV, K, K]``,
+            ``[B, HV, K, V]``, ``[B, HV, K]``, ``[B, HV, K, V]``, and
+            ``[B, HV, K]``.
+        output_final_state:
+            Whether to return the final recurrent state.
+        normalize:
+            Whether to divide by the optional masked denominator.
+        eps:
+            Numerical epsilon used by the normalized variant.
+        ridge:
+            Optional diagonal ridge added to ``S`` before querying. A nonzero value
+            is a stabilized variant and no longer exactly equals the pure masked
+            bilinear form.
+        scale:
+            Optional scale applied to queries. Defaults to ``K ** -0.5``.
+
+    Returns:
+        ``(o, final_state)`` where ``o`` has shape ``[B, T, HV, V]`` and
+        ``final_state`` is the state tuple if requested, otherwise ``None``.
+    """
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("q, k and v must all be rank-4 tensors")
+    if q.shape != k.shape:
+        raise ValueError(f"q and k must have the same shape, got {q.shape} and {k.shape}")
+    if q.shape[:2] != v.shape[:2]:
+        raise ValueError(f"q/k and v must share [B, T], got {q.shape[:2]} and {v.shape[:2]}")
+    if v.shape[2] % q.shape[2] != 0:
+        raise ValueError(f"value heads ({v.shape[2]}) must be divisible by q/k heads ({q.shape[2]})")
+
+    dtype = v.dtype
+    key_dim = q.shape[-1]
+    if scale is None:
+        scale = key_dim ** -0.5
+    if v.shape[2] != q.shape[2]:
+        groups = v.shape[2] // q.shape[2]
+        q = repeat(q, "b t h d -> b t (h g) d", g=groups)
+        k = repeat(k, "b t h d -> b t (h g) d", g=groups)
+
+    compute_dtype = torch.float32 if q.dtype in {torch.float16, torch.bfloat16} else q.dtype
+    q = (q * scale).to(compute_dtype)
+    k = k.to(compute_dtype)
+    v = v.to(compute_dtype)
+    S, C, m, G, h = _init_state(q, v, initial_state)
+    S, C, m, G, h = (x.to(device=q.device, dtype=compute_dtype) for x in (S, C, m, G, h))
+
+    outputs = []
+    eye = None
+    if ridge != 0.0:
+        eye = torch.eye(key_dim, device=q.device, dtype=compute_dtype).view(1, 1, key_dim, key_dim)
+
+    for idx in range(q.shape[1]):
+        q_t = q[:, idx]
+        k_t = k[:, idx]
+        v_t = v[:, idx]
+
+        S_prev, C_prev, m_prev, G_prev, h_prev = S, C, m, G, h
+        dS = torch.einsum("bhk,bhd->bhkd", k_t, k_t)
+        dC = torch.einsum("bhk,bhv->bhkv", q_t, v_t)
+        dm = q_t
+
+        S = S_prev + dS
+        C = C_prev + dC
+        m = m_prev + dm
+        G = G_prev + torch.einsum("bhkd,bhdv->bhkv", dS, C_prev)
+        h = h_prev + torch.einsum("bhkd,bhd->bhk", dS, m_prev)
+
+        S_eff = S if eye is None else S + ridge * eye
+        u = torch.einsum("bhk,bhkd->bhd", q_t, S_eff)
+        o = torch.einsum("bhk,bhkv->bhv", u, C) - torch.einsum("bhk,bhkv->bhv", q_t, G)
+        if normalize:
+            den = torch.einsum("bhk,bhk->bh", u, m) - torch.einsum("bhk,bhk->bh", q_t, h)
+            o = o / den.unsqueeze(-1).clamp_min(eps)
+        outputs.append(o)
+
+    output = torch.stack(outputs, dim=1).to(dtype)
+    final_state = (S, C, m, G, h) if output_final_state else None
+    return output, final_state

--- a/tests/ops/test_hla.py
+++ b/tests/ops/test_hla.py
@@ -11,7 +11,19 @@ from fla.layers import HigherOrderLinearAttention
 from fla.ops.hla import recurrent_hla
 
 
-def _parallel_masked_hla(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float | None = None) -> torch.Tensor:
+def _signed_clamp_min(x: torch.Tensor, eps: float) -> torch.Tensor:
+    sign = torch.where(x < 0, -torch.ones_like(x), torch.ones_like(x))
+    return sign * x.abs().clamp_min(eps)
+
+
+def _parallel_masked_hla(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float | None = None,
+    normalize: bool = False,
+    eps: float = 1e-6,
+) -> torch.Tensor:
     if scale is None:
         scale = q.shape[-1] ** -0.5
     q = q * scale
@@ -20,7 +32,11 @@ def _parallel_masked_hla(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scal
     weights = weights.masked_fill(~mask.view(1, 1, q.shape[1], q.shape[1]), 0.0)
     second_order = torch.matmul(weights, weights.transpose(-1, -2))
     second_order = second_order.masked_fill(~mask.view(1, 1, q.shape[1], q.shape[1]), 0.0)
-    return torch.einsum("bhts,bshv->bthv", second_order, v)
+    output = torch.einsum("bhts,bshv->bthv", second_order, v)
+    if normalize:
+        den = second_order.sum(dim=-1).transpose(1, 2).unsqueeze(-1)
+        output = output / _signed_clamp_min(den, eps)
+    return output
 
 
 def test_recurrent_hla_matches_parallel_masked_form():
@@ -67,6 +83,23 @@ def test_recurrent_hla_backward_matches_parallel_masked_form():
         torch.testing.assert_close(actual_grad, expected_grad, rtol=1e-10, atol=1e-10)
 
 
+def test_recurrent_hla_normalized_preserves_denominator_sign():
+    q = torch.tensor([[[[1.0]], [[-0.1]]]], dtype=torch.float64)
+    k = torch.ones_like(q)
+    v = torch.tensor([[[[1.0]], [[2.0]]]], dtype=torch.float64)
+    weights = torch.einsum("bthd,bshd->bhts", q, k)
+    mask = torch.tril(torch.ones(q.shape[1], q.shape[1], dtype=torch.bool, device=q.device))
+    second_order = torch.matmul(
+        weights.masked_fill(~mask.view(1, 1, q.shape[1], q.shape[1]), 0.0),
+        weights.masked_fill(~mask.view(1, 1, q.shape[1], q.shape[1]), 0.0).transpose(-1, -2),
+    ).masked_fill(~mask.view(1, 1, q.shape[1], q.shape[1]), 0.0)
+    assert second_order.sum(dim=-1)[0, 0, 1] < 0
+
+    expected = _parallel_masked_hla(q, k, v, normalize=True)
+    actual, _ = recurrent_hla(q, k, v, normalize=True)
+    torch.testing.assert_close(actual, expected, rtol=1e-10, atol=1e-10)
+
+
 def test_hla_layer_forward_shape():
     torch.manual_seed(3)
     layer = HigherOrderLinearAttention(hidden_size=32, num_heads=4, head_dim=8, output_norm="identity")
@@ -75,3 +108,17 @@ def test_hla_layer_forward_shape():
     assert y.shape == x.shape
     assert attentions is None
     assert cache is None
+
+
+def test_hla_layer_attention_mask_excludes_padded_qkv_state():
+    torch.manual_seed(4)
+    layer = HigherOrderLinearAttention(hidden_size=16, num_heads=2, head_dim=8, output_norm="identity")
+    x = torch.randn(1, 5, 16)
+    attention_mask = torch.tensor([[1, 1, 0, 1, 1]], dtype=x.dtype)
+    valid_positions = torch.tensor([0, 1, 3, 4])
+
+    masked, _, _ = layer(x, attention_mask=attention_mask)
+    trimmed, _, _ = layer(x[:, valid_positions])
+
+    torch.testing.assert_close(masked[:, valid_positions], trimmed, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(masked[:, 2], torch.zeros_like(masked[:, 2]), rtol=0, atol=1e-6)

--- a/tests/ops/test_hla.py
+++ b/tests/ops/test_hla.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+
+from fla.layers import HigherOrderLinearAttention
+from fla.ops.hla import recurrent_hla
+
+
+def _parallel_masked_hla(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: float | None = None) -> torch.Tensor:
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    q = q * scale
+    weights = torch.einsum("bthd,bshd->bhts", q, k)
+    mask = torch.tril(torch.ones(q.shape[1], q.shape[1], dtype=torch.bool, device=q.device))
+    weights = weights.masked_fill(~mask.view(1, 1, q.shape[1], q.shape[1]), 0.0)
+    second_order = torch.matmul(weights, weights.transpose(-1, -2))
+    second_order = second_order.masked_fill(~mask.view(1, 1, q.shape[1], q.shape[1]), 0.0)
+    return torch.einsum("bhts,bshv->bthv", second_order, v)
+
+
+def test_recurrent_hla_matches_parallel_masked_form():
+    torch.manual_seed(0)
+    q = torch.randn(2, 7, 3, 5, dtype=torch.float64)
+    k = torch.randn(2, 7, 3, 5, dtype=torch.float64)
+    v = torch.randn(2, 7, 3, 4, dtype=torch.float64)
+
+    actual, _ = recurrent_hla(q, k, v)
+    expected = _parallel_masked_hla(q, k, v)
+    torch.testing.assert_close(actual, expected, rtol=1e-10, atol=1e-10)
+
+
+def test_recurrent_hla_chunked_cache_matches_full_sequence():
+    torch.manual_seed(1)
+    q = torch.randn(2, 9, 4, 6)
+    k = torch.randn(2, 9, 4, 6)
+    v = torch.randn(2, 9, 4, 3)
+
+    full, _ = recurrent_hla(q, k, v)
+    first, state = recurrent_hla(q[:, :4], k[:, :4], v[:, :4], output_final_state=True)
+    second, _ = recurrent_hla(q[:, 4:], k[:, 4:], v[:, 4:], initial_state=state)
+    torch.testing.assert_close(torch.cat([first, second], dim=1), full, rtol=1e-5, atol=1e-5)
+
+
+def test_recurrent_hla_backward_matches_parallel_masked_form():
+    torch.manual_seed(2)
+    q = torch.randn(1, 5, 2, 4, dtype=torch.float64, requires_grad=True)
+    k = torch.randn(1, 5, 2, 4, dtype=torch.float64, requires_grad=True)
+    v = torch.randn(1, 5, 2, 3, dtype=torch.float64, requires_grad=True)
+
+    actual, _ = recurrent_hla(q, k, v)
+    actual.sum().backward()
+    actual_grads = [x.grad.detach().clone() for x in (q, k, v)]
+
+    q_ref = q.detach().clone().requires_grad_(True)
+    k_ref = k.detach().clone().requires_grad_(True)
+    v_ref = v.detach().clone().requires_grad_(True)
+    expected = _parallel_masked_hla(q_ref, k_ref, v_ref)
+    expected.sum().backward()
+    expected_grads = [x.grad.detach().clone() for x in (q_ref, k_ref, v_ref)]
+
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+        torch.testing.assert_close(actual_grad, expected_grad, rtol=1e-10, atol=1e-10)
+
+
+def test_hla_layer_forward_shape():
+    torch.manual_seed(3)
+    layer = HigherOrderLinearAttention(hidden_size=32, num_heads=4, head_dim=8, output_norm="identity")
+    x = torch.randn(2, 6, 32)
+    y, attentions, cache = layer(x)
+    assert y.shape == x.shape
+    assert attentions is None
+    assert cache is None


### PR DESCRIPTION
## Summary
- add a reference recurrent second-order Higher-order Linear Attention op
- expose HigherOrderLinearAttention as an FLA layer
- add tests comparing the streaming identity against the explicit masked quadratic form, cache chunking, backward gradients, and layer shape

## Notes
This is intentionally a PyTorch reference implementation first, matching the HLA masked streaming identity with state (S, C, m, G, h). It gives FLA a correct API/test target before adding a chunk/Triton/TileLang kernel.

## Validation
- python -m pytest tests/ops/test_hla.py -q
