### PR TITLE
[Fix] Detect consumer Blackwell (SM120) as Blackwell

### DIFF
--- a/fla/ops/utils/op.py
+++ b/fla/ops/utils/op.py
@@ -39,10 +39,11 @@ else:
 
 if IS_NVIDIA_BLACKWELL:
     """
-    Compute tl.dot with SM100 workaround.
+    Compute tl.dot with Blackwell workaround.
 
-    On SM100 (Blackwell) GPUs, wraps the result in inline assembly to prevent
-    the TritonGPUHoistTMEMAlloc pass from incorrectly fusing add and dot operations.
+    On SM100 datacenter and SM120 consumer Blackwell GPUs, wraps the result in
+    inline assembly to prevent the TritonGPUHoistTMEMAlloc pass from incorrectly
+    fusing add and dot operations.
     See: https://github.com/fla-org/flash-linear-attention/issues/638
 
     TODO: Remove this workaround once the Triton compiler bug is fixed.

--- a/fla/utils/_device.py
+++ b/fla/utils/_device.py
@@ -120,7 +120,7 @@ IS_INTEL = (device_platform == 'xpu')
 IS_INTEL_ALCHEMIST = (IS_INTEL and 'Intel(R) Arc(TM) A' in torch.xpu.get_device_name(0))
 IS_NVIDIA = (device_platform == 'cuda')
 IS_NPU = (device_platform == 'npu')
-IS_NVIDIA_BLACKWELL = (IS_NVIDIA and torch.cuda.get_device_capability()[0] == 10)
+IS_NVIDIA_BLACKWELL = (IS_NVIDIA and torch.cuda.get_device_capability()[0] in (10, 12))
 IS_NVIDIA_HOPPER = (IS_NVIDIA and ('NVIDIA H' in torch.cuda.get_device_name(0) or torch.cuda.get_device_capability()[0] == 9))
 USE_CUDA_GRAPH = (IS_NVIDIA and os.environ.get('FLA_USE_CUDA_GRAPH', '0') == '1')
 
@@ -148,7 +148,7 @@ if IS_TMA_SUPPORTED:
     logger.info('TMA is supported, using TMA by default.')
     triton.set_allocator(_default_alloc_fn)
 elif IS_NVIDIA_BLACKWELL:
-    # Blackwell (SM 10.0+): Triton compiler may emit global_scratch for
+    # Blackwell (SM100 datacenter / SM120 consumer): Triton compiler may emit global_scratch for
     # autotuned kernels even without TMA. Register a default allocator to
     # prevent NullAllocator crashes. See triton-lang/triton#10002.
     logger.info('Blackwell detected: registering default global_scratch allocator.')


### PR DESCRIPTION
`torch.cuda.get_device_capability()[0]` is 12 on consumer Blackwell GPUs (e.g. RTX 5090 / sm_120), not 10 like datacenter Blackwell (SM100).