### PR TITLE
[Test] Add zero-gate regime to chunk_gated_delta_rule tests

### DIFF
--- a/tests/ops/test_gated_delta.py
+++ b/tests/ops/test_gated_delta.py
@@ -87,7 +87,7 @@ def test_fused_recurrent(
             id="B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
         )
         for test in [
-            # non-GVA (HV == H)
+            (4, 1024, 4, 4, 128, 0.1, 1, 1.0, False, torch.float16),
             (2, 75, 4, 4, 64, 1, 0.01, 0, False, torch.float16),
             (2, 500, 3, 3, 60, 1, 1, 0, False, torch.float16),
             (2, 1000, 3, 3, 64, 0.1, 1, 0.5, False, torch.float16),
@@ -95,7 +95,6 @@ def test_fused_recurrent(
             (4, 1024, 4, 4, 128, 0.1, 1, 0, True, torch.float16),
             (2, 1500, 4, 4, 128, 0.1, 10, 0, False, torch.float16),
             (4, 2048, 8, 8, 64, 0.1, 1, 0, False, torch.float16),
-            # GVA (HV > H)
             (2, 256, 2, 4, 64, 1, 1, 0, False, torch.float16),
             (2, 512, 2, 8, 64, 1, 0.1, 0, True, torch.float16),
             (2, 1024, 4, 8, 128, 0.1, 1, 0, False, torch.float16),


### PR DESCRIPTION
## Summary

Adds an explicit zero-gate (`g = 0`, no decay) case to `test_chunk` in `tests/ops/test_gated_delta.py`, addressing #891.

The existing gates are all generated via `F.logsigmoid(...) / gate_logit_normalizer`, which is always non-positive and pushes the cumulative chunk gate strongly negative. As a result `exp(g_last)` is often near zero, attenuating state/gradient contributions at chunk boundaries and **hiding bugs in those paths** (e.g. the `chunk_bwd` shared-memory race from #889/#890, which was far easier to reproduce with `g = 0`).

The new case reuses the existing body: `mask_p=1.0` makes `(torch.rand_like(g) > mask_p)` always `False`, zeroing the whole gate without any code change.

## Test plan

- [ ] `pytest "tests/ops/test_gated_delta.py::test_chunk" -k "mask_p1.0" -v`
- [ ] full `pytest tests/ops/test_gated_delta.py` on a CUDA device