### PR TITLE
[Git] Ignore Python virtual environment directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,13 @@ log.*
 *.cfg
 *.ini
 
+# virtual environments
+.venv/
+venv/
+env/
+ENV/
+.env
+
 # pycache
 __pycache__
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,11 +31,10 @@ log.*
 *.ini
 
 # virtual environments
-.venv/
-venv/
-env/
-ENV/
 .env
+.venv
+env
+venv
 
 # pycache
 __pycache__
@@ -43,7 +42,6 @@ __pycache__
 # saved model
 *.pkl
 *.pt
-
 
 # vscode
 .vscode


### PR DESCRIPTION
## Summary

Add common Python virtual environment paths to `.gitignore` so locally created envs are not accidentally tracked.

Entries added:
- `.venv/`
- `venv/`
- `env/`
- `ENV/`
- `.env`

## Breaking changes

None.