### PR TITLE
[GDN] Fix GDN precision on Blackwell

### DIFF
--- a/fla/ops/common/backends/tilelang/__init__.py
+++ b/fla/ops/common/backends/tilelang/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import torch
 
 from fla.ops.backends import BaseBackend
+from fla.utils import IS_NVIDIA_BLACKWELL
 
 
 class TileLangBackend(BaseBackend):
@@ -50,6 +51,11 @@ class TileLangBackend(BaseBackend):
         chunk_size: int = 64,
         chunk_indices: torch.LongTensor | None = None,
     ) -> tuple[bool, str | None]:
+        if IS_NVIDIA_BLACKWELL:
+            return False, (
+                "TileLang chunk_bwd_dqkwg is numerically incorrect on Blackwell; "
+                "use the default Triton FLA kernel"
+            )
         if g is None:
             return False, "TileLang backend only supports gated case (g != None)"
         if g_gamma is not None:

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -550,7 +550,7 @@ def chunk_fwd_o(
         V=V,
         BT=BT,
         STATE_V_FIRST=state_v_first,
-        USE_BLACKWELL_SAFE_O=IS_NVIDIA_BLACKWELL,
+        USE_BLACKWELL_SAFE_O=IS_NVIDIA_BLACKWELL and v.dtype == torch.bfloat16,
     )
     return o
 

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -12,8 +12,8 @@ import triton.language as tl
 from fla.ops.common.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
-from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, autotune_cache_kwargs, check_shared_mem
+from fla.ops.utils.op import exp2, safe_dot
+from fla.utils import IS_NVIDIA_BLACKWELL, IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, autotune_cache_kwargs, check_shared_mem
 
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
@@ -30,7 +30,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
         triton.Config({'BK': 64, 'BV': 64}, num_warps=4, num_stages=3),
         triton.Config({'BK': 32, 'BV': 32}, num_warps=2, num_stages=3),
     ],
-    key=['H', 'HV', 'K', 'V', 'BT', 'STATE_V_FIRST'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'STATE_V_FIRST', 'USE_BLACKWELL_SAFE_O'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -56,6 +56,7 @@ def chunk_fwd_kernel_o(
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
+    USE_BLACKWELL_SAFE_O: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2).to(tl.int64)
@@ -125,7 +126,13 @@ def chunk_fwd_kernel_o(
     b_v = tl.load(p_v, boundary_check=(0, 1))
     # to fix mma -> mma layout conversion
     # already solved by triton v3.2 or higher
-    b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
+    if USE_BLACKWELL_SAFE_O:
+        # sm100 can produce sparse high-magnitude errors in this final bf16 MMA
+        # on long packed GDN sequences. Keep the computation inside this Triton
+        # kernel but force the local causal contribution through fp32/ieee dot.
+        b_o = b_o * scale + safe_dot(b_A, b_v.to(tl.float32), input_precision="ieee") * scale
+    else:
+        b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -543,6 +550,7 @@ def chunk_fwd_o(
         V=V,
         BT=BT,
         STATE_V_FIRST=state_v_first,
+        USE_BLACKWELL_SAFE_O=IS_NVIDIA_BLACKWELL,
     )
     return o
 

--- a/fla/ops/utils/op.py
+++ b/fla/ops/utils/op.py
@@ -50,19 +50,35 @@ if IS_NVIDIA_BLACKWELL:
     Track upstream issue at: https://github.com/triton-lang/triton/issues/8695
     """
     @triton.jit
-    def safe_dot(a, b, allow_tf32: tl.constexpr = None):
+    def safe_dot(
+        a,
+        b,
+        allow_tf32: tl.constexpr = None,
+        input_precision: tl.constexpr = None,
+    ):
+        if input_precision is None:
+            out = tl.dot(a, b, allow_tf32=allow_tf32)
+        else:
+            out = tl.dot(a, b, input_precision=input_precision)
         return tl.inline_asm_elementwise(
             asm="mov.f32 $0, $1;",
             constraints="=r,r",
-            args=[tl.dot(a, b, allow_tf32=allow_tf32)],
+            args=[out],
             dtype=tl.float32,
             is_pure=True,
             pack=1,
         )
 else:
     @triton.jit
-    def safe_dot(a, b, allow_tf32: tl.constexpr = None):
-        return tl.dot(a, b, allow_tf32=allow_tf32)
+    def safe_dot(
+        a,
+        b,
+        allow_tf32: tl.constexpr = None,
+        input_precision: tl.constexpr = None,
+    ):
+        if input_precision is None:
+            return tl.dot(a, b, allow_tf32=allow_tf32)
+        return tl.dot(a, b, input_precision=input_precision)
 
 
 if not IS_GATHER_SUPPORTED:

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -16,7 +16,14 @@ from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gat
 from fla.ops.gated_delta_rule.gate import fused_gdn_gate, naive_gdn_gate
 from fla.ops.gated_delta_rule.naive import naive_recurrent_gated_delta_rule
 from fla.ops.gated_delta_rule.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
-from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
+from fla.utils import (
+    IS_INTEL_ALCHEMIST,
+    IS_NVIDIA_BLACKWELL,
+    assert_close,
+    device,
+    get_abs_err,
+    get_err_ratio,
+)
 
 
 @pytest.mark.parametrize(
@@ -1170,3 +1177,90 @@ def test_prepare_wy_repr_bwd_no_g(B: int, T: int, H: int, HV: int, D: int):
     assert_close('dk', dk_zero_g, dk_no_g, 1e-4)
     assert_close('dv', dv_zero_g, dv_no_g, 1e-4)
     assert_close('db', db_zero_g, db_no_g, 1e-4)
+
+
+@pytest.mark.skipif(not IS_NVIDIA_BLACKWELL, reason="GDN Blackwell precision test requires an sm100/sm120 CUDA GPU")
+def test_chunk_blackwell_ulysses_shape_precision_and_dispatch():
+    torch.manual_seed(42)
+    B, T, H, HV, D = 1, 1216, 1, 3, 128
+    dtype = torch.bfloat16
+    scale = D ** -0.5
+
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device).requires_grad_(True)
+    k = torch.randn(B, T, H, D, dtype=dtype, device=device).requires_grad_(True)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device).requires_grad_(True)
+    beta = torch.randn(B, T, HV, dtype=torch.float32, device=device).sigmoid().requires_grad_(True)
+    g = (F.logsigmoid(torch.randn(B, T, HV, dtype=torch.float32, device=device)) / 16).requires_grad_(True)
+    h0 = torch.zeros(B, HV, D, D, dtype=torch.float32, device=device).requires_grad_(True)
+    do = (torch.randn_like(v) / 8).to(dtype)
+    dht = (torch.randn_like(h0) / 8).to(torch.float32)
+
+    from fla.ops.common.backends.tilelang import TileLangBackend
+
+    h = torch.empty(B, (T + 63) // 64, HV, D, D, dtype=dtype, device=device)
+    dh = torch.empty_like(h)
+    ok, reason = TileLangBackend().chunk_bwd_dqkwg_verifier(
+        q=q,
+        k=k,
+        v=v,
+        do=do,
+        h=h,
+        dh=dh,
+        g=g,
+        scale=scale,
+    )
+    print(
+        f"blackwell_gdn_dispatch verifier_ok={ok} reason={reason}",
+        flush=True,
+    )
+
+    tri, tri_ht = chunk_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+    )
+    ((tri.float() * do.float()).sum() + (tri_ht.float() * dht.float()).sum()).backward(retain_graph=True)
+    tri_grads = (q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad)
+    q.grad = k.grad = v.grad = beta.grad = g.grad = h0.grad = None
+
+    ref, ref_ht = naive_recurrent_gated_delta_rule(
+        q=F.normalize(repeat(q.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1),
+        k=F.normalize(repeat(k.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1),
+        v=v.clone(),
+        beta=beta.clone(),
+        g=g.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+    )
+    ((ref.float() * do.float()).sum() + (ref_ht.float() * dht.float()).sum()).backward(retain_graph=True)
+    ref_grads = (q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad)
+
+    def assert_blackwell_close(name, ref_tensor, tri_tensor, ratio, err_atol=1e-3):
+        print(
+            f"blackwell_gdn_metric name={name} "
+            f"max_abs={get_abs_err(ref_tensor, tri_tensor):.6g} "
+            f"err_ratio={get_err_ratio(ref_tensor, tri_tensor):.6g} "
+            f"ratio_limit={ratio:.6g} err_atol={err_atol:.6g}",
+            flush=True,
+        )
+        assert_close(f'blackwell_{name}', ref_tensor, tri_tensor, ratio, err_atol=err_atol)
+
+    assert_blackwell_close('o', ref, tri, 0.003)
+    assert_blackwell_close('ht', ref_ht, tri_ht, 0.006)
+    for name, ref_grad, tri_grad, ratio in zip(
+        ('dq', 'dk', 'dv', 'dbeta', 'dg', 'dh0'),
+        ref_grads,
+        tri_grads,
+        (0.02, 0.02, 0.02, 0.04, 0.04, 0.02),
+    ):
+        assert_blackwell_close(name, ref_grad, tri_grad, ratio)
+
+    assert not ok
+    assert reason is not None and 'Blackwell' in reason

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -1179,8 +1179,39 @@ def test_prepare_wy_repr_bwd_no_g(B: int, T: int, H: int, HV: int, D: int):
     assert_close('db', db_zero_g, db_no_g, 1e-4)
 
 
+@pytest.mark.skipif(not IS_NVIDIA_BLACKWELL, reason="GDN Blackwell dispatch test requires an sm100/sm120 CUDA GPU")
+def test_chunk_blackwell_tilelang_dqkwg_rejected_for_supported_shape():
+    torch.manual_seed(42)
+    B, T, H, HV, D = 1, 1216, 2, 2, 128
+    dtype = torch.bfloat16
+
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, T, HV, dtype=torch.float32, device=device)) / 16
+    do = torch.randn_like(v)
+    h = torch.empty(B, (T + 63) // 64, HV, D, D, dtype=dtype, device=device)
+    dh = torch.empty_like(h)
+
+    from fla.ops.common.backends.tilelang import TileLangBackend
+
+    ok, reason = TileLangBackend().chunk_bwd_dqkwg_verifier(
+        q=q,
+        k=k,
+        v=v,
+        do=do,
+        h=h,
+        dh=dh,
+        g=g,
+        scale=D ** -0.5,
+    )
+    print(f"blackwell_gdn_dispatch verifier_ok={ok} reason={reason}", flush=True)
+    assert not ok
+    assert reason is not None and 'Blackwell' in reason
+
+
 @pytest.mark.skipif(not IS_NVIDIA_BLACKWELL, reason="GDN Blackwell precision test requires an sm100/sm120 CUDA GPU")
-def test_chunk_blackwell_ulysses_shape_precision_and_dispatch():
+def test_chunk_blackwell_gqa_bf16_precision():
     torch.manual_seed(42)
     B, T, H, HV, D = 1, 1216, 1, 3, 128
     dtype = torch.bfloat16
@@ -1194,25 +1225,6 @@ def test_chunk_blackwell_ulysses_shape_precision_and_dispatch():
     h0 = torch.zeros(B, HV, D, D, dtype=torch.float32, device=device).requires_grad_(True)
     do = (torch.randn_like(v) / 8).to(dtype)
     dht = (torch.randn_like(h0) / 8).to(torch.float32)
-
-    from fla.ops.common.backends.tilelang import TileLangBackend
-
-    h = torch.empty(B, (T + 63) // 64, HV, D, D, dtype=dtype, device=device)
-    dh = torch.empty_like(h)
-    ok, reason = TileLangBackend().chunk_bwd_dqkwg_verifier(
-        q=q,
-        k=k,
-        v=v,
-        do=do,
-        h=h,
-        dh=dh,
-        g=g,
-        scale=scale,
-    )
-    print(
-        f"blackwell_gdn_dispatch verifier_ok={ok} reason={reason}",
-        flush=True,
-    )
 
     tri, tri_ht = chunk_gated_delta_rule(
         q=q.clone(),
@@ -1243,14 +1255,22 @@ def test_chunk_blackwell_ulysses_shape_precision_and_dispatch():
     ref_grads = (q.grad, k.grad, v.grad, beta.grad, g.grad, h0.grad)
 
     def assert_blackwell_close(name, ref_tensor, tri_tensor, ratio, err_atol=1e-3):
+        abs_err = get_abs_err(ref_tensor, tri_tensor)
+        err_ratio = get_err_ratio(ref_tensor, tri_tensor)
         print(
             f"blackwell_gdn_metric name={name} "
-            f"max_abs={get_abs_err(ref_tensor, tri_tensor):.6g} "
-            f"err_ratio={get_err_ratio(ref_tensor, tri_tensor):.6g} "
+            f"max_abs={abs_err:.6g} "
+            f"err_ratio={err_ratio:.6g} "
             f"ratio_limit={ratio:.6g} err_atol={err_atol:.6g}",
             flush=True,
         )
-        assert_close(f'blackwell_{name}', ref_tensor, tri_tensor, ratio, err_atol=err_atol)
+        assert torch.isfinite(ref_tensor).all(), f"blackwell_{name}: non-finite reference"
+        assert torch.isfinite(tri_tensor).all(), f"blackwell_{name}: non-finite candidate"
+        assert abs_err <= err_atol or err_ratio < ratio, (
+            f"blackwell_{name} diff exceeded hard limit: "
+            f"max_abs={abs_err:.6g} err_ratio={err_ratio:.6g} "
+            f"ratio_limit={ratio:.6g} err_atol={err_atol:.6g}"
+        )
 
     assert_blackwell_close('o', ref, tri, 0.003)
     assert_blackwell_close('ht', ref_ht, tri_ht, 0.006)
@@ -1261,6 +1281,3 @@ def test_chunk_blackwell_ulysses_shape_precision_and_dispatch():
         (0.02, 0.02, 0.02, 0.04, 0.04, 0.02),
     ):
         assert_blackwell_close(name, ref_grad, tri_grad, ratio)
-
-    assert not ok
-    assert reason is not None and 'Blackwell' in reason


### PR DESCRIPTION
## Summary
- Avoid the numerically incorrect TileLang `chunk_bwd_dqkwg` path on Blackwell and keep B200 on the default Triton FLA kernel path.
- Apply the Blackwell-safe `safe_dot(..., input_precision=...)` path for `chunk_fwd_o` on B200 bf16.
- Add focused B200/sm100 GDN regression tests covering a supported-shape TileLang dispatch rejection and a GQA bf16 precision check.

## Before
- On B200/sm100, the GDN backward path was far above the PyTorch-bf16 noise floor. A production-shaped B200 precision harness showed `dq/dk/dg` max-abs errors around `0.07-0.15`, while the torch-bf16 floor was around `6e-4`.
- The long packed shape also showed a forward/output drift class on B200: output max-abs around `6.8e-3` before the Blackwell-safe forward path, versus a floor around `5e-5`.
- The issue is Blackwell-specific; the same seed/shape class was clean on sm90.

## Minimal B200 Tests
Run on a B200/sm100 node:

```bash
python -m pytest   tests/ops/test_gdn.py::test_chunk_blackwell_tilelang_dqkwg_rejected_for_supported_shape   tests/ops/test_gdn.py::test_chunk_blackwell_gqa_bf16_precision   -q -s
```

After this PR, current HEAD `fb64110` was rerun on B200/sm100 on 2026-06-14 and passed in `127.34s`:

```text
blackwell_gdn_dispatch verifier_ok=False reason=TileLang chunk_bwd_dqkwg is numerically incorrect on Blackwell; use the default Triton FLA kernel
blackwell_gdn_metric name=o max_abs=0.000659347 err_ratio=0.00527312 ratio_limit=0.003 err_atol=0.001
blackwell_gdn_metric name=ht max_abs=0.00526351 err_ratio=0.00398938 ratio_limit=0.006 err_atol=0.001
blackwell_gdn_metric name=dq max_abs=0.000183105 err_ratio=0.00648269 ratio_limit=0.02 err_atol=0.001
blackwell_gdn_metric name=dk max_abs=0.00390625 err_ratio=0.0065176 ratio_limit=0.02 err_atol=0.001
blackwell_gdn_metric name=dv max_abs=0.00195312 err_ratio=0.00435267 ratio_limit=0.02 err_atol=0.001
blackwell_gdn_metric name=dbeta max_abs=0.00907183 err_ratio=0.0039143 ratio_limit=0.04 err_atol=0.001
blackwell_gdn_metric name=dg max_abs=0.0145966 err_ratio=0.00280642 ratio_limit=0.04 err_atol=0.001
blackwell_gdn_metric name=dh0 max_abs=6.08293e-05 err_ratio=0.00325633 ratio_limit=0.02 err_atol=0.001
```

## Manual B200 Topology Smoke
A manual Qwen-style TP4/CP4 mock-data harness was rerun on B200/sm100 with current FLA and FlashQLA branches. Each row compares the candidate backend against a PyTorch backend reference and times forward+backward throughput after warmup.

| profile | case | precision | tok/s | previous tok/s | delta |
|---|---:|---:|---:|---:|---:|
| `fla_separate` | short | PASS | 495,927 | 505,005 | -1.80% |
| `fla_separate` | long | PASS | 9,829,483 | 9,776,240 | +0.54% |
| `ulysses_fla` | short | PASS | 204,256 | 197,902 | +3.21% |
| `ulysses_fla` | long | PASS | 7,866,287 | 7,722,419 | +1.86% |
| `ulysses_flash_qla` | short | PASS | 147,391 | 145,081 | +1.59% |
| `ulysses_flash_qla` | long | PASS | 1,151,204 | 1,147,544 | +0.32% |

A second manual B200/sm100 smoke used a Qwen3.5-27B-like TP2/CP4 128k layout. The TP2 shard has `8 key / 24 value` heads; Ulysses CP4 gives each rank a `2 key / 6 value` full-sequence core. This run compared the Ulysses path against a real balanced CP-local wrapper baseline rather than a core-only timing.

| profile | case | precision | tok/s | vs real `fla_separate_cp` |
|---|---:|---:|---:|---:|
| `fla_separate_cp` | 128k | PASS | 1,778,013 | 1.00x |
| `ulysses_fla` | 128k | PASS | 4,059,666 | 2.28x |
| `ulysses_flash_qla` | 128k | PASS | 795,284 | 0.45x |

The `ulysses_fla` gain comes from using FLA's existing fused GDN gate and beta-sigmoid options in the integration wrapper, so no fallback path is involved. On the TP2/CP4 128k real-wrapper comparison, `ulysses_fla` is faster than the balanced CP-local `fla_separate_cp` baseline while preserving PyTorch-floor precision.

## Other Validation
- `pre-commit run --files fla/ops/common/backends/tilelang/__init__.py fla/ops/common/chunk_o.py fla/ops/utils/op.py tests/ops/test_gdn.py`: PASS.
- `python -m py_compile tests/ops/test_gdn.py fla/ops/common/chunk_o.py`: PASS.
- GitHub checks fixed: PR title, lint, and header now pass. The remaining H100 Actions failures are runner infra: logs show `RuntimeError: No CUDA GPUs are available` / `Can't initialize NVML`; I do not have admin rights to repair the runner.
