### PR TITLE
[CI] Add ascend-a2-ci workflow for Atlas A2 NPU module tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - nvidia-h100-1
+    - linux-aarch64-a2-1

--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -1,5 +1,7 @@
 name: ascend-a2-ci
 
+# Pinned stack: CANN 8.5.0, torch 2.6.0, torch-npu 2.6.0, triton-ascend 3.2.0
+
 on:
   workflow_dispatch:
   push:
@@ -19,8 +21,8 @@ on:
       - ".github/workflows/*.yml"
 
 jobs:
-  test-a2-npu-pytorch-2-7:
-    name: Test A2 NPU (PyTorch 2.7.1)
+  test-a2-npu-pytorch-2-6:
+    name: Test A2 NPU (PyTorch 2.6.0)
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
@@ -41,8 +43,8 @@ jobs:
           - "3.11"
         os:
           - "linux-aarch64-a2-1"
-        pytorch_npu:
-          - "2.7.1"
+        torch:
+          - "2.6.0"
 
     runs-on: ${{ matrix.os }}
 
@@ -51,7 +53,6 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     container:
-      # triton-ascend 3.2.0 官方标配 CANN 8.5.0
       image: ascendai/cann:8.5.0-910b-ubuntu22.04-py3.11
       options: >-
         --shm-size 16g
@@ -82,8 +83,8 @@ jobs:
           # triton-ascend imports pybind11 at runtime; see triton-ascend requirements.txt
           python -m pip install pybind11 cmake attrs sympy pyyaml scipy
           python -m pip install \
-            "torch==${{ matrix.pytorch_npu }}" \
-            "torch-npu==${{ matrix.pytorch_npu }}" \
+            "torch==${{ matrix.torch }}" \
+            "torch_npu==${{ matrix.torch }}" \
             "triton-ascend==3.2.0" \
             decorator \
             --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple

--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -1,0 +1,118 @@
+name: ascend-a2-ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/*.yml"
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/*.yml"
+
+jobs:
+  test-a2-npu-pytorch-2-7:
+    name: Test A2 NPU (PyTorch 2.7.1)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          contains(github.event.pull_request.title, 'npu') ||
+          contains(github.event.pull_request.title, 'NPU') ||
+          contains(github.event.pull_request.title, 'ascend') ||
+          contains(github.event.pull_request.title, 'Ascend') ||
+          contains(github.event.pull_request.title, 'ASCEND')
+        )
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.11"
+        os:
+          - "linux-aarch64-a2-1"
+        pytorch_npu:
+          - "2.7.1"
+
+    runs-on: ${{ matrix.os }}
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.python }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+    container:
+      # triton-ascend 3.2.0 官方标配 CANN 8.5.0
+      image: ascendai/cann:8.5.0-910b-ubuntu22.04-py3.11
+      options: >-
+        --shm-size 16g
+      env:
+        HF_ENDPOINT: https://hf-mirror.com
+
+    env:
+      FLA_CI_ENV: 1
+      ASCEND_RT_VISIBLE_DEVICES: "0"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check NPU and CANN info
+        run: |
+          cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -m)"-linux/ascend_toolkit_install.info
+          npu-smi info
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip setuptools wheel
+          # triton-ascend imports pybind11 at runtime; see triton-ascend requirements.txt
+          python -m pip install pybind11 cmake attrs sympy pyyaml scipy
+          python -m pip install \
+            "torch==${{ matrix.pytorch_npu }}" \
+            "torch-npu==${{ matrix.pytorch_npu }}" \
+            "triton-ascend==3.2.0" \
+            decorator \
+            --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple
+          python -m pip install -U pytest numpy packaging psutil ninja einops transformers
+          python -m pip install --no-deps ".[test]"
+
+      - name: Verify environment
+        shell: bash
+        run: |
+          source /usr/local/Ascend/ascend-toolkit/set_env.sh
+          python - <<'PY'
+          import torch
+          import torch_npu
+
+          print("torch:", torch.__version__)
+          print("torch_npu:", torch_npu.__version__)
+          print("npu available:", torch.npu.is_available())
+
+          import triton
+          print("triton:", triton.__version__)
+
+          from fla.utils import IS_NPU, device_platform
+          print("device_platform:", device_platform)
+          assert IS_NPU, "Expected NPU backend (IS_NPU=True)"
+          PY
+
+      # TODO: expand to `tests/modules/` after NPU failures are fixed
+      - name: Run rotary module tests
+        shell: bash
+        run: |
+          source /usr/local/Ascend/ascend-toolkit/set_env.sh
+          pytest -s -v --exitfirst tests/modules/test_rotary.py


### PR DESCRIPTION
## Summary

This PR adds the first Ascend NPU CI workflow for FLA on a self-hosted Atlas A2 runner. It mirrors the existing GPU CI style (e.g. H100) and validates the NPU stack end-to-end with a minimal module smoke test.

Changes:
- Add `.github/workflows/ascend-a2-ci.yml` with job `Test A2 NPU (PyTorch 2.6.0)`
- Register self-hosted runner label `linux-aarch64-a2-1` in `.github/actionlint.yaml`

Workflow highlights:
- **Runner**: `linux-aarch64-a2-1`
- **Container**: `ascendai/cann:8.5.0-910b-ubuntu22.04-py3.11` (paired with `triton-ascend==3.2.0`)
- **Pinned stack**: CANN 8.5.0, `torch`/`torch_npu` 2.6.0, `triton-ascend` 3.2.0, Python 3.11
- **Runtime deps**: `pybind11`, `cmake`, `attrs`, `sympy`, `pyyaml`, `scipy`, etc. (required by triton-ascend)
- **Test scope**: `pytest tests/modules/test_rotary.py` only (minimal smoke gate)
- **Triggers**:
  - `workflow_dispatch`
  - `push` to `main` (path-filtered: `**/*.py`, `pyproject.toml`, `.github/workflows/*.yml`)
  - `pull_request` to `main` when the PR title contains `npu` / `NPU` / `ascend` / `Ascend` / `ASCEND`

## Motivation

Upstream PR #927 added `triton_ascend` backend support for `fla/modules/`, but FLA still lacks dedicated NPU CI. This workflow provides an initial, low-cost regression gate on real Ascend A2 hardware before expanding coverage.

## Test plan

- [x] `ascend-a2-ci` passes on self-hosted runner `linux-aarch64-a2-1`
- [x] Environment verification succeeds (`torch.npu.is_available()`, `IS_NPU=True`, triton import)
- [x] `pytest tests/modules/test_rotary.py` passes
- [ ] Expand to full `tests/modules/` after remaining NPU failures are fixed (tracked via TODO in workflow)

Verified in the fork: [ascend-a2-ci run on pt-ecosystem/flash-linear-attention-dev](https://github.com/pt-ecosystem/flash-linear-attention-dev/actions/runs/27392351342/job/80952394550).

<img width="796" height="222" alt="image" src="https://github.com/user-attachments/assets/86cdd694-5e51-42cb-9475-9887d2d29750" />


## Notes

- PRs without `npu`/`ascend` in the title will skip the NPU job by design (workflow may still appear; job is skipped)