### PR TITLE
[Model] Add Preconditioned Gated DeltaNet (PGDN) and KDA (PKDA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 ## News
 
 - [2026-06] 🔭 Add Parallax implementation to `fla` ([paper](https://arxiv.org/abs/2605.29157)) — parameterized local linear attention: softmax attention with a learned first-order correction from a secondary query-side stream.
+- [2026-06] 🧮 Add Preconditioned Gated DeltaNet (PGDN) and Preconditioned KDA (PKDA) to `fla` ([paper](https://arxiv.org/abs/2604.21100)) — curvature-aware preconditioning of the linear recurrence via an ATK preconditioner.
 - [2026-06] 🧱 Add Wall attention implementation to `fla` ([blog](https://blog.tilderesearch.com/blog/wall-attn)) — full softmax attention with a learned per-channel multiplicative decay, a RoPE-free positional encoding from Tilde Research.
 - [2026-05] 🚪 Add Gated DeltaNet 2 (GDN-2) implementation to `fla` ([paper](https://arxiv.org/abs/2605.22791)) — decouples erase and write gates into independent channel-wise gates on top of KDA.
 - [2026-05] 🦅 Add Raven implementation to `fla` ([repo](https://github.com/goombalab/raven)).
@@ -113,6 +114,8 @@
 | 2026  |   Gated DeltaNet 2   | [Gated DeltaNet-2: Decoupling Erase and Write in Linear Attention](https://arxiv.org/abs/2605.22791)                                          | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/gdn2)                       |
 | 2026  |         Wall         | [Wall Attention: Length Generalization With Diagonal Gates](https://blog.tilderesearch.com/blog/wall-attn)                                    | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/wall_attn)                  |
 | 2026  |       Parallax       | [Parallax: Parameterized Local Linear Attention for Language Modeling](https://arxiv.org/abs/2605.29157)                                      | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/parallax)                   |
+| 2026  | Preconditioned Gated DeltaNet | [Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences](https://arxiv.org/abs/2604.21100)                | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/precond_gated_delta_rule)   |
+| 2026  | Preconditioned KDA   | [Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences](https://arxiv.org/abs/2604.21100)                         | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/precond_kda)                |
 
 ## Installation
 

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -346,6 +346,39 @@ register_op(OpConfig(
     category='gate_beta',
 ))
 
+register_op(OpConfig(
+    name='chunk_precond_gdn',
+    import_path='fla.ops.precond_gated_delta_rule',
+    inputs={
+        **_simple_qkv,
+        'g': TensorSpec(shape_BTH, transform=logsigmoid),
+        'beta': TensorSpec(shape_BTH, transform=sigmoid_transform),
+        'g_atk': TensorSpec(shape_BTH, transform=logsigmoid),
+        'beta_atk': TensorSpec(shape_BTH, transform=sigmoid_transform),
+        'log_atk_scale': TensorSpec(shape_H, dtype='float32'),
+    },
+    func_name='chunk_precond_gated_delta_rule',
+    extra_kwargs={'use_qk_l2norm_in_kernel': True, 'x': 1.5},
+    category='gate_beta',
+    test_file='tests/ops/test_precond_gated_delta.py',
+))
+
+register_op(OpConfig(
+    name='chunk_precond_kda',
+    import_path='fla.ops.precond_kda',
+    inputs={
+        **_simple_qkv,
+        'g': TensorSpec(shape_BTHD, transform=logsigmoid),
+        'beta': TensorSpec(shape_BTH, transform=sigmoid_transform),
+        'g_atk': TensorSpec(shape_BTH, transform=logsigmoid),
+        'beta_atk': TensorSpec(shape_BTH, transform=sigmoid_transform),
+        'log_atk_scale': TensorSpec(shape_H, dtype='float32'),
+    },
+    extra_kwargs={'x': 1.5},
+    category='gate_beta',
+    test_file='tests/ops/test_precond_kda.py',
+))
+
 # --- +head gate (g=[B,T,H] with logsigmoid) ---
 
 register_op(OpConfig(

--- a/fla/layers/__init__.py
+++ b/fla/layers/__init__.py
@@ -35,6 +35,8 @@ from .multiscale_retention import MultiScaleRetention
 from .nsa import NativeSparseAttention
 from .parallax import Parallax
 from .path_attn import PaTHAttention
+from .precond_gated_deltanet import PrecondGatedDeltaNet
+from .precond_kda import PrecondKDA
 from .raven import Raven
 from .rebased import ReBasedLinearAttention
 from .rodimus import RodimusAttention, SlidingWindowSharedKeyAttention
@@ -74,6 +76,8 @@ __all__ = [
     'NativeSparseAttention',
     'PaTHAttention',
     'Parallax',
+    'PrecondGatedDeltaNet',
+    'PrecondKDA',
     'RWKV6Attention',
     'RWKV7Attention',
     'Raven',

--- a/fla/layers/precond_gated_deltanet.py
+++ b/fla/layers/precond_gated_deltanet.py
@@ -1,0 +1,393 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+from torch.nn import functional as F
+
+from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
+from fla.ops.precond_gated_delta_rule import (
+    chunk_precond_gated_delta_rule,
+    fused_recurrent_precond_gated_delta_rule,
+    naive_recurrent_precond_gated_delta_rule,
+)
+
+if TYPE_CHECKING:
+    from transformers.processing_utils import Unpack
+
+    from fla.models.utils import Cache
+
+
+class PrecondGatedDeltaNet(nn.Module):
+    """
+    Preconditioned Gated Delta Networks (PGDN) layer implementation.
+
+    Reference: `Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences <https://arxiv.org/abs/2604.21100>`_
+
+    Similar to Mamba2, each layer contains around 6*hidden_size*hidden_size parameters.
+
+    Parameter allocation when use_gate=True:
+        - 0.75 * hidden_size * hidden_size for the q_proj and k_proj each
+        - 1.5 * hidden_size * hidden_size for the v_proj, g_proj and o_proj each
+        - Others are ignorably small.
+        - In total = 0.75 * 2 + 1.5 * 3 = 6 * hidden_size * hidden_size
+    NOTE: num_heads * head_dim = 0.75 * hidden_size, please make sure to set the correct num_heads and head_dim.
+
+    Parameter allocation when use_gate=False:
+        - 1 * hidden_size * hidden_size for the q_proj and k_proj each
+        - 2 * hidden_size * hidden_size for the v_proj and o_proj each
+        - Others are ignorably small.
+        - In total = 1 * 2 + 2 * 2 = 6 * hidden_size * hidden_size
+
+    Args:
+        hidden_size (int, Optional):
+            The hidden size of the input. Default: 2048.
+        expand_v (float, Optional):
+            The expansion ratio for the value dimension. Default: 2.0.
+        head_dim (int, Optional):
+            The dimension of each head. Default: 256.
+        num_heads (int, Optional):
+            The number of heads. Default: 6.
+        num_v_heads (int, Optional):
+            The number of heads for the value projection, equal to `num_heads` if `None`.
+            GVA (Grouped Value Attention) is applied if `num_v_heads` > `num_heads`,
+            where `num_v_heads` must be divisible by `num_heads`.
+            The kernels natively support GVA by mapping multiple value heads to each query/key head.
+            Default: `None`.
+        mode (str, Optional):
+            Which Preconditioned Gated DeltaNet kernel to use.
+            Currently available: `chunk`, `fused_recurrent`, and `naive`.
+            Default: `chunk`.
+        use_gate (bool, Optional):
+            Whether to use output gate. Default: `True`.
+        use_short_conv (bool, Optional):
+            Whether to use short convolutions. Default: `True`.
+        allow_neg_eigval (bool, Optional):
+            Allow negative eigenvalues. Default: `False`. If set to `True`, the beta will be multiplied by 2.
+            See reference:
+            `Unlocking State-Tracking in Linear RNNs Through Negative Eigenvalues <https://arxiv.org/abs/2411.12537>`_
+        conv_size (int, Optional):
+            The kernel size of the short convolution, only used when `use_short_conv` is `True`. Default: 4.
+        conv_bias (bool, Optional):
+            Whether to use bias in the short convolution, only used when `use_short_conv` is `True`. Default: `False`.
+        layer_idx (int, Optional):
+            The index of the layer. Default: None.
+        norm_eps (float, Optional):
+            The epsilon value for the normalization layer. Default: 1e-5.
+        squash_x (float, Optional):
+            The squash range parameter. Squashes preconditioner onto interval [1/x, x].
+            Needs to be <= 2.0 for eigenstability. Default: 1.5.
+        squash_eps (float, Optional):
+            The epsilon for numerical stability in the squash function. Default: 1e-6.
+        log_atk_scale_init (float, Optional):
+            The initial value for the learnable per-head log_atk_scale parameter. Default: -0.2.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        expand_v: float = 2,
+        head_dim: int = 256,
+        num_heads: int = 6,
+        num_v_heads: int = None,
+        mode: str = 'chunk',
+        use_gate: bool = True,
+        use_short_conv: bool = True,
+        allow_neg_eigval: bool = False,
+        conv_size: int = 4,
+        conv_bias: bool = False,
+        layer_idx: int = None,
+        norm_eps: float = 1e-5,
+        squash_x: float = 1.5,
+        squash_eps: float = 1e-6,
+        log_atk_scale_init: float = -0.2,
+        **kwargs,
+    ) -> PrecondGatedDeltaNet:
+        super().__init__()
+
+        self.mode = mode
+        self.allow_neg_eigval = allow_neg_eigval
+        self.hidden_size = hidden_size
+        self.expand_v = expand_v
+
+        self.use_gate = use_gate
+        self.use_short_conv = use_short_conv
+        self.conv_size = conv_size
+        self.conv_bias = conv_bias
+
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.num_v_heads = num_v_heads if num_v_heads is not None else num_heads
+
+        self.head_k_dim = head_dim
+        self.head_v_dim = int(self.head_dim * self.expand_v)
+        self.key_dim = int(self.num_heads * self.head_k_dim)
+        self.value_dim = int(self.num_v_heads * self.head_v_dim)
+        self.layer_idx = layer_idx
+
+        self.squash_x = squash_x
+        self.squash_eps = squash_eps
+        self.log_atk_scale_init = log_atk_scale_init
+
+        # Consistency check: Ensure expand_v produces integer values
+        if not math.isclose(self.num_v_heads * self.head_dim * expand_v, self.value_dim, rel_tol=1e-5):
+            raise ValueError(
+                f"expand_v={expand_v} does not produce an integer value when multiplied by key_dim={self.key_dim}. "
+                f"Resulting value_dim would be {self.num_v_heads * self.head_dim * expand_v}, which is invalid for nn.Linear.",
+            )
+        if self.num_v_heads > self.num_heads and self.num_v_heads % self.num_heads != 0:
+            raise ValueError(
+                f"num_v_heads={self.num_v_heads} must be divisible by num_heads={self.num_heads}.",
+            )
+        if not math.isclose(head_dim * expand_v, self.head_v_dim, rel_tol=1e-5):
+            raise ValueError(
+                f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}. "
+                f"Resulting head_v_dim would be {head_dim * expand_v}, which is invalid for FusedRMSNormGated.",
+            )
+        assert mode in ['chunk', 'fused_recurrent', 'naive'], f"Not supported mode `{mode}`."
+
+        self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, self.value_dim, bias=False)
+
+        # Gate and beta projections for preconditioned Gated DeltaNet recurrence
+        self.a_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
+        self.b_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
+
+        # Separate gate and beta projections for ATK preconditioner recurrence
+        self.a_atk_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
+        self.b_atk_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
+
+        # Learnable per-head log-space center for preconditioner
+        self.log_atk_scale = nn.Parameter(
+            torch.full((self.num_v_heads,), self.log_atk_scale_init, dtype=torch.float32)
+        )
+        self.log_atk_scale._no_weight_decay = True
+
+        # Gate parameters for preconditioned Gated DeltaNet main recurrence
+        A = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(1, 16)
+        self.A_log = nn.Parameter(torch.log(A))
+        self.A_log._no_weight_decay = True
+        # hard coded (taken from Gated DeltaNet layer)
+        dt_min = 0.001
+        dt_max = 0.1
+        dt_init_floor = 1e-4
+        dt = torch.exp(
+            torch.rand(self.num_v_heads) * (math.log(dt_max) - math.log(dt_min))
+            + math.log(dt_min),
+        )
+        dt = torch.clamp(dt, min=dt_init_floor)
+        # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+        inv_dt = dt + torch.log(-torch.expm1(-dt))
+        self.dt_bias = nn.Parameter(inv_dt)
+        # Just to be explicit. Without this we already don't put wd on dt_bias because of the check
+        # name.endswith("bias") in param_grouping.py
+        self.dt_bias._no_weight_decay = True
+
+        # Gate parameters for preconditioner recurrence
+        A_atk = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(1, 16)
+        self.A_log_atk = nn.Parameter(torch.log(A_atk))
+        self.A_log_atk._no_weight_decay = True
+
+        dt_atk = torch.exp(
+            torch.rand(self.num_v_heads) * (math.log(dt_max) - math.log(dt_min))
+            + math.log(dt_min),
+        )
+        dt_atk = torch.clamp(dt_atk, min=dt_init_floor)
+        inv_dt_atk = dt_atk + torch.log(-torch.expm1(-dt_atk))
+        self.dt_bias_atk = nn.Parameter(inv_dt_atk)
+        self.dt_bias_atk._no_weight_decay = True
+
+        if use_short_conv:
+            self.conv_size = conv_size
+            self.q_conv1d = ShortConvolution(
+                hidden_size=self.key_dim,
+                kernel_size=conv_size,
+                bias=conv_bias,
+                activation='silu',
+            )
+            self.k_conv1d = ShortConvolution(
+                hidden_size=self.key_dim,
+                kernel_size=conv_size,
+                bias=conv_bias,
+                activation='silu',
+            )
+            self.v_conv1d = ShortConvolution(
+                hidden_size=self.value_dim,
+                kernel_size=conv_size,
+                bias=conv_bias,
+                activation='silu',
+            )
+        else:
+            warnings.warn(
+                "ShortConvolution is crucial to the performance. "
+                "Do not turn it off, i.e., setting `use_short_conv=False` unless you know what you are doing.",
+            )
+
+        if use_gate:
+            self.g_proj = nn.Linear(hidden_size, self.value_dim, bias=False)
+            self.o_norm = FusedRMSNormGated(self.head_v_dim, eps=norm_eps)
+        else:
+            self.o_norm = RMSNorm(self.head_v_dim, eps=norm_eps, dtype=torch.float32)
+        self.o_proj = nn.Linear(self.value_dim, hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        output_attentions: bool | None = False,
+        **kwargs: Unpack[dict],
+    ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+        if attention_mask is not None:
+            assert len(attention_mask.shape) == 2, (
+                "Expected attention_mask as a 0-1 matrix with shape [batch_size, seq_len] "
+                "for padding purposes (0 indicating padding). "
+                "Arbitrary attention masks of shape [batch_size, seq_len, seq_len] are not allowed."
+            )
+
+        batch_size, q_len, _ = hidden_states.shape
+
+        # change to inference mode.
+        mode = self.mode
+        if q_len <= 64 and not self.training:
+            mode = 'fused_recurrent'
+        if self.training:
+            assert mode in ['chunk', 'naive'], "Only chunk/naive modes are supported in training."
+
+        last_state = get_layer_cache(self, past_key_values)
+
+        cu_seqlens = kwargs.get('cu_seqlens')
+        if attention_mask is not None:
+            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+
+        if self.use_short_conv:
+            conv_state_q, conv_state_k, conv_state_v = None, None, None
+            if last_state is not None:
+                conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
+            q, conv_state_q = self.q_conv1d(
+                x=self.q_proj(hidden_states),
+                cache=conv_state_q,
+                output_final_state=use_cache,
+                cu_seqlens=cu_seqlens,
+            )
+            k, conv_state_k = self.k_conv1d(
+                x=self.k_proj(hidden_states),
+                cache=conv_state_k,
+                output_final_state=use_cache,
+                cu_seqlens=cu_seqlens,
+            )
+            v, conv_state_v = self.v_conv1d(
+                x=self.v_proj(hidden_states),
+                cache=conv_state_v,
+                output_final_state=use_cache,
+                cu_seqlens=cu_seqlens,
+            )
+        else:
+            q = F.silu(self.q_proj(hidden_states))
+            k = F.silu(self.k_proj(hidden_states))
+            v = F.silu(self.v_proj(hidden_states))
+
+        q, k = map(lambda x: rearrange(x, '... (h d) -> ... h d', d=self.head_k_dim), (q, k))
+        v = rearrange(v, '... (h d) -> ... h d', d=self.head_v_dim)
+
+        beta = self.b_proj(hidden_states).sigmoid()
+        if self.allow_neg_eigval:
+            beta = beta * 2.0
+        g = -self.A_log.float().exp() * F.softplus(self.a_proj(hidden_states).float() + self.dt_bias)
+
+        beta_atk = self.b_atk_proj(hidden_states).sigmoid()
+        g_atk = -self.A_log_atk.float().exp() * F.softplus(self.a_atk_proj(hidden_states).float() + self.dt_bias_atk)
+        log_atk_scale = self.log_atk_scale
+
+        recurrent_state = last_state['recurrent_state'] if last_state is not None else None
+        A_state = last_state['A_state'] if last_state is not None else None
+        if mode == 'chunk':
+            o, recurrent_state, A_state = chunk_precond_gated_delta_rule(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                g_atk=g_atk,
+                beta=beta,
+                beta_atk=beta_atk,
+                initial_state=recurrent_state,
+                initial_A_state=A_state,
+                output_final_state=use_cache,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=cu_seqlens,
+                x=self.squash_x,
+                eps=self.squash_eps,
+                log_atk_scale=log_atk_scale,
+            )
+        elif mode == 'fused_recurrent':
+            o, recurrent_state, A_state = fused_recurrent_precond_gated_delta_rule(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                g_atk=g_atk,
+                beta=beta,
+                beta_atk=beta_atk,
+                initial_state=recurrent_state,
+                initial_A_state=A_state,
+                output_final_state=use_cache,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=cu_seqlens,
+                x=self.squash_x,
+                eps=self.squash_eps,
+                log_atk_scale=log_atk_scale,
+            )
+        elif mode == 'naive':
+            o, recurrent_state, A_state = naive_recurrent_precond_gated_delta_rule(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                g_atk=g_atk,
+                beta=beta,
+                beta_atk=beta_atk,
+                initial_state=recurrent_state,
+                initial_A_state=A_state,
+                output_final_state=use_cache,
+                x=self.squash_x,
+                eps=self.squash_eps,
+                log_atk_scale=log_atk_scale,
+            )
+        else:
+            raise NotImplementedError(f"Not supported mode `{mode}`.")
+
+        update_layer_cache(
+            self,
+            past_key_values,
+            recurrent_state=recurrent_state,
+            A_state=A_state,
+            conv_state=(conv_state_q, conv_state_k, conv_state_v) if self.use_short_conv else None,
+            offset=q_len,
+        )
+
+        if self.use_gate:
+            g = rearrange(self.g_proj(hidden_states), '... (h d) -> ... h d', d=self.head_v_dim)
+            o = self.o_norm(o, g)
+        else:
+            o = self.o_norm(o)
+        o = rearrange(o, 'b t h d -> b t (h d)')
+        o = self.o_proj(o)
+        if attention_mask is not None:
+            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+
+        return o, None, past_key_values

--- a/fla/layers/precond_gated_deltanet.py
+++ b/fla/layers/precond_gated_deltanet.py
@@ -166,13 +166,15 @@ class PrecondGatedDeltaNet(nn.Module):
         self.a_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
         self.b_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
 
-        # Separate gate and beta projections for ATK preconditioner recurrence
-        self.a_atk_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
-        self.b_atk_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
+        # Separate gate and beta projections for ATK preconditioner recurrence.
+        # NOTE: ATK preconditions the keys, which carry `num_heads` (not `num_v_heads`)
+        # heads, so all ATK-side parameters are sized by `num_heads`.
+        self.a_atk_proj = nn.Linear(hidden_size, self.num_heads, bias=False)
+        self.b_atk_proj = nn.Linear(hidden_size, self.num_heads, bias=False)
 
         # Learnable per-head log-space center for preconditioner
         self.log_atk_scale = nn.Parameter(
-            torch.full((self.num_v_heads,), self.log_atk_scale_init, dtype=torch.float32)
+            torch.full((self.num_heads,), self.log_atk_scale_init, dtype=torch.float32)
         )
         self.log_atk_scale._no_weight_decay = True
 
@@ -196,13 +198,13 @@ class PrecondGatedDeltaNet(nn.Module):
         # name.endswith("bias") in param_grouping.py
         self.dt_bias._no_weight_decay = True
 
-        # Gate parameters for preconditioner recurrence
-        A_atk = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(1, 16)
+        # Gate parameters for preconditioner recurrence (per key head)
+        A_atk = torch.empty(self.num_heads, dtype=torch.float32).uniform_(1, 16)
         self.A_log_atk = nn.Parameter(torch.log(A_atk))
         self.A_log_atk._no_weight_decay = True
 
         dt_atk = torch.exp(
-            torch.rand(self.num_v_heads) * (math.log(dt_max) - math.log(dt_min))
+            torch.rand(self.num_heads) * (math.log(dt_max) - math.log(dt_min))
             + math.log(dt_min),
         )
         dt_atk = torch.clamp(dt_atk, min=dt_init_floor)

--- a/fla/layers/precond_gated_deltanet.py
+++ b/fla/layers/precond_gated_deltanet.py
@@ -179,7 +179,8 @@ class PrecondGatedDeltaNet(nn.Module):
         self.log_atk_scale._no_weight_decay = True
 
         # Gate parameters for preconditioned Gated DeltaNet main recurrence
-        A = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(1, 16)
+        # (uniform(0, 16) matches the baseline GatedDeltaNet layer init)
+        A = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(0, 16)
         self.A_log = nn.Parameter(torch.log(A))
         self.A_log._no_weight_decay = True
         # hard coded (taken from Gated DeltaNet layer)
@@ -199,7 +200,7 @@ class PrecondGatedDeltaNet(nn.Module):
         self.dt_bias._no_weight_decay = True
 
         # Gate parameters for preconditioner recurrence (per key head)
-        A_atk = torch.empty(self.num_heads, dtype=torch.float32).uniform_(1, 16)
+        A_atk = torch.empty(self.num_heads, dtype=torch.float32).uniform_(0, 16)
         self.A_log_atk = nn.Parameter(torch.log(A_atk))
         self.A_log_atk._no_weight_decay = True
 

--- a/fla/layers/precond_kda.py
+++ b/fla/layers/precond_kda.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+from einops import rearrange, repeat
+from torch.nn import functional as F
+
+from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.modules import FusedRMSNormGated, ShortConvolution
+from fla.ops.kda.gate import fused_kda_gate
+from fla.ops.precond_kda import chunk_precond_kda, fused_recurrent_precond_kda
+
+if TYPE_CHECKING:
+    from transformers.processing_utils import Unpack
+
+    from fla.models.utils import Cache
+
+
+class PrecondKDA(nn.Module):
+    """
+    Preconditioned KDA (PrecondKDA) layer implementation.
+
+    Reference: `Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences <https://arxiv.org/abs/2604.21100>`_
+
+    Each layer contains around ``hidden_size * key_dim * 2 + hidden_size * value_dim * 3`` parameters
+    (q/k projections + v/g/o projections), plus the low-rank f_proj bottleneck and ATK projections.
+
+    Args:
+        hidden_size (int, Optional):
+            The hidden size of the input. Default: 2048.
+        expand_v (float, Optional):
+            The expansion ratio for the value dimension. Default: 1.0.
+        head_dim (int, Optional):
+            The dimension of each head. Default: 128.
+        num_heads (int, Optional):
+            The number of heads. Default: 16.
+        num_v_heads (int, Optional):
+            The number of heads for the value projection, equal to `num_heads` if `None`.
+            GVA (Grouped Value Attention) is applied if `num_v_heads` > `num_heads`,
+            where `num_v_heads` must be divisible by `num_heads`. Default: `None`.
+        mode (str, Optional):
+            Which PrecondKDA kernel to use.
+            Currently available: `chunk` and `fused_recurrent`.
+            Default: `chunk`.
+        use_short_conv (bool, Optional):
+            Whether to use short convolutions. Default: `True`.
+        allow_neg_eigval (bool, Optional):
+            Allow negative eigenvalues. Default: `False`. If set to `True`, the beta will be multiplied by 2.
+            See reference:
+            `Unlocking State-Tracking in Linear RNNs Through Negative Eigenvalues <https://arxiv.org/abs/2411.12537>`_
+        conv_size (int, Optional):
+            The kernel size of the short convolution, only used when `use_short_conv` is `True`. Default: 4.
+        conv_bias (bool, Optional):
+            Whether to use bias in the short convolution, only used when `use_short_conv` is `True`. Default: `False`.
+        safe_gate (bool, Optional):
+            Whether the kernel can assume the gate values (in log space) are in ``[lower_bound, 0)``
+            and use M=16 TensorCore acceleration. Requires ``lower_bound`` to be set.
+            See :func:`chunk_precond_kda` for details. Default: ``False``.
+        lower_bound (float, Optional):
+            Lower bound for the forget gate in log space. Clamps the gate output to ``[lower_bound, 0)``.
+            With ``-5``, the per-step decay ``exp(g) ≈ 0.0067`` at minimum — negligible impact on quality.
+            See :func:`chunk_precond_kda` for details. Default: ``None``.
+        layer_idx (int, Optional):
+            The index of the layer. Default: None.
+        norm_eps (float, Optional):
+            The epsilon value for the normalization layer. Default: 1e-5.
+        squash_x (float, Optional):
+            The squash range parameter. Squashes preconditioner onto interval [1/x, x].
+            Needs to be <= 2.0 for eigenstability. Default: 1.5.
+        squash_eps (float, Optional):
+            The epsilon for numerical stability in the squash function. Default: 1e-6.
+        log_atk_scale_init (float, Optional):
+            The initial value for the learnable per-head log_atk_scale parameter. Default: -0.2.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        expand_v: float = 1,
+        head_dim: int = 128,
+        num_heads: int = 16,
+        num_v_heads: int = None,
+        mode: str = "chunk",
+        use_short_conv: bool = True,
+        allow_neg_eigval: bool = False,
+        safe_gate: bool = False,
+        lower_bound: float | None = None,
+        conv_size: int = 4,
+        conv_bias: bool = False,
+        layer_idx: int = None,
+        norm_eps: float = 1e-5,
+        squash_x: float = 1.5,
+        squash_eps: float = 1e-6,
+        log_atk_scale_init: float = -0.2,
+        **kwargs,
+    ) -> PrecondKDA:
+        super().__init__()
+
+        self.mode = mode
+        self.allow_neg_eigval = allow_neg_eigval
+        self.safe_gate = safe_gate
+        self.lower_bound = lower_bound
+        self.hidden_size = hidden_size
+        self.expand_v = expand_v
+
+        self.use_short_conv = use_short_conv
+        self.conv_size = conv_size
+        self.conv_bias = conv_bias
+
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.num_v_heads = num_v_heads if num_v_heads is not None else num_heads
+
+        self.head_k_dim = head_dim
+        self.head_v_dim = int(self.head_dim * self.expand_v)
+        self.key_dim = int(self.num_heads * self.head_k_dim)
+        self.value_dim = int(self.num_v_heads * self.head_v_dim)
+        self.layer_idx = layer_idx
+
+        self.squash_x_val = squash_x
+        self.squash_eps = squash_eps
+        self.log_atk_scale_init = log_atk_scale_init
+
+        # Consistency check: Ensure expand_v produces integer values
+        if not math.isclose(self.num_v_heads * self.head_dim * expand_v, self.value_dim, rel_tol=1e-5):
+            raise ValueError(
+                f"expand_v={expand_v} does not produce an integer value when multiplied by key_dim={self.key_dim}. "
+                f"Resulting value_dim would be {self.num_v_heads * self.head_dim * expand_v}, which is invalid for nn.Linear.",
+            )
+        if self.num_v_heads > self.num_heads and self.num_v_heads % self.num_heads != 0:
+            raise ValueError(
+                f"num_v_heads={self.num_v_heads} must be divisible by num_heads={self.num_heads}.",
+            )
+
+        if not math.isclose(head_dim * expand_v, self.head_v_dim, rel_tol=1e-5):
+            raise ValueError(
+                f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}. "
+                f"Resulting head_v_dim would be {head_dim * expand_v}, which is invalid for FusedRMSNormGated.",
+            )
+        assert mode in ["chunk", "fused_recurrent"], f"Not supported mode `{mode}`."
+
+        self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, self.value_dim, bias=False)
+
+        # ATK gate projection (scalar per head)
+        self.a_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
+
+        # KDA gate projection (diagonal - per dimension, 2-layer MLP)
+        self.f_proj = nn.Sequential(
+            nn.Linear(hidden_size, self.head_v_dim, bias=False),
+            nn.Linear(self.head_v_dim, self.num_v_heads * self.head_k_dim, bias=False),
+        )
+
+        self.b_atk_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
+        self.b_proj = nn.Linear(hidden_size, self.num_heads, bias=False)
+
+        A_atk = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(0, 16)
+        self.A_log_atk = nn.Parameter(torch.log(A_atk))
+        self.A_log_atk._no_weight_decay = True
+
+        dt_min = 0.001
+        dt_max = 0.1
+        dt_init_floor = 1e-4
+        dt_atk = torch.exp(
+            torch.rand(self.num_v_heads) * (math.log(dt_max) - math.log(dt_min))
+            + math.log(dt_min),
+        )
+        dt_atk = torch.clamp(dt_atk, min=dt_init_floor)
+        inv_dt_atk = dt_atk + torch.log(-torch.expm1(-dt_atk))
+        self.dt_bias_atk = nn.Parameter(inv_dt_atk)
+        self.dt_bias_atk._no_weight_decay = True
+
+        if safe_gate:
+            self.A_log = nn.Parameter(torch.zeros(self.num_v_heads, dtype=torch.float32))
+        else:
+            self.A_log = nn.Parameter(torch.log(torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(1, 16)))
+        self.A_log._no_weight_decay = True
+        self.dt_bias = nn.Parameter(torch.zeros(self.num_v_heads * self.head_k_dim, dtype=torch.float32))
+        self.dt_bias._no_weight_decay = True
+
+        self.log_atk_scale = nn.Parameter(
+            torch.full((self.num_v_heads,), self.log_atk_scale_init, dtype=torch.float32)
+        )
+        self.log_atk_scale._no_weight_decay = True
+
+        if use_short_conv:
+            self.q_conv1d = ShortConvolution(
+                hidden_size=self.key_dim,
+                kernel_size=conv_size,
+                bias=conv_bias,
+                activation="silu",
+            )
+            self.k_conv1d = ShortConvolution(
+                hidden_size=self.key_dim,
+                kernel_size=conv_size,
+                bias=conv_bias,
+                activation="silu",
+            )
+            self.v_conv1d = ShortConvolution(
+                hidden_size=self.value_dim,
+                kernel_size=conv_size,
+                bias=conv_bias,
+                activation="silu",
+            )
+
+        self.g_proj = nn.Sequential(
+            nn.Linear(hidden_size, self.head_v_dim, bias=False),
+            nn.Linear(self.head_v_dim, self.value_dim, bias=True),
+        )
+        self.o_norm = FusedRMSNormGated(self.head_v_dim, activation="sigmoid", eps=norm_eps)
+        self.o_proj = nn.Linear(self.value_dim, hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        output_attentions: bool | None = False,
+        **kwargs: Unpack[dict],
+    ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+        if attention_mask is not None:
+            assert len(attention_mask.shape) == 2, (
+                "Expected attention_mask as a 0-1 matrix with shape [batch_size, seq_len] "
+                "for padding purposes (0 indicating padding). "
+                "Arbitrary attention masks of shape [batch_size, seq_len, seq_len] are not allowed."
+            )
+
+        batch_size, q_len, _ = hidden_states.shape
+
+        # change to inference mode.
+        mode = "fused_recurrent" if (q_len <= 64 and not self.training) else self.mode
+        if self.training:
+            assert mode == "chunk", "Only chunk mode is supported in training."
+
+        last_state = get_layer_cache(self, past_key_values)
+
+        cu_seqlens = kwargs.get("cu_seqlens")
+        if attention_mask is not None:
+            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+
+        if self.use_short_conv:
+            conv_state_q, conv_state_k, conv_state_v = None, None, None
+            if last_state is not None:
+                conv_state_q, conv_state_k, conv_state_v = last_state["conv_state"]
+            q, conv_state_q = self.q_conv1d(
+                x=self.q_proj(hidden_states),
+                cache=conv_state_q,
+                output_final_state=use_cache,
+                cu_seqlens=cu_seqlens,
+            )
+            k, conv_state_k = self.k_conv1d(
+                x=self.k_proj(hidden_states),
+                cache=conv_state_k,
+                output_final_state=use_cache,
+                cu_seqlens=cu_seqlens,
+            )
+            v, conv_state_v = self.v_conv1d(
+                x=self.v_proj(hidden_states),
+                cache=conv_state_v,
+                output_final_state=use_cache,
+                cu_seqlens=cu_seqlens,
+            )
+        else:
+            q = F.silu(self.q_proj(hidden_states))
+            k = F.silu(self.k_proj(hidden_states))
+            v = F.silu(self.v_proj(hidden_states))
+
+        g = self.f_proj(hidden_states)
+        beta = self.b_proj(hidden_states).sigmoid()
+
+        q, k, g = (rearrange(x, "... (h d) -> ... h d", d=self.head_k_dim) for x in (q, k, g))
+        v = rearrange(v, "... (h d) -> ... h d", d=self.head_v_dim)
+
+        # for multi-value attention, we repeat the inputs for simplicity.
+        # NOTE: g is projected to num_v_heads heads (via f_proj), so it must NOT be repeated;
+        # only the num_heads-shaped q/k/beta are expanded to num_v_heads.
+        if self.num_v_heads > self.num_heads:
+            q, k = (repeat(x, "... h d -> ... (h g) d", g=self.num_v_heads // self.num_heads) for x in (q, k))
+            beta = repeat(beta, "... h -> ... (h g)", g=self.num_v_heads // self.num_heads)
+
+        if self.allow_neg_eigval:
+            beta = beta * 2.0
+
+        beta_atk = self.b_atk_proj(hidden_states).sigmoid()
+        g_atk = -(self.A_log_atk.float().exp()) * F.softplus(self.a_proj(hidden_states).float() + self.dt_bias_atk)
+
+        recurrent_state = last_state["recurrent_state"] if last_state is not None else None
+        A_state = last_state["A_state"] if last_state is not None else None
+
+        if mode == "chunk":
+            g = fused_kda_gate(g=g, A_log=self.A_log, dt_bias=self.dt_bias, lower_bound=self.lower_bound)
+            o, recurrent_state, A_state = chunk_precond_kda(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                g_atk=g_atk,
+                beta_atk=beta_atk,
+                initial_state=recurrent_state,
+                initial_A_state=A_state,
+                output_final_state=use_cache,
+                use_qk_l2norm_in_kernel=True,
+                use_gate_in_kernel=False,
+                safe_gate=self.safe_gate,
+                lower_bound=self.lower_bound,
+                cu_seqlens=cu_seqlens,
+                x=self.squash_x_val,
+                eps=self.squash_eps,
+                log_atk_scale=self.log_atk_scale,
+            )
+        elif mode == "fused_recurrent":
+            g = fused_kda_gate(g=g, A_log=self.A_log, dt_bias=self.dt_bias, lower_bound=self.lower_bound)
+            o, recurrent_state, A_state = fused_recurrent_precond_kda(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                g_atk=g_atk,
+                beta_atk=beta_atk,
+                initial_state=recurrent_state,
+                initial_A_state=A_state,
+                output_final_state=use_cache,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=cu_seqlens,
+                x=self.squash_x_val,
+                eps=self.squash_eps,
+                log_atk_scale=self.log_atk_scale,
+            )
+        else:
+            raise NotImplementedError(f"Not supported mode `{mode}`.")
+
+        update_layer_cache(
+            self,
+            past_key_values,
+            recurrent_state=recurrent_state,
+            A_state=A_state,
+            conv_state=(conv_state_q, conv_state_k, conv_state_v) if self.use_short_conv else None,
+            offset=q_len,
+        )
+
+        o = self.o_norm(o, rearrange(self.g_proj(hidden_states), "... (h d) -> ... h d", d=self.head_v_dim))
+        o = rearrange(o, "b t h d -> b t (h d)")
+        o = self.o_proj(o)
+        if attention_mask is not None:
+            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+
+        return o, None, past_key_values

--- a/fla/layers/precond_kda.py
+++ b/fla/layers/precond_kda.py
@@ -165,7 +165,7 @@ class PrecondKDA(nn.Module):
         self.b_atk_proj = nn.Linear(hidden_size, self.num_v_heads, bias=False)
         self.b_proj = nn.Linear(hidden_size, self.num_heads, bias=False)
 
-        A_atk = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(0, 16)
+        A_atk = torch.empty(self.num_v_heads, dtype=torch.float32).uniform_(1, 16)
         self.A_log_atk = nn.Parameter(torch.log(A_atk))
         self.A_log_atk._no_weight_decay = True
 

--- a/fla/models/__init__.py
+++ b/fla/models/__init__.py
@@ -35,6 +35,16 @@ from fla.models.mom import MomConfig, MomForCausalLM, MomModel
 from fla.models.nsa import NSAConfig, NSAForCausalLM, NSAModel
 from fla.models.parallax import ParallaxConfig, ParallaxForCausalLM, ParallaxModel
 from fla.models.path_attn import PaTHAttentionConfig, PaTHAttentionForCausalLM, PaTHAttentionModel
+from fla.models.precond_gated_deltanet import (
+    PrecondGatedDeltaNetConfig,
+    PrecondGatedDeltaNetForCausalLM,
+    PrecondGatedDeltaNetModel,
+)
+from fla.models.precond_kda import (
+    PrecondKDAConfig,
+    PrecondKDAForCausalLM,
+    PrecondKDAModel,
+)
 from fla.models.raven import RavenConfig, RavenForCausalLM, RavenModel
 from fla.models.retnet import RetNetConfig, RetNetForCausalLM, RetNetModel
 from fla.models.rodimus import RodimusConfig, RodimusForCausalLM, RodimusModel
@@ -124,6 +134,12 @@ __all__ = [
     'ParallaxConfig',
     'ParallaxForCausalLM',
     'ParallaxModel',
+    'PrecondGatedDeltaNetConfig',
+    'PrecondGatedDeltaNetForCausalLM',
+    'PrecondGatedDeltaNetModel',
+    'PrecondKDAConfig',
+    'PrecondKDAForCausalLM',
+    'PrecondKDAModel',
     'RWKV6Config',
     'RWKV6ForCausalLM',
     'RWKV6Model',

--- a/fla/models/precond_gated_deltanet/__init__.py
+++ b/fla/models/precond_gated_deltanet/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+
+from fla.models.precond_gated_deltanet.configuration_precond_gated_deltanet import PrecondGatedDeltaNetConfig
+from fla.models.precond_gated_deltanet.modeling_precond_gated_deltanet import (
+    PrecondGatedDeltaNetForCausalLM,
+    PrecondGatedDeltaNetModel,
+)
+
+AutoConfig.register(PrecondGatedDeltaNetConfig.model_type, PrecondGatedDeltaNetConfig, exist_ok=True)
+AutoModel.register(PrecondGatedDeltaNetConfig, PrecondGatedDeltaNetModel, exist_ok=True)
+AutoModelForCausalLM.register(PrecondGatedDeltaNetConfig, PrecondGatedDeltaNetForCausalLM, exist_ok=True)
+
+__all__ = ['PrecondGatedDeltaNetConfig', 'PrecondGatedDeltaNetForCausalLM', 'PrecondGatedDeltaNetModel']

--- a/fla/models/precond_gated_deltanet/configuration_precond_gated_deltanet.py
+++ b/fla/models/precond_gated_deltanet/configuration_precond_gated_deltanet.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import warnings
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class PrecondGatedDeltaNetConfig(PretrainedConfig):
+    model_type = 'precond_gated_deltanet'
+    keys_to_ignore_at_inference = ['past_key_values']
+
+    def __init__(
+        self,
+        attn_mode: str = "chunk",
+        hidden_size: int = 2048,
+        expand_v: float = 2.0,
+        use_gate: bool = True,
+        use_short_conv: bool = True,
+        allow_neg_eigval: bool = False,
+        conv_size: int = 4,
+        head_dim: int = 256,
+        num_heads: int = 6,
+        num_v_heads: int | None = None,
+        max_position_embeddings: int = 2048,
+        hidden_ratio: int | None = 4,
+        intermediate_size: int | None = None,
+        hidden_act: str = "swish",
+        num_hidden_layers: int = 21,
+        norm_eps: float = 1e-6,
+        attn: dict | None = None,
+        use_cache: bool = True,
+        pad_token_id: int | None = None,
+        bos_token_id: int = 1,
+        eos_token_id: int = 2,
+        tie_word_embeddings: bool = False,
+        initializer_range: float = 0.02,
+        fuse_norm: bool = True,
+        fuse_swiglu: bool = True,
+        fuse_cross_entropy: bool = True,
+        fuse_linear_cross_entropy: bool = False,
+        use_l2warp: bool = False,
+        vocab_size: int = 32000,
+        # preconditioner settings
+        squash_x: float = 1.5,
+        squash_eps: float = 1e-6,
+        log_atk_scale_init: float = -0.2,
+        **kwargs,
+    ):
+        self.attn_mode = attn_mode
+        self.hidden_size = hidden_size
+        self.expand_v = expand_v
+        self.use_gate = use_gate
+        self.use_short_conv = use_short_conv
+        self.conv_size = conv_size
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.num_v_heads = num_v_heads
+        self.max_position_embeddings = max_position_embeddings
+
+        self.hidden_ratio = hidden_ratio
+        self.intermediate_size = intermediate_size
+        self.hidden_act = hidden_act
+        self.num_hidden_layers = num_hidden_layers
+        self.norm_eps = norm_eps
+        self.attn = attn
+        self.use_cache = use_cache
+        self.initializer_range = initializer_range
+
+        self.fuse_norm = fuse_norm
+        self.fuse_swiglu = fuse_swiglu
+        self.fuse_cross_entropy = fuse_cross_entropy
+        self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
+        self.use_l2warp = use_l2warp
+        self.vocab_size = vocab_size
+        self.allow_neg_eigval = allow_neg_eigval
+
+        # Preconditioner settings
+        self.squash_x = squash_x
+        self.squash_eps = squash_eps
+        self.log_atk_scale_init = log_atk_scale_init
+
+        if fuse_cross_entropy and fuse_linear_cross_entropy:
+            raise ValueError(
+                "`fuse_cross_entropy` and `fuse_linear_cross_entropy` cannot be True at the same time.",
+            )
+        if fuse_linear_cross_entropy:
+            warnings.warn(
+                "`fuse_linear_cross_entropy` is enabled, which can improves memory efficiency "
+                "at the potential cost of reduced precision. "
+                "If you observe issues like loss divergence, consider disabling this setting.",
+            )
+
+        if attn is not None:
+            if not isinstance(attn, dict):
+                raise ValueError("attn must be a dictionary")
+            if 'layers' not in attn:
+                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
+            if 'num_heads' not in attn:
+                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
+            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
+            attn['qkv_bias'] = attn.get('qkv_bias', False)
+            attn['window_size'] = attn.get('window_size', None)
+            attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/fla/models/precond_gated_deltanet/configuration_precond_gated_deltanet.py
+++ b/fla/models/precond_gated_deltanet/configuration_precond_gated_deltanet.py
@@ -50,7 +50,7 @@ class PrecondGatedDeltaNetConfig(PretrainedConfig):
         squash_eps: float = 1e-6,
         log_atk_scale_init: float = -0.2,
         # Lower bound of the uniform A_log/A_log_atk init distribution.
-        # The paper's experiments use 0; baseline (Gated)DeltaNet uses 1.
+        # Defaults to 0, matching baseline GatedDeltaNet (and the paper's experiments).
         a_log_init_lower: float = 0,
         **kwargs,
     ):

--- a/fla/models/precond_gated_deltanet/configuration_precond_gated_deltanet.py
+++ b/fla/models/precond_gated_deltanet/configuration_precond_gated_deltanet.py
@@ -49,6 +49,9 @@ class PrecondGatedDeltaNetConfig(PretrainedConfig):
         squash_x: float = 1.5,
         squash_eps: float = 1e-6,
         log_atk_scale_init: float = -0.2,
+        # Lower bound of the uniform A_log/A_log_atk init distribution.
+        # The paper's experiments use 0; baseline (Gated)DeltaNet uses 1.
+        a_log_init_lower: float = 0,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -83,6 +86,7 @@ class PrecondGatedDeltaNetConfig(PretrainedConfig):
         self.squash_x = squash_x
         self.squash_eps = squash_eps
         self.log_atk_scale_init = log_atk_scale_init
+        self.a_log_init_lower = a_log_init_lower
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(

--- a/fla/models/precond_gated_deltanet/modeling_precond_gated_deltanet.py
+++ b/fla/models/precond_gated_deltanet/modeling_precond_gated_deltanet.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.nn as nn
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import logging
+from transformers.utils.deprecation import deprecate_kwarg
+
+from fla.layers.attn import Attention
+from fla.layers.precond_gated_deltanet import PrecondGatedDeltaNet
+from fla.models.precond_gated_deltanet.configuration_precond_gated_deltanet import PrecondGatedDeltaNetConfig
+from fla.models.utils import Cache, FLAGenerationMixin
+from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
+from fla.modules import GatedMLP as PrecondGatedDeltaNetMLP
+from fla.modules.l2warp import l2_warp
+
+if TYPE_CHECKING:
+    from transformers.processing_utils import Unpack
+
+
+try:
+    from transformers.modeling_layers import GradientCheckpointingLayer
+except ImportError:
+    from fla.models.modeling_layers import GradientCheckpointingLayer
+
+logger = logging.get_logger(__name__)
+
+
+class PrecondGatedDeltaNetBlock(GradientCheckpointingLayer):
+
+    def __init__(self, config: PrecondGatedDeltaNetConfig, layer_idx: int):
+        super().__init__()
+
+        self.config = config
+        self.layer_idx = layer_idx
+
+        self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        if config.attn is not None and layer_idx in config.attn['layers']:
+            self.attn = Attention(
+                hidden_size=config.hidden_size,
+                num_heads=config.attn['num_heads'],
+                num_kv_heads=config.attn['num_kv_heads'],
+                qkv_bias=config.attn['qkv_bias'],
+                window_size=config.attn['window_size'],
+                rope_theta=config.attn['rope_theta'],
+                max_position_embeddings=config.max_position_embeddings,
+                layer_idx=layer_idx,
+            )
+        else:
+            self.attn = PrecondGatedDeltaNet(
+                mode=config.attn_mode,
+                hidden_size=config.hidden_size,
+                expand_v=config.expand_v,
+                head_dim=config.head_dim,
+                num_heads=config.num_heads,
+                num_v_heads=config.num_v_heads,
+                use_gate=config.use_gate,
+                use_short_conv=config.use_short_conv,
+                allow_neg_eigval=config.allow_neg_eigval,
+                conv_size=config.conv_size,
+                norm_eps=config.norm_eps,
+                layer_idx=layer_idx,
+                squash_x=config.squash_x,
+                squash_eps=config.squash_eps,
+                log_atk_scale_init=config.log_atk_scale_init,
+            )
+        self.mlp_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        self.mlp = PrecondGatedDeltaNetMLP(
+            hidden_size=config.hidden_size,
+            hidden_ratio=config.hidden_ratio,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            fuse_swiglu=config.fuse_swiglu,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        use_cache: bool | None = False,
+        output_attentions: bool | None = False,
+        **kwargs: Unpack[dict],
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
+        residual = hidden_states
+        hidden_states = self.attn_norm(hidden_states)
+        hidden_states, attentions, past_key_values = self.attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            **kwargs,
+        )
+        if self.config.fuse_norm:
+            hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
+        else:
+            hidden_states = residual + hidden_states
+            residual = hidden_states
+            hidden_states = self.mlp_norm(hidden_states)
+        hidden_states = self.mlp(hidden_states, **kwargs)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values)
+
+        return outputs
+
+
+class PrecondGatedDeltaNetPreTrainedModel(PreTrainedModel):
+
+    config_class = PrecondGatedDeltaNetConfig
+    base_model_prefix = 'model'
+    supports_gradient_checkpointing = True
+    _no_split_modules = ['PrecondGatedDeltaNetBlock']
+    _supports_cache_class = True
+
+    def __init__(self, *inputs, **kwargs):
+        super().__init__(*inputs, **kwargs)
+
+    def _init_weights(
+        self,
+        module: nn.Module,
+        prenorm_residual_strategy: str | None = None,
+        num_residuals_per_layer: int = 2,
+    ):
+        if isinstance(module, PrecondGatedDeltaNet) and next(module.parameters()).device.type != 'meta':
+            a_log_lower = getattr(self.config, 'a_log_init_lower', 0)
+            with torch.no_grad():
+                # Initialize A_log for main recurrence
+                if not getattr(module.A_log, '_is_hf_initialized', False):
+                    module.A_log.copy_(nn.init.uniform_(module.A_log, a=a_log_lower, b=16).log())
+                module.A_log._no_weight_decay = True
+
+                # Initialize dt_bias for main recurrence
+                if not getattr(module.dt_bias, '_is_hf_initialized', False):
+                    dt = torch.exp(
+                        nn.init.uniform_(module.dt_bias) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
+                    ).clamp(min=1e-4)
+                    # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                    inv_dt = dt + torch.log(-torch.expm1(-dt))
+                    module.dt_bias.copy_(inv_dt)
+                module.dt_bias._no_weight_decay = True
+
+                # Initialize A_log_atk for ATK recurrence
+                if not getattr(module.A_log_atk, '_is_hf_initialized', False):
+                    module.A_log_atk.copy_(nn.init.uniform_(module.A_log_atk, a=a_log_lower, b=16).log())
+                module.A_log_atk._no_weight_decay = True
+
+                # Initialize dt_bias_atk for ATK recurrence
+                if not getattr(module.dt_bias_atk, '_is_hf_initialized', False):
+                    dt_atk = torch.exp(
+                        nn.init.uniform_(module.dt_bias_atk) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
+                    ).clamp(min=1e-4)
+                    inv_dt_atk = dt_atk + torch.log(-torch.expm1(-dt_atk))
+                    module.dt_bias_atk.copy_(inv_dt_atk)
+                module.dt_bias_atk._no_weight_decay = True
+
+        elif isinstance(module, (nn.Linear, nn.Conv1d)):
+            # Slightly different from the TF version which uses truncated_normal for initialization
+            # cf https://github.com/pytorch/pytorch/pull/5617
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+        elif hasattr(module, 'reset_parameters'):
+            module.reset_parameters()
+
+        if prenorm_residual_strategy is not None:
+            # Reinitialize selected weights subject to the OpenAI GPT-2 Paper Scheme:
+            #   > A modified initialization which accounts for the accumulation on the residual path with model depth. Scale
+            #   > the weights of residual layers at initialization by a factor of 1/√N where N is the # of residual layers.
+            #   >   -- GPT-2 :: https://openai.com/blog/better-language-models/
+            #
+            # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
+            p = None
+            if hasattr(module, 'o_proj'):
+                p = module.o_proj.weight
+            elif hasattr(module, 'down_proj'):
+                p = module.down_proj.weight
+            if p is not None:
+                # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
+                # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
+                # We need to reinit p since this code could be called multiple times
+                # Having just p *= scale would repeatedly scale it down
+                if prenorm_residual_strategy == 'rescale':
+                    nn.init.kaiming_uniform_(p, a=math.sqrt(5))
+                    with torch.no_grad():
+                        p /= math.sqrt(num_residuals_per_layer * self.config.num_hidden_layers)
+                elif prenorm_residual_strategy == 'zero':
+                    nn.init.zeros_(p)
+                else:
+                    raise ValueError(f"Invalid prenorm_residual_strategy: {prenorm_residual_strategy}")
+
+
+class PrecondGatedDeltaNetModel(PrecondGatedDeltaNetPreTrainedModel):
+
+    def __init__(self, config: PrecondGatedDeltaNetConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([PrecondGatedDeltaNetBlock(config, layer_idx)
+                                    for layer_idx in range(config.num_hidden_layers)])
+        self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embeddings
+
+    def set_input_embeddings(self, value):
+        self.embeddings = value
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: Optional[torch.Tensor] = None,  # noqa
+        inputs_embeds: torch.FloatTensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        **kwargs: Unpack[dict],
+    ) -> tuple | BaseModelOutputWithPast:
+        if output_attentions:
+            warnings.warn("`PrecondGatedDeltaNetModel` does not `output_attentions` now, setting it to `False`.")
+            output_attentions = False
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        use_cache = use_cache if use_cache is not None else (self.config.use_cache if not self.training else False)
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # retrieve input_ids and inputs_embeds
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embeddings(input_ids)
+        hidden_states = inputs_embeds
+
+        if use_cache and not isinstance(past_key_values, Cache):
+            past_key_values = Cache.from_legacy_cache(past_key_values)
+
+        all_hidden_states = () if output_hidden_states else None
+        all_attns = () if output_attentions else None
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs,
+            )
+
+            if output_attentions:
+                all_attns += (attentions,)
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(i for i in [hidden_states, past_key_values, all_hidden_states, all_attns] if i is not None)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            hidden_states=all_hidden_states,
+            attentions=all_attns,
+        )
+
+
+class PrecondGatedDeltaNetForCausalLM(PrecondGatedDeltaNetPreTrainedModel, FLAGenerationMixin):
+
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = PrecondGatedDeltaNetModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.criterion = None
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embeddings
+
+    def set_input_embeddings(self, value):
+        self.model.embeddings = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def generate(self, *args, **kwargs):
+        try:
+            return super().generate(*args, **kwargs)
+        except AttributeError as exception:
+            if 'past_key_values' in str(exception):
+                raise AttributeError(
+                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
+                    f"which is not supported for {self.__class__.__name__}. "
+                    f"Try another generation strategy instead. "
+                    f"For the available generation strategies, check this doc: "
+                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
+                )
+            else:
+                raise exception
+
+    @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        logits_to_keep: int | None = 0,
+        **kwargs: Unpack[dict],
+    ) -> tuple | CausalLMOutputWithPast:
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs,
+        )
+
+        hidden_states = outputs[0]
+
+        loss, logits = None, None
+        if not self.config.fuse_linear_cross_entropy or labels is None:
+            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+        if labels is not None:
+            if getattr(self, 'criterion', None) is None:
+                if self.config.fuse_linear_cross_entropy:
+                    criterion = FusedLinearCrossEntropyLoss(use_l2warp=self.config.use_l2warp)
+                elif self.config.fuse_cross_entropy:
+                    criterion = FusedCrossEntropyLoss(inplace_backward=True)
+                else:
+                    criterion = nn.CrossEntropyLoss()
+            else:
+                criterion = self.criterion
+            labels = labels.to(hidden_states.device)
+            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            if self.config.fuse_linear_cross_entropy:
+                loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
+            else:
+                loss = criterion(logits.view(labels.numel(), -1), labels.view(-1))
+                loss = l2_warp(loss, logits) if self.config.use_l2warp else loss
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )

--- a/fla/models/precond_kda/__init__.py
+++ b/fla/models/precond_kda/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+
+from fla.models.precond_kda.configuration_precond_kda import PrecondKDAConfig
+from fla.models.precond_kda.modeling_precond_kda import PrecondKDAForCausalLM, PrecondKDAModel
+
+AutoConfig.register(PrecondKDAConfig.model_type, PrecondKDAConfig, exist_ok=True)
+AutoModel.register(PrecondKDAConfig, PrecondKDAModel, exist_ok=True)
+AutoModelForCausalLM.register(PrecondKDAConfig, PrecondKDAForCausalLM, exist_ok=True)
+
+__all__ = ['PrecondKDAConfig', 'PrecondKDAForCausalLM', 'PrecondKDAModel']

--- a/fla/models/precond_kda/configuration_precond_kda.py
+++ b/fla/models/precond_kda/configuration_precond_kda.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class PrecondKDAConfig(PretrainedConfig):
+    model_type = 'precond_kda'
+    keys_to_ignore_at_inference = ['past_key_values']
+
+    def __init__(
+        self,
+        attn_mode: str = "chunk",
+        hidden_size: int = 2048,
+        expand_v: float = 1.0,
+        use_short_conv: bool = True,
+        allow_neg_eigval: bool = False,
+        safe_gate: bool = False,
+        lower_bound: float | None = None,
+        conv_size: int = 4,
+        head_dim: int = 128,
+        num_heads: int = 16,
+        num_v_heads: int | None = None,
+        max_position_embeddings: int = 2048,
+        hidden_ratio: int | None = 4,
+        intermediate_size: int | None = None,
+        hidden_act: str = "swish",
+        num_hidden_layers: int = 24,
+        norm_eps: float = 1e-6,
+        attn: dict | None = None,
+        use_cache: bool = True,
+        pad_token_id: int | None = None,
+        bos_token_id: int = 1,
+        eos_token_id: int = 2,
+        tie_word_embeddings: bool = False,
+        initializer_range: float = 0.02,
+        fuse_norm: bool = True,
+        fuse_swiglu: bool = True,
+        fuse_cross_entropy: bool = True,
+        use_l2warp: bool = False,
+        vocab_size: int = 32000,
+        # Symmetric squash preconditioning
+        squash_x: float = 1.5,
+        squash_eps: float = 1e-6,
+        log_atk_scale_init: float = -0.2,
+        **kwargs,
+    ):
+        self.attn_mode = attn_mode
+        self.hidden_size = hidden_size
+        self.expand_v = expand_v
+        self.use_short_conv = use_short_conv
+        self.conv_size = conv_size
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.num_v_heads = num_v_heads
+        self.max_position_embeddings = max_position_embeddings
+
+        self.hidden_ratio = hidden_ratio
+        self.intermediate_size = intermediate_size
+        self.hidden_act = hidden_act
+        self.num_hidden_layers = num_hidden_layers
+        self.norm_eps = norm_eps
+        self.attn = attn
+        self.use_cache = use_cache
+        self.initializer_range = initializer_range
+
+        self.fuse_norm = fuse_norm
+        self.fuse_swiglu = fuse_swiglu
+        self.fuse_cross_entropy = fuse_cross_entropy
+        self.use_l2warp = use_l2warp
+        self.vocab_size = vocab_size
+        self.allow_neg_eigval = allow_neg_eigval
+        self.safe_gate = safe_gate
+        self.lower_bound = lower_bound
+
+        # Symmetric squash preconditioning
+        self.squash_x = squash_x
+        self.squash_eps = squash_eps
+        self.log_atk_scale_init = log_atk_scale_init
+
+        if safe_gate and lower_bound is None:
+            raise ValueError("`lower_bound` must be specified when `safe_gate=True` (recommended: -5).")
+
+        if attn is not None:
+            if not isinstance(attn, dict):
+                raise ValueError("attn must be a dictionary")
+            if 'layers' not in attn:
+                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
+            if 'num_heads' not in attn:
+                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
+            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
+            attn['qkv_bias'] = attn.get('qkv_bias', False)
+            attn['window_size'] = attn.get('window_size', None)
+            attn['rope_theta'] = attn.get('rope_theta', 10000.)
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/fla/models/precond_kda/configuration_precond_kda.py
+++ b/fla/models/precond_kda/configuration_precond_kda.py
@@ -47,6 +47,9 @@ class PrecondKDAConfig(PretrainedConfig):
         squash_x: float = 1.5,
         squash_eps: float = 1e-6,
         log_atk_scale_init: float = -0.2,
+        # Lower bound of the uniform A_log/A_log_atk init distribution.
+        # The paper's experiments use 0; baseline KDA uses 1.
+        a_log_init_lower: float = 0,
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -81,6 +84,7 @@ class PrecondKDAConfig(PretrainedConfig):
         self.squash_x = squash_x
         self.squash_eps = squash_eps
         self.log_atk_scale_init = log_atk_scale_init
+        self.a_log_init_lower = a_log_init_lower
 
         if safe_gate and lower_bound is None:
             raise ValueError("`lower_bound` must be specified when `safe_gate=True` (recommended: -5).")

--- a/fla/models/precond_kda/configuration_precond_kda.py
+++ b/fla/models/precond_kda/configuration_precond_kda.py
@@ -48,8 +48,8 @@ class PrecondKDAConfig(PretrainedConfig):
         squash_eps: float = 1e-6,
         log_atk_scale_init: float = -0.2,
         # Lower bound of the uniform A_log/A_log_atk init distribution.
-        # The paper's experiments use 0; baseline KDA uses 1.
-        a_log_init_lower: float = 0,
+        # Defaults to 1, matching baseline KDA; the paper's experiments used 0.
+        a_log_init_lower: float = 1,
         **kwargs,
     ):
         self.attn_mode = attn_mode

--- a/fla/models/precond_kda/modeling_precond_kda.py
+++ b/fla/models/precond_kda/modeling_precond_kda.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.nn as nn
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import logging
+from transformers.utils.deprecation import deprecate_kwarg
+
+from fla.layers.attn import Attention
+from fla.layers.precond_kda import PrecondKDA
+from fla.models.precond_kda.configuration_precond_kda import PrecondKDAConfig
+from fla.models.utils import Cache, FLAGenerationMixin
+from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
+from fla.modules import GatedMLP as PrecondKDAMLP
+from fla.modules.l2warp import l2_warp
+
+if TYPE_CHECKING:
+    from transformers.processing_utils import Unpack
+
+
+try:
+    from transformers.modeling_layers import GradientCheckpointingLayer
+except ImportError:
+    from fla.models.modeling_layers import GradientCheckpointingLayer
+
+logger = logging.get_logger(__name__)
+
+
+class PrecondKDABlock(GradientCheckpointingLayer):
+    def __init__(self, config: PrecondKDAConfig, layer_idx: int):
+        super().__init__()
+
+        self.config = config
+        self.layer_idx = layer_idx
+
+        self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        if config.attn is not None and layer_idx in config.attn["layers"]:
+            self.attn = Attention(
+                hidden_size=config.hidden_size,
+                num_heads=config.attn["num_heads"],
+                num_kv_heads=config.attn["num_kv_heads"],
+                qkv_bias=config.attn["qkv_bias"],
+                window_size=config.attn["window_size"],
+                rope_theta=config.attn["rope_theta"],
+                max_position_embeddings=config.max_position_embeddings,
+                layer_idx=layer_idx,
+            )
+        else:
+            self.attn = PrecondKDA(
+                mode=config.attn_mode,
+                hidden_size=config.hidden_size,
+                expand_v=config.expand_v,
+                head_dim=config.head_dim,
+                num_heads=config.num_heads,
+                num_v_heads=config.num_v_heads,
+                use_short_conv=config.use_short_conv,
+                allow_neg_eigval=config.allow_neg_eigval,
+                conv_size=config.conv_size,
+                norm_eps=config.norm_eps,
+                layer_idx=layer_idx,
+                squash_x=config.squash_x,
+                squash_eps=config.squash_eps,
+                log_atk_scale_init=config.log_atk_scale_init,
+                safe_gate=config.safe_gate,
+                lower_bound=config.lower_bound,
+            )
+        self.mlp_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+        self.mlp = PrecondKDAMLP(
+            hidden_size=config.hidden_size,
+            hidden_ratio=config.hidden_ratio,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            fuse_swiglu=config.fuse_swiglu,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        use_cache: bool | None = False,
+        output_attentions: bool | None = False,
+        **kwargs: Unpack[dict],
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
+        residual = hidden_states
+        hidden_states = self.attn_norm(hidden_states)
+        hidden_states, attentions, past_key_values = self.attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            **kwargs,
+        )
+        if self.config.fuse_norm:
+            hidden_states, residual = self.mlp_norm(hidden_states, residual, True)
+        else:
+            hidden_states = residual + hidden_states
+            residual = hidden_states
+            hidden_states = self.mlp_norm(hidden_states)
+        hidden_states = self.mlp(hidden_states, **kwargs)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, attentions, past_key_values)
+
+        return outputs
+
+
+class PrecondKDAPreTrainedModel(PreTrainedModel):
+    config_class = PrecondKDAConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["PrecondKDABlock"]
+    _supports_cache_class = True
+
+    def __init__(self, *inputs, **kwargs):
+        super().__init__(*inputs, **kwargs)
+
+    def _init_weights(
+        self,
+        module: nn.Module,
+        prenorm_residual_strategy: str | None = None,
+        num_residuals_per_layer: int = 2,
+    ):
+        if isinstance(module, PrecondKDA) and next(module.parameters()).device.type != "meta":
+            a_log_lower = getattr(self.config, "a_log_init_lower", 0)
+            with torch.no_grad():
+                # Initialize ATK gate parameters
+                if not getattr(module.A_log_atk, "_is_hf_initialized", False):
+                    module.A_log_atk.copy_(nn.init.uniform_(module.A_log_atk, a=a_log_lower, b=16).log())
+                module.A_log_atk._no_weight_decay = True
+                if not getattr(module.dt_bias_atk, "_is_hf_initialized", False):
+                    dt_atk = torch.exp(
+                        nn.init.uniform_(module.dt_bias_atk) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
+                    ).clamp(min=1e-4)
+                    inv_dt_atk = dt_atk + torch.log(-torch.expm1(-dt_atk))
+                    module.dt_bias_atk.copy_(inv_dt_atk)
+                module.dt_bias_atk._is_hf_initialized = True
+
+                # Initialize KDA gate parameters
+                if not getattr(module.A_log, "_is_hf_initialized", False):
+                    if module.safe_gate:
+                        module.A_log.zero_()
+                    else:
+                        module.A_log.copy_(nn.init.uniform_(module.A_log, a=a_log_lower, b=16).log())
+                module.A_log._no_weight_decay = True
+                if not getattr(module.dt_bias, "_is_hf_initialized", False):
+                    dt = torch.exp(
+                        nn.init.uniform_(module.dt_bias) * (math.log(0.1) - math.log(0.001)) + math.log(0.001),
+                    ).clamp(min=1e-4)
+                    inv_dt = dt + torch.log(-torch.expm1(-dt))
+                    module.dt_bias.copy_(inv_dt)
+                module.dt_bias._is_hf_initialized = True
+
+        if isinstance(module, (nn.Linear, nn.Conv1d)):
+            # Slightly different from the TF version which uses truncated_normal for initialization
+            # cf https://github.com/pytorch/pytorch/pull/5617
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None and not getattr(module.bias, "_is_hf_initialized", False):
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+        elif hasattr(module, "reset_parameters"):
+            module.reset_parameters()
+
+        if prenorm_residual_strategy is not None:
+            # Reinitialize selected weights subject to the OpenAI GPT-2 Paper Scheme:
+            #   > A modified initialization which accounts for the accumulation on the residual path with model depth. Scale
+            #   > the weights of residual layers at initialization by a factor of 1/√N where N is the # of residual layers.
+            #   >   -- GPT-2 :: https://openai.com/blog/better-language-models/
+            #
+            # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
+            p = None
+            if hasattr(module, "o_proj"):
+                p = module.o_proj.weight
+            elif hasattr(module, "down_proj"):
+                p = module.down_proj.weight
+            if p is not None:
+                # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
+                # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
+                # We need to reinit p since this code could be called multiple times
+                # Having just p *= scale would repeatedly scale it down
+                if prenorm_residual_strategy == "rescale":
+                    nn.init.kaiming_uniform_(p, a=math.sqrt(5))
+                    with torch.no_grad():
+                        p /= math.sqrt(num_residuals_per_layer * self.config.num_hidden_layers)
+                elif prenorm_residual_strategy == "zero":
+                    nn.init.zeros_(p)
+                else:
+                    raise ValueError(f"Invalid prenorm_residual_strategy: {prenorm_residual_strategy}")
+
+
+class PrecondKDAModel(PrecondKDAPreTrainedModel):
+    def __init__(self, config: PrecondKDAConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embeddings = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([PrecondKDABlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
+        self.norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
+
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embeddings
+
+    def set_input_embeddings(self, value):
+        self.embeddings = value
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: Optional[torch.Tensor] = None,  # noqa
+        inputs_embeds: torch.FloatTensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        **kwargs: Unpack[dict],
+    ) -> tuple | BaseModelOutputWithPast:
+        if output_attentions:
+            warnings.warn("`PrecondKDAModel` does not `output_attentions` now, setting it to `False`.")
+            output_attentions = False
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        use_cache = use_cache if use_cache is not None else (self.config.use_cache if not self.training else False)
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # retrieve input_ids and inputs_embeds
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embeddings(input_ids)
+        hidden_states = inputs_embeds
+
+        if use_cache and not isinstance(past_key_values, Cache):
+            past_key_values = Cache.from_legacy_cache(past_key_values)
+
+        all_hidden_states = () if output_hidden_states else None
+        all_attns = () if output_attentions else None
+        for layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            hidden_states, attentions, past_key_values = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                **kwargs,
+            )
+
+            if output_attentions:
+                all_attns += (attentions,)
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(i for i in [hidden_states, past_key_values, all_hidden_states, all_attns] if i is not None)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            hidden_states=all_hidden_states,
+            attentions=all_attns,
+        )
+
+
+class PrecondKDAForCausalLM(PrecondKDAPreTrainedModel, FLAGenerationMixin):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = PrecondKDAModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.criterion = None
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embeddings
+
+    def set_input_embeddings(self, value):
+        self.model.embeddings = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def generate(self, *args, **kwargs):
+        try:
+            return super().generate(*args, **kwargs)
+        except AttributeError as exception:
+            if "past_key_values" in str(exception):
+                raise AttributeError(
+                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
+                    f"which is not supported for {self.__class__.__name__}. "
+                    f"Try another generation strategy instead. "
+                    f"For the available generation strategies, check this doc: "
+                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
+                )
+            else:
+                raise exception
+
+    @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        past_key_values: Cache | list[torch.FloatTensor] | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        logits_to_keep: int | None = 0,
+        **kwargs: Unpack[dict],
+    ) -> tuple | CausalLMOutputWithPast:
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs,
+        )
+
+        hidden_states = outputs[0]
+        fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training and labels is not None
+
+        loss, logits = None, None
+        if not fuse_linear_and_cross_entropy or labels is None:
+            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+        if labels is not None:
+            if getattr(self, "criterion", None) is None:
+                if fuse_linear_and_cross_entropy:
+                    criterion = FusedLinearCrossEntropyLoss(use_l2warp=self.config.use_l2warp)
+                elif self.config.fuse_cross_entropy:
+                    criterion = FusedCrossEntropyLoss(inplace_backward=True)
+                else:
+                    criterion = nn.CrossEntropyLoss()
+            else:
+                criterion = self.criterion
+            labels = labels.to(hidden_states.device)
+            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            if fuse_linear_and_cross_entropy:
+                loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
+            else:
+                loss = criterion(logits.view(labels.numel(), -1), labels.view(-1))
+                loss = l2_warp(loss, logits) if self.config.use_l2warp else loss
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )

--- a/fla/models/precond_kda/modeling_precond_kda.py
+++ b/fla/models/precond_kda/modeling_precond_kda.py
@@ -135,7 +135,7 @@ class PrecondKDAPreTrainedModel(PreTrainedModel):
         num_residuals_per_layer: int = 2,
     ):
         if isinstance(module, PrecondKDA) and next(module.parameters()).device.type != "meta":
-            a_log_lower = getattr(self.config, "a_log_init_lower", 0)
+            a_log_lower = getattr(self.config, "a_log_init_lower", 1)
             with torch.no_grad():
                 # Initialize ATK gate parameters
                 if not getattr(module.A_log_atk, "_is_hf_initialized", False):

--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -46,6 +46,7 @@ class FLALayer(CacheLayerMixin):
         attn_state: tuple[torch.Tensor, ...] | None = None,
         conv_state: Any | None = None,
         ffn_state: Any | None = None,
+        A_state: torch.Tensor | None = None,
         offset: int = 1,
         cache_kwargs: dict[str, Any] | None = None,
         **_: Any,
@@ -63,6 +64,7 @@ class FLALayer(CacheLayerMixin):
                 "attn_state": None,
                 "conv_state": None,
                 "ffn_state": None,
+                "A_state": None,
             }
 
         if recurrent_state is not None:
@@ -108,10 +110,12 @@ class FLALayer(CacheLayerMixin):
             self.state["conv_state"] = conv_state
         if ffn_state is not None:
             self.state["ffn_state"] = ffn_state
+        if A_state is not None:
+            self.state["A_state"] = A_state
 
         if not hasattr(self, 'device'):
             self.device = 'cpu'
-        for state in (recurrent_state, attn_state, conv_state, ffn_state):
+        for state in (recurrent_state, attn_state, conv_state, ffn_state, A_state):
             if state is not None:
                 if isinstance(state, torch.Tensor):
                     self.device = state.device
@@ -155,7 +159,7 @@ class FLALayer(CacheLayerMixin):
 
         def to_cpu(x):
             return x.to("cpu", non_blocking=True) if isinstance(x, torch.Tensor) else x
-        for k in ("recurrent_state", "attn_state", "conv_state", "ffn_state"):
+        for k in ("recurrent_state", "attn_state", "conv_state", "ffn_state", "A_state"):
             v = self.state.get(k, None)
             if v is None:
                 continue
@@ -170,7 +174,7 @@ class FLALayer(CacheLayerMixin):
 
         def to_dev(x):
             return x.to(self.device, non_blocking=True) if isinstance(x, torch.Tensor) else x
-        for k in ("recurrent_state", "attn_state", "conv_state", "ffn_state"):
+        for k in ("recurrent_state", "attn_state", "conv_state", "ffn_state", "A_state"):
             v = self.state.get(k, None)
             if v is None:
                 continue
@@ -388,6 +392,7 @@ class FLACache(HFCacheBase):
         attn_state: tuple[torch.Tensor] | None = None,
         conv_state: tuple[torch.Tensor] | None = None,
         ffn_state: tuple[torch.Tensor] | None = None,
+        A_state: torch.Tensor | None = None,
         layer_idx: int = 0,
         offset: int | None = 1,
         cache_kwargs: dict[str, Any] | None = None,
@@ -404,6 +409,7 @@ class FLACache(HFCacheBase):
             attn_state=attn_state,
             conv_state=conv_state,
             ffn_state=ffn_state,
+            A_state=A_state,
             offset=offset if offset is not None else 1,
             cache_kwargs=cache_kwargs,
         )

--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -233,6 +233,7 @@ class LegacyFLACache(HFCacheBase):
         layer_idx: int = 0,
         offset: int | None = 1,
         cache_kwargs: dict[str, Any] | None = None,
+        A_state: torch.Tensor | None = None,
     ) -> dict[str, Any]:
         """
         Args:
@@ -250,6 +251,8 @@ class LegacyFLACache(HFCacheBase):
                 The number of new tokens being processed.
             cache_kwargs (`Dict[str, Any]`):
                 Additional arguments for the cache subclass.
+            A_state (`torch.Tensor`, optional):
+                The new auxiliary preconditioner state to cache. Default: `None`.
 
         Return:
             Dictionary of the updated state.
@@ -274,6 +277,7 @@ class LegacyFLACache(HFCacheBase):
                 attn_state=attn_state,
                 conv_state=conv_state,
                 ffn_state=ffn_state,
+                A_state=A_state,
             )
             self.states.append(state)
         else:
@@ -323,6 +327,8 @@ class LegacyFLACache(HFCacheBase):
                 state['conv_state'] = conv_state
             if ffn_state is not None:
                 state['ffn_state'] = ffn_state
+            if A_state is not None:
+                state['A_state'] = A_state
 
         return state
 

--- a/fla/ops/__init__.py
+++ b/fla/ops/__init__.py
@@ -30,6 +30,8 @@ from .mesa_net import chunk_mesa_net
 from .nsa import parallel_nsa
 from .parallax import parallel_parallax
 from .path_attn import parallel_path_attn
+from .precond_gated_delta_rule import chunk_precond_gated_delta_rule, fused_recurrent_precond_gated_delta_rule
+from .precond_kda import chunk_precond_kda, fused_recurrent_precond_kda
 from .retention import chunk_retention, fused_chunk_retention, fused_recurrent_retention, parallel_retention
 from .rwkv6 import chunk_rwkv6, fused_recurrent_rwkv6
 from .rwkv7 import chunk_rwkv7, fused_recurrent_rwkv7
@@ -51,6 +53,8 @@ __all__ = [
     'chunk_linear_attn',
     'chunk_log_linear_attn',
     'chunk_mesa_net',
+    'chunk_precond_gated_delta_rule',
+    'chunk_precond_kda',
     'chunk_retention',
     'chunk_rwkv6',
     'chunk_rwkv7',
@@ -74,6 +78,8 @@ __all__ = [
     'fused_recurrent_kda',
     'fused_recurrent_lightning_attn',
     'fused_recurrent_linear_attn',
+    'fused_recurrent_precond_gated_delta_rule',
+    'fused_recurrent_precond_kda',
     'fused_recurrent_retention',
     'fused_recurrent_rwkv6',
     'fused_recurrent_rwkv7',

--- a/fla/ops/atk/__init__.py
+++ b/fla/ops/atk/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+# ATK kernels
+# Shared by precond_gated_delta_rule and precond_kda
+
+from fla.ops.atk.chunk_atk_bwd import chunk_atk_bwd
+from fla.ops.atk.chunk_atk_fwd import chunk_atk_fwd, recompute_atk_fwd
+
+__all__ = ['chunk_atk_bwd', 'chunk_atk_fwd', 'recompute_atk_fwd']

--- a/fla/ops/atk/chunk_atk_bwd.py
+++ b/fla/ops/atk/chunk_atk_bwd.py
@@ -1,0 +1,560 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+# Copyright (c) 2023-2025
+
+import math
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils import prepare_chunk_indices
+
+
+@triton.heuristics({
+    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def _atk_backward_chunk_out(
+    k,                # *f32 [B, T, H, D]
+    log_g,            # *f32 [B, T, H]
+    beta,             # *f32 [B, T, H] - beta scaling
+    ac,               # *f32 [B, C, H, D]  (forward prefix contexts)
+    h0,               # *f32 [N, H, D] or None - initial ATK state
+    g_kp,             # *f32 [B, T, H, D]  upstream grad on k_precond
+    # outputs (accumulators; +=)
+    gk_out,           # *f32 [B, T, H, D]
+    gg_out,           # *f32 [B, T, H]
+    gbeta_out,        # *f32 [B, T, H] - gradient for beta
+    gac_prev,         # *f32 [B, C, H, D]  grad wrt ac_{i-1}, stored at index i-1
+    dh0,              # *f32 [N, H, D] or None - gradient for initial ATK state
+    g_log_atk_scale_out,  # *f32 [H] - per-head log_atk_scale gradients (atomic add)
+    cu_seqlens,       # *i32 [N+1] - cumulative sequence lengths
+    chunk_indices,    # *i32 [NT, 2] - (seq_idx, chunk_idx) pairs
+    log_atk_scale,    # *f32 [H] - per-head log-space center (learnable or fixed)
+    logx,             # scalar float32 - log(x) for squash range
+    eps,              # scalar float32 - epsilon for log safety
+    B: tl.constexpr, T, H: tl.constexpr, D: tl.constexpr,
+    CHUNK_LEN: tl.constexpr,
+    k_stride_b, k_stride_t, k_stride_h, k_stride_d,
+    log_g_stride_b, log_g_stride_t, log_g_stride_h,
+    beta_stride_b, beta_stride_t, beta_stride_h,
+    ac_stride_b, ac_stride_c, ac_stride_h, ac_stride_d,
+    gkp_stride_b, gkp_stride_t, gkp_stride_h, gkp_stride_d,
+    gk_stride_b, gk_stride_t, gk_stride_h, gk_stride_d,
+    gg_stride_b, gg_stride_t, gg_stride_h,
+    gbeta_stride_b, gbeta_stride_t, gbeta_stride_h,
+    gac_stride_b, gac_stride_c, gac_stride_h, gac_stride_d,
+    BK: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Per-chunk backward kernel for ATK. K-tiled variant.
+    """
+    i_t = tl.program_id(0)
+    h = tl.program_id(1)
+    chunk_id = tl.program_id(2)
+
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        b = i_n
+    else:
+        b = tl.program_id(0)
+        i_n = b
+        bos = 0
+        eos = T
+
+    if h >= H:
+        return
+
+    if chunk_id * CHUNK_LEN >= T:
+        return
+
+    T_range = chunk_id * CHUNK_LEN + tl.arange(0, CHUNK_LEN)
+    mask_T = T_range < T
+    C_range = tl.arange(0, CHUNK_LEN)
+
+    if IS_VARLEN:
+        log_g_ptr = log_g + h * log_g_stride_h + (log_g_stride_t * (bos + T_range))
+        beta_ptr = beta + h * beta_stride_h + (beta_stride_t * (bos + T_range))
+    else:
+        log_g_ptr = log_g + b * log_g_stride_b + h * log_g_stride_h + (log_g_stride_t * T_range)
+        beta_ptr = beta + b * beta_stride_b + h * beta_stride_h + (beta_stride_t * T_range)
+
+    log_g_val = tl.load(log_g_ptr, mask=mask_T, other=0.0).to(tl.float32)
+    beta_val = tl.load(beta_ptr, mask=mask_T, other=0.0).to(tl.float32)
+    g_val = tl.exp(log_g_val)
+
+    la_cumsum = tl.cumsum(log_g_val)
+
+    roll_mat = (C_range[:, None] == (C_range[None, :] + 1)).to(tl.float32)
+    la_cumsum_roll = tl.sum(roll_mat[:, :] * la_cumsum[None, :], 1)
+    M = tl.exp(la_cumsum_roll[:, None] - la_cumsum[None, :])
+    M = tl.where(C_range[:, None] > C_range[None, :], M, 0.0)
+
+    base_decays = tl.exp(la_cumsum_roll * (C_range > 0).to(tl.float32))
+
+    center = tl.load(log_atk_scale + h).to(tl.float32)
+
+    gg_val = tl.zeros([CHUNK_LEN], dtype=tl.float32)
+    gbeta_val = tl.zeros([CHUNK_LEN], dtype=tl.float32)
+    g_center = tl.zeros([], dtype=tl.float32)
+    gbase_decays = tl.zeros([CHUNK_LEN], dtype=tl.float32)
+    gM = tl.zeros([CHUNK_LEN, CHUNK_LEN], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(D, BK)):
+        d_offset = i_k * BK
+        D_range = d_offset + tl.arange(0, BK)
+        mask_D = D_range < D
+
+        if IS_VARLEN:
+            k_ptr = k + h * k_stride_h + (k_stride_t * (bos + T_range))[:, None] + (k_stride_d) * D_range[None, :]
+            gkp_ptr = g_kp + h * gkp_stride_h + (gkp_stride_t * (bos + T_range))[:, None] + (gkp_stride_d) * D_range[None, :]
+        else:
+            k_ptr = k + b * k_stride_b + h * k_stride_h + (k_stride_t * T_range)[:, None] + (k_stride_d) * D_range[None, :]
+            gkp_ptr = g_kp + b * gkp_stride_b + h * gkp_stride_h + \
+                (gkp_stride_t * T_range)[:, None] + (gkp_stride_d) * D_range[None, :]
+
+        k_val = tl.load(k_ptr, mask=mask_T[:, None] * mask_D[None, :], other=0.0).to(tl.float32)
+        gkp_val = tl.load(gkp_ptr, mask=mask_T[:, None] * mask_D[None, :], other=0.0).to(tl.float32)
+
+        k_sq = k_val * k_val
+        U = beta_val[:, None] * k_sq
+
+        ac_ptr = ac + b * ac_stride_b + h * ac_stride_h + (chunk_id - 1) * ac_stride_c + D_range * ac_stride_d
+        if chunk_id == 0:
+            if USE_INITIAL_STATE:
+                ac_val = tl.load(h0 + (i_n * H + h) * D + D_range, mask=mask_D, other=0).to(tl.float32)
+            else:
+                ac_val = tl.zeros([BK], dtype=tl.float32)
+        else:
+            ac_val = tl.load(ac_ptr, mask=mask_D)
+
+        raw_state = base_decays[:, None] * ac_val[None, :] + tl.dot(M, U)
+        A_t = g_val[:, None] * raw_state + U
+
+        ell = tl.log(A_t + eps)
+        r = ell - center
+        abs_r = tl.abs(r)
+        one_plus_abs_r = 1.0 + abs_r
+        s = r / one_plus_abs_r
+        ds_dr = 1.0 / (one_plus_abs_r * one_plus_abs_r)
+        M_mult = tl.exp(-logx * s)
+
+        gk_val = gkp_val * M_mult
+        gM_from_kprecond = gkp_val * k_val
+        gs = gM_from_kprecond * (-logx * M_mult)
+
+        gr_local = gs * ds_dr
+        g_center += -tl.sum(gr_local)
+        gA_t = gr_local / (A_t + eps)
+        graw_state = gA_t * g_val[:, None]
+        gg_val += tl.sum(gA_t * raw_state, 1)
+        gU = gA_t
+
+        gU_from_M = tl.dot(tl.trans(M), graw_state)
+
+        gk_sq = (gU + gU_from_M) * beta_val[:, None]
+        gbeta_val += tl.sum(gU * k_sq, 1) + tl.sum(gU_from_M * k_sq, 1)
+        gk_val += 2 * k_val * gk_sq
+
+        gac_tile = tl.sum(graw_state * base_decays[:, None], 0)
+        gac_ptr = gac_prev + i_n * gac_stride_b + h * gac_stride_h + (chunk_id - 1) * gac_stride_c + D_range * gac_stride_d
+        if chunk_id > 0:
+            tl.store(gac_ptr, gac_tile, mask=mask_D)
+        elif USE_INITIAL_STATE:
+            tl.store(dh0 + (i_n * H + h) * D + D_range, gac_tile, mask=mask_D)
+
+        gbase_decays += tl.sum(graw_state * ac_val[None, :], 1)
+        gM += tl.dot(graw_state, tl.trans(U))
+
+        if IS_VARLEN:
+            gk_ptr = gk_out + (bos + T_range)[:, None] * gk_stride_t + h * gk_stride_h + D_range[None, :] * gk_stride_d
+        else:
+            gk_ptr = gk_out + b * gk_stride_b + T_range[:, None] * \
+                gk_stride_t + h * gk_stride_h + D_range[None, :] * gk_stride_d
+        tl.store(gk_ptr, gk_val, mask=mask_T[:, None] * mask_D[None, :])
+
+    glog_g_val = gg_val * g_val
+
+    gbase_decays = gbase_decays * (C_range > 0)
+    gla_cumsum_roll = gbase_decays * base_decays
+
+    gM = tl.where(C_range[:, None] > C_range[None, :], gM, 0.0)
+    ginner_sum = M * gM
+    gla_cumsum_roll += tl.sum(ginner_sum, 1)
+    gla_cumsum = -1 * tl.sum(ginner_sum, 0)
+
+    roll_mat = (C_range[:, None] == (C_range[None, :] + 1)).to(tl.float32)
+    gla_cumsum += tl.sum(roll_mat * gla_cumsum_roll[:, None], 0) * (C_range < (CHUNK_LEN - 1)).to(tl.float32)
+
+    glog_g_val += tl.cumsum(gla_cumsum, reverse=True)
+
+    if IS_VARLEN:
+        gg_ptr = gg_out + (bos + T_range) * gg_stride_t + h * gg_stride_h
+        gbeta_ptr = gbeta_out + (bos + T_range) * gbeta_stride_t + h * gbeta_stride_h
+    else:
+        gg_ptr = gg_out + b * gg_stride_b + T_range * gg_stride_t + h * gg_stride_h
+        gbeta_ptr = gbeta_out + b * gbeta_stride_b + T_range * gbeta_stride_t + h * gbeta_stride_h
+
+    tl.store(gg_ptr, glog_g_val, mask=mask_T)
+    tl.store(gbeta_ptr, gbeta_val, mask=mask_T)
+    tl.atomic_add(g_log_atk_scale_out + h, g_center)
+
+
+@triton.heuristics({
+    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def _atk_backward_pass_chunks(
+    a, sa, ac,            # forward buffers
+    h0,                   # *f32 [N, H, D] or None - initial ATK state
+    gac_from_out,         # grad entering each ac[i] from later usage
+    ga, gsa,              # outputs (+=)
+    dh0,                  # *f32 [N, H, D] or None - gradient for initial ATK state (accumulated)
+    cu_seqlens,           # *i32 [N+1] - cumulative sequence lengths
+    B: tl.constexpr, T, H: tl.constexpr, D: tl.constexpr,
+    CHUNK_LEN: tl.constexpr,
+    a_stride_b, a_stride_c, a_stride_h, a_stride_d,
+    sa_stride_b, sa_stride_c, sa_stride_h,
+    ac_stride_b, ac_stride_c, ac_stride_h, ac_stride_d,
+    gac_stride_b, gac_stride_c, gac_stride_h, gac_stride_d,
+    ga_stride_b, ga_stride_c, ga_stride_h, ga_stride_d,
+    gsa_stride_b, gsa_stride_c, gsa_stride_h,
+    BLOCK_D: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Sequential backward pass across chunks.
+    Not K-tiled due to cross-D reduction in gsa_val computation.
+    """
+    i_nh = tl.program_id(0)
+
+    if IS_VARLEN:
+        i_n = i_nh // H
+        h = i_nh % H
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        b = i_n
+    else:
+        b = i_nh // H
+        h = i_nh % H
+        i_n = b
+        if b >= B:
+            return
+
+    if h >= H:
+        return
+
+    N_chunks = tl.cdiv(T, CHUNK_LEN)
+    D_range = tl.arange(0, BLOCK_D)
+    D_mask = D_range < D
+
+    sa_ptr = sa + b * sa_stride_b + h * sa_stride_h + (N_chunks - 1) * sa_stride_c
+    a_ptr = a + b * a_stride_b + h * a_stride_h + D_range * a_stride_d + (N_chunks - 1) * a_stride_c
+    ac_ptr = ac + b * ac_stride_b + h * ac_stride_h + D_range * ac_stride_d + (N_chunks - 1) * ac_stride_c
+    gac_ptr = gac_from_out + b * gac_stride_b + h * gac_stride_h + D_range * gac_stride_d + (N_chunks - 1) * gac_stride_c
+    gsa_ptr = gsa + b * gsa_stride_b + h * gsa_stride_h + (N_chunks - 1) * gsa_stride_c
+    ga_ptr = ga + b * ga_stride_b + h * ga_stride_h + D_range * ga_stride_d + (N_chunks - 1) * ga_stride_c
+
+    gac_val = tl.zeros([BLOCK_D], dtype=tl.float32)
+
+    for chunk_id in tl.range(N_chunks - 1, -1, -1):
+        gac_val += tl.load(gac_ptr, mask=D_mask)
+
+        tl.store(ga_ptr, gac_val, mask=D_mask)
+
+        sa_val = tl.load(sa_ptr).to(tl.float32)
+
+        if chunk_id > 0:
+            ac_prev_ptr = ac + b * ac_stride_b + h * ac_stride_h + D_range * ac_stride_d + (chunk_id - 1) * ac_stride_c
+            ac_prev_val = tl.load(ac_prev_ptr, mask=D_mask)
+            gsa_val = tl.sum(gac_val * ac_prev_val) * tl.exp(sa_val)
+        else:
+            if USE_INITIAL_STATE:
+                h0_val = tl.load(h0 + i_nh * D + D_range, mask=D_mask, other=0).to(tl.float32)
+                gsa_val = tl.sum(gac_val * h0_val) * tl.exp(sa_val)
+            else:
+                gsa_val = 0.0
+
+        gac_val = gac_val * tl.exp(sa_val)
+
+        tl.store(gsa_ptr, gsa_val)
+
+        sa_ptr -= sa_stride_c
+        a_ptr -= a_stride_c
+        ac_ptr -= ac_stride_c
+        gac_ptr -= gac_stride_c
+        ga_ptr -= ga_stride_c
+        gsa_ptr -= gsa_stride_c
+
+    if USE_INITIAL_STATE:
+        p_dh0 = dh0 + i_nh * D + D_range
+        tl.store(p_dh0, tl.load(p_dh0, mask=D_mask, other=0).to(tl.float32) + gac_val, mask=D_mask)
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def _atk_backward_chunk_summary(
+    k, log_g, beta,    # inputs for recompute
+    ga, gsa,           # grads from scan-backward
+    gk_out, gg_out, gbeta_out,
+    cu_seqlens,        # *i32 [N+1] - cumulative sequence lengths
+    chunk_indices,     # *i32 [NT, 2] - (seq_idx, chunk_idx) pairs
+    B: tl.constexpr, T, H: tl.constexpr, D: tl.constexpr,
+    CHUNK_LEN: tl.constexpr,
+    k_stride_b, k_stride_t, k_stride_h, k_stride_d,
+    lg_stride_b, lg_stride_t, lg_stride_h,
+    beta_stride_b, beta_stride_t, beta_stride_h,
+    ga_stride_b, ga_stride_c, ga_stride_h, ga_stride_d,
+    gsa_stride_b, gsa_stride_c, gsa_stride_h,
+    gk_stride_b, gk_stride_t, gk_stride_h, gk_stride_d,
+    gg_stride_b, gg_stride_t, gg_stride_h,
+    gbeta_stride_b, gbeta_stride_t, gbeta_stride_h,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    h = tl.program_id(1)
+    chunk_id = tl.program_id(2)
+
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        b = i_n
+    else:
+        b = tl.program_id(0)
+        i_n = b
+        bos = 0
+        eos = T
+
+    if h >= H:
+        return
+
+    if chunk_id * CHUNK_LEN >= T:
+        return
+
+    T_range = chunk_id * CHUNK_LEN + tl.arange(0, CHUNK_LEN)
+    mask_T = T_range < T
+
+    if IS_VARLEN:
+        log_g_ptr = log_g + (bos + T_range) * lg_stride_t + h * lg_stride_h
+        beta_ptr = beta + (bos + T_range) * beta_stride_t + h * beta_stride_h
+    else:
+        log_g_ptr = log_g + b * lg_stride_b + T_range * lg_stride_t + h * lg_stride_h
+        beta_ptr = beta + b * beta_stride_b + T_range * beta_stride_t + h * beta_stride_h
+
+    log_g_val = tl.load(log_g_ptr, mask=mask_T, other=0.0).to(tl.float32)
+    beta_val = tl.load(beta_ptr, mask=mask_T, other=0.0).to(tl.float32)
+
+    sa_val = tl.sum(log_g_val)
+    decays = tl.exp(sa_val - tl.cumsum(log_g_val))
+
+    gsa_ptr = gsa + i_n * gsa_stride_b + h * gsa_stride_h + chunk_id * gsa_stride_c
+    gsa_val = tl.load(gsa_ptr).to(tl.float32)
+
+    gdecays = tl.zeros([CHUNK_LEN], dtype=tl.float32)
+    gbeta_val = tl.zeros([CHUNK_LEN], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(D, BK)):
+        d_offset = i_k * BK
+        D_range = d_offset + tl.arange(0, BK)
+        mask_D = D_range < D
+
+        if IS_VARLEN:
+            k_ptr = k + (bos + T_range)[:, None] * k_stride_t + h * k_stride_h + D_range[None, :] * k_stride_d
+            gk_ptr = gk_out + (bos + T_range)[:, None] * gk_stride_t + h * gk_stride_h + D_range[None, :] * gk_stride_d
+        else:
+            k_ptr = k + b * k_stride_b + T_range[:, None] * k_stride_t + h * k_stride_h + D_range[None, :] * k_stride_d
+            gk_ptr = gk_out + b * gk_stride_b + T_range[:, None] * \
+                gk_stride_t + h * gk_stride_h + D_range[None, :] * gk_stride_d
+
+        ga_ptr = ga + i_n * ga_stride_b + h * ga_stride_h + chunk_id * ga_stride_c + (ga_stride_d) * D_range
+
+        k_val = tl.load(k_ptr, mask=mask_T[:, None] * mask_D[None, :], other=0.0).to(tl.float32)
+        ga_val = tl.load(ga_ptr, mask=mask_D, other=0.0).to(tl.float32)
+
+        k_sq = k_val * k_val
+        U = beta_val[:, None] * k_sq
+
+        gdecays += tl.sum(ga_val[None, :] * U, 1)
+
+        gU = ga_val[None, :] * decays[:, None]
+        gbeta_val += tl.sum(gU * k_sq, 1)
+
+        gk_sq = gU * beta_val[:, None]
+        gk_val = gk_sq * k_val * 2
+
+        tl.atomic_add(gk_ptr, gk_val, mask=mask_T[:, None] * mask_D[None, :])
+
+    gdecays_exp = decays * gdecays
+
+    gsa_val += tl.sum(gdecays_exp)
+    glog_g_val = -1 * tl.cumsum(gdecays_exp, reverse=True)
+
+    glog_g_val += gsa_val
+
+    if IS_VARLEN:
+        gg_ptr = gg_out + (bos + T_range) * gg_stride_t + h * gg_stride_h
+        gbeta_ptr = gbeta_out + (bos + T_range) * gbeta_stride_t + h * gbeta_stride_h
+    else:
+        gg_ptr = gg_out + b * gg_stride_b + T_range * gg_stride_t + h * gg_stride_h
+        gbeta_ptr = gbeta_out + b * gbeta_stride_b + T_range * gbeta_stride_t + h * gbeta_stride_h
+
+    tl.atomic_add(gg_ptr, glog_g_val, mask=mask_T)
+    tl.atomic_add(gbeta_ptr, gbeta_val, mask=mask_T)
+
+
+def chunk_atk_bwd(
+    k: torch.Tensor,
+    g_raw: torch.Tensor,
+    beta: torch.Tensor,
+    dk_precond: torch.Tensor,
+    ac: torch.Tensor,
+    a: torch.Tensor,
+    sa: torch.Tensor,
+    chunk_size: int = 64,
+    initial_A_state: torch.Tensor | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    r"""
+    ATK backward pass. Takes precomputed forward intermediates from ``recompute_atk_fwd``.
+
+    Args:
+        k: Keys ``[B, T, H, K]``.
+        g_raw: Raw gate values (NOT cumsum) ``[B, T, H]``.
+        beta: Beta scaling ``[B, T, H]``.
+        dk_precond: Gradient w.r.t. k_precond ``[B, T, H, K]``.
+        ac: Prefix-sum ATK states from ``recompute_atk_fwd`` ``[B, C, H, K]``.
+        a: Per-chunk summaries from ``recompute_atk_fwd`` ``[B, C, H, K]``.
+        sa: Per-chunk log-gate sums from ``recompute_atk_fwd`` ``[B, C, H]``.
+        chunk_size: Chunk size.
+        initial_A_state: Initial ATK diagonal state ``[N, H, K]``.
+        cu_seqlens: Cumulative sequence lengths ``[N+1]`` for varlen.
+        x: Squash range parameter.
+        eps: Epsilon for numerical stability.
+        log_atk_scale: Per-head log-space center ``[H]``.
+
+    Returns:
+        dk_atk: Gradient contribution to k ``[B, T, H, K]``.
+        dbeta_atk: Gradient for beta ``[B, T, H]``.
+        dg_atk: Gradient for g ``[B, T, H]``.
+        d_log_atk_scale: Gradient for log_atk_scale ``[H]``.
+        dh0_atk: Gradient for initial_A_state ``[N, H, K]`` or ``None``.
+    """
+    B, T, H, K = k.shape
+    CHUNK_LEN = chunk_size
+
+    is_varlen = cu_seqlens is not None
+    chunk_indices = prepare_chunk_indices(cu_seqlens, CHUNK_LEN) if is_varlen else None
+    NT = triton.cdiv(T, CHUNK_LEN) if not is_varlen else len(chunk_indices)
+    N = len(cu_seqlens) - 1 if is_varlen else B
+
+    BK = K if os.environ.get('ATK_NO_KTILE') else 32  # K-tile size (set ATK_NO_KTILE=1 to disable)
+    BLOCK_D = triton.next_power_of_2(K)
+
+    k = k.contiguous()
+    g_raw = g_raw.contiguous()
+    beta = beta.contiguous()
+    dk_precond = dk_precond.contiguous()
+
+    if log_atk_scale is None:
+        log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32, device=k.device)
+    else:
+        log_atk_scale = log_atk_scale.contiguous()
+
+    logx = math.log(x) if x > 0 else 0.0
+
+    gk = torch.zeros_like(k, dtype=torch.float32)
+    g_log_atk_scale = torch.zeros(H, device=k.device, dtype=torch.float32)
+    gg = torch.zeros_like(g_raw, dtype=torch.float32)
+    gbeta = torch.zeros_like(beta, dtype=torch.float32)
+    gac_prev = torch.zeros_like(ac, dtype=torch.float32)
+    dh0 = torch.zeros(N, H, K, device=k.device, dtype=torch.float32) if initial_A_state is not None else None
+    ga = torch.empty_like(a, dtype=torch.float32)
+    gsa = torch.empty_like(sa, dtype=torch.float32)
+
+    if cu_seqlens is None:
+        grid = (B, H, triton.cdiv(T, CHUNK_LEN))
+        grid2 = (B * H,)
+    else:
+        grid = (NT, H, 1)
+        grid2 = (N * H,)
+
+    _atk_backward_chunk_out[grid](
+        k, g_raw, beta, ac, initial_A_state, dk_precond,
+        gk, gg, gbeta, gac_prev, dh0,
+        g_log_atk_scale,
+        cu_seqlens, chunk_indices,
+        log_atk_scale, logx, eps,
+        B, T, H, K, CHUNK_LEN,
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        g_raw.stride(0), g_raw.stride(1), g_raw.stride(2),
+        beta.stride(0), beta.stride(1), beta.stride(2),
+        ac.stride(0), ac.stride(1), ac.stride(2), ac.stride(3),
+        dk_precond.stride(0), dk_precond.stride(1), dk_precond.stride(2), dk_precond.stride(3),
+        gk.stride(0), gk.stride(1), gk.stride(2), gk.stride(3),
+        gg.stride(0), gg.stride(1), gg.stride(2),
+        gbeta.stride(0), gbeta.stride(1), gbeta.stride(2),
+        gac_prev.stride(0), gac_prev.stride(1), gac_prev.stride(2), gac_prev.stride(3),
+        BK=BK, num_warps=4,
+    )
+
+    _atk_backward_pass_chunks[grid2](
+        a, sa, ac,
+        initial_A_state,
+        gac_prev,
+        ga, gsa,
+        dh0,
+        cu_seqlens,
+        B, T, H, K, CHUNK_LEN,
+        a.stride(0), a.stride(1), a.stride(2), a.stride(3),
+        sa.stride(0), sa.stride(1), sa.stride(2),
+        ac.stride(0), ac.stride(1), ac.stride(2), ac.stride(3),
+        gac_prev.stride(0), gac_prev.stride(1), gac_prev.stride(2), gac_prev.stride(3),
+        ga.stride(0), ga.stride(1), ga.stride(2), ga.stride(3),
+        gsa.stride(0), gsa.stride(1), gsa.stride(2),
+        BLOCK_D, num_warps=4
+    )
+
+    _atk_backward_chunk_summary[grid](
+        k, g_raw, beta,
+        ga, gsa,
+        gk, gg, gbeta,
+        cu_seqlens, chunk_indices,
+        B, T, H, K, CHUNK_LEN,
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        g_raw.stride(0), g_raw.stride(1), g_raw.stride(2),
+        beta.stride(0), beta.stride(1), beta.stride(2),
+        ga.stride(0), ga.stride(1), ga.stride(2), ga.stride(3),
+        gsa.stride(0), gsa.stride(1), gsa.stride(2),
+        gk.stride(0), gk.stride(1), gk.stride(2), gk.stride(3),
+        gg.stride(0), gg.stride(1), gg.stride(2),
+        gbeta.stride(0), gbeta.stride(1), gbeta.stride(2),
+        BK, num_warps=4
+    )
+
+    return gk, gbeta, gg, g_log_atk_scale, dh0

--- a/fla/ops/atk/chunk_atk_bwd.py
+++ b/fla/ops/atk/chunk_atk_bwd.py
@@ -61,17 +61,17 @@ def _atk_backward_chunk_out(
     """
     i_t = tl.program_id(0)
     h = tl.program_id(1)
-    chunk_id = tl.program_id(2)
+    chunk_id = tl.program_id(2).to(tl.int64)
 
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos = tl.load(cu_seqlens + i_n).to(tl.int32)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
-        b = i_n
+        b = i_n.to(tl.int64)
     else:
-        b = tl.program_id(0)
+        b = tl.program_id(0).to(tl.int64)
         i_n = b
         bos = 0
         eos = T
@@ -242,7 +242,7 @@ def _atk_backward_pass_chunks(
     Sequential backward pass across chunks.
     Not K-tiled due to cross-D reduction in gsa_val computation.
     """
-    i_nh = tl.program_id(0)
+    i_nh = tl.program_id(0).to(tl.int64)
 
     if IS_VARLEN:
         i_n = i_nh // H
@@ -250,7 +250,7 @@ def _atk_backward_pass_chunks(
         bos = tl.load(cu_seqlens + i_n).to(tl.int32)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
-        b = i_n
+        b = i_n.to(tl.int64)
     else:
         b = i_nh // H
         h = i_nh % H
@@ -333,17 +333,17 @@ def _atk_backward_chunk_summary(
 ):
     i_t = tl.program_id(0)
     h = tl.program_id(1)
-    chunk_id = tl.program_id(2)
+    chunk_id = tl.program_id(2).to(tl.int64)
 
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos = tl.load(cu_seqlens + i_n).to(tl.int32)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
-        b = i_n
+        b = i_n.to(tl.int64)
     else:
-        b = tl.program_id(0)
+        b = tl.program_id(0).to(tl.int64)
         i_n = b
         bos = 0
         eos = T
@@ -439,6 +439,7 @@ def chunk_atk_bwd(
     x: float = 1.5,
     eps: float = 1e-6,
     log_atk_scale: torch.Tensor = None,
+    dat: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     r"""
     ATK backward pass. Takes precomputed forward intermediates from ``recompute_atk_fwd``.
@@ -457,6 +458,7 @@ def chunk_atk_bwd(
         x: Squash range parameter.
         eps: Epsilon for numerical stability.
         log_atk_scale: Per-head log-space center ``[H]``.
+        dat: Incoming gradient w.r.t. the final ATK state ``[N, H, K]`` or ``None``.
 
     Returns:
         dk_atk: Gradient contribution to k ``[B, T, H, K]``.
@@ -493,6 +495,18 @@ def chunk_atk_bwd(
     gg = torch.zeros_like(g_raw, dtype=torch.float32)
     gbeta = torch.zeros_like(beta, dtype=torch.float32)
     gac_prev = torch.zeros_like(ac, dtype=torch.float32)
+    if dat is not None:
+        # The final ATK state `at` equals `ac[:, last_chunk]`, so its incoming
+        # gradient enters the reverse scan as the carry at the final chunk;
+        # `gac_prev[:, last_chunk]` is never written by the local-backward kernel.
+        if cu_seqlens is None:
+            gac_prev[:, NT - 1] += dat
+        else:
+            seqlens = cu_seqlens[1:] - cu_seqlens[:-1]
+            last_chunk = torch.clamp((seqlens + CHUNK_LEN - 1) // CHUNK_LEN - 1, min=0)
+            valid = seqlens > 0
+            idx = torch.arange(N, device=k.device)
+            gac_prev[idx[valid], last_chunk[valid]] += dat[valid]
     dh0 = torch.zeros(N, H, K, device=k.device, dtype=torch.float32) if initial_A_state is not None else None
     ga = torch.empty_like(a, dtype=torch.float32)
     gsa = torch.empty_like(sa, dtype=torch.float32)

--- a/fla/ops/atk/chunk_atk_fwd.py
+++ b/fla/ops/atk/chunk_atk_fwd.py
@@ -1,0 +1,465 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""
+Chunked ATK forward kernel for preconditioned delta rules.
+K-tiled variant: processes head dimension in BK blocks.
+
+ATK recurrence:
+    A_t = exp(g) * A_{t-1} + beta * k^2
+
+Preconditioner (symmetric fast squash):
+    ell = log(A_t + eps)
+    r = ell - log_atk_scale                # deviation from learned center
+    s = r / (1 + |r|)                      # fast squash, bounded in (-1, 1)
+    M = exp(-log(x) * s)                   # bounded multiplier in [1/x, x]
+    k_precond = k * M
+"""
+import math
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None
+})
+@triton.jit(do_not_specialize=['T'])
+def _forward_chunk_summary(
+    k,                # *f32 [B, T, H, D]
+    beta,             # *f32 [B, T, H]
+    log_g,            # *f32 [B, T, H]
+    a,                # *f32 [B, C, H, D]
+    sa,               # *f32 [B, C, H]
+    cu_seqlens,       # *i32 [N+1] - cumulative sequence lengths (None if not varlen)
+    chunk_indices,    # *i32 [NT, 2] - (sequence_idx, chunk_idx) pairs (None if not varlen)
+    B: tl.constexpr,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    CHUNK_LEN: tl.constexpr,
+    k_stride_b, k_stride_t, k_stride_h, k_stride_d,
+    beta_stride_b, beta_stride_t, beta_stride_h,
+    log_g_stride_b, log_g_stride_t, log_g_stride_h,
+    a_stride_b, a_stride_c, a_stride_h, a_stride_d,
+    sa_stride_b, sa_stride_c, sa_stride_h,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    h = tl.program_id(1)
+    chunk_id = tl.program_id(2)
+
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        b = i_n
+    else:
+        b = tl.program_id(0)
+        bos = 0
+        eos = T
+
+    if h >= H:
+        return
+
+    if chunk_id * CHUNK_LEN >= T:
+        return
+
+    T_range = chunk_id * CHUNK_LEN + tl.arange(0, CHUNK_LEN)
+    mask_T = T_range < T
+
+    if IS_VARLEN:
+        beta_ptr = beta + (bos + T_range) * beta_stride_t + h * beta_stride_h
+        log_g_ptr = log_g + (bos + T_range) * log_g_stride_t + h * log_g_stride_h
+    else:
+        beta_ptr = beta + b * beta_stride_b + T_range * beta_stride_t + h * beta_stride_h
+        log_g_ptr = log_g + b * log_g_stride_b + T_range * log_g_stride_t + h * log_g_stride_h
+
+    beta_val = tl.load(beta_ptr, mask=mask_T, other=0.0).to(tl.float32)
+    log_g_val = tl.load(log_g_ptr, mask=mask_T, other=0.0).to(tl.float32)
+
+    sa_val = tl.sum(log_g_val)
+    decays = tl.exp(sa_val - tl.cumsum(log_g_val))
+
+    for i_k in range(tl.cdiv(D, BK)):
+        d_offset = i_k * BK
+        D_range = d_offset + tl.arange(0, BK)
+        mask_D = D_range < D
+
+        if IS_VARLEN:
+            k_ptr = k + (bos + T_range)[:, None] * k_stride_t + h * k_stride_h + D_range[None, :] * k_stride_d
+        else:
+            k_ptr = k + b * k_stride_b + T_range[:, None] * k_stride_t + h * k_stride_h + D_range[None, :] * k_stride_d
+
+        k_val = tl.load(k_ptr, mask=mask_T[:, None] * mask_D[None, :], other=0.0).to(tl.float32)
+
+        k_sq = k_val * k_val
+        U = beta_val[:, None] * k_sq
+        a_val = tl.sum(decays[:, None] * U, 0)
+
+        a_ptr = a + b * a_stride_b + h * a_stride_h + chunk_id * a_stride_c + D_range * a_stride_d
+        tl.store(a_ptr, a_val, mask=mask_D)
+
+    sa_ptr = sa + b * sa_stride_b + h * sa_stride_h + chunk_id * sa_stride_c
+    tl.store(sa_ptr, sa_val)
+
+
+@triton.heuristics({
+    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def _forward_pass_chunks(
+    a,            # *f32 [B, C, H, D]
+    sa,           # *f32 [B, C, H]
+    ac,           # *f32 [B, C, H, D]
+    h0,           # *f32 [N, H, D] or None
+    cu_seqlens,   # *i32 [N+1]
+    B: tl.constexpr,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    CHUNK_LEN: tl.constexpr,
+    a_stride_b, a_stride_c, a_stride_h, a_stride_d,
+    sa_stride_b, sa_stride_c, sa_stride_h,
+    ac_stride_b, ac_stride_c, ac_stride_h, ac_stride_d,
+    BK: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_nh = tl.program_id(0)
+
+    if IS_VARLEN:
+        i_n = i_nh // H
+        h = i_nh % H
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        b = i_n
+    else:
+        b = i_nh // H
+        h = i_nh % H
+        if b >= B:
+            return
+
+    if h >= H:
+        return
+
+    N_chunks = tl.cdiv(T, CHUNK_LEN)
+
+    for i_k in range(tl.cdiv(D, BK)):
+        d_offset = i_k * BK
+        D_range = d_offset + tl.arange(0, BK)
+        D_mask = D_range < D
+
+        sa_ptr = sa + b * sa_stride_b + h * sa_stride_h
+        a_ptr = a + b * a_stride_b + h * a_stride_h + D_range * a_stride_d
+        ac_ptr = ac + b * ac_stride_b + h * ac_stride_h + D_range * ac_stride_d
+
+        if USE_INITIAL_STATE:
+            ac_val = tl.load(h0 + i_nh * D + D_range, mask=D_mask, other=0).to(tl.float32)
+        else:
+            ac_val = tl.zeros([BK], dtype=tl.float32)
+
+        for chunk_id in tl.range(N_chunks):
+            a_val = tl.load(a_ptr, D_mask).to(tl.float32)
+            sa_val = tl.load(sa_ptr).to(tl.float32)
+
+            ac_val = tl.exp(sa_val) * ac_val + a_val
+
+            tl.store(ac_ptr, ac_val, mask=D_mask)
+
+            sa_ptr += sa_stride_c
+            a_ptr += a_stride_c
+            ac_ptr += ac_stride_c
+
+
+@triton.heuristics({
+    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def _forward_chunk_out(
+    k,                # *f32 [B, T, H, D]
+    beta,             # *f32 [B, T, H]
+    log_g,            # *f32 [B, T, H]
+    ac,               # *f32 [B, C, H, D]
+    h0,               # *f32 [N, H, D] or None
+    k_precond,        # *f32 [B, T, H, D]
+    log_atk_scale,    # *f32 [H] - per-head log-space center (learnable or fixed)
+    logx,             # scalar float32 - log(x) for squash range
+    eps,              # scalar float32 - epsilon for log safety
+    cu_seqlens,
+    chunk_indices,
+    B: tl.constexpr,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    CHUNK_LEN: tl.constexpr,
+    k_stride_b, k_stride_t, k_stride_h, k_stride_d,
+    beta_stride_b, beta_stride_t, beta_stride_h,
+    log_g_stride_b, log_g_stride_t, log_g_stride_h,
+    ac_stride_b, ac_stride_c, ac_stride_h, ac_stride_d,
+    kp_stride_b, kp_stride_t, kp_stride_h, kp_stride_d,
+    BK: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    h = tl.program_id(1)
+    chunk_id = tl.program_id(2)
+
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        b = i_n
+    else:
+        b = tl.program_id(0)
+        bos = 0
+        eos = T
+
+    if h >= H:
+        return
+
+    if chunk_id * CHUNK_LEN >= T:
+        return
+
+    T_range = chunk_id * CHUNK_LEN + tl.arange(0, CHUNK_LEN)
+    mask_T = T_range < T
+    C_range = tl.arange(0, CHUNK_LEN)
+
+    if IS_VARLEN:
+        beta_ptr = beta + (bos + T_range) * beta_stride_t + h * beta_stride_h
+        log_g_ptr = log_g + (bos + T_range) * log_g_stride_t + h * log_g_stride_h
+    else:
+        beta_ptr = beta + b * beta_stride_b + T_range * beta_stride_t + h * beta_stride_h
+        log_g_ptr = log_g + b * log_g_stride_b + h * log_g_stride_h + (log_g_stride_t * T_range)
+
+    beta_val = tl.load(beta_ptr, mask=mask_T, other=0.0).to(tl.float32)
+    log_g_val = tl.load(log_g_ptr, mask=mask_T, other=0.0).to(tl.float32)
+    g_val = tl.exp(log_g_val)
+
+    la_cumsum = tl.cumsum(log_g_val)
+
+    roll_mat = (C_range[:, None] == (C_range[None, :] + 1)).to(tl.float32)
+    la_cumsum_roll = tl.sum(roll_mat[:, :] * la_cumsum[None, :], 1)
+    M = tl.exp(la_cumsum_roll[:, None] - la_cumsum[None, :])
+    M = tl.where(C_range[:, None] > C_range[None, :], M, 0.0)
+
+    base_decays = tl.exp(la_cumsum_roll * (C_range > 0).to(tl.float32))
+
+    center = tl.load(log_atk_scale + h).to(tl.float32)
+
+    for i_k in range(tl.cdiv(D, BK)):
+        d_offset = i_k * BK
+        D_range = d_offset + tl.arange(0, BK)
+        mask_D = D_range < D
+
+        if IS_VARLEN:
+            k_ptr = k + (bos + T_range)[:, None] * k_stride_t + h * k_stride_h + D_range[None, :] * k_stride_d
+            kp_ptr = k_precond + (bos + T_range)[:, None] * kp_stride_t + h * kp_stride_h + D_range[None, :] * kp_stride_d
+        else:
+            k_ptr = k + b * k_stride_b + h * k_stride_h + (k_stride_t * T_range)[:, None] + (k_stride_d) * D_range[None, :]
+            kp_ptr = k_precond + b * kp_stride_b + h * kp_stride_h + \
+                (kp_stride_t * T_range)[:, None] + (kp_stride_d) * D_range[None, :]
+
+        k_val = tl.load(k_ptr, mask=mask_T[:, None] * mask_D[None, :], other=0.0).to(tl.float32)
+
+        k_sq = k_val * k_val
+        U = beta_val[:, None] * k_sq
+
+        ac_ptr = ac + b * ac_stride_b + h * ac_stride_h + (chunk_id - 1) * ac_stride_c + D_range * ac_stride_d
+
+        if chunk_id == 0:
+            if USE_INITIAL_STATE:
+                ac_val = tl.load(h0 + (b * H + h) * D + D_range, mask=mask_D, other=0).to(tl.float32)
+            else:
+                ac_val = tl.zeros([BK], dtype=tl.float32)
+        else:
+            ac_val = tl.load(ac_ptr, mask=mask_D)
+
+        raw_state = base_decays[:, None] * ac_val[None, :] + tl.dot(M, U)
+
+        A_t = g_val[:, None] * raw_state + U
+
+        ell = tl.log(A_t + eps)
+        r = ell - center
+        s = r / (1.0 + tl.abs(r))
+        M_precond = tl.exp(-logx * s)
+        k_precond_val = k_val * M_precond
+
+        tl.store(kp_ptr, k_precond_val, mask=mask_T[:, None] * mask_D[None, :])
+
+
+def _atk_fwd_stages(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    log_g: torch.Tensor,
+    chunk_size: int,
+    initial_A_state: torch.Tensor | None,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None,
+    x: float,
+    eps: float,
+    log_atk_scale: torch.Tensor | None,
+):
+    """Run the 3-stage ATK forward algorithm.
+
+    Returns:
+        k_precond, ac, a, sa, at
+    """
+    B, T, H, D = k.shape
+    CHUNK_LEN = chunk_size
+
+    BK = D if os.environ.get('ATK_NO_KTILE') else 32  # K-tile size (set ATK_NO_KTILE=1 to disable)
+
+    is_varlen = cu_seqlens is not None
+
+    if is_varlen:
+        from fla.ops.utils import prepare_chunk_indices
+        N = len(cu_seqlens) - 1
+        chunk_indices = prepare_chunk_indices(cu_seqlens, CHUNK_LEN)
+        NT = len(chunk_indices)
+
+        seq_lens = [cu_seqlens[i + 1] - cu_seqlens[i] for i in range(N)]
+        max_chunks = max(triton.cdiv(s.item(), CHUNK_LEN) for s in seq_lens)
+
+        a = torch.empty(N, max_chunks, H, D, dtype=torch.float32, device=k.device)
+        sa = torch.empty(N, max_chunks, H, dtype=torch.float32, device=k.device)
+        ac = torch.empty(N, max_chunks, H, D, dtype=torch.float32, device=k.device)
+    else:
+        N = B
+        num_chunks = math.ceil(T / CHUNK_LEN)
+        chunk_indices = None
+        NT = B * num_chunks
+
+        a = torch.empty(B, num_chunks, H, D, dtype=torch.float32, device=k.device)
+        sa = torch.empty(B, num_chunks, H, dtype=torch.float32, device=k.device)
+        ac = torch.empty(B, num_chunks, H, D, dtype=torch.float32, device=k.device)
+
+    k_precond = torch.empty_like(k)
+
+    k = k.contiguous()
+    beta = beta.contiguous()
+    log_g = log_g.contiguous()
+
+    if log_atk_scale is None:
+        log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32, device=k.device)
+    else:
+        log_atk_scale = log_atk_scale.contiguous()
+
+    logx = math.log(x) if x > 0 else 0.0
+
+    if is_varlen:
+        grid = (NT, H, 1)
+        grid2 = (N * H,)
+    else:
+        grid = (B, H, num_chunks)
+        grid2 = (B * H,)
+
+    _forward_chunk_summary[grid](
+        k, beta, log_g, a, sa,
+        cu_seqlens, chunk_indices,
+        B, T, H, D, CHUNK_LEN,
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        beta.stride(0), beta.stride(1), beta.stride(2),
+        log_g.stride(0), log_g.stride(1), log_g.stride(2),
+        a.stride(0), a.stride(1), a.stride(2), a.stride(3),
+        sa.stride(0), sa.stride(1), sa.stride(2),
+        BK, num_warps=4
+    )
+
+    _forward_pass_chunks[grid2](
+        a, sa, ac,
+        initial_A_state,
+        cu_seqlens,
+        B if not is_varlen else N, T, H, D, CHUNK_LEN,
+        a.stride(0), a.stride(1), a.stride(2), a.stride(3),
+        sa.stride(0), sa.stride(1), sa.stride(2),
+        ac.stride(0), ac.stride(1), ac.stride(2), ac.stride(3),
+        BK, num_warps=4
+    )
+
+    _forward_chunk_out[grid](
+        k, beta, log_g, ac, initial_A_state, k_precond,
+        log_atk_scale, logx, eps,
+        cu_seqlens, chunk_indices,
+        B, T, H, D, CHUNK_LEN,
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        beta.stride(0), beta.stride(1), beta.stride(2),
+        log_g.stride(0), log_g.stride(1), log_g.stride(2),
+        ac.stride(0), ac.stride(1), ac.stride(2), ac.stride(3),
+        k_precond.stride(0), k_precond.stride(1), k_precond.stride(2), k_precond.stride(3),
+        BK,
+        num_warps=4
+    )
+
+    at = None
+    if output_final_state:
+        if is_varlen:
+            seq_lens = [cu_seqlens[i + 1] - cu_seqlens[i] for i in range(N)]
+            last_chunk_indices = [triton.cdiv(s.item(), CHUNK_LEN) - 1 for s in seq_lens]
+            at = torch.stack([ac[i, last_chunk_indices[i], :, :] for i in range(N)], dim=0).to(k.dtype)
+        else:
+            at = ac[:, -1, :, :].contiguous().to(k.dtype)
+
+    return k_precond.to(k.dtype), ac, a, sa, at
+
+
+@torch._dynamo.disable
+def chunk_atk_fwd(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    log_g: torch.Tensor = None,
+    chunk_size: int = 64,
+    initial_A_state: torch.Tensor = None,
+    output_final_state: bool = True,
+    cu_seqlens: torch.Tensor = None,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+):
+    r"""
+    Chunked ATK forward: computes preconditioned keys via 3-stage chunk algorithm.
+    """
+    k_precond, _, _, _, at = _atk_fwd_stages(
+        k, beta, log_g, chunk_size,
+        initial_A_state, output_final_state, cu_seqlens,
+        x, eps, log_atk_scale,
+    )
+    return k_precond, at
+
+
+@torch._dynamo.disable
+def recompute_atk_fwd(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    log_g: torch.Tensor,
+    chunk_size: int = 64,
+    initial_A_state: torch.Tensor = None,
+    cu_seqlens: torch.Tensor = None,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+):
+    r"""
+    Recompute ATK forward intermediates for use in backward pass.
+    """
+    k_precond, ac, a, sa, _ = _atk_fwd_stages(
+        k, beta, log_g, chunk_size,
+        initial_A_state, False, cu_seqlens,
+        x, eps, log_atk_scale,
+    )
+    return k_precond, ac, a, sa

--- a/fla/ops/atk/chunk_atk_fwd.py
+++ b/fla/ops/atk/chunk_atk_fwd.py
@@ -54,17 +54,17 @@ def _forward_chunk_summary(
 ):
     i_t = tl.program_id(0)
     h = tl.program_id(1)
-    chunk_id = tl.program_id(2)
+    chunk_id = tl.program_id(2).to(tl.int64)
 
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos = tl.load(cu_seqlens + i_n).to(tl.int32)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
-        b = i_n
+        b = i_n.to(tl.int64)
     else:
-        b = tl.program_id(0)
+        b = tl.program_id(0).to(tl.int64)
         bos = 0
         eos = T
 
@@ -136,7 +136,7 @@ def _forward_pass_chunks(
     USE_INITIAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_nh = tl.program_id(0)
+    i_nh = tl.program_id(0).to(tl.int64)
 
     if IS_VARLEN:
         i_n = i_nh // H
@@ -144,7 +144,7 @@ def _forward_pass_chunks(
         bos = tl.load(cu_seqlens + i_n).to(tl.int32)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
-        b = i_n
+        b = i_n.to(tl.int64)
     else:
         b = i_nh // H
         h = i_nh % H
@@ -216,17 +216,17 @@ def _forward_chunk_out(
 ):
     i_t = tl.program_id(0)
     h = tl.program_id(1)
-    chunk_id = tl.program_id(2)
+    chunk_id = tl.program_id(2).to(tl.int64)
 
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        chunk_id = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos = tl.load(cu_seqlens + i_n).to(tl.int32)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
-        b = i_n
+        b = i_n.to(tl.int64)
     else:
-        b = tl.program_id(0)
+        b = tl.program_id(0).to(tl.int64)
         bos = 0
         eos = T
 

--- a/fla/ops/precond_gated_delta_rule/__init__.py
+++ b/fla/ops/precond_gated_delta_rule/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from .chunk import chunk_precond_gated_delta_rule
+from .fused_recurrent import fused_recurrent_precond_gated_delta_rule
+from .naive import naive_recurrent_precond_gated_delta_rule
+
+__all__ = [
+    "chunk_precond_gated_delta_rule",
+    "fused_recurrent_precond_gated_delta_rule",
+    "naive_recurrent_precond_gated_delta_rule",
+]

--- a/fla/ops/precond_gated_delta_rule/chunk.py
+++ b/fla/ops/precond_gated_delta_rule/chunk.py
@@ -1,0 +1,581 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import warnings
+
+import torch
+
+from fla.modules.l2norm import l2norm_bwd, l2norm_fwd
+from fla.ops.atk.chunk_atk_bwd import chunk_atk_bwd
+from fla.ops.atk.chunk_atk_fwd import chunk_atk_fwd, recompute_atk_fwd
+from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
+from fla.ops.common.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
+from fla.ops.cp import FLACPContext
+from fla.ops.gated_delta_rule.wy_fast import recompute_w_u_fwd
+from fla.ops.precond_gated_delta_rule.chunk_precond_kkt_fwd import chunk_precond_kkt_fwd
+from fla.ops.precond_gated_delta_rule.chunk_precond_wy_bwd import prepare_precond_wy_repr_bwd
+from fla.ops.utils import chunk_local_cumsum, solve_tril
+from fla.ops.utils.constant import RCP_LN2
+from fla.ops.utils.index import prepare_chunk_indices
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+
+
+def chunk_precond_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k_read: torch.Tensor,
+    k_write: torch.Tensor,
+    v: torch.Tensor,
+    g_atk: torch.Tensor,
+    g: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    initial_A_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = True,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    transpose_state_layout: bool = False,
+):
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, 64)
+
+    k_precond, at = chunk_atk_fwd(
+        k=k_write,
+        beta=beta_atk,
+        log_g=g_atk,
+        chunk_size=64,
+        initial_A_state=initial_A_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        x=x,
+        eps=eps,
+        log_atk_scale=log_atk_scale,
+    )
+
+    g = chunk_local_cumsum(
+        g,
+        chunk_size=64,
+        scale=RCP_LN2 if use_exp2 else None,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    # Asymmetric KKT: uses k_read for correction, k_precond for write
+    A = chunk_precond_kkt_fwd(
+        k=k_read,
+        k_precond=k_precond,
+        g=g,
+        beta=beta,
+        chunk_size=64,
+        output_dtype=torch.float32,
+        cu_seqlens=cu_seqlens,
+        use_exp2=use_exp2,
+    )
+    A = solve_tril(
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        output_dtype=k_read.dtype,
+    )
+    # obtain WY representation. u is actually the new v.
+    w, u = recompute_w_u_fwd(
+        k=k_read,
+        v=v,
+        beta=beta,
+        A=A,
+        g=g,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=k_precond,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+
+    o = chunk_fwd_o(
+        q=q,
+        k=k_precond,
+        v=v_new,
+        h=h,
+        g=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+
+    return g, o, A, final_state, at
+
+
+def chunk_precond_gated_delta_rule_bwd(
+    q: torch.Tensor,
+    k_read: torch.Tensor,
+    k_write: torch.Tensor,
+    v: torch.Tensor,
+    g_atk: torch.Tensor,
+    g: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    initial_A_state: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = True,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    transpose_state_layout: bool = False,
+):
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, 64)
+
+    # Recompute ATK forward intermediates
+    k_precond, ac_atk, a_atk, sa_atk = recompute_atk_fwd(
+        k=k_write,
+        beta=beta_atk,
+        log_g=g_atk,
+        chunk_size=64,
+        initial_A_state=initial_A_state,
+        cu_seqlens=cu_seqlens,
+        x=x,
+        eps=eps,
+        log_atk_scale=log_atk_scale,
+    )
+
+    w, u = recompute_w_u_fwd(
+        k=k_read,
+        v=v,
+        beta=beta,
+        A=A,
+        g=g,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+        k=k_precond,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=False,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+    dv = chunk_bwd_dv_local(
+        q=q,
+        k=k_precond,
+        g=g,
+        do=do,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
+        q=q,
+        k=k_precond,
+        w=w,
+        g=g,
+        h0=initial_state,
+        dht=dht,
+        do=do,
+        dv=dv,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+    dq, dk_precond, dw, dg = chunk_bwd_dqkwg(
+        q=q,
+        k=k_precond,
+        v=v_new,
+        w=w,
+        g=g,
+        h=h,
+        dv=dv,
+        do=do,
+        dh=dh,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+    # Asymmetric WY backward: produces separate grads for k_read and k_precond
+    dk_read_wy, dk_precond_wy, dv, dbeta_wy, dg2 = prepare_precond_wy_repr_bwd(
+        k=k_read,
+        k_precond=k_precond,
+        v=v,
+        beta=beta,
+        g=g,
+        A=A,
+        dw=dw,
+        du=dv,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        use_exp2=use_exp2,
+    )
+
+    dbeta = dbeta_wy
+    dk_precond.add_(dk_precond_wy)
+
+    # ATK backward (uses precomputed forward intermediates)
+    dk_write_atk, dbeta_atk, dg_atk, d_log_atk_scale, dh0_atk = chunk_atk_bwd(
+        k=k_write,
+        g_raw=g_atk,
+        beta=beta_atk,
+        dk_precond=dk_precond,
+        ac=ac_atk,
+        a=a_atk,
+        sa=sa_atk,
+        initial_A_state=initial_A_state,
+        cu_seqlens=cu_seqlens,
+        x=x,
+        eps=eps,
+        log_atk_scale=log_atk_scale,
+    )
+
+    dk_read = dk_read_wy
+    dk_write = dk_write_atk
+
+    dg.add_(dg2)
+    dg = chunk_local_cumsum(dg, chunk_size=64, reverse=True, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+
+    return dq, dk_read, dk_write, dv, dbeta_atk, dbeta, dg_atk, dg, dh0, dh0_atk, d_log_atk_scale
+
+
+class ChunkPrecondGatedDeltaRuleFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g_atk: torch.Tensor,
+        g: torch.Tensor,
+        beta_atk: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor,
+        initial_A_state: torch.Tensor,
+        output_final_state: bool,
+        use_qk_l2norm_in_kernel: bool = True,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_cpu: torch.LongTensor | None = None,
+        cp_context: FLACPContext | None = None,
+        transpose_state_layout: bool = False,
+        x: float = 1.5,
+        eps: float = 1e-6,
+        log_atk_scale: torch.Tensor = None,
+    ):
+        q_rstd, k_rstd = None, None
+        if use_qk_l2norm_in_kernel:
+            q, q_rstd = l2norm_fwd(q)
+            k, k_rstd = l2norm_fwd(k)
+
+        k_read = k
+        k_write = k
+
+        H = k.shape[2]
+        log_atk_scale_was_tensor = isinstance(log_atk_scale, torch.Tensor)
+
+        if log_atk_scale is None:
+            log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32, device=k.device)
+
+        chunk_indices = prepare_chunk_indices(
+            cu_seqlens, 64, cu_seqlens_cpu=cu_seqlens_cpu) if cu_seqlens is not None else None
+
+        g, o, A, h_final, at = chunk_precond_gated_delta_rule_fwd(
+            q=q,
+            k_read=k_read,
+            k_write=k_write,
+            v=v,
+            g_atk=g_atk,
+            g=g,
+            beta_atk=beta_atk,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            initial_A_state=initial_A_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
+            chunk_indices=chunk_indices,
+            use_exp2=True,
+            x=x,
+            eps=eps,
+            log_atk_scale=log_atk_scale,
+            transpose_state_layout=transpose_state_layout,
+        )
+
+        ctx.save_for_backward(
+            q, q_rstd, k, k_rstd, v,
+            g_atk, g,
+            beta_atk, beta,
+            A, initial_state, cu_seqlens,
+            log_atk_scale, chunk_indices
+        )
+        ctx.scale = scale
+        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        ctx.initial_A_state = initial_A_state
+        ctx.cp_context = cp_context
+        ctx.transpose_state_layout = transpose_state_layout
+        ctx.x = x
+        ctx.eps = eps
+        ctx.log_atk_scale_was_tensor = log_atk_scale_was_tensor
+
+        return o.to(q.dtype), h_final, at
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(ctx, do, dht, dat):
+        (q, q_rstd, k, k_rstd, v,
+         g_atk, g,
+         beta_atk, beta,
+         A, initial_state, cu_seqlens,
+         log_atk_scale, chunk_indices) = ctx.saved_tensors
+
+        k_read = k
+        k_write = k
+
+        dq, dk_read, dk_write, dv, dbeta_atk, dbeta, dg_atk, dg, dh0, dh0_atk, d_log_atk_scale = chunk_precond_gated_delta_rule_bwd(
+            q=q,
+            k_read=k_read,
+            k_write=k_write,
+            v=v,
+            g_atk=g_atk,
+            g=g,
+            beta_atk=beta_atk,
+            beta=beta,
+            A=A,
+            scale=ctx.scale,
+            initial_state=initial_state,
+            initial_A_state=ctx.initial_A_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=cu_seqlens,
+            cp_context=ctx.cp_context,
+            chunk_indices=chunk_indices,
+            use_exp2=True,
+            x=ctx.x,
+            eps=ctx.eps,
+            log_atk_scale=log_atk_scale,
+            transpose_state_layout=ctx.transpose_state_layout,
+        )
+
+        dk_read.add_(dk_write)
+        dk = dk_read
+
+        if ctx.use_qk_l2norm_in_kernel:
+            dq = l2norm_bwd(q, q_rstd, dq)
+            dk = l2norm_bwd(k, k_rstd, dk)
+
+        d_log_atk_scale_out = d_log_atk_scale.to(log_atk_scale) if ctx.log_atk_scale_was_tensor else None
+        return (
+            dq.to(q), dk.to(k), dv.to(v),
+            dg_atk.to(g_atk), dg.to(g),
+            dbeta_atk.to(beta_atk), dbeta.to(beta),
+            None, dh0, dh0_atk, None,  # scale, initial_state, initial_A_state, output_final_state
+            None, None, None, None, None,  # use_qk_l2norm_in_kernel, cu_seqlens, cu_seqlens_cpu, cp_context, transpose_state_layout
+            None, None,  # x, eps
+            d_log_atk_scale_out,  # log_atk_scale
+        )
+
+
+@torch.compiler.disable
+def chunk_precond_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g_atk: torch.Tensor,
+    g: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    initial_A_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
+    transpose_state_layout: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    **kwargs,
+):
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, HV, V]`.
+            GVA (Grouped Value Attention) is applied if `HV > H`, where `HV` must be divisible by `H`.
+        g_atk (torch.Tensor):
+            ATK gates (decays) in log space of shape `[B, T, H]`.
+        g (torch.Tensor):
+            gates (decays) in log space of shape `[B, T, HV]`.
+        beta_atk (torch.Tensor):
+            ATK betas of shape `[B, T, H]`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, HV]`.
+        scale (Optional[float]):
+            Scale factor for attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial recurrent state of shape `[N, HV, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        initial_A_state (Optional[torch.Tensor]):
+            Initial ATK diagonal state of shape `[N, H, K]`. Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, HV, K, V]`. Default: `False`.
+        use_qk_l2norm_in_kernel (bool):
+            Whether to apply L2norm to the q/k tensor internally. Default: `True`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        cp_context (Optional[FLACPContext]):
+            Context parallel context for distributed training across multiple devices.
+            When provided, `initial_state` and `output_final_state` are not supported,
+            and `cu_seqlens` will be overridden by the context. Default: `None`.
+        transpose_state_layout (Optional[bool]):
+            Whether to use the transposed state layout for the hidden state.
+            Default: `False`.
+        x (float):
+            Squash range parameter. Default: `1.5`.
+        eps (float):
+            Epsilon for numerical stability in the squash function. Default: `1e-6`.
+        log_atk_scale (Optional[torch.Tensor]):
+            Per-head log-space center of shape `[H]`. Default: `None`.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, HV, V]`.
+        recurrent_state (torch.Tensor):
+            Final recurrent state of shape `[N, HV, K, V]` if `output_final_state=True` else `None`.
+        A_state (torch.Tensor):
+            Final ATK diagonal state of shape `[N, H, K]` if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.precond_gated_delta_rule import chunk_precond_gated_delta_rule
+        # inputs with equal lengths
+        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+        >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
+        >>> beta_atk = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
+        >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
+        >>> g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
+        >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
+        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> o, ht, at = chunk_precond_gated_delta_rule(
+            q, k, v, g_atk, g, beta_atk, beta,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, beta_atk, beta, g_atk, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta_atk, beta, g_atk, g))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o, ht, at = chunk_precond_gated_delta_rule(
+            q, k, v, g_atk, g, beta_atk, beta,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    # Validate head dimensions
+    if q.shape[2] != k.shape[2]:
+        raise ValueError(
+            f"q and k must have the same number of heads, "
+            f"but got q.shape[2]={q.shape[2]} and k.shape[2]={k.shape[2]}"
+        )
+    H, HV = q.shape[2], v.shape[2]
+    if HV % H != 0:
+        raise ValueError(
+            f"For GVA, num_v_heads (HV={HV}) must be evenly divisible by "
+            f"num_heads (H={H}), but got HV % H = {HV % H}"
+        )
+
+    if 'head_first' in kwargs:
+        warnings.warn(
+            "head_first is deprecated and will be removed in a future version. "
+            "Please use head_first=False for now instead.",
+        )
+
+    if cp_context is not None:
+        assert initial_state is None, "Initial state is not supported for CP"
+        assert output_final_state is False, "Output final state is not supported for CP"
+        assert cp_context.cu_seqlens is not None, "cu_seqlens is required for CP"
+        cu_seqlens = cp_context.cu_seqlens
+        if cp_context.cu_seqlens_cpu is not None:
+            cu_seqlens_cpu = cp_context.cu_seqlens_cpu
+
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing.",
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.",
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    o, h_final, a_final = ChunkPrecondGatedDeltaRuleFunction.apply(
+        q, k, v,
+        g_atk, g,
+        beta_atk, beta,
+        scale,
+        initial_state,
+        initial_A_state,
+        output_final_state,
+        use_qk_l2norm_in_kernel,
+        cu_seqlens,
+        cu_seqlens_cpu,
+        cp_context,
+        transpose_state_layout,
+        x,
+        eps,
+        log_atk_scale,
+    )
+
+    return o, h_final, a_final

--- a/fla/ops/precond_gated_delta_rule/chunk.py
+++ b/fla/ops/precond_gated_delta_rule/chunk.py
@@ -5,8 +5,6 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-import warnings
-
 import torch
 
 from fla.modules.l2norm import l2norm_bwd, l2norm_fwd
@@ -529,9 +527,8 @@ def chunk_precond_gated_delta_rule(
         )
 
     if 'head_first' in kwargs:
-        warnings.warn(
-            "head_first is deprecated and will be removed in a future version. "
-            "Please use head_first=False for now instead.",
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
         )
 
     if cp_context is not None:

--- a/fla/ops/precond_gated_delta_rule/chunk.py
+++ b/fla/ops/precond_gated_delta_rule/chunk.py
@@ -148,6 +148,7 @@ def chunk_precond_gated_delta_rule_bwd(
     eps: float = 1e-6,
     log_atk_scale: torch.Tensor = None,
     transpose_state_layout: bool = False,
+    dat: torch.Tensor | None = None,
 ):
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, 64)
@@ -257,6 +258,7 @@ def chunk_precond_gated_delta_rule_bwd(
         x=x,
         eps=eps,
         log_atk_scale=log_atk_scale,
+        dat=dat,
     )
 
     dk_read = dk_read_wy
@@ -389,6 +391,7 @@ class ChunkPrecondGatedDeltaRuleFunction(torch.autograd.Function):
             eps=ctx.eps,
             log_atk_scale=log_atk_scale,
             transpose_state_layout=ctx.transpose_state_layout,
+            dat=dat,
         )
 
         dk_read.add_(dk_write)
@@ -467,9 +470,8 @@ def chunk_precond_gated_delta_rule(
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
         cp_context (Optional[FLACPContext]):
-            Context parallel context for distributed training across multiple devices.
-            When provided, `initial_state` and `output_final_state` are not supported,
-            and `cu_seqlens` will be overridden by the context. Default: `None`.
+            Context parallelism is not yet supported for the preconditioned path;
+            passing a context raises `NotImplementedError`. Default: `None`.
         transpose_state_layout (Optional[bool]):
             Whether to use the transposed state layout for the hidden state.
             Default: `False`.
@@ -539,12 +541,11 @@ def chunk_precond_gated_delta_rule(
         )
 
     if cp_context is not None:
-        assert initial_state is None, "Initial state is not supported for CP"
-        assert output_final_state is False, "Output final state is not supported for CP"
-        assert cp_context.cu_seqlens is not None, "cu_seqlens is required for CP"
-        cu_seqlens = cp_context.cu_seqlens
-        if cp_context.cu_seqlens_cpu is not None:
-            cu_seqlens_cpu = cp_context.cu_seqlens_cpu
+        raise NotImplementedError(
+            "Context parallelism is not yet supported for chunk_precond_gated_delta_rule: "
+            "the preconditioned path lacks the CP state compression/expansion plumbing. "
+            "Please run without `cp_context`."
+        )
 
     if cu_seqlens is not None:
         if q.shape[0] != 1:

--- a/fla/ops/precond_gated_delta_rule/chunk.py
+++ b/fla/ops/precond_gated_delta_rule/chunk.py
@@ -40,7 +40,6 @@ def chunk_precond_gated_delta_rule_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = True,
     x: float = 1.5,
     eps: float = 1e-6,
     log_atk_scale: torch.Tensor = None,
@@ -65,7 +64,7 @@ def chunk_precond_gated_delta_rule_fwd(
     g = chunk_local_cumsum(
         g,
         chunk_size=64,
-        scale=RCP_LN2 if use_exp2 else None,
+        scale=RCP_LN2,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
     )
@@ -79,7 +78,6 @@ def chunk_precond_gated_delta_rule_fwd(
         chunk_size=64,
         output_dtype=torch.float32,
         cu_seqlens=cu_seqlens,
-        use_exp2=use_exp2,
     )
     A = solve_tril(
         A=A,
@@ -143,7 +141,6 @@ def chunk_precond_gated_delta_rule_bwd(
     cu_seqlens: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = True,
     x: float = 1.5,
     eps: float = 1e-6,
     log_atk_scale: torch.Tensor = None,
@@ -238,7 +235,6 @@ def chunk_precond_gated_delta_rule_bwd(
         du=dv,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        use_exp2=use_exp2,
     )
 
     dbeta = dbeta_wy
@@ -330,7 +326,6 @@ class ChunkPrecondGatedDeltaRuleFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             cp_context=cp_context,
             chunk_indices=chunk_indices,
-            use_exp2=True,
             x=x,
             eps=eps,
             log_atk_scale=log_atk_scale,
@@ -386,7 +381,6 @@ class ChunkPrecondGatedDeltaRuleFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             cp_context=ctx.cp_context,
             chunk_indices=chunk_indices,
-            use_exp2=True,
             x=ctx.x,
             eps=ctx.eps,
             log_atk_scale=log_atk_scale,

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+# Copyright (c) 2023-2025
+# Asymmetric KKT kernel for preconditioned gated delta rule
+# Computes k @ k_precond^T (asymmetric) instead of k @ k^T (symmetric)
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.op import exp, exp2
+from fla.utils import autotune_cache_kwargs
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['H', 'K', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_precond_kkt_fwd_kernel(
+    k,              # [B, T, H, K] - original keys
+    k_precond,      # [B, T, H, K] - pre-computed preconditioned keys
+    g,              # [B, T, H] - gate (cumsum)
+    beta,           # [B, T, H] - beta scaling
+    A,              # [B, T, H, BT] - output asymmetric KKT matrix
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Compute asymmetric KKT matrix using pre-computed k_precond.
+
+    A_ij = beta_i * k_i @ k_precond_j^T * exp(g_i - g_j)
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        i_n = i_b
+        bos, eos = i_b * T, i_b * T + T
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+
+    p_b = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_b = tl.load(p_b, boundary_check=(0,))
+
+    p_g = tl.make_block_ptr(g + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_g = tl.load(p_g, boundary_check=(0,))
+
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+
+        p_kp = tl.make_block_ptr(k_precond + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_kp = tl.load(p_kp, boundary_check=(0, 1))
+
+        b_A += tl.dot(b_k, tl.trans(b_kp))
+
+    # Attention gating and beta scaling
+    if USE_EXP2:
+        b_A *= exp2(b_g[:, None] - b_g[None, :])
+    else:
+        b_A *= exp(b_g[:, None] - b_g[None, :])
+    b_A *= b_b[:, None]
+
+    # Causal mask
+    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A, b_A, 0)
+
+    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (BT*H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_precond_kkt_fwd(
+    k: torch.Tensor,
+    k_precond: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype = torch.float32,
+    cu_seqlens: torch.LongTensor | None = None,
+    use_exp2: bool = True,
+) -> torch.Tensor:
+    r"""
+    Compute beta * K * K_precond^T (asymmetric).
+
+    Args:
+        k (torch.Tensor):
+            The key tensor of shape `[B, T, H, K]`.
+        k_precond (torch.Tensor):
+            The preconditioned key tensor of shape `[B, T, H, K]`.
+        g (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, H]`.
+        beta (torch.Tensor):
+            The beta tensor of shape `[B, T, H]`.
+        cu_seqlens (torch.LongTensor):
+            The cumulative sequence lengths of the input tensor.
+            Default: None
+        chunk_size (int):
+            The chunk size. Default: 64.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float32`
+
+    Returns:
+        beta * K * K_precond^T of shape `[B, T, H, BT]` where `BT` is the chunk size.
+    """
+    B, T, H, K = k.shape
+    BT = chunk_size
+
+    chunk_indices = prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
+
+    chunk_precond_kkt_fwd_kernel[(NT, B * H)](
+        k=k,
+        k_precond=k_precond,
+        g=g,
+        beta=beta,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        USE_EXP2=use_exp2,
+    )
+
+    return A

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
@@ -67,20 +67,19 @@ def chunk_precond_kkt_fwd_kernel(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
 
-    p_b = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
-
-    p_g = tl.make_block_ptr(g + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_g = tl.load(p_g, boundary_check=(0,))
+    b_b = tl.load(beta + bos*H + i_h + o_t*H, mask=m_t, other=0.0)
+    b_g = tl.load(g + bos*H + i_h + o_t*H, mask=m_t, other=0.0)
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
 
-        p_kp = tl.make_block_ptr(k_precond + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_kp = tl.load(p_kp, boundary_check=(0, 1))
+        p_kp = k_precond + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_kp = tl.load(p_kp, mask=m_tk, other=0.0)
 
         b_A += tl.dot(b_k, tl.trans(b_kp))
 
@@ -95,8 +94,9 @@ def chunk_precond_kkt_fwd_kernel(
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (BT*H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (BT*H) + o_A[None, :]
+    tl.store(p_A, b_A.to(A.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
 
 
 def chunk_precond_kkt_fwd(

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
@@ -14,7 +14,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs
 
 
@@ -46,7 +46,6 @@ def chunk_precond_kkt_fwd_kernel(
     K: tl.constexpr,
     BT: tl.constexpr,
     BK: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     """
@@ -88,11 +87,8 @@ def chunk_precond_kkt_fwd_kernel(
 
         b_A += tl.dot(b_k, tl.trans(b_kp))
 
-    # Attention gating and beta scaling
-    if USE_EXP2:
-        b_A *= exp2(b_g[:, None] - b_g[None, :])
-    else:
-        b_A *= exp(b_g[:, None] - b_g[None, :])
+    # Attention gating and beta scaling (gates are pre-scaled by RCP_LN2 upstream)
+    b_A *= exp2(b_g[:, None] - b_g[None, :])
     b_A *= b_b[:, None]
 
     # Causal mask
@@ -112,7 +108,6 @@ def chunk_precond_kkt_fwd(
     chunk_size: int = 64,
     output_dtype: torch.dtype = torch.float32,
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = True,
 ) -> torch.Tensor:
     r"""
     Compute beta * K * K_precond^T (asymmetric).
@@ -161,7 +156,6 @@ def chunk_precond_kkt_fwd(
         HV=HV,
         K=K,
         BT=BT,
-        USE_EXP2=use_exp2,
     )
 
     return A

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_kkt_fwd.py
@@ -35,13 +35,14 @@ from fla.utils import autotune_cache_kwargs
 def chunk_precond_kkt_fwd_kernel(
     k,              # [B, T, H, K] - original keys
     k_precond,      # [B, T, H, K] - pre-computed preconditioned keys
-    g,              # [B, T, H] - gate (cumsum)
-    beta,           # [B, T, H] - beta scaling
-    A,              # [B, T, H, BT] - output asymmetric KKT matrix
+    g,              # [B, T, HV] - gate (cumsum)
+    beta,           # [B, T, HV] - beta scaling
+    A,              # [B, T, HV, BT] - output asymmetric KKT matrix
     cu_seqlens,
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     BK: tl.constexpr,
@@ -52,13 +53,17 @@ def chunk_precond_kkt_fwd_kernel(
     Compute asymmetric KKT matrix using pre-computed k_precond.
 
     A_ij = beta_i * k_i @ k_precond_j^T * exp(g_i - g_j)
+
+    GVA (`HV > H`) is supported: `k`/`k_precond` carry `H` heads while `g`/`beta`/`A`
+    carry `HV` heads; each value head reads its shared key head via `i_hv // (HV // H)`.
     """
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         i_n = i_b
@@ -67,8 +72,8 @@ def chunk_precond_kkt_fwd_kernel(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
 
-    b_b = tl.load(beta + bos*H + i_h + o_t*H, mask=m_t, other=0.0)
-    b_g = tl.load(g + bos*H + i_h + o_t*H, mask=m_t, other=0.0)
+    b_b = tl.load(beta + bos*HV + i_hv + o_t*HV, mask=m_t, other=0.0)
+    b_g = tl.load(g + bos*HV + i_hv + o_t*HV, mask=m_t, other=0.0)
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
 
@@ -95,7 +100,7 @@ def chunk_precond_kkt_fwd_kernel(
     b_A = tl.where(m_A, b_A, 0)
 
     o_A = tl.arange(0, BT)
-    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (BT*H) + o_A[None, :]
+    p_A = A + (bos*HV + i_hv) * BT + o_t[:, None] * (BT*HV) + o_A[None, :]
     tl.store(p_A, b_A.to(A.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
 
 
@@ -118,9 +123,10 @@ def chunk_precond_kkt_fwd(
         k_precond (torch.Tensor):
             The preconditioned key tensor of shape `[B, T, H, K]`.
         g (torch.Tensor):
-            The cumulative sum of the gate tensor of shape `[B, T, H]`.
+            The cumulative sum of the gate tensor of shape `[B, T, HV]`.
+            GVA is applied if `HV > H`, where `HV` must be divisible by `H`.
         beta (torch.Tensor):
-            The beta tensor of shape `[B, T, H]`.
+            The beta tensor of shape `[B, T, HV]`.
         cu_seqlens (torch.LongTensor):
             The cumulative sequence lengths of the input tensor.
             Default: None
@@ -130,17 +136,19 @@ def chunk_precond_kkt_fwd(
             The dtype of the output tensor. Default: `torch.float32`
 
     Returns:
-        beta * K * K_precond^T of shape `[B, T, H, BT]` where `BT` is the chunk size.
+        beta * K * K_precond^T of shape `[B, T, HV, BT]` where `BT` is the chunk size.
     """
     B, T, H, K = k.shape
+    HV = beta.shape[-1]
+    assert HV % H == 0, f"HV ({HV}) must be divisible by H ({H})"
     BT = chunk_size
 
     chunk_indices = prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
+    A = torch.empty(B, T, HV, BT, device=k.device, dtype=output_dtype)
 
-    chunk_precond_kkt_fwd_kernel[(NT, B * H)](
+    chunk_precond_kkt_fwd_kernel[(NT, B * HV)](
         k=k,
         k_precond=k_precond,
         g=g,
@@ -150,6 +158,7 @@ def chunk_precond_kkt_fwd(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         BT=BT,
         USE_EXP2=use_exp2,

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.op import exp, exp2
+from fla.utils import IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
+
+if IS_NVIDIA_BLACKWELL:
+    """
+    Compute tl.dot with SM100 workaround.
+
+    On SM100 (Blackwell) GPUs, wraps the result in inline assembly to prevent
+    the TritonGPUHoistTMEMAlloc pass from incorrectly fusing add and dot operations.
+    See: https://github.com/fla-org/flash-linear-attention/issues/638
+
+    TODO: Remove this workaround once the Triton compiler bug is fixed.
+    Track upstream issue at: https://github.com/triton-lang/triton/issues/8695
+    """
+    @triton.jit
+    def safe_dot(a, b):
+        return tl.inline_asm_elementwise(
+            asm="mov.f32 $0, $1;",
+            constraints="=r,r",
+            args=[tl.dot(a, b)],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+else:
+    @triton.jit
+    def safe_dot(a, b):
+        return tl.dot(a, b)
+
+
+# ==============================================================================
+# Asymmetric WY Backward Kernel for Preconditioned Gated Delta Rule
+# ==============================================================================
+# Key difference from symmetric version:
+# - Forward KKT: baseKKT_ij = beta_i * <k_i, k_precond_j>
+# - Backward must use: b_A = (beta*k) @ k_precond^T
+# - Row-side gradients -> dk
+# - Column-side gradients -> dk_precond (separate output for ATK backward)
+
+
+@triton.heuristics({
+    'USE_G': lambda args: args['g'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def prepare_precond_wy_repr_bwd_kernel(
+    k,           # [B, T, H, K] - original k (READ key, row side)
+    k_precond,   # [B, T, H, K] - preconditioned k (WRITE key, column side)
+    v,           # [B, T, HV, V]
+    beta,        # [B, T, HV]
+    g,           # [B, T, HV] - gate cumsum
+    A,           # [B, T, HV, BT] - inverse WY matrix
+    dw,          # [B, T, HV, K] - gradient of w
+    du,          # [B, T, HV, V] - gradient of u
+    dk,          # [B, T, HV, K] - output: gradient w.r.t. original k (row side)
+    dk_precond,  # [B, T, HV, K] - output: gradient w.r.t. k_precond (column side)
+    dv,          # [B, T, HV, V] - output: gradient w.r.t. v
+    db,          # [B, T, HV] - output: gradient w.r.t. beta
+    dg,          # [B, T, HV] - output: gradient w.r.t. g (cumsum)
+    cu_seqlens,     # *i32 [N+1] - cumulative sequence lengths
+    chunk_indices,  # *i32 [NT, 2] - (seq_idx, chunk_idx) pairs
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Asymmetric WY backward for preconditioned gated delta rule.
+
+    Key insight: The forward uses asymmetric KKT matrix:
+        baseKKT_ij = beta_i * <k_i, k_precond_j>
+
+    Row index (i) uses original k (READ key)
+    Column index (j) uses k_precond (WRITE key)
+
+    Gradient flow:
+    - Row-side (from dA @ K_precond): goes to dk and dbeta
+    - Column-side (from dA^T @ (beta*k)): goes to dk_precond only
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    p_b = tl.make_block_ptr(beta + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    p_db = tl.make_block_ptr(db + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    p_A = tl.make_block_ptr(A + (bos*HV + i_hv) * BT, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
+
+    b_b = tl.load(p_b, boundary_check=(0,))
+    b_db = tl.zeros([BT], dtype=tl.float32)
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+
+    if USE_G:
+        p_g = tl.make_block_ptr(g + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        b_g = tl.load(p_g, boundary_check=(0,))
+        if USE_EXP2:
+            b_g_exp = exp2(b_g)
+        else:
+            b_g_exp = tl.exp(b_g)
+        b_dg = tl.zeros([BT], dtype=tl.float32)
+
+    # First pass: accumulate dA from dw using original k (for w = A^-1 @ (k * beta * g))
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dw = tl.make_block_ptr(dw + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+
+        # [BT, BK]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        if USE_G:
+            b_kbg = b_k * (b_b * b_g_exp)[:, None]
+        else:
+            b_kbg = b_k * b_b[:, None]
+        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+
+        # dA contribution from dw: dA += dw @ kbg^T
+        b_dA += safe_dot(b_dw, tl.trans(b_kbg).to(b_dw.dtype))
+
+        # dk contribution from first term: A @ dw
+        b_dkbg = safe_dot(b_A, b_dw.to(b_A.dtype))
+        if USE_G:
+            b_dk = b_dkbg * (b_g_exp * b_b)[:, None]
+            b_db += tl.sum(b_dkbg * b_k * b_g_exp[:, None], 1)
+            b_dg += tl.sum(b_dkbg * b_kbg, 1)
+        else:
+            b_dk = b_dkbg * b_b[:, None]
+            b_db += tl.sum(b_dkbg * b_k, 1)
+
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+
+    # Process dv and du (u = A^-1 @ (v * beta), same as symmetric)
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(v + (bos*HV + i_hv) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = tl.make_block_ptr(dv + (bos*HV + i_hv) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_du = tl.make_block_ptr(du + (bos*HV + i_hv) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
+        b_du = tl.load(p_du, boundary_check=(0, 1))
+        b_dA += safe_dot(b_du, tl.trans(b_vb))
+        b_dvb = safe_dot(b_A, b_du.to(b_A.dtype))
+        b_dv = b_dvb * b_b[:, None]
+        b_db += tl.sum(b_dvb * b_v, 1)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+    # Transform dA through lower triangular inversion
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
+    b_dA = tl.where(m_A, b_dA, 0)
+    b_dA = safe_dot(b_dA.to(b_A.dtype), b_A)
+    b_dA = safe_dot(b_A, b_dA.to(b_A.dtype))
+
+    if USE_G:
+        if USE_EXP2:
+            b_dA *= exp2(b_g[:, None] - b_g[None, :])
+        else:
+            b_dA *= exp(b_g[:, None] - b_g[None, :])
+
+    b_dA = tl.where(m_A, -b_dA, 0)
+
+    b_dA = b_dA.to(k.dtype.element_ty)
+
+    tl.debug_barrier()
+    # ==== ASYMMETRIC PART ====
+    # Reconstruct b_A (the asymmetric KKT) and compute gradients
+    # baseKKT_ij = beta_i * <k_i, k_precond_j>
+    # Row index i: uses k (READ key)
+    # Column index j: uses k_precond (WRITE key)
+    #
+    # From the gradient chain rule:
+    # - dL/dk_i += sum_j dA_ij * k_precond_j * beta_i  (row-side)
+    # - dL/dk_precond_j += sum_i dA_ij * k_i * beta_i  (column-side)
+    # - dL/dbeta_i += sum_j dA_ij * <k_i, k_precond_j>
+
+    b_A_asymm = tl.zeros([BT, BT], dtype=tl.float32)  # Asymmetric KKT matrix
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_kp = tl.make_block_ptr(k_precond + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dkp = tl.make_block_ptr(dk_precond + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+
+        b_k = tl.load(p_k, boundary_check=(0, 1))   # [BT, BK] - original k
+        b_kp = tl.load(p_kp, boundary_check=(0, 1))  # [BT, BK] - k_precond
+        b_dk = tl.load(p_dk, boundary_check=(0, 1))  # Load existing dk from first pass
+
+        # kb = k * beta (used on row side)
+        b_kb = (b_k * b_b[:, None]).to(b_k.dtype)
+
+        # Build asymmetric KKT: (beta * k) @ k_precond^T
+        b_A_asymm += safe_dot(b_kb, tl.trans(b_kp))
+
+        # Row-side gradient: dkb = dA @ k_precond
+        b_dkb = safe_dot(b_dA, b_kp)
+        # dk contribution: dkb * beta
+        b_dk += b_dkb * b_b[:, None]
+        # dbeta contribution: <dkb, k>
+        b_db += tl.sum(b_dkb * b_k, 1)
+
+        # Column-side gradient: dk_precond = dA^T @ (beta * k)
+        b_dkp = safe_dot(tl.trans(b_dA), b_kb)
+
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dkp, b_dkp.to(p_dkp.dtype.element_ty), boundary_check=(0, 1))
+
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+
+    # dg using the asymmetric KKT matrix
+    if USE_G:
+        b_AdA = b_dA * b_A_asymm
+        p_dg = tl.make_block_ptr(dg + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        b_dg += tl.sum(b_AdA, axis=1) - tl.sum(b_AdA, axis=0)
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+
+
+def prepare_precond_wy_repr_bwd(
+    k: torch.Tensor,
+    k_precond: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    dw: torch.Tensor,
+    du: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    use_exp2: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Asymmetric WY backward for preconditioned gated delta rule.
+
+    Unlike the symmetric version that uses the same k for both row and column
+    of the KKT matrix, this version uses:
+    - k (original) for row side (READ key)
+    - k_precond for column side (WRITE key)
+
+    Args:
+        k: Original keys [B, T, H, K]
+        k_precond: Preconditioned keys [B, T, H, K]
+        v: Values [B, T, H, V]
+        beta: Beta scaling [B, T, H]
+        g: Gate cumsum [B, T, H]
+        A: Inverse WY matrix [B, T, H, BT]
+        dw: Gradient of w [B, T, H, K]
+        du: Gradient of u [B, T, H, V]
+        cu_seqlens: Cumulative sequence lengths [N+1] for varlen
+        chunk_indices: Precomputed chunk indices [NT, 2] for varlen
+
+    Returns:
+        dk: Gradient w.r.t. original k (row-side) [B, T, H, K]
+        dk_precond: Gradient w.r.t. k_precond (column-side) [B, T, H, K]
+        dv: Gradient w.r.t. v [B, T, H, V]
+        dbeta: Gradient w.r.t. beta [B, T, H]
+        dg: Gradient w.r.t. g cumsum [B, T, H]
+    """
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HV = v.shape[2]
+    BT = 64
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    CONST_TILING = 64 if check_shared_mem() else 32
+    BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
+    BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
+
+    dk = k.new_empty(B, T, HV, K)
+    dk_precond = k.new_empty(B, T, HV, K)
+    dv = torch.empty_like(v)
+    dg = torch.empty_like(g) if g is not None else None
+    db = torch.empty_like(beta)
+
+    prepare_precond_wy_repr_bwd_kernel[(NT, B * HV)](
+        k=k,
+        k_precond=k_precond,
+        v=v,
+        beta=beta,
+        g=g,
+        A=A,
+        dw=dw,
+        du=du,
+        dk=dk,
+        dk_precond=dk_precond,
+        dv=dv,
+        db=db,
+        dg=dg,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+        USE_EXP2=use_exp2,
+    )
+
+    if H != HV:
+        dk = dk.view(B, T, H, HV // H, K).sum(3)
+        dk_precond = dk_precond.view(B, T, H, HV // H, K).sum(3)
+
+    return dk, dk_precond, dv, db, dg

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
 
 if IS_NVIDIA_BLACKWELL:
@@ -89,7 +89,6 @@ def prepare_precond_wy_repr_bwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     """
@@ -128,10 +127,7 @@ def prepare_precond_wy_repr_bwd_kernel(
 
     if USE_G:
         b_g = tl.load(g + (bos*HV + i_hv) + o_t*HV, mask=m_t, other=0.0)
-        if USE_EXP2:
-            b_g_exp = exp2(b_g)
-        else:
-            b_g_exp = tl.exp(b_g)
+        b_g_exp = exp2(b_g)
         b_dg = tl.zeros([BT], dtype=tl.float32)
 
     # First pass: accumulate dA from dw using original k (for w = A^-1 @ (k * beta * g))
@@ -188,10 +184,7 @@ def prepare_precond_wy_repr_bwd_kernel(
     b_dA = safe_dot(b_A, b_dA.to(b_A.dtype))
 
     if USE_G:
-        if USE_EXP2:
-            b_dA *= exp2(b_g[:, None] - b_g[None, :])
-        else:
-            b_dA *= exp(b_g[:, None] - b_g[None, :])
+        b_dA *= exp2(b_g[:, None] - b_g[None, :])
 
     b_dA = tl.where(m_A, -b_dA, 0)
 
@@ -262,7 +255,6 @@ def prepare_precond_wy_repr_bwd(
     du: torch.Tensor,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
-    use_exp2: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Asymmetric WY backward for preconditioned gated delta rule.
@@ -333,7 +325,6 @@ def prepare_precond_wy_repr_bwd(
         BT=BT,
         BK=BK,
         BV=BV,
-        USE_EXP2=use_exp2,
     )
 
     if H != HV:

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
@@ -116,18 +116,18 @@ def prepare_precond_wy_repr_bwd_kernel(
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_b = tl.make_block_ptr(beta + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*HV + i_hv) * BT, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    o_r = tl.arange(0, BT)
 
-    b_b = tl.load(p_b, boundary_check=(0,))
+    b_b = tl.load(beta + (bos*HV + i_hv) + o_t*HV, mask=m_t, other=0.0)
     b_db = tl.zeros([BT], dtype=tl.float32)
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    p_A = A + (bos*HV + i_hv) * BT + o_r[:, None] + o_t[None, :] * (HV*BT)
+    b_A = tl.load(p_A, mask=(o_r[:, None] < BT) & m_t[None, :], other=0.0)
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
     if USE_G:
-        p_g = tl.make_block_ptr(g + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        b_g = tl.load(g + (bos*HV + i_hv) + o_t*HV, mask=m_t, other=0.0)
         if USE_EXP2:
             b_g_exp = exp2(b_g)
         else:
@@ -136,17 +136,19 @@ def prepare_precond_wy_repr_bwd_kernel(
 
     # First pass: accumulate dA from dw using original k (for w = A^-1 @ (k * beta * g))
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*HV + i_hv) * K + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dw = dw + (bos*HV + i_hv) * K + o_t[:, None] * (HV*K) + o_k[None, :]
 
         # [BT, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
         if USE_G:
             b_kbg = b_k * (b_b * b_g_exp)[:, None]
         else:
             b_kbg = b_k * b_b[:, None]
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+        b_dw = tl.load(p_dw, mask=m_tk, other=0.0)
 
         # dA contribution from dw: dA += dw @ kbg^T
         b_dA += safe_dot(b_dw, tl.trans(b_kbg).to(b_dw.dtype))
@@ -161,25 +163,25 @@ def prepare_precond_wy_repr_bwd_kernel(
             b_dk = b_dkbg * b_b[:, None]
             b_db += tl.sum(b_dkbg * b_k, 1)
 
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(dk.dtype.element_ty), mask=m_tk)
 
     # Process dv and du (u = A^-1 @ (v * beta), same as symmetric)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*HV + i_hv) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos*HV + i_hv) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos*HV + i_hv) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*HV + i_hv) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_dv = dv + (bos*HV + i_hv) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_du = du + (bos*HV + i_hv) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
-        b_du = tl.load(p_du, boundary_check=(0, 1))
+        b_du = tl.load(p_du, mask=m_tv, other=0.0)
         b_dA += safe_dot(b_du, tl.trans(b_vb))
         b_dvb = safe_dot(b_A, b_du.to(b_A.dtype))
         b_dv = b_dvb * b_b[:, None]
         b_db += tl.sum(b_dvb * b_v, 1)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(dv.dtype.element_ty), mask=m_tv)
 
     # Transform dA through lower triangular inversion
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA, 0)
     b_dA = safe_dot(b_dA.to(b_A.dtype), b_A)
@@ -210,14 +212,16 @@ def prepare_precond_wy_repr_bwd_kernel(
     b_A_asymm = tl.zeros([BT, BT], dtype=tl.float32)  # Asymmetric KKT matrix
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_kp = tl.make_block_ptr(k_precond + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dkp = tl.make_block_ptr(dk_precond + (bos*HV + i_hv) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_kp = k_precond + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*HV + i_hv) * K + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dkp = dk_precond + (bos*HV + i_hv) * K + o_t[:, None] * (HV*K) + o_k[None, :]
 
-        b_k = tl.load(p_k, boundary_check=(0, 1))   # [BT, BK] - original k
-        b_kp = tl.load(p_kp, boundary_check=(0, 1))  # [BT, BK] - k_precond
-        b_dk = tl.load(p_dk, boundary_check=(0, 1))  # Load existing dk from first pass
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)   # [BT, BK] - original k
+        b_kp = tl.load(p_kp, mask=m_tk, other=0.0)  # [BT, BK] - k_precond
+        b_dk = tl.load(p_dk, mask=m_tk, other=0.0)  # Load existing dk from first pass
 
         # kb = k * beta (used on row side)
         b_kb = (b_k * b_b[:, None]).to(b_k.dtype)
@@ -235,17 +239,16 @@ def prepare_precond_wy_repr_bwd_kernel(
         # Column-side gradient: dk_precond = dA^T @ (beta * k)
         b_dkp = safe_dot(tl.trans(b_dA), b_kb)
 
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dkp, b_dkp.to(p_dkp.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(dk.dtype.element_ty), mask=m_tk)
+        tl.store(p_dkp, b_dkp.to(dk_precond.dtype.element_ty), mask=m_tk)
 
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    tl.store(db + (bos*HV + i_hv) + o_t*HV, b_db.to(db.dtype.element_ty), mask=m_t)
 
     # dg using the asymmetric KKT matrix
     if USE_G:
         b_AdA = b_dA * b_A_asymm
-        p_dg = tl.make_block_ptr(dg + (bos*HV + i_hv), (T,), (HV,), (i_t * BT,), (BT,), (0,))
         b_dg += tl.sum(b_AdA, axis=1) - tl.sum(b_AdA, axis=0)
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+        tl.store(dg + (bos*HV + i_hv) + o_t*HV, b_dg.to(dg.dtype.element_ty), mask=m_t)
 
 
 def prepare_precond_wy_repr_bwd(

--- a/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
+++ b/fla/ops/precond_gated_delta_rule/chunk_precond_wy_bwd.py
@@ -105,13 +105,13 @@ def prepare_precond_wy_repr_bwd_kernel(
     - Row-side (from dA @ K_precond): goes to dk and dbeta
     - Column-side (from dA^T @ (beta*k)): goes to dk_precond only
     """
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T

--- a/fla/ops/precond_gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/precond_gated_delta_rule/fused_recurrent.py
@@ -1,0 +1,518 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.op import exp, exp2
+from fla.utils import input_guard
+
+
+@triton.heuristics({
+    'USE_G': lambda args: args['g'] is not None,
+    'USE_GK': lambda args: args['gk'] is not None,
+    'USE_GV': lambda args: args['gv'] is not None,
+    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
+    'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
+    'USE_INITIAL_ATK': lambda args: args['a0'] is not None,
+    'STORE_FINAL_ATK': lambda args: args['at'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T'])
+def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    gk,
+    gv,
+    beta,
+    g_atk,
+    beta_atk,
+    log_atk_scale,
+    o,
+    h0,
+    ht,
+    a0,
+    at,
+    cu_seqlens,
+    scale,
+    x,
+    eps,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_BETA_HEADWISE: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    USE_INITIAL_ATK: tl.constexpr,
+    STORE_FINAL_ATK: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_q = q + (bos * H + i_h) * K + o_k
+    p_k = k + (bos * H + i_h) * K + o_k
+    p_v = v + (bos * HV + i_hv) * V + o_v
+    if USE_G:
+        p_g = g + bos * HV + i_hv
+    if USE_GK:
+        p_gk = gk + (bos * HV + i_hv) * K + o_k
+    if USE_GV:
+        p_gv = gv + (bos * HV + i_hv) * V + o_v
+    if IS_BETA_HEADWISE:
+        p_beta = beta + bos * HV + i_hv
+    else:
+        p_beta = beta + (bos * HV + i_hv) * V + o_v
+
+    # ATK pointers (per-HV-head: g_atk, beta_atk, log_atk_scale are shape-HV like v/beta/g)
+    p_g_atk = g_atk + bos * HV + i_hv
+    p_beta_atk = beta_atk + bos * HV + i_hv
+
+    scale_val = tl.load(log_atk_scale + i_hv).to(tl.float32)
+    logx = tl.log(tl.cast(x, tl.float32))
+
+    p_o = o + (bos * HV + i_hv) * V + o_v
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    if TRANSPOSE_STATE:
+        mask_h = mask_v[:, None] & mask_k[None, :]
+    else:
+        mask_h = mask_k[:, None] & mask_v[None, :]
+
+    if TRANSPOSE_STATE:
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        if TRANSPOSE_STATE:
+            p_h0 = h0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+
+    # ATK state
+    b_a = tl.zeros([BK], dtype=tl.float32)
+    if USE_INITIAL_ATK:
+        p_a0 = a0 + i_nh * K + o_k
+        b_a += tl.load(p_a0, mask=mask_k, other=0).to(tl.float32)
+
+    for _ in tl.range(0, T):
+        b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q = b_q * scale
+        if IS_BETA_HEADWISE:
+            b_beta = tl.load(p_beta).to(tl.float32)
+        else:
+            b_beta = tl.load(p_beta, mask=mask_v, other=0).to(tl.float32)
+
+        # ATK: A_t = exp(g_atk) * A_{t-1} + beta_atk * k^2
+        b_g_atk = tl.load(p_g_atk).to(tl.float32)
+        b_beta_atk = tl.load(p_beta_atk).to(tl.float32)
+        b_a = exp(b_g_atk) * b_a + b_beta_atk * (b_k * b_k)
+
+        # Symmetric fast squash preconditioner
+        b_ell = tl.log(b_a + eps)
+        b_r = b_ell - scale_val
+        b_s = b_r / (1.0 + tl.abs(b_r))
+        b_M = tl.exp(-logx * b_s)
+        b_k_precond = b_k * b_M
+
+        if USE_G:
+            b_g = tl.load(p_g).to(tl.float32)
+            if USE_EXP2:
+                b_h *= exp2(b_g)
+            else:
+                b_h *= exp(b_g)
+
+        if USE_GK:
+            b_gk = tl.load(p_gk).to(tl.float32)
+            if USE_EXP2:
+                if TRANSPOSE_STATE:
+                    b_h *= exp2(b_gk[None, :])
+                else:
+                    b_h *= exp2(b_gk[:, None])
+            else:
+                if TRANSPOSE_STATE:
+                    b_h *= exp(b_gk[None, :])
+                else:
+                    b_h *= exp(b_gk[:, None])
+
+        if USE_GV:
+            b_gv = tl.load(p_gv).to(tl.float32)
+            if USE_EXP2:
+                if TRANSPOSE_STATE:
+                    b_h *= exp2(b_gv[:, None])
+                else:
+                    b_h *= exp2(b_gv[None, :])
+            else:
+                if TRANSPOSE_STATE:
+                    b_h *= exp(b_gv[:, None])
+                else:
+                    b_h *= exp(b_gv[None, :])
+
+        # Delta rule update using k_precond for the write side
+        if TRANSPOSE_STATE:
+            b_v = b_beta * (b_v - tl.sum(b_h * b_k[None, :], 1))
+            b_h += b_v[:, None] * b_k_precond[None, :]
+            b_o = tl.sum(b_h * b_q[None, :], 1)
+        else:
+            b_v = b_beta * (b_v - tl.sum(b_h * b_k[:, None], 0))
+            b_h += b_k_precond[:, None] * b_v
+            b_o = tl.sum(b_h * b_q[:, None], 0)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+
+        p_q += H*K
+        p_k += H*K
+        p_v += HV*V
+        if USE_G:
+            p_g += HV
+        if USE_GK:
+            p_gk += HV*K
+        if USE_GV:
+            p_gv += HV*V
+        p_beta += HV * (1 if IS_BETA_HEADWISE else V)
+        p_o += HV*V
+        p_g_atk += HV
+        p_beta_atk += HV
+
+    if STORE_FINAL_STATE:
+        if TRANSPOSE_STATE:
+            p_ht = ht + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+
+    if STORE_FINAL_ATK:
+        if i_v == 0:
+            p_at = at + i_nh * K + o_k
+            tl.store(p_at, b_a.to(p_at.dtype.element_ty), mask=mask_k)
+
+
+def fused_recurrent_precond_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    g_atk: torch.Tensor = None,
+    beta_atk: torch.Tensor = None,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    initial_A_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    use_exp2: bool = False,
+    transpose_state_layout: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HV = v.shape[2]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    BK = triton.next_power_of_2(K)
+    BV = min(8, triton.next_power_of_2(V)) if gv is None else triton.next_power_of_2(V)
+    NV = triton.cdiv(V, BV)
+
+    if log_atk_scale is None:
+        log_atk_scale = torch.full((HV,), -0.2, device=k.device, dtype=torch.float32)
+
+    o = torch.empty_like(v)
+    if output_final_state:
+        if transpose_state_layout:
+            final_state = q.new_empty(N, HV, V, K, dtype=torch.float32)
+        else:
+            final_state = q.new_empty(N, HV, K, V, dtype=torch.float32)
+        final_A_state = q.new_empty(N, HV, K, dtype=torch.float32)
+    else:
+        final_state = None
+        final_A_state = None
+
+    grid = (NV, N * HV)
+    fused_recurrent_precond_gated_delta_rule_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        gk=gk,
+        gv=gv,
+        beta=beta,
+        g_atk=g_atk,
+        beta_atk=beta_atk,
+        log_atk_scale=log_atk_scale,
+        o=o,
+        h0=initial_state,
+        ht=final_state,
+        a0=initial_A_state,
+        at=final_A_state,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        x=x,
+        eps=eps,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        IS_BETA_HEADWISE=beta.ndim != v.ndim,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        USE_EXP2=use_exp2,
+        TRANSPOSE_STATE=transpose_state_layout,
+        num_warps=1,
+        num_stages=3,
+    )
+    return o, final_state, final_A_state
+
+
+class FusedRecurrentPrecondGatedDeltaRuleFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor | None = None,
+        gk: torch.Tensor | None = None,
+        gv: torch.Tensor | None = None,
+        beta: torch.Tensor | None = None,
+        g_atk: torch.Tensor = None,
+        beta_atk: torch.Tensor = None,
+        scale: float = None,
+        initial_state: torch.Tensor = None,
+        initial_A_state: torch.Tensor = None,
+        output_final_state: bool = False,
+        use_qk_l2norm_in_kernel: bool = False,
+        cu_seqlens: torch.LongTensor | None = None,
+        use_exp2: bool = False,
+        transpose_state_layout: bool = False,
+        x: float = 1.5,
+        eps: float = 1e-6,
+        log_atk_scale: torch.Tensor = None,
+    ):
+        o, final_state, final_A_state = fused_recurrent_precond_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            gk=gk,
+            gv=gv,
+            beta=beta,
+            g_atk=g_atk,
+            beta_atk=beta_atk,
+            scale=scale,
+            initial_state=initial_state,
+            initial_A_state=initial_A_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            cu_seqlens=cu_seqlens,
+            use_exp2=use_exp2,
+            transpose_state_layout=transpose_state_layout,
+            x=x,
+            eps=eps,
+            log_atk_scale=log_atk_scale,
+        )
+
+        return o, final_state, final_A_state
+
+    @staticmethod
+    @input_guard
+    def backward(ctx, do, dht, dat):
+        raise NotImplementedError(
+            "Backward pass is not implemented yet and we do not have plans to implement it "
+            "because we haven't figured out how to compute dg without materializing the full "
+            "hidden states for all time steps.",
+        )
+
+
+def fused_recurrent_precond_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    g_atk: torch.Tensor = None,
+    beta_atk: torch.Tensor = None,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    initial_A_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    use_exp2: bool = False,
+    transpose_state_layout: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, HV, V]`.
+            GVA (Grouped Value Attention) is applied if `HV > H`, where `HV` must be divisible by `H`.
+        g (torch.Tensor):
+            g (decays) of shape `[B, T, HV]`. Default: `None`.
+        gk (torch.Tensor):
+            gk (decays) of shape `[B, T, HV, K]`. Default: `None`.
+        gv (torch.Tensor):
+            gv (decays) of shape `[B, T, HV, V]`. Default: `None`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, HV]`.
+        g_atk (torch.Tensor):
+            ATK gates (decays) in log space of shape `[B, T, H]`.
+        beta_atk (torch.Tensor):
+            ATK betas of shape `[B, T, H]`.
+        scale (Optional[float]):
+            Scale factor for the attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, HV, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        initial_A_state (Optional[torch.Tensor]):
+            Initial ATK diagonal state of shape `[N, HV, K]`. Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, HV, K, V]`. Default: `False`.
+        use_qk_l2norm_in_kernel (Optional[bool]):
+            Whether to use L2 normalization in the kernel. Default: `True`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        use_exp2 (bool):
+            Whether to use exp2 instead of exp for gate application. Default: `False`.
+        transpose_state_layout (bool):
+            Whether to use transposed state layout `[V, K]` instead of `[K, V]`. Default: `False`.
+        x (float):
+            Squash range parameter. Default: `1.5`.
+        eps (float):
+            Epsilon for numerical stability in the squash function. Default: `1e-6`.
+        log_atk_scale (Optional[torch.Tensor]):
+            Per-head log-space center of shape `[H]`. Default: `None`.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, HV, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, HV, K, V]` if `output_final_state=True` else `None`.
+        final_A_state (torch.Tensor):
+            Final ATK diagonal state of shape `[N, HV, K]` if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.precond_gated_delta_rule import fused_recurrent_precond_gated_delta_rule
+        # inputs with equal lengths
+        >>> B, T, H, HV, K, V = 4, 2048, 4, 8, 512, 512
+        >>> q = torch.randn(B, T, H, K, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, H, K, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, HV, V, device='cuda')
+        >>> g = F.logsigmoid(torch.rand(B, T, HV, device='cuda'))
+        >>> beta = torch.rand(B, T, HV, device='cuda').sigmoid()
+        >>> g_atk = F.logsigmoid(torch.rand(B, T, H, device='cuda'))
+        >>> beta_atk = torch.rand(B, T, H, device='cuda').sigmoid()
+        >>> h0 = torch.randn(B, HV, K, V, device='cuda')
+        >>> o, ht, at = fused_recurrent_precond_gated_delta_rule(
+            q, k, v, g=g, beta=beta,
+            g_atk=g_atk, beta_atk=beta_atk,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, g, beta = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, g, beta))
+        >>> g_atk, beta_atk = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (g_atk, beta_atk))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o, ht, at = fused_recurrent_precond_gated_delta_rule(
+            q, k, v, g=g, beta=beta,
+            g_atk=g_atk, beta_atk=beta_atk,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing.",
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.",
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    if beta is None:
+        beta = torch.ones_like(q[..., 0])
+
+    o, final_state, final_A_state = FusedRecurrentPrecondGatedDeltaRuleFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        gk,
+        gv,
+        beta,
+        g_atk,
+        beta_atk,
+        scale,
+        initial_state,
+        initial_A_state,
+        output_final_state,
+        use_qk_l2norm_in_kernel,
+        cu_seqlens,
+        use_exp2,
+        transpose_state_layout,
+        x,
+        eps,
+        log_atk_scale,
+    )
+    return o, final_state, final_A_state
+
+
+fused_recurrent_pgdn = fused_recurrent_precond_gated_delta_rule

--- a/fla/ops/precond_gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/precond_gated_delta_rule/fused_recurrent.py
@@ -64,7 +64,7 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_v, i_nh = tl.program_id(0), tl.program_id(1).to(tl.int64)
     i_n, i_hv = i_nh // HV, i_nh % HV
     i_h = i_hv // (HV // H)
 
@@ -90,11 +90,12 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
     else:
         p_beta = beta + (bos * HV + i_hv) * V + o_v
 
-    # ATK pointers (per-HV-head: g_atk, beta_atk, log_atk_scale are shape-HV like v/beta/g)
-    p_g_atk = g_atk + bos * HV + i_hv
-    p_beta_atk = beta_atk + bos * HV + i_hv
+    # ATK pointers (per key head: ATK preconditions k, so g_atk, beta_atk and
+    # log_atk_scale carry H heads; under GVA every value head in a group shares them)
+    p_g_atk = g_atk + bos * H + i_h
+    p_beta_atk = beta_atk + bos * H + i_h
 
-    scale_val = tl.load(log_atk_scale + i_hv).to(tl.float32)
+    scale_val = tl.load(log_atk_scale + i_h).to(tl.float32)
     logx = tl.log(tl.cast(x, tl.float32))
 
     p_o = o + (bos * HV + i_hv) * V + o_v
@@ -117,10 +118,10 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
             p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
         b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
-    # ATK state
+    # ATK state (per key head: [N, H, K])
     b_a = tl.zeros([BK], dtype=tl.float32)
     if USE_INITIAL_ATK:
-        p_a0 = a0 + i_nh * K + o_k
+        p_a0 = a0 + (i_n * H + i_h) * K + o_k
         b_a += tl.load(p_a0, mask=mask_k, other=0).to(tl.float32)
 
     for _ in tl.range(0, T):
@@ -156,7 +157,7 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
                 b_h *= exp(b_g)
 
         if USE_GK:
-            b_gk = tl.load(p_gk).to(tl.float32)
+            b_gk = tl.load(p_gk, mask=mask_k, other=0).to(tl.float32)
             if USE_EXP2:
                 if TRANSPOSE_STATE:
                     b_h *= exp2(b_gk[None, :])
@@ -169,7 +170,7 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
                     b_h *= exp(b_gk[:, None])
 
         if USE_GV:
-            b_gv = tl.load(p_gv).to(tl.float32)
+            b_gv = tl.load(p_gv, mask=mask_v, other=0).to(tl.float32)
             if USE_EXP2:
                 if TRANSPOSE_STATE:
                     b_h *= exp2(b_gv[:, None])
@@ -203,8 +204,8 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
             p_gv += HV*V
         p_beta += HV * (1 if IS_BETA_HEADWISE else V)
         p_o += HV*V
-        p_g_atk += HV
-        p_beta_atk += HV
+        p_g_atk += H
+        p_beta_atk += H
 
     if STORE_FINAL_STATE:
         if TRANSPOSE_STATE:
@@ -214,8 +215,10 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
         tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
     if STORE_FINAL_ATK:
-        if i_v == 0:
-            p_at = at + i_nh * K + o_k
+        # The ATK state is shared by all value heads in a GVA group; only the
+        # first program of each (i_v, group) stores it to avoid duplicate writes.
+        if (i_v == 0) and (i_hv % (HV // H) == 0):
+            p_at = at + (i_n * H + i_h) * K + o_k
             tl.store(p_at, b_a.to(p_at.dtype.element_ty), mask=mask_k)
 
 
@@ -249,7 +252,7 @@ def fused_recurrent_precond_gated_delta_rule_fwd(
     NV = triton.cdiv(V, BV)
 
     if log_atk_scale is None:
-        log_atk_scale = torch.full((HV,), -0.2, device=k.device, dtype=torch.float32)
+        log_atk_scale = torch.full((H,), -0.2, device=k.device, dtype=torch.float32)
 
     o = torch.empty_like(v)
     if output_final_state:
@@ -257,7 +260,7 @@ def fused_recurrent_precond_gated_delta_rule_fwd(
             final_state = q.new_empty(N, HV, V, K, dtype=torch.float32)
         else:
             final_state = q.new_empty(N, HV, K, V, dtype=torch.float32)
-        final_A_state = q.new_empty(N, HV, K, dtype=torch.float32)
+        final_A_state = q.new_empty(N, H, K, dtype=torch.float32)
     else:
         final_state = None
         final_A_state = None
@@ -413,7 +416,8 @@ def fused_recurrent_precond_gated_delta_rule(
             For equal-length input sequences, `N` equals the batch size `B`.
             Default: `None`.
         initial_A_state (Optional[torch.Tensor]):
-            Initial ATK diagonal state of shape `[N, HV, K]`. Default: `None`.
+            Initial ATK diagonal state of shape `[N, H, K]`; the ATK preconditioner
+            acts on the keys, so its state carries `H` (key) heads. Default: `None`.
         output_final_state (Optional[bool]):
             Whether to output the final state of shape `[N, HV, K, V]`. Default: `False`.
         use_qk_l2norm_in_kernel (Optional[bool]):
@@ -438,7 +442,7 @@ def fused_recurrent_precond_gated_delta_rule(
         final_state (torch.Tensor):
             Final state of shape `[N, HV, K, V]` if `output_final_state=True` else `None`.
         final_A_state (torch.Tensor):
-            Final ATK diagonal state of shape `[N, HV, K]` if `output_final_state=True` else `None`.
+            Final ATK diagonal state of shape `[N, H, K]` if `output_final_state=True` else `None`.
 
     Examples::
         >>> import torch

--- a/fla/ops/precond_gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/precond_gated_delta_rule/fused_recurrent.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils.op import exp, exp2
+from fla.ops.utils.op import exp
 from fla.utils import input_guard
 
 
@@ -60,7 +60,6 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     USE_INITIAL_ATK: tl.constexpr,
     STORE_FINAL_ATK: tl.constexpr,
-    USE_EXP2: tl.constexpr,
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
@@ -151,36 +150,21 @@ def fused_recurrent_precond_gated_delta_rule_fwd_kernel(
 
         if USE_G:
             b_g = tl.load(p_g).to(tl.float32)
-            if USE_EXP2:
-                b_h *= exp2(b_g)
-            else:
-                b_h *= exp(b_g)
+            b_h *= exp(b_g)
 
         if USE_GK:
             b_gk = tl.load(p_gk, mask=mask_k, other=0).to(tl.float32)
-            if USE_EXP2:
-                if TRANSPOSE_STATE:
-                    b_h *= exp2(b_gk[None, :])
-                else:
-                    b_h *= exp2(b_gk[:, None])
+            if TRANSPOSE_STATE:
+                b_h *= exp(b_gk[None, :])
             else:
-                if TRANSPOSE_STATE:
-                    b_h *= exp(b_gk[None, :])
-                else:
-                    b_h *= exp(b_gk[:, None])
+                b_h *= exp(b_gk[:, None])
 
         if USE_GV:
             b_gv = tl.load(p_gv, mask=mask_v, other=0).to(tl.float32)
-            if USE_EXP2:
-                if TRANSPOSE_STATE:
-                    b_h *= exp2(b_gv[:, None])
-                else:
-                    b_h *= exp2(b_gv[None, :])
+            if TRANSPOSE_STATE:
+                b_h *= exp(b_gv[:, None])
             else:
-                if TRANSPOSE_STATE:
-                    b_h *= exp(b_gv[:, None])
-                else:
-                    b_h *= exp(b_gv[None, :])
+                b_h *= exp(b_gv[None, :])
 
         # Delta rule update using k_precond for the write side
         if TRANSPOSE_STATE:
@@ -238,7 +222,6 @@ def fused_recurrent_precond_gated_delta_rule_fwd(
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = True,
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
     x: float = 1.5,
     eps: float = 1e-6,
@@ -295,7 +278,6 @@ def fused_recurrent_precond_gated_delta_rule_fwd(
         BV=BV,
         IS_BETA_HEADWISE=beta.ndim != v.ndim,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
-        USE_EXP2=use_exp2,
         TRANSPOSE_STATE=transpose_state_layout,
         num_warps=1,
         num_stages=3,
@@ -324,8 +306,7 @@ class FusedRecurrentPrecondGatedDeltaRuleFunction(torch.autograd.Function):
         output_final_state: bool = False,
         use_qk_l2norm_in_kernel: bool = False,
         cu_seqlens: torch.LongTensor | None = None,
-        use_exp2: bool = False,
-        transpose_state_layout: bool = False,
+            transpose_state_layout: bool = False,
         x: float = 1.5,
         eps: float = 1e-6,
         log_atk_scale: torch.Tensor = None,
@@ -346,7 +327,6 @@ class FusedRecurrentPrecondGatedDeltaRuleFunction(torch.autograd.Function):
             output_final_state=output_final_state,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
             cu_seqlens=cu_seqlens,
-            use_exp2=use_exp2,
             transpose_state_layout=transpose_state_layout,
             x=x,
             eps=eps,
@@ -381,7 +361,6 @@ def fused_recurrent_precond_gated_delta_rule(
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = True,
     cu_seqlens: torch.LongTensor | None = None,
-    use_exp2: bool = False,
     transpose_state_layout: bool = False,
     x: float = 1.5,
     eps: float = 1e-6,
@@ -425,8 +404,6 @@ def fused_recurrent_precond_gated_delta_rule(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
-        use_exp2 (bool):
-            Whether to use exp2 instead of exp for gate application. Default: `False`.
         transpose_state_layout (bool):
             Whether to use transposed state layout `[V, K]` instead of `[K, V]`. Default: `False`.
         x (float):
@@ -510,7 +487,6 @@ def fused_recurrent_precond_gated_delta_rule(
         output_final_state,
         use_qk_l2norm_in_kernel,
         cu_seqlens,
-        use_exp2,
         transpose_state_layout,
         x,
         eps,

--- a/fla/ops/precond_gated_delta_rule/naive.py
+++ b/fla/ops/precond_gated_delta_rule/naive.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import torch.nn.functional as F
+
+
+def naive_recurrent_precond_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g_atk: torch.Tensor,
+    g: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    initial_A_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor | float = None,
+):
+    """
+    Reference PyTorch implementation of recurrent preconditioned gated delta rule.
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        v: [B, T, H, V]
+        g_atk: [B, T, H]
+        g: [B, T, H]
+        beta_atk: [B, T, H]
+        beta: [B, T, H]
+        scale: float, optional
+        initial_state: [B, H, K, V], optional
+        initial_A_state: [B, H, K], optional
+        output_final_state: bool
+
+    Returns:
+        o: [B, T, H, V]
+        final_state: [B, H, K, V] if output_final_state else None
+        final_A_state: [B, H, K] if output_final_state else None
+    """
+    q, k, v, g_atk, g, beta_atk, beta = map(
+        lambda t: t.transpose(1, 2).contiguous().to(torch.float32),
+        [q, k, v, g_atk, g, beta_atk, beta]
+    )
+    B, H, T, K, V = *k.shape, v.shape[-1]
+    o = torch.zeros(B, H, T, V).to(v)
+    S = torch.zeros(B, H, K, V).to(v)
+    A = torch.zeros(B, H, K).to(v)
+    if initial_state is not None:
+        S = initial_state.clone()
+    if initial_A_state is not None:
+        A = initial_A_state.clone()
+    if scale is None:
+        scale = 1 / (K ** 0.5)
+
+    # L2 normalize q and k, then apply scale
+    q = F.normalize(q, p=2, dim=-1) * scale
+    k = F.normalize(k, p=2, dim=-1)
+
+    if log_atk_scale is None:
+        log_atk_scale = -0.2
+    if isinstance(log_atk_scale, (int, float)):
+        center = torch.tensor(log_atk_scale, dtype=torch.float32, device=k.device)
+    else:
+        center = log_atk_scale.to(torch.float32).view(1, H, 1)
+
+    logx = torch.log(torch.tensor(x, dtype=torch.float32, device=k.device))
+
+    for i in range(T):
+        b_q = q[:, :, i]
+        b_k = k[:, :, i]
+        b_v = v[:, :, i].clone()
+        b_g_atk = g_atk[:, :, i]
+        b_g = g[:, :, i]
+        b_beta_atk = beta_atk[:, :, i]
+        b_beta = beta[:, :, i]
+
+        # ATK recurrence
+        A = A.clone() * b_g_atk.exp().unsqueeze(-1) + b_beta_atk.unsqueeze(-1) * (b_k ** 2)
+
+        # Symmetric fast squash
+        ell = torch.log(A + eps)
+        r = ell - center
+        s = r / (1.0 + torch.abs(r))
+        M = torch.exp(-logx * s)
+        b_k_precond = b_k * M
+
+        # Gated delta rule
+        S = S.clone() * b_g.exp()[..., None, None]
+        b_v = b_v - (S.clone() * b_k[..., None]).sum(-2)
+        b_v = b_v * b_beta[..., None]
+        S = S.clone() + b_k_precond.unsqueeze(-1) * b_v.unsqueeze(-2)
+        o[:, :, i] = torch.einsum('bhd,bhdm->bhm', b_q, S)
+
+    if not output_final_state:
+        S = None
+        A = None
+    o = o.transpose(1, 2).contiguous()
+    return o, S, A

--- a/fla/ops/precond_gated_delta_rule/naive.py
+++ b/fla/ops/precond_gated_delta_rule/naive.py
@@ -31,21 +31,34 @@ def naive_recurrent_precond_gated_delta_rule(
     Args:
         q: [B, T, H, K]
         k: [B, T, H, K]
-        v: [B, T, H, V]
+        v: [B, T, HV, V]
         g_atk: [B, T, H]
-        g: [B, T, H]
+        g: [B, T, HV]
         beta_atk: [B, T, H]
-        beta: [B, T, H]
+        beta: [B, T, HV]
         scale: float, optional
-        initial_state: [B, H, K, V], optional
+        initial_state: [B, HV, K, V], optional
         initial_A_state: [B, H, K], optional
         output_final_state: bool
 
+    GVA is applied if `HV > H` (with `HV` divisible by `H`): each group of
+    `HV // H` value heads shares one key head and its ATK preconditioner state.
+
     Returns:
-        o: [B, T, H, V]
-        final_state: [B, H, K, V] if output_final_state else None
+        o: [B, T, HV, V]
+        final_state: [B, HV, K, V] if output_final_state else None
         final_A_state: [B, H, K] if output_final_state else None
     """
+    num_heads, num_v_heads = k.shape[2], v.shape[2]
+    n_rep = num_v_heads // num_heads
+    if n_rep > 1:
+        # GVA: value heads in a group share the key head and ATK state
+        q, k, g_atk, beta_atk = (t.repeat_interleave(n_rep, dim=2) for t in (q, k, g_atk, beta_atk))
+        if initial_A_state is not None:
+            initial_A_state = initial_A_state.repeat_interleave(n_rep, dim=1)
+        if log_atk_scale is not None and not isinstance(log_atk_scale, (int, float)):
+            log_atk_scale = log_atk_scale.repeat_interleave(n_rep, dim=0)
+
     q, k, v, g_atk, g, beta_atk, beta = map(
         lambda t: t.transpose(1, 2).contiguous().to(torch.float32),
         [q, k, v, g_atk, g, beta_atk, beta]
@@ -103,5 +116,9 @@ def naive_recurrent_precond_gated_delta_rule(
     if not output_final_state:
         S = None
         A = None
+    elif n_rep > 1:
+        # all value heads in a group carry the identical shared ATK state;
+        # return one copy per key head
+        A = A[:, ::n_rep]
     o = o.transpose(1, 2).contiguous()
     return o, S, A

--- a/fla/ops/precond_kda/__init__.py
+++ b/fla/ops/precond_kda/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from .chunk import chunk_precond_kda
+from .fused_recurrent import fused_recurrent_precond_kda
+from .naive import naive_recurrent_precond_kda
+
+__all__ = [
+    "chunk_precond_kda",
+    "fused_recurrent_precond_kda",
+    "naive_recurrent_precond_kda",
+]

--- a/fla/ops/precond_kda/chunk.py
+++ b/fla/ops/precond_kda/chunk.py
@@ -1,0 +1,813 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+# Related files are modified and supported by the Moonshot AI Team
+
+import torch
+
+from fla.modules.l2norm import l2norm_bwd, l2norm_fwd
+from fla.ops.atk.chunk_atk_bwd import chunk_atk_bwd
+from fla.ops.atk.chunk_atk_fwd import chunk_atk_fwd, recompute_atk_fwd
+from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
+from fla.ops.cp import FLACPContext
+from fla.ops.gla.chunk import chunk_gla_fwd_o_gk
+from fla.ops.kda.gate import kda_gate_bwd, kda_gate_chunk_cumsum
+from fla.ops.precond_kda.chunk_bwd import chunk_precond_kda_bwd_dAv, chunk_precond_kda_bwd_wy_dqkg
+from fla.ops.precond_kda.chunk_intra import chunk_precond_kda_bwd_intra, chunk_precond_kda_fwd_intra
+from fla.ops.precond_kda.wy_fast import recompute_w_u_fwd
+from fla.ops.utils import chunk_local_cumsum
+from fla.ops.utils.constant import RCP_LN2
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+
+
+def chunk_precond_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,           # Diagonal gate for KDA [B, T, H, K] - ALREADY cumsummed
+    g_atk: torch.Tensor,       # Scalar gate for ATK [B, T, H]
+    beta_atk: torch.Tensor,    # Beta for ATK [B, T, H]
+    beta: torch.Tensor,    # Beta for KDA [B, T, H]
+    scale: float,
+    initial_state: torch.Tensor,
+    initial_A_state: torch.Tensor,
+    output_final_state: bool,
+    chunk_size: int = 64,
+    cu_seqlens: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    solve_tril_precision: str | None = None,
+    safe_gate: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    transpose_state_layout: bool = False,
+):
+    """
+    Forward pass for preconditioned KDA.
+
+    Args:
+        q: [B, T, H, K] - queries
+        k: [B, T, H, K] - keys
+        v: [B, T, H, V] - values
+        g: [B, T, H, K] - diagonal gate for KDA (chunk-local cumsum, log2 space)
+        g_atk: [B, T, H] - scalar gate for ATK (log space)
+        beta_atk: [B, T, H] - beta for ATK
+        beta: [B, T, H] - beta for KDA
+        scale: attention scale
+        initial_state: [B, H, K, V] or None
+        output_final_state: bool
+        x: range parameter for symmetric squash. M in [1/x, x]
+        eps: epsilon for log safety
+        log_atk_scale: per-head log-space center [H]
+
+    Returns:
+        o, Aqk, Akk, final_state, at
+    """
+    B, T, H, K = k.shape
+
+    # Step 1: ATK preconditioning with symmetric fast squash
+    # Only need k_precond and at (final state); ac/a_atk/sa_atk recomputed in backward
+    k_precond, at = chunk_atk_fwd(
+        k=k,
+        beta=beta_atk,
+        log_g=g_atk,
+        chunk_size=chunk_size,
+        initial_A_state=initial_A_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        x=x,
+        eps=eps,
+        log_atk_scale=log_atk_scale,
+    )
+
+    # Step 2: KDA intra-chunk computation (asymmetric)
+    # Aqk = q @ k_precond^T, Akk = k @ k_precond^T
+    w, u, kg, Aqk, Akk = chunk_precond_kda_fwd_intra(
+        q=q,
+        k=k,           # Original k for Akk row side, w computation
+        k_precond=k_precond,  # k_precond for column side, kg
+        v=v,
+        gk=g,
+        beta=beta,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        solve_tril_precision=solve_tril_precision,
+        safe_gate=safe_gate,
+    )
+
+    # Step 3: Hidden state update (uses kg which is k_precond gated)
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=kg,  # k_precond gated for write
+        w=w,
+        u=u,
+        gk=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+
+    # Step 4: Output computation
+    o = chunk_gla_fwd_o_gk(
+        q=q,
+        v=v_new,
+        g=g,
+        A=Aqk,
+        h=h,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+
+    return o, Aqk, Akk, final_state, at, w, u, kg, v_new, h
+
+
+def chunk_precond_kda_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,            # Gate cumsum (log2 space)
+    g_atk: torch.Tensor,        # Raw ATK gate
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    initial_A_state: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    transpose_state_layout: bool = False,
+    safe_gate: bool = False,
+    disable_recompute: bool = False,
+    w: torch.Tensor | None = None,
+    u: torch.Tensor | None = None,
+    kg: torch.Tensor | None = None,
+    v_new: torch.Tensor | None = None,
+    h: torch.Tensor | None = None,
+):
+    """
+    Backward pass for preconditioned KDA with symmetric fast squash preconditioning.
+
+    Returns:
+        dq, dk, dv, dg, dg_atk, dbeta_atk, dbeta, d_log_atk_scale, dh0
+    """
+    # Recompute ATK forward intermediates (k_precond, ac, a_atk, sa_atk)
+    k_precond, ac, a_atk, sa_atk = recompute_atk_fwd(
+        k=k,
+        beta=beta_atk,
+        log_g=g_atk,
+        chunk_size=chunk_size,
+        initial_A_state=initial_A_state,
+        cu_seqlens=cu_seqlens,
+        x=x,
+        eps=eps,
+        log_atk_scale=log_atk_scale,
+    )
+
+    if not disable_recompute:
+        # Step 1: Recompute WY representation (asymmetric)
+        w, u, qg, kg = recompute_w_u_fwd(
+            k=k,
+            k_precond=k_precond,
+            v=v,
+            beta=beta,
+            A=Akk,
+            gk=g,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            q=q,
+            output_qg=True,
+            output_kg=True,
+        )
+
+        # Step 2: Recompute hidden state (uses kg = gated k_precond)
+        h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+            k=kg,
+            w=w,
+            u=u,
+            gk=g,
+            initial_state=initial_state,
+            output_final_state=False,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            state_v_first=transpose_state_layout,
+        )
+    else:
+        # Intermediates (w, u, kg, v_new, h) saved from forward; only need qg
+        _, _, qg, _ = recompute_w_u_fwd(
+            k=k,
+            k_precond=k_precond,
+            v=v,
+            beta=beta,
+            A=Akk,
+            gk=g,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            q=q,
+            output_qg=True,
+            output_kg=False,
+        )
+
+    BT = chunk_size
+
+    # Step 3: dAqk and local dv (matching KDA's chunk_kda_bwd_dAv)
+    dAqk, dv = chunk_precond_kda_bwd_dAv(
+        q=q,
+        k=k,
+        v=v_new,
+        do=do,
+        A=Aqk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=BT,
+        chunk_indices=chunk_indices,
+    )
+
+    # Step 4: Backward through hidden state
+    dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
+        q=qg,
+        k=kg,
+        w=w,
+        gk=g,
+        h0=initial_state,
+        dht=dht,
+        do=do,
+        dv=dv,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        state_v_first=transpose_state_layout,
+    )
+
+    # Step 5+6: Inter-chunk + WY backward (matching KDA's chunk_kda_bwd_wy_dqkg_fused)
+    dq, dk, dkg, dv, dbeta, dg, dAkk = chunk_precond_kda_bwd_wy_dqkg(
+        q=q,
+        k=k,
+        k_precond=k_precond,
+        v=v,
+        v_new=v_new,
+        g=g,
+        beta=beta,
+        A=Akk,
+        h=h,
+        do=do,
+        dh=dh,
+        dv=dv,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=BT,
+        chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
+    )
+
+    # Step 7: Asymmetric intra backward
+    dq2, dk_intra, dk_precond2, dbeta2, dg3 = chunk_precond_kda_bwd_intra(
+        q=q,
+        k=k,
+        k_precond=k_precond,
+        g=g,
+        beta=beta,
+        dAqk=dAqk,
+        dAkk=dAkk,
+        dq=dq,
+        dk=dk,
+        dk_precond=dkg,
+        db=dbeta,
+        dg=dg,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        safe_gate=safe_gate,
+    )
+
+    dk_precond_total = dk_precond2
+    dk = dk_intra
+
+    dk_atk, dbeta_atk_grad, dg_atk, d_log_atk_scale, dh0_atk = chunk_atk_bwd(
+        k=k,
+        g_raw=g_atk,
+        beta=beta_atk,
+        ac=ac,
+        a=a_atk,
+        sa=sa_atk,
+        dk_precond=dk_precond_total,
+        initial_A_state=initial_A_state,
+        cu_seqlens=cu_seqlens,
+        x=x,
+        eps=eps,
+        log_atk_scale=log_atk_scale,
+    )
+
+    # Combine dk gradients
+    dk_total = dk + dk_atk
+
+    # dg3 from asymmetric intra backward already has reverse cumsum applied
+    dg_total = dg3
+
+    return dq2, dk_total, dv, dg_total, dg_atk, dbeta_atk_grad, dbeta2, d_log_atk_scale, dh0, dh0_atk
+
+
+class ChunkPrecondKDAFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        g_atk: torch.Tensor,
+        beta_atk: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor,
+        initial_A_state: torch.Tensor,
+        output_final_state: bool,
+        use_qk_l2norm_in_kernel: bool = False,
+        use_gate_in_kernel: bool = False,
+        A_log: torch.Tensor | None = None,
+        dt_bias: torch.Tensor | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_cpu: torch.LongTensor | None = None,
+        chunk_indices: torch.LongTensor | None = None,
+        safe_gate: bool = False,
+        cp_context: FLACPContext | None = None,
+        transpose_state_layout: bool = False,
+        x: float = 1.5,
+        eps: float = 1e-6,
+        log_atk_scale: torch.Tensor = None,
+        lower_bound: float | None = None,
+        solve_tril_precision: str | None = None,
+        disable_recompute: bool = False,
+        return_intermediate_states: bool = False,
+    ):
+        chunk_size = 64
+
+        # Apply L2 normalization
+        q_rstd, k_rstd = None, None
+        if use_qk_l2norm_in_kernel:
+            q, q_rstd = l2norm_fwd(q)
+            k, k_rstd = l2norm_fwd(k)
+
+        # Compute gate + cumsum
+        g_org = None
+        if use_gate_in_kernel:
+            g_org = g
+            g = kda_gate_chunk_cumsum(
+                g=g_org,
+                A_log=A_log,
+                chunk_size=chunk_size,
+                scale=RCP_LN2,
+                dt_bias=dt_bias,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                lower_bound=lower_bound,
+            )
+        else:
+            g = chunk_local_cumsum(
+                g=g,
+                chunk_size=chunk_size,
+                scale=RCP_LN2,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+            )
+
+        o, Aqk, Akk, final_state, at, w, u, kg, v_new, h = chunk_precond_kda_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_atk=g_atk,
+            beta_atk=beta_atk,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            initial_A_state=initial_A_state,
+            output_final_state=output_final_state,
+            chunk_size=chunk_size,
+            cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
+            chunk_indices=chunk_indices,
+            solve_tril_precision=solve_tril_precision,
+            safe_gate=safe_gate,
+            x=x,
+            eps=eps,
+            log_atk_scale=log_atk_scale,
+            transpose_state_layout=transpose_state_layout,
+        )
+
+        if return_intermediate_states:
+            assert torch.is_inference_mode_enabled(), "return_intermediate_states is only allowed in inference mode"
+            assert disable_recompute is False, "return_intermediate_states must be used with disable_recompute=False"
+            return o.to(q.dtype), final_state, at, h
+
+        # Don't save computed g when use_gate_in_kernel (will recompute in backward)
+        if use_gate_in_kernel:
+            g = None
+
+        # When disable_recompute=False (default), delete intermediates to save memory
+        if not disable_recompute:
+            w, u, kg, v_new, h = None, None, None, None, None
+
+        ctx.save_for_backward(
+            q, q_rstd, k, k_rstd, v, g, g_org, g_atk, beta_atk, beta,
+            Aqk, Akk, initial_state,
+            A_log, dt_bias, log_atk_scale, cu_seqlens, chunk_indices,
+            w, u, kg, v_new, h
+        )
+        ctx.scale = scale
+        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        ctx.use_gate_in_kernel = use_gate_in_kernel
+        ctx.safe_gate = safe_gate
+        ctx.chunk_size = chunk_size
+        ctx.initial_A_state = initial_A_state
+        ctx.cp_context = cp_context
+        ctx.transpose_state_layout = transpose_state_layout
+        ctx.x = x
+        ctx.eps = eps
+        ctx.lower_bound = lower_bound
+        ctx.disable_recompute = disable_recompute
+
+        return o.to(q.dtype), final_state, at
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(ctx, do, dht, dat):
+        (q, q_rstd, k, k_rstd, v, g, g_org, g_atk, beta_atk, beta,
+         Aqk, Akk, initial_state,
+         A_log, dt_bias, log_atk_scale, cu_seqlens, chunk_indices,
+         w, u, kg, v_new, h) = ctx.saved_tensors
+
+        # Recompute g (cumsummed) if use_gate_in_kernel was used
+        if ctx.use_gate_in_kernel:
+            g = kda_gate_chunk_cumsum(
+                g=g_org,
+                A_log=A_log,
+                chunk_size=ctx.chunk_size,
+                scale=RCP_LN2,
+                dt_bias=dt_bias,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                lower_bound=ctx.lower_bound,
+            )
+
+        dq, dk, dv, dg, dg_atk, dbeta_atk, dbeta, d_log_atk_scale, dh0, dh0_atk = chunk_precond_kda_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_atk=g_atk,
+            beta_atk=beta_atk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akk,
+            scale=ctx.scale,
+            initial_state=initial_state,
+            initial_A_state=ctx.initial_A_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=cu_seqlens,
+            cp_context=ctx.cp_context,
+            chunk_indices=chunk_indices,
+            chunk_size=ctx.chunk_size,
+            x=ctx.x,
+            eps=ctx.eps,
+            log_atk_scale=log_atk_scale,
+            transpose_state_layout=ctx.transpose_state_layout,
+            safe_gate=ctx.safe_gate,
+            disable_recompute=ctx.disable_recompute,
+            w=w,
+            u=u,
+            kg=kg,
+            v_new=v_new,
+            h=h,
+        )
+
+        if ctx.use_qk_l2norm_in_kernel:
+            dq = l2norm_bwd(q, q_rstd, dq)
+            dk = l2norm_bwd(k, k_rstd, dk)
+
+        # Compute gradients for A_log and dt_bias if use_gate_in_kernel
+        dA_log, ddt_bias = None, None
+        if ctx.use_gate_in_kernel:
+            dg, dA_log, ddt_bias = kda_gate_bwd(
+                g=g_org,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                dyg=dg,
+                lower_bound=ctx.lower_bound,
+            )
+            dA_log = dA_log.to(A_log)
+            if dt_bias is not None:
+                ddt_bias = ddt_bias.to(dt_bias)
+
+        # For return, use g_org if use_gate_in_kernel, else g
+        g_for_dtype = g_org if ctx.use_gate_in_kernel else g
+
+        # Format d_log_atk_scale for return
+        if log_atk_scale is not None and d_log_atk_scale is not None:
+            d_log_atk_scale = d_log_atk_scale.to(log_atk_scale)
+        else:
+            d_log_atk_scale = None
+
+        return (
+            dq.to(q),
+            dk.to(k),
+            dv.to(v),
+            dg.to(g_for_dtype),
+            dg_atk.to(g_atk),
+            dbeta_atk.to(beta_atk),
+            dbeta.to(beta),
+            None,  # scale
+            dh0,   # initial_state
+            dh0_atk,  # initial_A_state
+            None,  # output_final_state
+            None,  # use_qk_l2norm_in_kernel
+            None,  # use_gate_in_kernel
+            dA_log,  # A_log
+            ddt_bias,  # dt_bias
+            None,  # cu_seqlens
+            None,  # cu_seqlens_cpu
+            None,  # chunk_indices
+            None,  # safe_gate
+            None,  # cp_context
+            None,  # transpose_state_layout
+            None,  # x
+            None,  # eps
+            d_log_atk_scale,  # log_atk_scale
+            None,  # lower_bound
+            None,  # solve_tril_precision
+            None,  # disable_recompute
+            None,  # return_intermediate_states
+        )
+
+
+@torch.compiler.disable
+def chunk_precond_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_atk: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    initial_A_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_gate_in_kernel: bool = False,
+    safe_gate: bool = False,
+    lower_bound: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
+    transpose_state_layout: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    solve_tril_precision: str | None = None,
+    disable_recompute: bool = False,
+    return_intermediate_states: bool = False,
+    **kwargs,
+):
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, H, V]`.
+        g (torch.Tensor):
+            (forget) gating tensor (in log space!) of shape `[B, T, H, K]`.
+        g_atk (torch.Tensor):
+            ATK gates (decays) in log space of shape `[B, T, H]`.
+        beta_atk (torch.Tensor):
+            ATK betas of shape `[B, T, H]`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, H]`.
+        scale (Optional[float]):
+            Scale factor for the attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        initial_A_state (Optional[torch.Tensor]):
+            Initial ATK diagonal state of shape `[N, H, K]`. Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+        use_gate_in_kernel (bool):
+            Whether to compute the log-space KDA decay internally.
+            - If `True`:
+              The passed `g` acts as the raw input for `-exp(A_log).view(H, -1) * softplus(g + dt_bias.view(H, K))`.
+              Note that as part of the input arguments,
+              `A_log` (shape `[H]`) and the optional `dt_bias` (shape `[H * K]`) should be provided.
+            - If `False`, `g` is expected to be the pre-computed decay value.
+            Default: `False`.
+        safe_gate (bool):
+            Whether the kernel can assume the gate values (in log space) are in a safe range
+            and use M=16 TensorCore acceleration for higher throughput.
+            The safe range is ``[lower_bound, 0)``. With the default ``lower_bound=-5``,
+            the per-step decay factor ``exp(g)`` is bounded in ``[exp(-5), 1) ≈ [0.0067, 1)``,
+            meaning each step retains at least ~0.67% of the state -- a negligible loss that
+            has minimal impact on model quality while enabling significant speedup.
+            Requires ``lower_bound`` to be set. Default: ``False``.
+        lower_bound (Optional[float]):
+            Lower bound for the forget gate (in log space) when ``use_gate_in_kernel=True``.
+            Changes the gate activation from ``-exp(A_log) * softplus(g + dt_bias)``
+            to ``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``,
+            which naturally clamps the output to ``[lower_bound, 0)``.
+            Recommended value: ``-5`` (i.e., ``exp(-5) ≈ 0.0067``). Default: ``None``.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        cu_seqlens_cpu (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        disable_recompute (bool):
+            Whether to disable gradient recomputation in the kernel. When `True`, the kernel
+            will save all intermediate activations for backward pass, which is beneficial
+            for training small models at the cost of increased memory usage. Default: `False`.
+        return_intermediate_states (bool):
+            If True, returns intermediate state `h` for inference scenarios (e.g., vLLM).
+            Must be used within `torch.inference_mode()` and will return a 4-tuple instead of 3-tuple.
+            This is not intended for training as it bypasses autograd. Default: `False`.
+        cp_context (Optional[FLACPContext]):
+            Context parallel context for distributed training across multiple devices.
+            When provided, `initial_state` and `output_final_state` are not supported,
+            and `cu_seqlens` will be overridden by the context. Default: `None`.
+        transpose_state_layout (Optional[bool]):
+            Whether to use the transposed state layout for the hidden state.
+            Default: `False`.
+        x (float):
+            Squash range parameter. Default: `1.5`.
+        eps (float):
+            Epsilon for numerical stability in the squash function. Default: `1e-6`.
+        log_atk_scale (Optional[torch.Tensor]):
+            Per-head log-space center of shape `[H]`. Default: `None`.
+
+    Returns:
+        - Normal mode (return_intermediate_states=False): A tuple (o, final_state, A_state)
+            o (torch.Tensor):
+                Outputs of shape `[B, T, H, V]`.
+            final_state (torch.Tensor):
+                Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+            A_state (torch.Tensor):
+                Final ATK diagonal state of shape `[N, H, K]` if `output_final_state=True` else `None`.
+        - Inference mode (return_intermediate_states=True): A tuple (o, final_state, A_state, h)
+            o (torch.Tensor):
+                Outputs of shape `[B, T, H, V]`.
+            final_state (torch.Tensor):
+                Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+            A_state (torch.Tensor):
+                Final ATK diagonal state of shape `[N, H, K]` if `output_final_state=True` else `None`.
+            h (torch.Tensor):
+                Intermediate states of shape `[B, NT, H, K, V]` and dtype `bfloat16` for caching or further processing.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.precond_kda import chunk_precond_kda
+        # inputs with equal lengths
+        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+        >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+        >>> k = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+        >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
+        >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda')
+        >>> beta_atk = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda')
+        >>> g = torch.rand(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+        >>> g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
+        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> A_log = torch.randn(H, dtype=torch.float32, device='cuda')
+        >>> dt_bias = torch.randn(H * K, dtype=torch.float32, device='cuda')
+        >>> o, ht, at = chunk_precond_kda(
+            q, k, v, g, g_atk, beta_atk, beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            use_gate_in_kernel=True,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, beta, beta_atk, g, g_atk = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, beta_atk, g, g_atk))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o, ht, at = chunk_precond_kda(
+            q, k, v, g, g_atk, beta_atk, beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            use_gate_in_kernel=True,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+
+    if cp_context is not None:
+        assert initial_state is None, "Initial state is not supported for CP"
+        assert output_final_state is False, "Output final state is not supported for CP"
+        assert cp_context.cu_seqlens is not None, "cu_seqlens is required for CP"
+        # Override cu_seqlens and cu_seqlens_cpu with the ones from the context
+        cu_seqlens = cp_context.cu_seqlens
+        if cp_context.cu_seqlens_cpu is not None:
+            cu_seqlens_cpu = cp_context.cu_seqlens_cpu
+
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing.",
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.",
+            )
+    if initial_state is not None:
+        assert initial_state.dtype == torch.float32, "initial_state must be in float32."
+
+    if safe_gate and use_gate_in_kernel:
+        if lower_bound is None:
+            raise ValueError("`lower_bound` must be specified when `safe_gate=True` and `use_gate_in_kernel=True`.")
+        if not (-5 <= lower_bound < 0):
+            raise ValueError(f"`lower_bound` must be in the safe range [-5, 0), got {lower_bound}.")
+
+    assert q.shape == k.shape == g.shape, "q, k, g must have the same shape."
+    assert k.shape[-1] <= 256, "Currently we only support key headdim <=256 for KDA :-("
+    assert beta.shape == q.shape[:3], "beta must be of shape (batch size, seq len, num of head)."
+    assert v.shape == (*q.shape[:3], v.shape[-1]), "v must be of shape (batch size, seq len, num of head, head dim)."
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    # Prepare log_atk_scale with default if needed
+    H = k.shape[2]
+    if log_atk_scale is None:
+        log_atk_scale = torch.full((H,), -0.2, device=k.device, dtype=torch.float32)
+
+    A_log, dt_bias = None, None
+    if use_gate_in_kernel:
+        assert "A_log" in kwargs, "A_log must be provided when use_gate_in_kernel=True."
+        A_log, dt_bias = kwargs["A_log"], kwargs.get("dt_bias")
+
+    results = ChunkPrecondKDAFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        g_atk,
+        beta_atk,
+        beta,
+        scale,
+        initial_state,
+        initial_A_state,
+        output_final_state,
+        True,   # use_qk_l2norm_in_kernel (always True)
+        use_gate_in_kernel,
+        A_log,
+        dt_bias,
+        cu_seqlens,
+        cu_seqlens_cpu,
+        chunk_indices,
+        safe_gate,
+        cp_context,
+        transpose_state_layout,
+        x,
+        eps,
+        log_atk_scale,
+        lower_bound,
+        solve_tril_precision,
+        disable_recompute,
+        return_intermediate_states,
+    )
+
+    if return_intermediate_states:
+        # returns (o, final_state, at, h)
+        return results
+
+    o, h_final, a_final = results
+    return o, h_final, a_final

--- a/fla/ops/precond_kda/chunk.py
+++ b/fla/ops/precond_kda/chunk.py
@@ -372,9 +372,8 @@ class ChunkPrecondKDAFunction(torch.autograd.Function):
             k, k_rstd = l2norm_fwd(k)
 
         # Compute gate + cumsum
-        g_org = None
+        g_org = g
         if use_gate_in_kernel:
-            g_org = g
             g = kda_gate_chunk_cumsum(
                 g=g_org,
                 A_log=A_log,
@@ -525,9 +524,6 @@ class ChunkPrecondKDAFunction(torch.autograd.Function):
             if dt_bias is not None:
                 ddt_bias = ddt_bias.to(dt_bias)
 
-        # For return, use g_org if use_gate_in_kernel, else g
-        g_for_dtype = g_org if ctx.use_gate_in_kernel else g
-
         # Format d_log_atk_scale for return
         if log_atk_scale is not None and d_log_atk_scale is not None:
             d_log_atk_scale = d_log_atk_scale.to(log_atk_scale)
@@ -538,7 +534,7 @@ class ChunkPrecondKDAFunction(torch.autograd.Function):
             dq.to(q),
             dk.to(k),
             dv.to(v),
-            dg.to(g_for_dtype),
+            dg.to(g_org),
             dg_atk.to(g_atk),
             dbeta_atk.to(beta_atk),
             dbeta.to(beta),

--- a/fla/ops/precond_kda/chunk.py
+++ b/fla/ops/precond_kda/chunk.py
@@ -162,6 +162,7 @@ def chunk_precond_kda_bwd(
     kg: torch.Tensor | None = None,
     v_new: torch.Tensor | None = None,
     h: torch.Tensor | None = None,
+    dat: torch.Tensor | None = None,
 ):
     """
     Backward pass for preconditioned KDA with symmetric fast squash preconditioning.
@@ -314,6 +315,7 @@ def chunk_precond_kda_bwd(
         x=x,
         eps=eps,
         log_atk_scale=log_atk_scale,
+        dat=dat,
     )
 
     # Combine dk gradients
@@ -502,6 +504,7 @@ class ChunkPrecondKDAFunction(torch.autograd.Function):
             kg=kg,
             v_new=v_new,
             h=h,
+            dat=dat,
         )
 
         if ctx.use_qk_l2norm_in_kernel:
@@ -656,9 +659,8 @@ def chunk_precond_kda(
             Must be used within `torch.inference_mode()` and will return a 4-tuple instead of 3-tuple.
             This is not intended for training as it bypasses autograd. Default: `False`.
         cp_context (Optional[FLACPContext]):
-            Context parallel context for distributed training across multiple devices.
-            When provided, `initial_state` and `output_final_state` are not supported,
-            and `cu_seqlens` will be overridden by the context. Default: `None`.
+            Context parallelism is not yet supported for the preconditioned path;
+            passing a context raises `NotImplementedError`. Default: `None`.
         transpose_state_layout (Optional[bool]):
             Whether to use the transposed state layout for the hidden state.
             Default: `False`.
@@ -728,13 +730,11 @@ def chunk_precond_kda(
     """
 
     if cp_context is not None:
-        assert initial_state is None, "Initial state is not supported for CP"
-        assert output_final_state is False, "Output final state is not supported for CP"
-        assert cp_context.cu_seqlens is not None, "cu_seqlens is required for CP"
-        # Override cu_seqlens and cu_seqlens_cpu with the ones from the context
-        cu_seqlens = cp_context.cu_seqlens
-        if cp_context.cu_seqlens_cpu is not None:
-            cu_seqlens_cpu = cp_context.cu_seqlens_cpu
+        raise NotImplementedError(
+            "Context parallelism is not yet supported for chunk_precond_kda: "
+            "the preconditioned path lacks the CP state compression/expansion plumbing. "
+            "Please run without `cp_context`."
+        )
 
     if cu_seqlens is not None:
         if q.shape[0] != 1:

--- a/fla/ops/precond_kda/chunk_bwd.py
+++ b/fla/ops/precond_kda/chunk_bwd.py
@@ -1,0 +1,457 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.op import exp2
+from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
+
+BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
+BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
+NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
+
+
+# ==============================================================================
+# dAv kernel: compute dA and dv from inter-chunk backward
+# Matches KDA's chunk_kda_bwd_kernel_dAv
+# ==============================================================================
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in NUM_WARPS
+        for num_stages in [2, 3, 4]
+    ],
+    key=['H', 'K', 'V', 'BT', 'BK', 'BV'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_precond_kda_bwd_kernel_dAv(
+    q,
+    k,
+    v,
+    A,
+    do,
+    dv,
+    dA,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    # offset calculation
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    do += (bos * H + i_h) * V
+    dv += (bos * H + i_h) * V
+    dA += (bos * H + i_h) * BT
+
+    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
+        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        # [BV, BT]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        # [BT, BV]
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+        # [BT, BT]
+        b_dA += tl.dot(b_do, b_v)
+        # [BT, BV]
+        b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+    p_dA = tl.make_block_ptr(dA, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.)
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_precond_kda_bwd_dAv(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    A: torch.Tensor | None = None,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, do.shape[-1]
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    # H100 can have larger block size
+    if check_shared_mem('hopper', k.device.index):
+        CONST_TILING = 128
+    elif check_shared_mem():
+        CONST_TILING = 64
+    else:
+        CONST_TILING = 32
+    BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
+    BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dA = v.new_empty(B, T, H, BT, dtype=torch.float)
+    dv = torch.empty_like(do)
+    grid = (NT, B * H)
+    chunk_precond_kda_bwd_kernel_dAv[grid](
+        q=q,
+        k=k,
+        v=v,
+        A=A,
+        do=do,
+        dv=dv,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+    )
+    return dA, dv
+
+
+# ==============================================================================
+# WY + inter-chunk backward kernel: compute dq, dk, dkg, dv, db, dg, dA
+# Matches KDA's chunk_kda_bwd_kernel_wy_dqkg_fused with k/k_precond asymmetry
+# ==============================================================================
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BK_LIST
+        for BV in BV_LIST
+        for num_warps in NUM_WARPS
+        for num_stages in [2, 3, 4]
+        if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
+    ],
+    key=['BT', 'TRANSPOSE_STATE'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_precond_kda_bwd_kernel_wy_dqkg(
+    q,
+    k,           # original k (for WY backward)
+    k_precond,   # preconditioned k (for inter backward)
+    v,
+    v_new,
+    g,
+    beta,
+    A,
+    h,
+    do,
+    dh,
+    dq,
+    dk,          # dk from WY backward (original k)
+    dkg,         # dkg from inter backward (k_precond)
+    dv,
+    dv2,
+    dg,
+    db,
+    dA,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_tg = i_t.to(tl.int64)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = (i_b * NT + i_t).to(tl.int64)
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_last = (o_t == min(T, i_t * BT + BT) - 1)
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    k_precond += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    v_new += (bos * H + i_h) * V
+    g += (bos * H + i_h) * K
+    beta += bos * H + i_h
+    A += (bos * H + i_h) * BT
+    h += (i_tg * H + i_h) * K*V
+    do += (bos * H + i_h) * V
+    dh += (i_tg * H + i_h) * K*V
+    dq += (bos * H + i_h) * K
+    dk += (bos * H + i_h) * K
+    dkg += (bos * H + i_h) * K
+    dv += (bos * H + i_h) * V
+    dv2 += (bos * H + i_h) * V
+    dg += (bos * H + i_h) * K
+    db += bos * H + i_h
+    dA += (bos * H + i_h) * BT
+
+    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+
+    p_A = tl.make_block_ptr(A, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    b_db = tl.zeros([BT], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_kp = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kp = tl.load(p_kp, boundary_check=(0, 1))
+        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+
+        p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * H*K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
+
+        b_dq = tl.zeros([BT, BK], dtype=tl.float32)
+        b_dkg_raw = tl.zeros([BT, BK], dtype=tl.float32)
+        b_dw = tl.zeros([BT, BK], dtype=tl.float32)
+        b_dgk = tl.zeros([BK], dtype=tl.float32)
+
+        for i_v in range(tl.cdiv(V, BV)):
+            p_v_new = tl.make_block_ptr(v_new, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            else:
+                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            # [BT, BV]
+            b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
+            b_do = tl.load(p_do, boundary_check=(0, 1))
+            # [BV, BK]
+            b_h = tl.load(p_h, boundary_check=(0, 1))
+            b_dh = tl.load(p_dh, boundary_check=(0, 1))
+            # [BT, BV]
+            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+
+            b_dgk += tl.sum(b_h * b_dh, axis=0)
+            b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
+            b_dkg_raw += tl.dot(b_v_new, b_dh.to(b_v_new.dtype))
+            b_dw += tl.dot(b_dv.to(b_v_new.dtype), b_h.to(b_v_new.dtype))
+            tl.debug_barrier()  # DO NOT REMOVE THIS LINE!
+            if i_k == 0:
+                p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_dv2 = tl.make_block_ptr(dv2, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+
+                b_v = tl.load(p_v, boundary_check=(0, 1))
+
+                b_dA += tl.dot(b_dv, tl.trans(b_v))
+
+                b_dvb = tl.dot(b_A, b_dv)
+                b_dv2 = b_dvb * b_beta[:, None]
+                b_db += tl.sum(b_dvb * b_v, 1)
+
+                tl.store(p_dv2, b_dv2.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
+
+        b_gk_exp = exp2(b_g)
+        b_gb = b_gk_exp * b_beta[:, None]
+        b_dgk *= exp2(b_gn)
+        b_dq = b_dq * b_gk_exp * scale
+
+        # WY backward: uses original k
+        b_kg_orig = b_k * b_gk_exp
+
+        b_dw = -b_dw.to(b_A.dtype)
+        b_dA += tl.dot(b_dw, tl.trans(b_kg_orig.to(b_A.dtype)))
+
+        b_dkgb = tl.dot(b_A, b_dw)
+        b_db += tl.sum(b_dkgb * b_kg_orig, 1)
+
+        # dk from WY backward (original k)
+        b_dk = b_dkgb * b_gb
+
+        # Inter backward: uses k_precond
+        b_gn_g = tl.where(m_t[:, None], exp2(b_gn[None, :] - b_g), 0)
+        b_dkg = b_dkg_raw * b_gn_g
+
+        b_kg_precond = b_kp * b_gn_g
+        b_kp_dkg = b_kg_precond * b_dkg_raw
+        b_dgk += tl.sum(b_kp_dkg, axis=0)
+
+        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+
+        b_dg = (b_q * b_dq                           # inter query
+                - b_kp_dkg                              # inter write key
+                + m_last[:, None] * b_dgk               # accumulated last position
+                + b_kg_orig * b_dkgb * b_beta[:, None])  # WY backward
+
+        p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dkg = tl.make_block_ptr(dkg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dkg, b_dkg.to(p_dkg.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+
+    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
+    b_dA = tl.where(m_A, b_dA * b_beta[None, :], 0)
+    b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
+    b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
+    b_dA = tl.where(m_A, -b_dA, 0)
+
+    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_db = tl.make_block_ptr(db, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+
+
+def chunk_precond_kda_bwd_wy_dqkg(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    k_precond: torch.Tensor,
+    v: torch.Tensor,
+    v_new: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    dv: torch.Tensor,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
+):
+    """
+    Inter-chunk + WY backward for preconditioned KDA.
+
+    Matches KDA's chunk_kda_bwd_wy_dqkg_fused but with k/k_precond asymmetry:
+    - WY backward uses original k (for w = A @ (k * beta * exp(gk)))
+    - Inter backward uses k_precond (for kg = k_precond * exp(gn - gk))
+
+    Args:
+        q: [B, T, H, K] - queries
+        k: [B, T, H, K] - original k (for WY backward)
+        k_precond: [B, T, H, K] - preconditioned k (for inter backward)
+        v: [B, T, H, V] - original v (for WY backward)
+        v_new: [B, T, H, V] - corrected v (for inter backward)
+        g: [B, T, H, K] - gate cumsum (log2 space)
+        beta: [B, T, H] - beta scaling
+        A: [B, T, H, BT] - WY inverse matrix
+        h: [NT, H, K, V] - per-chunk hidden states
+        do: [B, T, H, V] - output gradient
+        dh: [NT, H, K, V] - hidden state gradient
+        dv: [B, T, H, V] - dv from h backward (= du for WY)
+
+    Returns:
+        dq, dk, dkg, dv, db, dg, dA
+    """
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dq = torch.empty_like(q, dtype=torch.float)
+    dk = torch.empty_like(k, dtype=torch.float)
+    dkg = torch.empty_like(k_precond, dtype=torch.float)
+    dv2 = torch.empty_like(v)
+    dg = torch.empty_like(g, dtype=torch.float)
+    db = torch.empty_like(beta, dtype=torch.float)
+    dA = torch.empty_like(A, dtype=torch.float)
+
+    grid = (NT, B * H)
+    chunk_precond_kda_bwd_kernel_wy_dqkg[grid](
+        q=q,
+        k=k,
+        k_precond=k_precond,
+        v=v,
+        v_new=v_new,
+        g=g,
+        beta=beta,
+        A=A,
+        h=h,
+        do=do,
+        dh=dh,
+        dq=dq,
+        dk=dk,
+        dkg=dkg,
+        dv=dv,
+        dv2=dv2,
+        dg=dg,
+        db=db,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        TRANSPOSE_STATE=transpose_state_layout,
+    )
+    dv = dv2
+    return dq, dk, dkg, dv, db, dg, dA

--- a/fla/ops/precond_kda/chunk_bwd.py
+++ b/fla/ops/precond_kda/chunk_bwd.py
@@ -73,32 +73,37 @@ def chunk_precond_kda_bwd_kernel_dAv(
     dv += (bos * H + i_h) * V
     dA += (bos * H + i_h) * BT
 
-    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
+    o_r = tl.arange(0, BT)
+    p_A = A + (bos * H + i_h) * BT + o_r[:, None] + o_t[None, :] * (H*BT)
+    b_A = tl.load(p_A, mask=(o_r[:, None] < BT) & m_t[None, :], other=0.0)
+
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        # [BV, BT]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        m_tv = m_t[:, None] & m_v[None, :]
+        # [BV, BT] transposed
+        p_v = v + o_v[:, None] + o_t[None, :] * (H*V)
+        p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv = dv + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v[:, None] & m_t[None, :], other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
         # [BT, BT]
         b_dA += tl.dot(b_do, b_v)
         # [BT, BV]
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(dv.dtype.element_ty), mask=m_tv)
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_A = tl.arange(0, BT)
+    p_dA = dA + o_t[:, None] * (H*BT) + o_A[None, :]
     b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.)
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dA, b_dA.to(dA.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
 
 
 def chunk_precond_kda_bwd_dAv(
@@ -244,11 +249,11 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
     db += bos * H + i_h
     dA += (bos * H + i_h) * BT
 
-    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
+    b_beta = tl.load(beta + o_t*H, mask=m_t, other=0.0)
 
-    p_A = tl.make_block_ptr(A, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    o_r = tl.arange(0, BT)
+    p_A = A + o_r[:, None] + o_t[None, :] * (H * BT)
+    b_A = tl.load(p_A, mask=(o_r[:, None] < BT) & m_t[None, :], other=0.0)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     b_db = tl.zeros([BT], dtype=tl.float32)
@@ -257,12 +262,13 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_kp = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_kp = tl.load(p_kp, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        m_tk = m_t[:, None] & m_k[None, :]
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        p_kp = k_precond + o_t[:, None] * (H*K) + o_k[None, :]
+        p_g = g + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
+        b_kp = tl.load(p_kp, mask=m_tk, other=0.0)
+        b_g = tl.load(p_g, mask=m_tk, other=0.0).to(tl.float32)
 
         p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * H*K + o_k
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
@@ -273,23 +279,27 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
         b_dgk = tl.zeros([BK], dtype=tl.float32)
 
         for i_v in range(tl.cdiv(V, BV)):
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            o_v = i_v * BV + tl.arange(0, BV)
+            m_v = o_v < V
+            m_tv = m_t[:, None] & m_v[None, :]
+            m_vk = m_v[:, None] & m_k[None, :]
+            p_v_new = v_new + o_t[:, None] * (H*V) + o_v[None, :]
+            p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
             if TRANSPOSE_STATE:
-                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_h = h + o_v[:, None] * K + o_k[None, :]
+                p_dh = dh + o_v[:, None] * K + o_k[None, :]
             else:
-                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_h = h + o_v[:, None] + o_k[None, :] * V
+                p_dh = dh + o_v[:, None] + o_k[None, :] * V
+            p_dv = dv + o_t[:, None] * (H*V) + o_v[None, :]
             # [BT, BV]
-            b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
+            b_v_new = tl.load(p_v_new, mask=m_tv, other=0.0)
+            b_do = tl.load(p_do, mask=m_tv, other=0.0)
             # [BV, BK]
-            b_h = tl.load(p_h, boundary_check=(0, 1))
-            b_dh = tl.load(p_dh, boundary_check=(0, 1))
+            b_h = tl.load(p_h, mask=m_vk, other=0.0)
+            b_dh = tl.load(p_dh, mask=m_vk, other=0.0)
             # [BT, BV]
-            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+            b_dv = tl.load(p_dv, mask=m_tv, other=0.0)
 
             b_dgk += tl.sum(b_h * b_dh, axis=0)
             b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
@@ -297,10 +307,10 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
             b_dw += tl.dot(b_dv.to(b_v_new.dtype), b_h.to(b_v_new.dtype))
             tl.debug_barrier()  # DO NOT REMOVE THIS LINE!
             if i_k == 0:
-                p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-                p_dv2 = tl.make_block_ptr(dv2, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+                p_dv2 = dv2 + o_t[:, None] * (H*V) + o_v[None, :]
 
-                b_v = tl.load(p_v, boundary_check=(0, 1))
+                b_v = tl.load(p_v, mask=m_tv, other=0.0)
 
                 b_dA += tl.dot(b_dv, tl.trans(b_v))
 
@@ -308,7 +318,7 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
                 b_dv2 = b_dvb * b_beta[:, None]
                 b_db += tl.sum(b_dvb * b_v, 1)
 
-                tl.store(p_dv2, b_dv2.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
+                tl.store(p_dv2, b_dv2.to(dv2.dtype.element_ty), mask=m_tv)
 
         b_gk_exp = exp2(b_g)
         b_gb = b_gk_exp * b_beta[:, None]
@@ -335,22 +345,22 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
         b_kp_dkg = b_kg_precond * b_dkg_raw
         b_dgk += tl.sum(b_kp_dkg, axis=0)
 
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_tk, other=0.0)
 
         b_dg = (b_q * b_dq                           # inter query
                 - b_kp_dkg                              # inter write key
                 + m_last[:, None] * b_dgk               # accumulated last position
                 + b_kg_orig * b_dkgb * b_beta[:, None])  # WY backward
 
-        p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dkg = tl.make_block_ptr(dkg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dkg, b_dkg.to(p_dkg.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+        p_dq = dq + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dkg = dkg + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dg = dg + o_t[:, None] * (H*K) + o_k[None, :]
+        tl.store(p_dq, b_dq.to(dq.dtype.element_ty), mask=m_tk)
+        tl.store(p_dk, b_dk.to(dk.dtype.element_ty), mask=m_tk)
+        tl.store(p_dkg, b_dkg.to(dkg.dtype.element_ty), mask=m_tk)
+        tl.store(p_dg, b_dg.to(dg.dtype.element_ty), mask=m_tk)
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA * b_beta[None, :], 0)
@@ -358,10 +368,10 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
     b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
     b_dA = tl.where(m_A, -b_dA, 0)
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_db = tl.make_block_ptr(db, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    o_A = tl.arange(0, BT)
+    p_dA = dA + o_t[:, None] * (H * BT) + o_A[None, :]
+    tl.store(p_dA, b_dA.to(dA.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
+    tl.store(db + o_t*H, b_db.to(db.dtype.element_ty), mask=m_t)
 
 
 def chunk_precond_kda_bwd_wy_dqkg(

--- a/fla/ops/precond_kda/chunk_bwd.py
+++ b/fla/ops/precond_kda/chunk_bwd.py
@@ -56,11 +56,11 @@ def chunk_precond_kda_bwd_kernel_dAv(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -211,12 +211,12 @@ def chunk_precond_kda_bwd_kernel_wy_dqkg(
     TRANSPOSE_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         NT = tl.cdiv(T, BT)

--- a/fla/ops/precond_kda/chunk_intra.py
+++ b/fla/ops/precond_kda/chunk_intra.py
@@ -1,0 +1,1009 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.precond_kda.chunk_intra_token_parallel import chunk_precond_kda_fwd_intra_token_parallel
+from fla.ops.precond_kda.wy_fast import recompute_w_u_fwd
+from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
+from fla.ops.utils.op import exp2, gather
+from fla.utils import IS_GATHER_SUPPORTED, IS_TF32_SUPPORTED, autotune_cache_kwargs
+
+DEFAULT_SOLVE_TRIL_PRECISION = 'tf32x3' if IS_TF32_SUPPORTED else 'ieee'
+
+
+################################################################################
+# Fused inter + solve_tril kernel: compute off-diagonal Akk and solve in one pass
+################################################################################
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+    'BK': lambda args: min(triton.next_power_of_2(args['K']), 64),
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps)
+        for num_warps in [1, 2, 4]
+    ],
+    key=["H", "K", "BC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_precond_kda_fwd_kernel_inter_solve_fused(
+    q,
+    k,           # Original k (for Akk row side)
+    k_precond,   # Preconditioned k (for column side)
+    g,
+    beta,
+    Aqk,
+    Akk_diag,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    SOLVE_TRIL_DOT_PRECISION: tl.constexpr = 'tf32x3',
+    USE_SAFE_GATE: tl.constexpr = False,
+):
+    """
+    Fused kernel: compute inter-subchunk Akk + solve_tril in one pass.
+    Asymmetric version: Aqk = q @ k_precond^T, Akk = k @ k_precond^T
+    Prerequisite: token_parallel has already computed diagonal Akk blocks in Akk_diag.
+
+    This kernel:
+    1. Computes off-diagonal Aqk blocks -> writes to global
+    2. Computes off-diagonal Akk blocks -> keeps in registers
+    3. Loads diagonal Akk blocks from Akk_diag (fp32)
+    4. Does forward substitution on diagonals (skipped when USE_SAFE_GATE)
+    5. Computes merged Akk_inv
+    6. Writes Akk_inv to Akk
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    k_precond += (bos * H + i_h) * K
+    g += (bos * H + i_h) * K
+    Aqk += (bos * H + i_h) * BT
+    Akk += (bos * H + i_h) * BT
+    Akk_diag += (bos * H + i_h) * BC
+
+    m_tc1 = (i_tc1 + tl.arange(0, BC)) < T
+    m_tc2 = (i_tc2 + tl.arange(0, BC)) < T
+    m_tc3 = (i_tc3 + tl.arange(0, BC)) < T
+
+    b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk21 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    ################################################################################
+    # 1. off-diagonal blocks - ASYMMETRIC: column uses k_precond, row uses k
+    ################################################################################
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        # Column side: load k_precond transposed (for Aqk and Akk column)
+        p_kp0 = tl.make_block_ptr(k_precond, (K, T), (1, H*K), (i_k * BK, i_tc0), (BK, BC), (0, 1))
+        p_g0 = tl.make_block_ptr(g, (K, T), (1, H*K), (i_k * BK, i_tc0), (BK, BC), (0, 1))
+        b_kpt0 = tl.load(p_kp0, boundary_check=(0, 1)).to(tl.float32)  # k_precond transposed
+        b_gt0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+
+        b_kpt1, b_gt1 = b_kpt0, b_gt0
+        b_kpt2, b_gt2 = b_kpt0, b_gt0
+
+        if i_tc1 < T:
+            # Row side: q for Aqk, original k for Akk
+            p_q1 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_k1 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_kp1 = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_g1 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            # [BC, BK]
+            b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
+            b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)  # Original k for row
+            b_kp1 = tl.load(p_kp1, boundary_check=(0, 1)).to(tl.float32)  # k_precond for column
+            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+            # [BK, BC]
+            b_kpt1 = tl.trans(b_kp1)  # k_precond transposed
+            b_gt1 = tl.trans(b_g1)
+            # [BK]
+            b_gn1 = tl.load(g + i_tc1 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+            # [BC, BK]
+            b_gqn1 = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
+            b_qg1 = b_q1 * b_gqn1
+            b_kg1 = b_k1 * b_gqn1  # Original k for Akk row
+            # [BK, BC]
+            b_kpgt = b_kpt0 * exp2(b_gn1[:, None] - b_gt0)  # k_precond for column
+            # [BC, BC]
+            b_Aqk10 += tl.dot(b_qg1, b_kpgt)
+            b_Akk10 += tl.dot(b_kg1, b_kpgt)  # Asymmetric: k @ k_precond^T
+
+        if i_tc2 < T:
+            p_q2 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_k2 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_kp2 = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_g2 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+
+            b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
+            b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
+            b_kp2 = tl.load(p_kp2, boundary_check=(0, 1)).to(tl.float32)
+            b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+            b_kpt2 = tl.trans(b_kp2)
+            b_gt2 = tl.trans(b_g2)
+
+            b_gn2 = tl.load(g + i_tc2 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+            b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
+            b_qg2 = b_q2 * b_gqn2
+            b_kg2 = b_k2 * b_gqn2
+            b_kpgt = b_kpt0 * exp2(b_gn2[:, None] - b_gt0)
+            b_Aqk20 += tl.dot(b_qg2, b_kpgt)
+            b_Akk20 += tl.dot(b_kg2, b_kpgt)
+
+            b_kpgt = b_kpt1 * exp2(b_gn2[:, None] - b_gt1)
+            b_Aqk21 += tl.dot(b_qg2, b_kpgt)
+            b_Akk21 += tl.dot(b_kg2, b_kpgt)
+
+        if i_tc3 < T:
+            p_q3 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            p_k3 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            p_g3 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
+            b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
+            b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+
+            b_gn3 = tl.load(g + i_tc3 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+            b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
+            b_qg3 = b_q3 * b_gqn3
+            b_kg3 = b_k3 * b_gqn3
+            b_kpgt = b_kpt0 * exp2(b_gn3[:, None] - b_gt0)
+            b_Aqk30 += tl.dot(b_qg3, b_kpgt)
+            b_Akk30 += tl.dot(b_kg3, b_kpgt)
+
+            b_kpgt = b_kpt1 * exp2(b_gn3[:, None] - b_gt1)
+            b_Aqk31 += tl.dot(b_qg3, b_kpgt)
+            b_Akk31 += tl.dot(b_kg3, b_kpgt)
+
+            b_kpgt = b_kpt2 * exp2(b_gn3[:, None] - b_gt2)
+            b_Aqk32 += tl.dot(b_qg3, b_kpgt)
+            b_Akk32 += tl.dot(b_kg3, b_kpgt)
+
+    ################################################################################
+    # 2. save off-diagonal Aqk blocks and prepare Akk
+    ################################################################################
+    if i_tc1 < T:
+        p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b1 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+        b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+        b_Akk10 = b_Akk10 * b_b1[:, None]
+    if i_tc2 < T:
+        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b2 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+        b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+        b_Akk20 = b_Akk20 * b_b2[:, None]
+        b_Akk21 = b_Akk21 * b_b2[:, None]
+    if i_tc3 < T:
+        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
+        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b3 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+        b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+        b_Akk30 = b_Akk30 * b_b3[:, None]
+        b_Akk31 = b_Akk31 * b_b3[:, None]
+        b_Akk32 = b_Akk32 * b_b3[:, None]
+
+    ################################################################################
+    # 3. load diagonal Akk blocks
+    ################################################################################
+    p_Akk00 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_Akk11 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    p_Akk22 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
+    p_Akk33 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
+    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+
+    ################################################################################
+    # 4. forward substitution on diagonals
+    ################################################################################
+    o_i = tl.arange(0, BC)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    if not USE_SAFE_GATE:
+        b_Ai00 = -tl.where(m_A, b_Ai00, 0)
+        b_Ai11 = -tl.where(m_A, b_Ai11, 0)
+        b_Ai22 = -tl.where(m_A, b_Ai22, 0)
+        b_Ai33 = -tl.where(m_A, b_Ai33, 0)
+
+        for i in range(2, min(BC, T - i_tc0)):
+            b_a00 = -tl.load(Akk_diag + (i_tc0 + i) * H*BC + o_i)
+            b_a00 = tl.where(o_i < i, b_a00, 0.)
+            b_a00 += tl.sum(b_a00[:, None] * b_Ai00, 0)
+            b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+        for i in range(BC + 2, min(2*BC, T - i_tc0)):
+            b_a11 = -tl.load(Akk_diag + (i_tc0 + i) * H*BC + o_i)
+            b_a11 = tl.where(o_i < i - BC, b_a11, 0.)
+            b_a11 += tl.sum(b_a11[:, None] * b_Ai11, 0)
+            b_Ai11 = tl.where((o_i == i - BC)[:, None], b_a11, b_Ai11)
+        for i in range(2*BC + 2, min(3*BC, T - i_tc0)):
+            b_a22 = -tl.load(Akk_diag + (i_tc0 + i) * H*BC + o_i)
+            b_a22 = tl.where(o_i < i - 2*BC, b_a22, 0.)
+            b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
+            b_Ai22 = tl.where((o_i == i - 2*BC)[:, None], b_a22, b_Ai22)
+        for i in range(3*BC + 2, min(4*BC, T - i_tc0)):
+            b_a33 = -tl.load(Akk_diag + (i_tc0 + i) * H*BC + o_i)
+            b_a33 = tl.where(o_i < i - 3*BC, b_a33, 0.)
+            b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
+            b_Ai33 = tl.where((o_i == i - 3*BC)[:, None], b_a33, b_Ai33)
+
+        b_Ai00 += m_I
+        b_Ai11 += m_I
+        b_Ai22 += m_I
+        b_Ai33 += m_I
+
+    ################################################################################
+    # 5. compute merged inverse using off-diagonals
+    ################################################################################
+
+    # we used tf32 to maintain matrix inverse's precision whenever possible.
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_Akk10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_Akk21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai11,
+        input_precision=SOLVE_TRIL_DOT_PRECISION
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_Akk32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai22,
+        input_precision=SOLVE_TRIL_DOT_PRECISION
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_Akk20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+        tl.dot(b_Akk21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+        tl.dot(b_Akk32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+        tl.dot(b_Akk31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION) +
+        tl.dot(b_Akk32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION
+    )
+
+    ################################################################################
+    # 6. store full Akk_inv to Akk
+    ################################################################################
+    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+    p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+    p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+    p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
+    p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+    p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+    p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
+    p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
+
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "BC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_precond_kda_fwd_kernel_intra_sub_chunk(
+    q,
+    k,           # Original k (for Akk row side)
+    k_precond,   # Preconditioned k (for column side)
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_GATHER: tl.constexpr,
+):
+    """
+    Asymmetric sub_chunk kernel for preconditioned KDA.
+    Computes diagonal Aqk and Akk blocks using block-level dot products.
+    Key difference from symmetric KDA: column side uses k_precond.
+    """
+    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_c = i_ti + tl.arange(0, BC)
+    m_c = o_c < T
+
+    q = q + (bos * H + i_h) * K
+    k = k + (bos * H + i_h) * K
+    k_precond = k_precond + (bos * H + i_h) * K
+    g = g + (bos * H + i_h) * K
+    beta = beta + bos * H + i_h
+    Aqk = Aqk + (bos * H + i_h) * BT
+    Akk = Akk + (bos * H + i_h) * BC
+
+    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_kp = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+
+    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_kp = tl.load(p_kp, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+
+    if USE_GATHER:
+        b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
+    else:
+        # calculate offset
+        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + tl.arange(0, BK)
+        b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
+        b_gn = b_gn[None, :]
+
+    # current block, keep numerical stability by subtracting the left boundary
+    # less than 85 to avoid overflow in exp2
+    b_gm = (b_g - b_gn).to(tl.float32)
+
+    b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.)
+    b_gk = tl.where(m_c[:, None], exp2(-b_gm), 0.)
+
+    # Asymmetric: column side uses k_precond
+    b_kpgt = tl.trans(b_kp * b_gk)
+
+    b_Aqk = tl.dot(b_q * b_gq, b_kpgt) * scale
+    b_Akk = tl.dot(b_k * b_gq, b_kpgt) * b_beta[:, None]
+
+    o_i = tl.arange(0, BC)
+    m_Aqk = o_i[:, None] >= o_i[None, :]
+    m_Akk = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
+    b_Akk = tl.where(m_Akk, b_Akk, 0.0)
+
+    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+    p_Akk = tl.make_block_ptr(Akk, (T, BC), (H*BC, 1), (i_ti, 0), (BC, BC), (1, 0))
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+    tl.debug_barrier()
+
+    ################################################################################
+    # forward substitution
+    ################################################################################
+
+    b_Ai = -b_Akk
+    for i in range(2, min(BC, T - i_ti)):
+        b_a = -tl.load(Akk + (i_ti + i) * H*BC + o_i)
+        b_a = tl.where(o_i < i, b_a, 0.)
+        b_a += tl.sum(b_a[:, None] * b_Ai, 0)
+        b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
+    b_Ai += m_I
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_precond_kda_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    k_precond: torch.Tensor,
+    v: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    solve_tril_precision: str | None = None,
+    safe_gate: bool = False,
+):
+    """
+    Forward pass for preconditioned KDA intra-chunk.
+
+    Args:
+        q: [B, T, H, K] - queries
+        k: [B, T, H, K] - original keys (for Akk row side, WY w computation)
+        k_precond: [B, T, H, K] - preconditioned keys (for column side, kg output)
+        v: [B, T, H, V] - values
+        gk: [B, T, H, K] - cumsum of gates
+        beta: [B, T, H] - beta scaling
+        scale: attention scale
+
+    Returns:
+        w: [B, T, H, K] - WY w vector (uses original k)
+        u: [B, T, H, V] - WY u vector
+        kg: [B, T, H, K] - gated k_precond for hidden state update
+        Aqk: [B, T, H, BT] - q @ k_precond^T attention matrix
+        Akk: [B, T, H, BT] - k @ k_precond^T (asymmetric) for WY
+    """
+    if solve_tril_precision is None:
+        solve_tril_precision = DEFAULT_SOLVE_TRIL_PRECISION
+
+    B, T, H, K = k.shape
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    BC = 16
+    NC = triton.cdiv(BT, BC)
+
+    Aqk = torch.empty(B, T, H, BT, device=k.device, dtype=k.dtype)
+    # Akk must be zero-initialized - kernel only writes lower triangular
+    Akk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    # Separate fp32 buffer for diagonal 16x16 blocks (for precision in solve_tril)
+    Akk_diag = torch.empty(B, T, H, BC, device=k.device, dtype=torch.float32)
+
+    # Step 1: Compute diagonal blocks into Akk_diag (fp32)
+    if safe_gate:
+        grid = (NT, NC, B * H)
+        BK = triton.next_power_of_2(K)
+        chunk_precond_kda_fwd_kernel_intra_sub_chunk[grid](
+            q=q,
+            k=k,
+            k_precond=k_precond,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akk_diag,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            USE_GATHER=IS_GATHER_SUPPORTED,
+        )
+    else:
+        Aqk, Akk_diag = chunk_precond_kda_fwd_intra_token_parallel(
+            q=q,
+            k=k,
+            k_precond=k_precond,
+            gk=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akk_diag,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=BT,
+            sub_chunk_size=BC,
+        )
+
+    # Step 2: Fused inter + solve_tril
+    grid = (NT, B * H)
+    chunk_precond_kda_fwd_kernel_inter_solve_fused[grid](
+        q=q,
+        k=k,
+        k_precond=k_precond,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akk_diag=Akk_diag,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        SOLVE_TRIL_DOT_PRECISION=solve_tril_precision,
+        USE_SAFE_GATE=safe_gate,
+    )
+
+    # Step 3: WY representation
+    # w uses original k (for read/correction), kg uses k_precond (for write/h update)
+    w, u, _, kg = recompute_w_u_fwd(
+        k=k,           # Original k for w
+        k_precond=k_precond,  # k_precond for kg
+        v=v,
+        beta=beta,
+        A=Akk,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    return w, u, kg, Aqk, Akk
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BK', 'NC', 'BT'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['B', 'T'])
+def chunk_precond_kda_bwd_kernel_intra(
+    q,              # [B, T, H, K] - queries
+    k,              # [B, T, H, K] - original k (for Akk row side)
+    k_precond,      # [B, T, H, K] - preconditioned k (for column side)
+    g,              # [B, T, H, K] - gate cumsum
+    beta,           # [B, T, H]
+    dAqk,           # [B, T, H, BT] - gradient of Aqk
+    dAkk,           # [B, T, H, BT] - gradient of Akk (asymmetric)
+    dq,             # [B, T, H, K] - input: accumulated dq
+    dq2,            # [B, T, H, K] - output: updated dq
+    dk,             # [B, T, H, K] - input: accumulated dk (original k)
+    dk2,            # [B, T, H, K] - output: updated dk
+    dk_precond,     # [B, T, H, K] - input: accumulated dk_precond
+    dk_precond2,    # [B, T, H, K] - output: updated dk_precond
+    dg,             # [B, T, H, K] - input: accumulated dg
+    dg2,            # [B, T, H, K] - output: updated dg
+    db,             # [NK, B, T, H] - output: accumulated dbeta
+    cu_seqlens,
+    chunk_indices,
+    B,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    SAFE_GATE: tl.constexpr = False,
+    USE_GATHER: tl.constexpr = False,
+):
+    """
+    Asymmetric intra backward for preconditioned KDA.
+
+    Key differences from symmetric KDA:
+    - Row side of Akk uses original k
+    - Column side uses k_precond
+    - dAkk flows to both dk (row) and dk_precond (column)
+    - dAqk flows to dq (row) and dk_precond (column)
+
+    Forward:
+        Aqk[t, s] = q[t] @ k_precond[s]^T * exp(g[t] - g[s]) * beta[s]  (for t >= s)
+        Akk[t, s] = k[t] @ k_precond[s]^T * exp(g[t] - g[s]) * beta[s]  (for t > s)
+    """
+    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_k = i_kc // NC
+    i_i = i_kc % NC
+
+    all_BT = B * T
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_i = tl.arange(0, BC)
+    m_k = o_k < K
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    k_precond += (bos * H + i_h) * K
+    g += (bos * H + i_h) * K
+    beta += bos * H + i_h
+    dAqk += (bos * H + i_h) * BT
+    dAkk += (bos * H + i_h) * BT
+    dq += (bos * H + i_h) * K
+    dq2 += (bos * H + i_h) * K
+    dk += (bos * H + i_h) * K
+    dk2 += (bos * H + i_h) * K
+    dk_precond += (bos * H + i_h) * K
+    dk_precond2 += (bos * H + i_h) * K
+    dg += (bos * H + i_h) * K
+    dg2 += (bos * H + i_h) * K
+    db += (i_k * all_BT + bos) * H + i_h  # Like KDA line 416
+
+    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_b = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+
+    p_gn_start = g + i_ti * H*K + o_k
+    b_gn_start = tl.load(p_gn_start, mask=m_k, other=0).to(tl.float32)
+
+    b_dq2 = tl.zeros([BC, BK], dtype=tl.float32)
+    b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
+
+    for i_j in range(0, i_i):
+        p_kp = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+        p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+        # [BC, BK]
+        b_kp = tl.load(p_kp, boundary_check=(0, 1)).to(tl.float32)
+        b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+        b_kpg = b_kp * exp2(b_gn_start[None, :] - b_gk)
+        # [BC, BC]
+        b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
+        b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+        # [BC, BK]
+        b_dq2 += tl.dot(b_dAqk, b_kpg)
+        b_dk2 += tl.dot(b_dAkk, b_kpg)
+
+    b_gqn = exp2(b_g - b_gn_start[None, :])
+    b_dq2 *= b_gqn
+    b_dk2 *= b_gqn
+
+    o_dA = (i_ti + o_i) * H*BT + i_i * BC
+    p_kpj = k_precond + i_ti * H*K + o_k
+    p_gkj = g + i_ti * H*K + o_k
+    m_dA = (i_ti + o_i) < T
+
+    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
+    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+
+    if SAFE_GATE:
+        # Vectorized upper diagonal (dq2/dk2): column side uses k_precond
+        if USE_GATHER:
+            b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
+        else:
+            p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + o_k
+            b_gn = tl.load(p_gn, mask=m_k, other=0)[None, :]
+
+        p_kp_diag = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+        b_kp_diag = tl.load(p_kp_diag, boundary_check=(0, 1)).to(tl.float32)
+
+        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+        b_dAqk_diag_qk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
+        b_dAkk_diag_qk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+
+        m_i_diag_qk = (o_i[:, None] >= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
+        m_j_diag_qk = (i_ti + o_i[:, None]) < T
+
+        b_dAqk_diag_qk = tl.where(m_i_diag_qk, b_dAqk_diag_qk, 0.)
+        b_dAkk_diag_qk = tl.where(m_i_diag_qk, b_dAkk_diag_qk, 0.)
+        b_g_diag_qk = tl.where(m_j_diag_qk, b_g - b_gn, 0.)
+        exp_b_g_diag_qk = tl.where(m_j_diag_qk, exp2(b_g_diag_qk), 0.)
+        exp_neg_b_g_diag_qk = tl.where(m_j_diag_qk, exp2(-b_g_diag_qk), 0.)
+
+        # Asymmetric: column side uses k_precond
+        b_kp_exp_diag_qk = b_kp_diag * exp_neg_b_g_diag_qk
+        b_dq2 += tl.dot(b_dAqk_diag_qk, b_kp_exp_diag_qk) * exp_b_g_diag_qk
+        b_dk2 += tl.dot(b_dAkk_diag_qk, b_kp_exp_diag_qk) * exp_b_g_diag_qk
+    else:
+        for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+            b_dAqk_val = tl.load(dAqk + o_dA + j, mask=m_dA, other=0).to(tl.float32)
+            b_dAkk_val = tl.load(dAkk + o_dA + j, mask=m_dA, other=0).to(tl.float32)
+
+            b_kpj = tl.load(p_kpj, mask=m_k, other=0).to(tl.float32)
+            b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+
+            m_ij = o_i[:, None] >= j
+            b_kpgj = b_kpj[None, :] * exp2(b_g - b_gkj[None, :])
+            b_dq2 += tl.where(m_ij, b_dAqk_val[:, None] * b_kpgj, 0.)
+            b_dk2 += tl.where(m_ij, b_dAkk_val[:, None] * b_kpgj, 0.)
+
+            p_kpj += H*K
+            p_gkj += H*K
+
+    b_db = tl.sum(b_dk2 * b_k, 1)
+    p_db = tl.make_block_ptr(db, (T,), (H,), (i_ti,), (BC,), (0,))
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    b_dk2 *= b_b[:, None]
+
+    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dq2 = tl.make_block_ptr(dq2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+
+    b_dg2 = b_q * b_dq2
+    b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
+    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), boundary_check=(0, 1))
+
+    tl.debug_barrier()
+    b_dkt = tl.zeros([BC, BK], dtype=tl.float32)  # Final dk_precond (with beta from rows)
+
+    NC_actual = min(NC, tl.cdiv(T - i_t * BT, BC))
+    if i_i < NC_actual - 1:
+        p_gn_t = g + (min(i_ti + BC, T) - 1) * H*K + o_k
+        b_gn_t = tl.load(p_gn_t, mask=m_k, other=0).to(tl.float32)
+
+        for i_j in range(i_i + 1, NC_actual):
+            p_q_t = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
+            p_k_t = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
+            p_gk_t = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
+            p_b_row = tl.make_block_ptr(beta, (T,), (H,), (i_t*BT+i_j*BC,), (BC,), (0,))  # beta at ROW positions
+            p_dAqk_t = tl.make_block_ptr(dAqk, (BT, T), (1, H*BT), (i_i*BC, i_t*BT+i_j*BC), (BC, BC), (0, 1))
+            p_dAkk_t = tl.make_block_ptr(dAkk, (BT, T), (1, H*BT), (i_i*BC, i_t*BT+i_j*BC), (BC, BC), (0, 1))
+
+            # [BC]
+            b_b_row = tl.load(p_b_row, boundary_check=(0,)).to(tl.float32)  # beta from ROW positions
+            # [BC, BK]
+            b_q_t = tl.load(p_q_t, boundary_check=(0, 1)).to(tl.float32)
+            b_k_t = tl.load(p_k_t, boundary_check=(0, 1)).to(tl.float32)
+            b_gk_t = tl.load(p_gk_t, boundary_check=(0, 1)).to(tl.float32)
+            # [BC, BC]
+            b_dAqk_t = tl.load(p_dAqk_t, boundary_check=(0, 1)).to(tl.float32)
+            b_dAkk_t = tl.load(p_dAkk_t, boundary_check=(0, 1)).to(tl.float32)
+
+            o_j = i_t * BT + i_j * BC + o_i
+            m_j = o_j < T
+            # [BC, BK]
+            b_gkn_t = tl.where(m_j[:, None], exp2(b_gk_t - b_gn_t[None, :]), 0)
+            b_qg_t = b_q_t * b_gkn_t
+            b_kg_t = b_k_t * b_gkn_t * b_b_row[:, None]  # beta from ROW positions
+            # [BC, BK]
+            b_dkt += tl.dot(b_dAqk_t, b_qg_t)
+            b_dkt += tl.dot(b_dAkk_t, b_kg_t)
+
+        b_dkt *= exp2(b_gn_t[None, :] - b_g)
+
+    if SAFE_GATE:
+        # Vectorized lower diagonal (dkt): row side uses q and k*beta
+        if USE_GATHER:
+            b_gn_t2 = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
+        else:
+            p_gn_t2 = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + o_k
+            b_gn_t2 = tl.load(p_gn_t2, mask=m_k, other=0).to(tl.float32)[None, :]
+        p_q_diag = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+        b_q_diag = tl.load(p_q_diag, boundary_check=(0, 1)).to(tl.float32)
+        p_b_diag = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
+        b_b_diag = tl.load(p_b_diag, boundary_check=(0,)).to(tl.float32)
+
+        p_dAqk_diag_kk = tl.make_block_ptr(dAqk, (BT, T), (1, H*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
+        p_dAkk_diag_kk = tl.make_block_ptr(dAkk, (BT, T), (1, H*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
+        b_dAqk_diag_kk = tl.load(p_dAqk_diag_kk, boundary_check=(0, 1)).to(tl.float32)
+        b_dAkk_diag_kk = tl.load(p_dAkk_diag_kk, boundary_check=(0, 1)).to(tl.float32)
+
+        m_i_diag_kk = (o_i[:, None] <= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
+        m_j_diag_kk = (i_ti + o_i[:, None]) < T
+
+        b_dAqk_diag_kk = tl.where(m_i_diag_kk, b_dAqk_diag_kk, 0.)
+        b_dAkk_diag_kk = tl.where(m_i_diag_kk, b_dAkk_diag_kk, 0.)
+        # ensure numerical stability
+        b_g_diag_kk = tl.where(m_j_diag_kk, b_g - b_gn_t2, 0.)
+        exp_b_g_diag_kk = tl.where(m_j_diag_kk, exp2(b_g_diag_kk), 0.)
+        exp_neg_b_g_diag_kk = tl.where(m_j_diag_kk, exp2(-b_g_diag_kk), 0.)
+
+        # Row-side values: q (for Aqk) and k*beta (for Akk)
+        b_q_exp = b_q_diag * exp_b_g_diag_kk
+        b_kb_exp = b_k * b_b_diag[:, None] * exp_b_g_diag_kk
+
+        b_dkt += tl.dot(b_dAqk_diag_kk, b_q_exp) * exp_neg_b_g_diag_kk
+        b_dkt += tl.dot(b_dAkk_diag_kk, b_kb_exp) * exp_neg_b_g_diag_kk
+    else:
+        o_dA_t = i_ti * H*BT + i_i * BC + o_i
+        p_qj = q + i_ti * H*K + o_k
+        p_kj = k + i_ti * H*K + o_k
+        p_gkj_t = g + i_ti * H*K + o_k
+        p_bj = beta + i_ti * H
+
+        for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+            # [BC]
+            b_dAqk_t = tl.load(dAqk + o_dA_t + j * H*BT).to(tl.float32)
+            b_dAkk_t = tl.load(dAkk + o_dA_t + j * H*BT).to(tl.float32)
+            # [BK]
+            b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
+            b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
+            b_gkj_t = tl.load(p_gkj_t, mask=m_k, other=0).to(tl.float32)
+            b_bj = tl.load(p_bj).to(tl.float32)  # beta at row position j
+            # [BC, BK]
+            m_ij = o_i[:, None] <= j
+            b_gkq_t = exp2(b_gkj_t[None, :] - b_g)
+            # k with beta from ROW position, q without beta (Aqk has no beta)
+            b_dkt += tl.where(m_ij, (b_dAkk_t[:, None] * b_kj[None, :] * b_bj +
+                              b_dAqk_t[:, None] * b_qj[None, :]) * b_gkq_t, 0.)
+
+            p_qj += H*K
+            p_kj += H*K
+            p_gkj_t += H*K
+            p_bj += H
+
+    p_kp_local = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    b_kp_local = tl.load(p_kp_local, boundary_check=(0, 1)).to(tl.float32)
+
+    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk2 = tl.make_block_ptr(dk2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk_precond = tl.make_block_ptr(dk_precond, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk_precond2 = tl.make_block_ptr(dk_precond2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dg2 = tl.make_block_ptr(dg2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+
+    b_dg2 += b_dk2 * b_k - b_dkt * b_kp_local + tl.load(p_dg, boundary_check=(0, 1))
+    b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
+    b_dk_precond2 = b_dkt + tl.load(p_dk_precond, boundary_check=(0, 1))
+
+    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk_precond2, b_dk_precond2.to(p_dk_precond2.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_precond_kda_bwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    k_precond: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    dAqk: torch.Tensor,
+    dAkk: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dk_precond: torch.Tensor,
+    db: torch.Tensor,
+    dg: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    safe_gate: bool = False,
+):
+    """
+    Asymmetric intra backward for preconditioned KDA.
+    """
+    B, T, H, K = k.shape
+    BT = chunk_size
+    BC = min(16, BT)
+    BK = min(32, triton.next_power_of_2(K))
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+    NK = triton.cdiv(K, BK)
+
+    dq2 = torch.empty_like(q)
+    dk2 = torch.empty_like(k)
+    dk_precond2 = torch.empty_like(k_precond)
+    db2 = beta.new_empty(NK, *beta.shape, dtype=torch.float)
+    dg2 = torch.empty_like(dg, dtype=torch.float)
+
+    grid = (NK * NC, NT, B * H)
+    chunk_precond_kda_bwd_kernel_intra[grid](
+        q=q,
+        k=k,
+        k_precond=k_precond,
+        g=g,
+        beta=beta,
+        dAqk=dAqk,
+        dAkk=dAkk,
+        dq=dq,
+        dq2=dq2,
+        dk=dk,
+        dk2=dk2,
+        dk_precond=dk_precond,
+        dk_precond2=dk_precond2,
+        dg=dg,
+        dg2=dg2,
+        db=db2,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        B=B,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        BK=BK,
+        NC=NC,
+        SAFE_GATE=safe_gate,
+        USE_GATHER=IS_GATHER_SUPPORTED,
+    )
+
+    dq = dq2
+    dk = dk2
+    dk_precond = dk_precond2
+    db = db2.sum(0).add_(db)
+    dg = chunk_local_cumsum(
+        dg2,
+        chunk_size=chunk_size,
+        reverse=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    return dq, dk, dk_precond, db, dg

--- a/fla/ops/precond_kda/chunk_intra.py
+++ b/fla/ops/precond_kda/chunk_intra.py
@@ -97,9 +97,15 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
     Akk += (bos * H + i_h) * BT
     Akk_diag += (bos * H + i_h) * BC
 
-    m_tc1 = (i_tc1 + tl.arange(0, BC)) < T
-    m_tc2 = (i_tc2 + tl.arange(0, BC)) < T
-    m_tc3 = (i_tc3 + tl.arange(0, BC)) < T
+    o_i = tl.arange(0, BC)
+    o_c0 = i_tc0 + o_i
+    o_c1 = i_tc1 + o_i
+    o_c2 = i_tc2 + o_i
+    o_c3 = i_tc3 + o_i
+    m_tc0 = o_c0 < T
+    m_tc1 = o_c1 < T
+    m_tc2 = o_c2 < T
+    m_tc3 = o_c3 < T
 
     b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
     b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
@@ -124,25 +130,27 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
         m_k = o_k < K
 
         # Column side: load k_precond transposed (for Aqk and Akk column)
-        p_kp0 = tl.make_block_ptr(k_precond, (K, T), (1, H*K), (i_k * BK, i_tc0), (BK, BC), (0, 1))
-        p_g0 = tl.make_block_ptr(g, (K, T), (1, H*K), (i_k * BK, i_tc0), (BK, BC), (0, 1))
-        b_kpt0 = tl.load(p_kp0, boundary_check=(0, 1)).to(tl.float32)  # k_precond transposed
-        b_gt0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+        m_kc0 = m_k[:, None] & m_tc0[None, :]
+        p_kp0 = k_precond + o_k[:, None] + o_c0[None, :] * (H*K)
+        p_g0 = g + o_k[:, None] + o_c0[None, :] * (H*K)
+        b_kpt0 = tl.load(p_kp0, mask=m_kc0, other=0.0).to(tl.float32)  # k_precond transposed
+        b_gt0 = tl.load(p_g0, mask=m_kc0, other=0.0).to(tl.float32)
 
         b_kpt1, b_gt1 = b_kpt0, b_gt0
         b_kpt2, b_gt2 = b_kpt0, b_gt0
 
         if i_tc1 < T:
             # Row side: q for Aqk, original k for Akk
-            p_q1 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_k1 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_kp1 = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_g1 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            m_c1k = m_tc1[:, None] & m_k[None, :]
+            p_q1 = q + o_c1[:, None] * (H*K) + o_k[None, :]
+            p_k1 = k + o_c1[:, None] * (H*K) + o_k[None, :]
+            p_kp1 = k_precond + o_c1[:, None] * (H*K) + o_k[None, :]
+            p_g1 = g + o_c1[:, None] * (H*K) + o_k[None, :]
             # [BC, BK]
-            b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
-            b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)  # Original k for row
-            b_kp1 = tl.load(p_kp1, boundary_check=(0, 1)).to(tl.float32)  # k_precond for column
-            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+            b_q1 = tl.load(p_q1, mask=m_c1k, other=0.0).to(tl.float32)
+            b_k1 = tl.load(p_k1, mask=m_c1k, other=0.0).to(tl.float32)  # Original k for row
+            b_kp1 = tl.load(p_kp1, mask=m_c1k, other=0.0).to(tl.float32)  # k_precond for column
+            b_g1 = tl.load(p_g1, mask=m_c1k, other=0.0).to(tl.float32)
             # [BK, BC]
             b_kpt1 = tl.trans(b_kp1)  # k_precond transposed
             b_gt1 = tl.trans(b_g1)
@@ -159,15 +167,16 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
             b_Akk10 += tl.dot(b_kg1, b_kpgt)  # Asymmetric: k @ k_precond^T
 
         if i_tc2 < T:
-            p_q2 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-            p_k2 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-            p_kp2 = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-            p_g2 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            m_c2k = m_tc2[:, None] & m_k[None, :]
+            p_q2 = q + o_c2[:, None] * (H*K) + o_k[None, :]
+            p_k2 = k + o_c2[:, None] * (H*K) + o_k[None, :]
+            p_kp2 = k_precond + o_c2[:, None] * (H*K) + o_k[None, :]
+            p_g2 = g + o_c2[:, None] * (H*K) + o_k[None, :]
 
-            b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
-            b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
-            b_kp2 = tl.load(p_kp2, boundary_check=(0, 1)).to(tl.float32)
-            b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+            b_q2 = tl.load(p_q2, mask=m_c2k, other=0.0).to(tl.float32)
+            b_k2 = tl.load(p_k2, mask=m_c2k, other=0.0).to(tl.float32)
+            b_kp2 = tl.load(p_kp2, mask=m_c2k, other=0.0).to(tl.float32)
+            b_g2 = tl.load(p_g2, mask=m_c2k, other=0.0).to(tl.float32)
             b_kpt2 = tl.trans(b_kp2)
             b_gt2 = tl.trans(b_g2)
 
@@ -184,12 +193,13 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
             b_Akk21 += tl.dot(b_kg2, b_kpgt)
 
         if i_tc3 < T:
-            p_q3 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-            p_k3 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-            p_g3 = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-            b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
-            b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
-            b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+            m_c3k = m_tc3[:, None] & m_k[None, :]
+            p_q3 = q + o_c3[:, None] * (H*K) + o_k[None, :]
+            p_k3 = k + o_c3[:, None] * (H*K) + o_k[None, :]
+            p_g3 = g + o_c3[:, None] * (H*K) + o_k[None, :]
+            b_q3 = tl.load(p_q3, mask=m_c3k, other=0.0).to(tl.float32)
+            b_k3 = tl.load(p_k3, mask=m_c3k, other=0.0).to(tl.float32)
+            b_g3 = tl.load(p_g3, mask=m_c3k, other=0.0).to(tl.float32)
 
             b_gn3 = tl.load(g + i_tc3 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
             b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
@@ -211,32 +221,29 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
     # 2. save off-diagonal Aqk blocks and prepare Akk
     ################################################################################
     if i_tc1 < T:
-        p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk10 = Aqk + o_c1[:, None] * (H*BT) + o_i[None, :]
+        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), mask=m_tc1[:, None] & (o_i[None, :] < BC))
 
-        p_b1 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
-        b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+        b_b1 = tl.load(beta + bos * H + i_h + o_c1*H, mask=m_tc1, other=0.0).to(tl.float32)
         b_Akk10 = b_Akk10 * b_b1[:, None]
     if i_tc2 < T:
-        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk20 = Aqk + o_c2[:, None] * (H*BT) + o_i[None, :]
+        p_Aqk21 = Aqk + o_c2[:, None] * (H*BT) + (o_i + BC)[None, :]
+        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), mask=m_tc2[:, None] & (o_i[None, :] < BC))
+        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), mask=m_tc2[:, None] & (o_i[None, :] < BC))
 
-        p_b2 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
-        b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+        b_b2 = tl.load(beta + bos * H + i_h + o_c2*H, mask=m_tc2, other=0.0).to(tl.float32)
         b_Akk20 = b_Akk20 * b_b2[:, None]
         b_Akk21 = b_Akk21 * b_b2[:, None]
     if i_tc3 < T:
-        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
-        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk30 = Aqk + o_c3[:, None] * (H*BT) + o_i[None, :]
+        p_Aqk31 = Aqk + o_c3[:, None] * (H*BT) + (o_i + BC)[None, :]
+        p_Aqk32 = Aqk + o_c3[:, None] * (H*BT) + (o_i + 2*BC)[None, :]
+        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), mask=m_tc3[:, None] & (o_i[None, :] < BC))
+        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), mask=m_tc3[:, None] & (o_i[None, :] < BC))
+        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), mask=m_tc3[:, None] & (o_i[None, :] < BC))
 
-        p_b3 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
-        b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+        b_b3 = tl.load(beta + bos * H + i_h + o_c3*H, mask=m_tc3, other=0.0).to(tl.float32)
         b_Akk30 = b_Akk30 * b_b3[:, None]
         b_Akk31 = b_Akk31 * b_b3[:, None]
         b_Akk32 = b_Akk32 * b_b3[:, None]
@@ -244,14 +251,14 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
     ################################################################################
     # 3. load diagonal Akk blocks
     ################################################################################
-    p_Akk00 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akk_diag, (T, BC), (H*BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+    p_Akk00 = Akk_diag + o_c0[:, None] * (H*BC) + o_i[None, :]
+    p_Akk11 = Akk_diag + o_c1[:, None] * (H*BC) + o_i[None, :]
+    p_Akk22 = Akk_diag + o_c2[:, None] * (H*BC) + o_i[None, :]
+    p_Akk33 = Akk_diag + o_c3[:, None] * (H*BC) + o_i[None, :]
+    b_Ai00 = tl.load(p_Akk00, mask=m_tc0[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, mask=m_tc1[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+    b_Ai22 = tl.load(p_Akk22, mask=m_tc2[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+    b_Ai33 = tl.load(p_Akk33, mask=m_tc3[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
 
     ################################################################################
     # 4. forward substitution on diagonals
@@ -336,27 +343,28 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
     ################################################################################
     # 6. store full Akk_inv to Akk
     ################################################################################
-    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
-    p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
-    p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-    p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (H*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
+    m_col = o_i[None, :] < BC
+    p_Akk00 = Akk + o_c0[:, None] * (H*BT) + o_i[None, :]
+    p_Akk10 = Akk + o_c1[:, None] * (H*BT) + o_i[None, :]
+    p_Akk11 = Akk + o_c1[:, None] * (H*BT) + (o_i + BC)[None, :]
+    p_Akk20 = Akk + o_c2[:, None] * (H*BT) + o_i[None, :]
+    p_Akk21 = Akk + o_c2[:, None] * (H*BT) + (o_i + BC)[None, :]
+    p_Akk22 = Akk + o_c2[:, None] * (H*BT) + (o_i + 2*BC)[None, :]
+    p_Akk30 = Akk + o_c3[:, None] * (H*BT) + o_i[None, :]
+    p_Akk31 = Akk + o_c3[:, None] * (H*BT) + (o_i + BC)[None, :]
+    p_Akk32 = Akk + o_c3[:, None] * (H*BT) + (o_i + 2*BC)[None, :]
+    p_Akk33 = Akk + o_c3[:, None] * (H*BT) + (o_i + 3*BC)[None, :]
 
-    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), mask=m_tc0[:, None] & m_col)
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), mask=m_tc1[:, None] & m_col)
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), mask=m_tc1[:, None] & m_col)
+    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), mask=m_tc2[:, None] & m_col)
+    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), mask=m_tc2[:, None] & m_col)
+    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), mask=m_tc2[:, None] & m_col)
+    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & m_col)
+    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & m_col)
+    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & m_col)
+    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & m_col)
 
 
 @triton.heuristics({
@@ -422,18 +430,18 @@ def chunk_precond_kda_fwd_kernel_intra_sub_chunk(
     Aqk = Aqk + (bos * H + i_h) * BT
     Akk = Akk + (bos * H + i_h) * BC
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_kp = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_ck = m_c[:, None] & (o_k[None, :] < K)
+    p_q = q + o_c[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_c[:, None] * (H*K) + o_k[None, :]
+    p_kp = k_precond + o_c[:, None] * (H*K) + o_k[None, :]
+    p_g = g + o_c[:, None] * (H*K) + o_k[None, :]
 
-    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
-
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_kp = tl.load(p_kp, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
+    b_q = tl.load(p_q, mask=m_ck, other=0.0)
+    b_k = tl.load(p_k, mask=m_ck, other=0.0)
+    b_kp = tl.load(p_kp, mask=m_ck, other=0.0)
+    b_g = tl.load(p_g, mask=m_ck, other=0.0)
+    b_beta = tl.load(beta + o_c*H, mask=m_c, other=0.0)
 
     if USE_GATHER:
         b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
@@ -464,10 +472,10 @@ def chunk_precond_kda_fwd_kernel_intra_sub_chunk(
     b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
     b_Akk = tl.where(m_Akk, b_Akk, 0.0)
 
-    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-    p_Akk = tl.make_block_ptr(Akk, (T, BC), (H*BC, 1), (i_ti, 0), (BC, BC), (1, 0))
-    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    p_Aqk = Aqk + o_c[:, None] * (H*BT) + (i_i * BC + o_i)[None, :]
+    p_Akk = Akk + o_c[:, None] * (H*BC) + o_i[None, :]
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), mask=m_c[:, None] & (o_i[None, :] < BC))
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), mask=m_c[:, None] & (o_i[None, :] < BC))
 
     tl.debug_barrier()
 
@@ -482,7 +490,7 @@ def chunk_precond_kda_fwd_kernel_intra_sub_chunk(
         b_a += tl.sum(b_a[:, None] * b_Ai, 0)
         b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
     b_Ai += m_I
-    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), mask=m_c[:, None] & (o_i[None, :] < BC))
 
 
 def chunk_precond_kda_fwd_intra(
@@ -690,6 +698,8 @@ def chunk_precond_kda_bwd_kernel_intra(
     o_k = i_k * BK + tl.arange(0, BK)
     o_i = tl.arange(0, BC)
     m_k = o_k < K
+    o_ti = i_ti + o_i
+    m_ti = o_ti < T
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
@@ -708,10 +718,9 @@ def chunk_precond_kda_bwd_kernel_intra(
     dg2 += (bos * H + i_h) * K
     db += (i_k * all_BT + bos) * H + i_h  # Like KDA line 416
 
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_b = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-    b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+    p_g = g + o_ti[:, None] * (H*K) + o_k[None, :]
+    b_g = tl.load(p_g, mask=m_ti[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+    b_b = tl.load(beta + o_ti*H, mask=m_ti, other=0.0).to(tl.float32)
 
     p_gn_start = g + i_ti * H*K + o_k
     b_gn_start = tl.load(p_gn_start, mask=m_k, other=0).to(tl.float32)
@@ -720,17 +729,19 @@ def chunk_precond_kda_bwd_kernel_intra(
     b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
 
     for i_j in range(0, i_i):
-        p_kp = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-        p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
-        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+        o_cj = i_t * BT + i_j * BC + o_i
+        m_cj = o_cj < T
+        p_kp = k_precond + o_cj[:, None] * (H*K) + o_k[None, :]
+        p_gk = g + o_cj[:, None] * (H*K) + o_k[None, :]
+        p_dAqk = dAqk + o_ti[:, None] * (H*BT) + (i_j * BC + o_i)[None, :]
+        p_dAkk = dAkk + o_ti[:, None] * (H*BT) + (i_j * BC + o_i)[None, :]
         # [BC, BK]
-        b_kp = tl.load(p_kp, boundary_check=(0, 1)).to(tl.float32)
-        b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+        b_kp = tl.load(p_kp, mask=m_cj[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+        b_gk = tl.load(p_gk, mask=m_cj[:, None] & m_k[None, :], other=0.0).to(tl.float32)
         b_kpg = b_kp * exp2(b_gn_start[None, :] - b_gk)
         # [BC, BC]
-        b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+        b_dAqk = tl.load(p_dAqk, mask=m_ti[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+        b_dAkk = tl.load(p_dAkk, mask=m_ti[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
         # [BC, BK]
         b_dq2 += tl.dot(b_dAqk, b_kpg)
         b_dk2 += tl.dot(b_dAkk, b_kpg)
@@ -744,10 +755,10 @@ def chunk_precond_kda_bwd_kernel_intra(
     p_gkj = g + i_ti * H*K + o_k
     m_dA = (i_ti + o_i) < T
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
-    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+    p_q = q + o_ti[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_ti[:, None] * (H*K) + o_k[None, :]
+    b_q = tl.load(p_q, mask=m_ti[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+    b_k = tl.load(p_k, mask=m_ti[:, None] & m_k[None, :], other=0.0).to(tl.float32)
 
     if SAFE_GATE:
         # Vectorized upper diagonal (dq2/dk2): column side uses k_precond
@@ -757,13 +768,13 @@ def chunk_precond_kda_bwd_kernel_intra(
             p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0)[None, :]
 
-        p_kp_diag = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-        b_kp_diag = tl.load(p_kp_diag, boundary_check=(0, 1)).to(tl.float32)
+        p_kp_diag = k_precond + o_ti[:, None] * (H*K) + o_k[None, :]
+        b_kp_diag = tl.load(p_kp_diag, mask=m_ti[:, None] & m_k[None, :], other=0.0).to(tl.float32)
 
-        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        b_dAqk_diag_qk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_qk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+        p_dAqk = dAqk + o_ti[:, None] * (H*BT) + (i_i * BC + o_i)[None, :]
+        p_dAkk = dAkk + o_ti[:, None] * (H*BT) + (i_i * BC + o_i)[None, :]
+        b_dAqk_diag_qk = tl.load(p_dAqk, mask=m_ti[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+        b_dAkk_diag_qk = tl.load(p_dAkk, mask=m_ti[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
 
         m_i_diag_qk = (o_i[:, None] >= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
         m_j_diag_qk = (i_ti + o_i[:, None]) < T
@@ -795,16 +806,17 @@ def chunk_precond_kda_bwd_kernel_intra(
             p_gkj += H*K
 
     b_db = tl.sum(b_dk2 * b_k, 1)
-    p_db = tl.make_block_ptr(db, (T,), (H,), (i_ti,), (BC,), (0,))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    p_db = db + o_ti*H
+    tl.store(p_db, b_db.to(db.dtype.element_ty), mask=m_ti)
     b_dk2 *= b_b[:, None]
 
-    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dq2 = tl.make_block_ptr(dq2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    m_tik = m_ti[:, None] & m_k[None, :]
+    p_dq = dq + o_ti[:, None] * (H*K) + o_k[None, :]
+    p_dq2 = dq2 + o_ti[:, None] * (H*K) + o_k[None, :]
 
     b_dg2 = b_q * b_dq2
-    b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
-    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), boundary_check=(0, 1))
+    b_dq2 = b_dq2 + tl.load(p_dq, mask=m_tik, other=0.0)
+    tl.store(p_dq2, b_dq2.to(dq2.dtype.element_ty), mask=m_tik)
 
     tl.debug_barrier()
     b_dkt = tl.zeros([BC, BK], dtype=tl.float32)  # Final dk_precond (with beta from rows)
@@ -815,22 +827,25 @@ def chunk_precond_kda_bwd_kernel_intra(
         b_gn_t = tl.load(p_gn_t, mask=m_k, other=0).to(tl.float32)
 
         for i_j in range(i_i + 1, NC_actual):
-            p_q_t = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_k_t = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_gk_t = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_b_row = tl.make_block_ptr(beta, (T,), (H,), (i_t*BT+i_j*BC,), (BC,), (0,))  # beta at ROW positions
-            p_dAqk_t = tl.make_block_ptr(dAqk, (BT, T), (1, H*BT), (i_i*BC, i_t*BT+i_j*BC), (BC, BC), (0, 1))
-            p_dAkk_t = tl.make_block_ptr(dAkk, (BT, T), (1, H*BT), (i_i*BC, i_t*BT+i_j*BC), (BC, BC), (0, 1))
+            o_rj = i_t*BT + i_j*BC + o_i
+            m_rj = o_rj < T
+            p_q_t = q + o_rj[:, None] * (H*K) + o_k[None, :]
+            p_k_t = k + o_rj[:, None] * (H*K) + o_k[None, :]
+            p_gk_t = g + o_rj[:, None] * (H*K) + o_k[None, :]
+            p_b_row = beta + o_rj*H  # beta at ROW positions
+            p_dAqk_t = dAqk + (i_i*BC + o_i)[:, None] + o_rj[None, :] * (H*BT)
+            p_dAkk_t = dAkk + (i_i*BC + o_i)[:, None] + o_rj[None, :] * (H*BT)
+            m_dA_t = (o_i[:, None] < BC) & m_rj[None, :]
 
             # [BC]
-            b_b_row = tl.load(p_b_row, boundary_check=(0,)).to(tl.float32)  # beta from ROW positions
+            b_b_row = tl.load(p_b_row, mask=m_rj, other=0.0).to(tl.float32)  # beta from ROW positions
             # [BC, BK]
-            b_q_t = tl.load(p_q_t, boundary_check=(0, 1)).to(tl.float32)
-            b_k_t = tl.load(p_k_t, boundary_check=(0, 1)).to(tl.float32)
-            b_gk_t = tl.load(p_gk_t, boundary_check=(0, 1)).to(tl.float32)
+            b_q_t = tl.load(p_q_t, mask=m_rj[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+            b_k_t = tl.load(p_k_t, mask=m_rj[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+            b_gk_t = tl.load(p_gk_t, mask=m_rj[:, None] & m_k[None, :], other=0.0).to(tl.float32)
             # [BC, BC]
-            b_dAqk_t = tl.load(p_dAqk_t, boundary_check=(0, 1)).to(tl.float32)
-            b_dAkk_t = tl.load(p_dAkk_t, boundary_check=(0, 1)).to(tl.float32)
+            b_dAqk_t = tl.load(p_dAqk_t, mask=m_dA_t, other=0.0).to(tl.float32)
+            b_dAkk_t = tl.load(p_dAkk_t, mask=m_dA_t, other=0.0).to(tl.float32)
 
             o_j = i_t * BT + i_j * BC + o_i
             m_j = o_j < T
@@ -851,15 +866,15 @@ def chunk_precond_kda_bwd_kernel_intra(
         else:
             p_gn_t2 = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H*K + o_k
             b_gn_t2 = tl.load(p_gn_t2, mask=m_k, other=0).to(tl.float32)[None, :]
-        p_q_diag = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-        b_q_diag = tl.load(p_q_diag, boundary_check=(0, 1)).to(tl.float32)
-        p_b_diag = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
-        b_b_diag = tl.load(p_b_diag, boundary_check=(0,)).to(tl.float32)
+        p_q_diag = q + o_ti[:, None] * (H*K) + o_k[None, :]
+        b_q_diag = tl.load(p_q_diag, mask=m_ti[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+        b_b_diag = tl.load(beta + o_ti*H, mask=m_ti, other=0.0).to(tl.float32)
 
-        p_dAqk_diag_kk = tl.make_block_ptr(dAqk, (BT, T), (1, H*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        p_dAkk_diag_kk = tl.make_block_ptr(dAkk, (BT, T), (1, H*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        b_dAqk_diag_kk = tl.load(p_dAqk_diag_kk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_kk = tl.load(p_dAkk_diag_kk, boundary_check=(0, 1)).to(tl.float32)
+        p_dAqk_diag_kk = dAqk + (i_i * BC + o_i)[:, None] + o_ti[None, :] * (H*BT)
+        p_dAkk_diag_kk = dAkk + (i_i * BC + o_i)[:, None] + o_ti[None, :] * (H*BT)
+        m_dA_kk = (o_i[:, None] < BC) & m_ti[None, :]
+        b_dAqk_diag_kk = tl.load(p_dAqk_diag_kk, mask=m_dA_kk, other=0.0).to(tl.float32)
+        b_dAkk_diag_kk = tl.load(p_dAkk_diag_kk, mask=m_dA_kk, other=0.0).to(tl.float32)
 
         m_i_diag_kk = (o_i[:, None] <= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
         m_j_diag_kk = (i_ti + o_i[:, None]) < T
@@ -905,23 +920,23 @@ def chunk_precond_kda_bwd_kernel_intra(
             p_gkj_t += H*K
             p_bj += H
 
-    p_kp_local = tl.make_block_ptr(k_precond, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_kp_local = tl.load(p_kp_local, boundary_check=(0, 1)).to(tl.float32)
+    p_kp_local = k_precond + o_ti[:, None] * (H*K) + o_k[None, :]
+    b_kp_local = tl.load(p_kp_local, mask=m_tik, other=0.0).to(tl.float32)
 
-    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dk2 = tl.make_block_ptr(dk2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dk_precond = tl.make_block_ptr(dk_precond, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dk_precond2 = tl.make_block_ptr(dk_precond2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg2 = tl.make_block_ptr(dg2, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk = dk + o_ti[:, None] * (H*K) + o_k[None, :]
+    p_dk2 = dk2 + o_ti[:, None] * (H*K) + o_k[None, :]
+    p_dk_precond = dk_precond + o_ti[:, None] * (H*K) + o_k[None, :]
+    p_dk_precond2 = dk_precond2 + o_ti[:, None] * (H*K) + o_k[None, :]
+    p_dg = dg + o_ti[:, None] * (H*K) + o_k[None, :]
+    p_dg2 = dg2 + o_ti[:, None] * (H*K) + o_k[None, :]
 
-    b_dg2 += b_dk2 * b_k - b_dkt * b_kp_local + tl.load(p_dg, boundary_check=(0, 1))
-    b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
-    b_dk_precond2 = b_dkt + tl.load(p_dk_precond, boundary_check=(0, 1))
+    b_dg2 += b_dk2 * b_k - b_dkt * b_kp_local + tl.load(p_dg, mask=m_tik, other=0.0)
+    b_dk2 += tl.load(p_dk, mask=m_tik, other=0.0)
+    b_dk_precond2 = b_dkt + tl.load(p_dk_precond, mask=m_tik, other=0.0)
 
-    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk_precond2, b_dk_precond2.to(p_dk_precond2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk2, b_dk2.to(dk2.dtype.element_ty), mask=m_tik)
+    tl.store(p_dk_precond2, b_dk_precond2.to(dk_precond2.dtype.element_ty), mask=m_tik)
+    tl.store(p_dg2, b_dg2.to(dg2.dtype.element_ty), mask=m_tik)
 
 
 def chunk_precond_kda_bwd_intra(

--- a/fla/ops/precond_kda/chunk_intra.py
+++ b/fla/ops/precond_kda/chunk_intra.py
@@ -71,12 +71,12 @@ def chunk_precond_kda_fwd_kernel_inter_solve_fused(
     5. Computes merged Akk_inv
     6. Writes Akk_inv to Akk
     """
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -405,12 +405,12 @@ def chunk_precond_kda_fwd_kernel_intra_sub_chunk(
     Computes diagonal Aqk and Akk blocks using block-level dot products.
     Key difference from symmetric KDA: column side uses k_precond.
     """
-    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -677,7 +677,7 @@ def chunk_precond_kda_bwd_kernel_intra(
         Aqk[t, s] = q[t] @ k_precond[s]^T * exp(g[t] - g[s]) * beta[s]  (for t >= s)
         Akk[t, s] = k[t] @ k_precond[s]^T * exp(g[t] - g[s]) * beta[s]  (for t > s)
     """
-    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     i_k = i_kc // NC
     i_i = i_kc % NC
@@ -685,8 +685,8 @@ def chunk_precond_kda_bwd_kernel_intra(
     all_BT = B * T
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -821,7 +821,9 @@ def chunk_precond_kda_bwd_kernel_intra(
     tl.debug_barrier()
     b_dkt = tl.zeros([BC, BK], dtype=tl.float32)  # Final dk_precond (with beta from rows)
 
-    NC_actual = min(NC, tl.cdiv(T - i_t * BT, BC))
+    # cast back to int32: `i_t` is int64 for pointer arithmetic, but the loop
+    # counter below must match the type of its int32 initial value `i_i + 1`
+    NC_actual = min(NC, tl.cdiv(T - i_t * BT, BC)).to(tl.int32)
     if i_i < NC_actual - 1:
         p_gn_t = g + (min(i_ti + BC, T) - 1) * H*K + o_k
         b_gn_t = tl.load(p_gn_t, mask=m_k, other=0).to(tl.float32)

--- a/fla/ops/precond_kda/chunk_intra_token_parallel.py
+++ b/fla/ops/precond_kda/chunk_intra_token_parallel.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.op import exp2
+from fla.utils import autotune_cache_kwargs
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BH': BH}, num_warps=num_warps)
+        for BH in [1, 2, 4, 8]
+        for num_warps in [1, 2, 4, 8]
+    ],
+    key=["K", "H"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T', 'N'])
+def chunk_precond_kda_fwd_kernel_intra_token_parallel(
+    q,
+    k,           # Original k (for Akk row side)
+    k_precond,   # Preconditioned k (for column side of both Aqk and Akk)
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    N,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BH: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Asymmetric version for precond_kda:
+    - Aqk = q @ k_precond^T (column uses k_precond)
+    - Akk = k @ k_precond^T (row uses original k, column uses k_precond)
+    """
+    i_tg, i_hg = tl.program_id(0), tl.program_id(1)
+
+    if IS_VARLEN:
+        i_n = 0
+        left, right = 0, N
+
+        # Unrolled binary search (max B=2^32)
+        # We can limit iterations based on expected max batch size if needed
+        # 20 iterations covers B=1M, usually enough
+        for _ in range(20):
+            if left < right:
+                mid = (left + right) // 2
+                if i_tg < tl.load(cu_seqlens + mid + 1).to(tl.int32):
+                    right = mid
+                else:
+                    left = mid + 1
+        i_n = left
+
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        i_t = i_tg - bos
+    else:
+        bos = (i_tg // T) * T
+        i_t = i_tg % T
+
+    if i_t >= T:
+        return
+
+    i_c = i_t // BT
+    i_s = (i_t % BT) // BC
+    i_tc = i_c * BT
+    i_ts = i_tc + i_s * BC
+
+    q += bos * H*K
+    k += bos * H*K
+    k_precond += bos * H*K
+    g += bos * H*K
+    Aqk += bos * H*BT
+    Akk += bos * H*BC
+    beta += bos * H
+
+    BK: tl.constexpr = triton.next_power_of_2(K)
+    o_h = tl.arange(0, BH)
+    o_k = tl.arange(0, BK)
+    m_h = (i_hg * BH + o_h) < H
+    m_k = o_k < K
+
+    p_q = tl.make_block_ptr(q + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_k = tl.make_block_ptr(k + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_g = tl.make_block_ptr(g + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_beta = tl.make_block_ptr(beta + i_t * H, (H,), (1,), (i_hg * BH,), (BH,), (0,))
+
+    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
+    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)  # Original k for row
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_k = b_k * tl.load(p_beta, boundary_check=(0,)).to(tl.float32)[:, None]
+
+    for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
+        # Load k_precond at position j (column side) - ASYMMETRIC: use k_precond here
+        p_kpj = tl.make_block_ptr(k_precond + j * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+        p_gj = tl.make_block_ptr(g + j * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+
+        b_kpj = tl.load(p_kpj, boundary_check=(0, 1)).to(tl.float32)  # k_precond for column
+        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+
+        # k_precond gated at position j
+        b_kpgj = b_kpj * exp2(b_g - b_gj)
+        b_kpgj = tl.where(m_k[None, :], b_kpgj, 0.0)
+
+        # Aqk: q (row i) @ k_precond^T (col j)
+        b_Aqk = tl.sum(b_q * b_kpgj, axis=1) * scale
+        # Akk: k (row i, beta-scaled) @ k_precond^T (col j) - ASYMMETRIC
+        b_Akk = tl.sum(b_k * b_kpgj, axis=1) * tl.where(j < i_t, 1.0, 0.0)
+
+        tl.store(Aqk + i_t * H*BT + (i_hg * BH + o_h) * BT + j % BT, b_Aqk.to(Aqk.dtype.element_ty), mask=m_h)
+        tl.store(Akk + i_t * H*BC + (i_hg * BH + o_h) * BC + j - i_ts, b_Akk.to(Akk.dtype.element_ty), mask=m_h)
+
+
+def chunk_precond_kda_fwd_intra_token_parallel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    k_precond: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    sub_chunk_size: int = 16,
+) -> None:
+    """
+    Token-parallel implementation for preconditioned KDA.
+    Supports both fixed-length and variable-length sequences.
+    Reduces wasted computation on padding.
+    Asymmetric: uses k for Akk row side, k_precond for column side.
+
+    Writes directly to Aqk and Akk tensors (in-place).
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K] - original k (for Akk row side)
+        k_precond: [B, T, H, K] - preconditioned k (for column side)
+        gk: [B, T, H, K] cumsum of gates
+        beta: [B, T, H]
+        Aqk: [B, T, H, BT] output tensor
+        Akk: [B, T, H, BC] output tensor for diagonal blocks (fp32)
+        scale: attention scale
+    """
+    B, T, H, K = q.shape
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BT = chunk_size
+    BC = sub_chunk_size
+
+    def grid(meta): return (B * T, triton.cdiv(H, meta['BH']))
+    chunk_precond_kda_fwd_kernel_intra_token_parallel[grid](
+        q=q,
+        k=k,
+        k_precond=k_precond,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        N=N,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+    )
+    return Aqk, Akk

--- a/fla/ops/precond_kda/chunk_intra_token_parallel.py
+++ b/fla/ops/precond_kda/chunk_intra_token_parallel.py
@@ -97,23 +97,26 @@ def chunk_precond_kda_fwd_kernel_intra_token_parallel(
     m_h = (i_hg * BH + o_h) < H
     m_k = o_k < K
 
-    p_q = tl.make_block_ptr(q + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_g = tl.make_block_ptr(g + i_t * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_beta = tl.make_block_ptr(beta + i_t * H, (H,), (1,), (i_hg * BH,), (BH,), (0,))
+    o_hh = i_hg * BH + o_h
+    m_hk = m_h[:, None] & m_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
-    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)  # Original k for row
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-    b_k = b_k * tl.load(p_beta, boundary_check=(0,)).to(tl.float32)[:, None]
+    p_q = q + i_t * H*K + o_hh[:, None] * K + o_k[None, :]
+    p_k = k + i_t * H*K + o_hh[:, None] * K + o_k[None, :]
+    p_g = g + i_t * H*K + o_hh[:, None] * K + o_k[None, :]
+    p_beta = beta + i_t * H + o_hh
+
+    b_q = tl.load(p_q, mask=m_hk, other=0.0).to(tl.float32)
+    b_k = tl.load(p_k, mask=m_hk, other=0.0).to(tl.float32)  # Original k for row
+    b_g = tl.load(p_g, mask=m_hk, other=0.0).to(tl.float32)
+    b_k = b_k * tl.load(p_beta, mask=m_h, other=0.0).to(tl.float32)[:, None]
 
     for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
         # Load k_precond at position j (column side) - ASYMMETRIC: use k_precond here
-        p_kpj = tl.make_block_ptr(k_precond + j * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-        p_gj = tl.make_block_ptr(g + j * H*K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+        p_kpj = k_precond + j * H*K + o_hh[:, None] * K + o_k[None, :]
+        p_gj = g + j * H*K + o_hh[:, None] * K + o_k[None, :]
 
-        b_kpj = tl.load(p_kpj, boundary_check=(0, 1)).to(tl.float32)  # k_precond for column
-        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+        b_kpj = tl.load(p_kpj, mask=m_hk, other=0.0).to(tl.float32)  # k_precond for column
+        b_gj = tl.load(p_gj, mask=m_hk, other=0.0).to(tl.float32)
 
         # k_precond gated at position j
         b_kpgj = b_kpj * exp2(b_g - b_gj)

--- a/fla/ops/precond_kda/chunk_intra_token_parallel.py
+++ b/fla/ops/precond_kda/chunk_intra_token_parallel.py
@@ -50,7 +50,7 @@ def chunk_precond_kda_fwd_kernel_intra_token_parallel(
     - Aqk = q @ k_precond^T (column uses k_precond)
     - Akk = k @ k_precond^T (row uses original k, column uses k_precond)
     """
-    i_tg, i_hg = tl.program_id(0), tl.program_id(1)
+    i_tg, i_hg = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
     if IS_VARLEN:
         i_n = 0
@@ -68,7 +68,7 @@ def chunk_precond_kda_fwd_kernel_intra_token_parallel(
                     left = mid + 1
         i_n = left
 
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
         i_t = i_tg - bos
     else:

--- a/fla/ops/precond_kda/fused_recurrent.py
+++ b/fla/ops/precond_kda/fused_recurrent.py
@@ -1,0 +1,577 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+# This kernel is modified from the Decode kernel of the vllm gdn/kda model.
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.op import exp
+from fla.ops.utils.softplus import softplus
+from fla.utils import input_guard
+
+
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "USE_INITIAL_ATK": lambda args: args["a0"] is not None,
+        "STORE_FINAL_ATK": lambda args: args["at"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
+        "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
+        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["N", "T"])
+def fused_recurrent_precond_kda_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    g_atk,
+    beta_atk,
+    beta,
+    A_log,
+    dt_bias,
+    o,
+    h0,
+    ht,
+    a0,
+    at,
+    cu_seqlens,
+    ssm_state_indices,
+    num_accepted_tokens,
+    lower_bound,
+    log_atk_scale,
+    scale: tl.constexpr,
+    logx,
+    eps,
+    N: tl.int64,  # num of sequences
+    T: tl.int64,  # num of tokens
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    stride_init_state_token: tl.constexpr,
+    stride_final_state_token: tl.constexpr,
+    stride_indices_seq: tl.constexpr,
+    stride_indices_tok: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,  # whether to use initial state
+    INPLACE_FINAL_STATE: tl.constexpr,  # whether to store final state inplace
+    IS_BETA_HEADWISE: tl.constexpr,  # whether beta is headwise vector or scalar,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    IS_CONTINUOUS_BATCHING: tl.constexpr,
+    IS_SPEC_DECODING: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    USE_INITIAL_ATK: tl.constexpr,
+    STORE_FINAL_ATK: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    USE_GATE_IN_KERNEL: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
+    num_stages: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    NV = tl.cdiv(V, BV)
+    NK = tl.cdiv(K, BK)
+    i_k = pid % NK
+    pid_rest = pid // NK
+
+    i_v = pid_rest % NV
+    i_nh = pid_rest // NV
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+
+    if T == 0:
+        # no tokens to process for this sequence
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_q = q + (bos * H + i_h) * K + o_k
+    p_k = k + (bos * H + i_h) * K + o_k
+    p_v = v + (bos * HV + i_hv) * V + o_v
+    if IS_BETA_HEADWISE:
+        p_beta = beta + (bos * HV + i_hv) * V + o_v
+    else:
+        p_beta = beta + bos * HV + i_hv
+
+    p_g = g + (bos * HV + i_hv) * K + o_k
+    # ATK pointers (per-HV-head: g_atk, beta_atk, log_atk_scale are shape-HV like v/beta/g)
+    p_g_atk = g_atk + bos * HV + i_hv
+    p_beta_atk = beta_atk + bos * HV + i_hv
+    p_o = o + (bos * HV + i_hv) * V + o_v
+
+    center = tl.load(log_atk_scale + i_hv).to(tl.float32)
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    if TRANSPOSE_STATE:
+        mask_h = mask_v[:, None] & mask_k[None, :]
+    else:
+        mask_h = mask_k[:, None] & mask_v[None, :]
+
+    if TRANSPOSE_STATE:
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        if IS_CONTINUOUS_BATCHING:
+            if IS_SPEC_DECODING:
+                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+            else:
+                i_t = 0
+            p_h0 = (
+                h0
+                + tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
+                    tl.int64
+                )
+                * stride_init_state_token
+            )
+            if TRANSPOSE_STATE:
+                p_h0 = p_h0 + i_hv * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_h0 = p_h0 + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+        else:
+            if TRANSPOSE_STATE:
+                p_h0 = h0 + (i_n * HV + i_hv) * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_h0 = h0 + (i_n * HV + i_hv) * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+
+    b_a = tl.zeros([BK], dtype=tl.float32)
+    if USE_INITIAL_ATK:
+        if IS_CONTINUOUS_BATCHING:
+            if IS_SPEC_DECODING:
+                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+            else:
+                i_t = 0
+            p_a0 = (
+                a0
+                + tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
+                    tl.int64
+                )
+                * stride_init_state_token
+            )
+            p_a0 = p_a0 + i_hv * K + o_k
+        else:
+            p_a0 = a0 + (i_n * HV + i_hv) * K + o_k
+        b_a += tl.load(p_a0, mask=mask_k, other=0).to(tl.float32)
+
+    for i_t in tl.range(0, T, num_stages=num_stages):
+        b_q = tl.load(p_q, mask=mask_k, other=0, eviction_policy='evict_last').to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0, eviction_policy='evict_last').to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0, eviction_policy='evict_first').to(tl.float32)
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q = b_q * scale
+        b_g = tl.load(p_g, eviction_policy='evict_last').to(tl.float32)
+
+        if USE_GATE_IN_KERNEL:
+            b_A = tl.load(A_log + i_hv).to(tl.float32)
+
+            if HAS_DT_BIAS:
+                b_bias = tl.load(dt_bias + i_hv * K + o_k, mask=mask_k, other=0).to(tl.float32)
+                b_g = b_g + b_bias
+
+            if USE_LOWER_BOUND:
+                b_gk = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+            else:
+                b_gk = -exp(b_A) * softplus(b_g)
+        else:
+            b_gk = b_g
+
+        b_g_atk = tl.load(p_g_atk).to(tl.float32)
+        b_beta_atk = tl.load(p_beta_atk).to(tl.float32)
+
+        # ATK: A_t = exp(g_atk) * A_{t-1} + beta_atk * k^2
+        b_a = exp(b_g_atk) * b_a + b_beta_atk * (b_k * b_k)
+
+        b_ell = tl.log(b_a + eps)
+        b_r = b_ell - center
+        b_s = b_r / (1.0 + tl.abs(b_r))
+        b_M = tl.exp(-logx * b_s)
+        b_k_precond = b_k * b_M
+
+        if TRANSPOSE_STATE:
+            b_h *= exp(b_gk[None, :])
+        else:
+            b_h *= exp(b_gk[:, None])
+
+        if TRANSPOSE_STATE:
+            b_v -= tl.sum(b_h * b_k[None, :], 1)
+        else:
+            b_v -= tl.sum(b_h * b_k[:, None], 0)
+        if IS_BETA_HEADWISE:
+            b_beta = tl.load(p_beta, mask=mask_v, other=0, eviction_policy='evict_first').to(tl.float32)
+        else:
+            b_beta = tl.load(p_beta, eviction_policy='evict_last').to(tl.float32)
+        b_v *= b_beta
+        if TRANSPOSE_STATE:
+            b_h += b_v[:, None] * b_k_precond[None, :]
+            b_o = tl.sum(b_h * b_q[None, :], 1)
+        else:
+            b_h += b_k_precond[:, None] * b_v[None, :]
+            b_o = tl.sum(b_h * b_q[:, None], 0)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v, eviction_policy='evict_first')
+
+        if IS_CONTINUOUS_BATCHING:
+            if INPLACE_FINAL_STATE:
+                p_ht = (
+                    ht
+                    + tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
+                        tl.int64
+                    )
+                    * stride_final_state_token
+                )
+            else:
+                p_ht = ht + (bos + i_t) * stride_final_state_token
+            if TRANSPOSE_STATE:
+                p_ht = p_ht + i_hv * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_ht = p_ht + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+
+            # Store ATK state per timestep during continuous batching (only from first v-block and k-block)
+            if i_v == 0 and i_k == 0:
+                if INPLACE_FINAL_STATE:
+                    p_at_cb = (
+                        at
+                        + tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
+                            tl.int64
+                        )
+                        * stride_final_state_token
+                    )
+                else:
+                    p_at_cb = at + (bos + i_t) * stride_final_state_token
+                p_at_cb = p_at_cb + i_hv * K + o_k
+                tl.store(p_at_cb, b_a.to(p_at_cb.dtype.element_ty), mask=mask_k)
+
+        p_q += H * K
+        p_k += H * K
+        p_o += HV * V
+        p_v += HV * V
+        p_g += HV * K
+        p_g_atk += HV
+        p_beta_atk += HV
+        p_beta += HV * (V if IS_BETA_HEADWISE else 1)
+
+    if not IS_CONTINUOUS_BATCHING:
+        if STORE_FINAL_STATE:
+            if TRANSPOSE_STATE:
+                p_ht = ht + (i_n * HV + i_hv) * K * V + o_v[:, None] * K + o_k[None, :]
+            else:
+                p_ht = ht + (i_n * HV + i_hv) * K * V + o_k[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+
+        if STORE_FINAL_ATK:
+            if i_v == 0 and i_k == 0:
+                p_at = at + (i_n * HV + i_hv) * K + o_k
+                tl.store(p_at, b_a.to(p_at.dtype.element_ty), mask=mask_k)
+
+
+@torch.compiler.disable
+def fused_recurrent_precond_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_atk: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    initial_A_state: torch.Tensor | None = None,
+    scale: float | None = None,
+    output_final_state: bool = False,
+    inplace_final_state: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    ssm_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    use_gate_in_kernel: bool = False,
+    lower_bound: float | None = None,
+    out: torch.Tensor | None = None,
+    transpose_state_layout: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HV = v.shape[2]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    BK = triton.next_power_of_2(K)
+    BV = 32
+
+    if log_atk_scale is None:
+        log_atk_scale = torch.full((HV,), -0.2, device=k.device, dtype=torch.float32)
+    log_atk_scale = log_atk_scale.contiguous()
+
+    logx = math.log(x) if x > 0 else 0.0
+
+    if out is None:
+        out = torch.zeros_like(v)
+    else:
+        assert out.shape == v.shape
+    if inplace_final_state:
+        assert initial_state is not None
+        final_state = initial_state
+        final_A_state = initial_A_state
+    elif output_final_state:
+        if transpose_state_layout:
+            final_state = q.new_empty(N, HV, V, K, dtype=torch.float32)
+        else:
+            final_state = q.new_empty(N, HV, K, V, dtype=torch.float32)
+        final_A_state = q.new_empty(N, HV, K, dtype=torch.float32)
+    else:
+        final_state = None
+        final_A_state = None
+
+    stride_init_state_token = initial_state.stride(0) if initial_state is not None else 1
+    stride_final_state_token = final_state.stride(0) if final_state is not None else 1
+
+    if ssm_state_indices is None:
+        stride_indices_seq, stride_indices_tok = 1, 1
+    elif ssm_state_indices.ndim == 1:
+        stride_indices_seq, stride_indices_tok = ssm_state_indices.stride(0), 1
+    else:
+        stride_indices_seq, stride_indices_tok = ssm_state_indices.stride()
+
+    NK = triton.cdiv(K, BK)
+    grid = (triton.cdiv(V, BV) * NK * N * HV, )
+    fused_recurrent_precond_kda_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        g_atk=g_atk,
+        beta_atk=beta_atk,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        o=out,
+        h0=initial_state,
+        ht=final_state,
+        a0=initial_A_state,
+        at=final_A_state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        lower_bound=lower_bound,
+        log_atk_scale=log_atk_scale,
+        scale=scale,
+        logx=logx,
+        eps=eps,
+        N=N,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        stride_init_state_token=stride_init_state_token,
+        stride_final_state_token=stride_final_state_token,
+        stride_indices_seq=stride_indices_seq,
+        stride_indices_tok=stride_indices_tok,
+        IS_BETA_HEADWISE=beta.ndim == v.ndim,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        INPLACE_FINAL_STATE=inplace_final_state,
+        USE_GATE_IN_KERNEL=use_gate_in_kernel,
+        TRANSPOSE_STATE=transpose_state_layout,
+        num_warps=4,
+        num_stages=2,
+    )
+
+    return out, final_state, final_A_state
+
+
+@input_guard
+def fused_recurrent_precond_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_atk: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    scale: float | None = None,
+    initial_state: torch.Tensor = None,
+    initial_A_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    use_gate_in_kernel: bool = False,
+    lower_bound: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor = None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, HV, V]`.
+            GVA is applied if `HV > H`.
+        g (torch.Tensor):
+            g (decays) of shape `[B, T, HV, K]`.
+        g_atk (torch.Tensor):
+            scalar gate for ATK in log space of shape `[B, T, H]`.
+        beta_atk (torch.Tensor):
+            betas for ATK of shape `[B, T, H]`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, HV]`.
+        A_log (Optional[torch.Tensor]):
+            Per-head log decay parameter of shape `[H]`. Required when `use_gate_in_kernel=True`.
+            Default: `None`.
+        dt_bias (Optional[torch.Tensor]):
+            Per-head-key bias of shape `[H * K]`. Used when `use_gate_in_kernel=True`.
+            Default: `None`.
+        scale (Optional[float]):
+            Scale factor for attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, HV, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        initial_A_state (Optional[torch.Tensor]):
+            Initial ATK diagonal state of shape `[N, H, K]`. Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, HV, K, V]`. Default: `False`.
+        use_qk_l2norm_in_kernel (Optional[bool]):
+            Whether to use L2 normalization in the kernel. Default: `False`.
+        use_gate_in_kernel (Optional[bool]):
+            Whether to compute the log-space KDA decay internally.
+            If `True`, `g` acts as the raw input for `-exp(A_log) * softplus(g + dt_bias)`.
+            `A_log` must be provided. Default: `False`.
+        lower_bound (Optional[float]):
+            If provided, uses `lower_bound * sigmoid(exp(A_log) * g)` instead of
+            `-exp(A_log) * softplus(g)` for gate computation. Only used when
+            `use_gate_in_kernel=True`. Default: `None`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        transpose_state_layout (bool):
+            Whether to use transposed state layout `[V, K]` instead of `[K, V]`. Default: `False`.
+        x (float):
+            Squash range parameter. Default: `1.5`.
+        eps (float):
+            Epsilon for numerical stability. Default: `1e-6`.
+        log_atk_scale (Optional[torch.Tensor]):
+            Per-head log-space center of shape `[H]`. Default: `None`.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, HV, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, HV, K, V]` if `output_final_state=True` else `None`.
+        A_state (torch.Tensor):
+            Final ATK diagonal state of shape `[N, H, K]` if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.precond_kda import fused_recurrent_precond_kda
+        # inputs with equal lengths
+        >>> B, T, H, HV, K, V = 4, 2048, 4, 8, 512, 512
+        >>> q = torch.randn(B, T, H, K, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, H, K, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, HV, V, device='cuda')
+        >>> g = F.logsigmoid(torch.rand(B, T, HV, K, device='cuda'))
+        >>> g_atk = F.logsigmoid(torch.rand(B, T, H, device='cuda'))
+        >>> beta_atk = torch.rand(B, T, H, device='cuda').sigmoid()
+        >>> beta = torch.rand(B, T, HV, device='cuda').sigmoid()
+        >>> h0 = torch.randn(B, HV, K, V, device='cuda')
+        >>> o, ht, at = fused_recurrent_precond_kda(
+            q, k, v, g, g_atk, beta_atk, beta,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, g))
+        >>> g_atk, beta_atk, beta = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (g_atk, beta_atk, beta))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o_var, ht_var, at_var = fused_recurrent_precond_kda(
+            q, k, v, g, g_atk, beta_atk, beta,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing.",
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.",
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    o, final_state, final_A_state = fused_recurrent_precond_kda_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        g_atk=g_atk,
+        beta_atk=beta_atk,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state,
+        initial_A_state=initial_A_state,
+        inplace_final_state=False,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_gate_in_kernel=use_gate_in_kernel,
+        lower_bound=lower_bound,
+        cu_seqlens=cu_seqlens,
+        transpose_state_layout=transpose_state_layout,
+        x=x,
+        eps=eps,
+        log_atk_scale=log_atk_scale,
+    )
+    return o, final_state, final_A_state

--- a/fla/ops/precond_kda/fused_recurrent.py
+++ b/fla/ops/precond_kda/fused_recurrent.py
@@ -83,7 +83,7 @@ def fused_recurrent_precond_kda_fwd_kernel(
     TRANSPOSE_STATE: tl.constexpr,
     num_stages: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
     NK = tl.cdiv(K, BK)
     i_k = pid % NK
@@ -188,7 +188,7 @@ def fused_recurrent_precond_kda_fwd_kernel(
             b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
             b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
         b_q = b_q * scale
-        b_g = tl.load(p_g, eviction_policy='evict_last').to(tl.float32)
+        b_g = tl.load(p_g, mask=mask_k, other=0, eviction_policy='evict_last').to(tl.float32)
 
         if USE_GATE_IN_KERNEL:
             b_A = tl.load(A_log + i_hv).to(tl.float32)

--- a/fla/ops/precond_kda/naive.py
+++ b/fla/ops/precond_kda/naive.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+
+
+def naive_recurrent_precond_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_atk: torch.Tensor,
+    beta_atk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    initial_A_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    x: float = 1.5,
+    eps: float = 1e-6,
+    log_atk_scale: torch.Tensor | float = None,
+):
+    dtype = v.dtype
+    B, T, H, K, V = *q.shape, v.shape[-1]
+    if scale is None:
+        scale = K ** -0.5
+
+    q, k, v, g, g_atk, beta_atk, beta = map(
+        lambda x: x.to(torch.float32),
+        [q, k, v, g, g_atk, beta_atk, beta]
+    )
+    q = q * scale
+
+    if log_atk_scale is None:
+        log_atk_scale = -0.2
+    if isinstance(log_atk_scale, (int, float)):
+        center = torch.tensor(log_atk_scale, dtype=torch.float32, device=k.device)
+    else:
+        center = log_atk_scale.to(torch.float32).view(1, H, 1)
+
+    logx = torch.log(torch.tensor(x, dtype=torch.float32, device=k.device))
+
+    A = k.new_zeros(B, H, K)
+    if initial_A_state is not None:
+        A += initial_A_state
+
+    S = k.new_zeros(B, H, K, V)
+    if initial_state is not None:
+        S += initial_state
+
+    o = torch.zeros_like(v)
+
+    for i in range(T):
+        q_i, k_i, v_i, g_i = q[:, i], k[:, i], v[:, i], g[:, i]
+        g_atk_i, beta_atk_i, beta_i = g_atk[:, i], beta_atk[:, i], beta[:, i]
+
+        A = g_atk_i.exp().unsqueeze(-1) * A + beta_atk_i.unsqueeze(-1) * (k_i ** 2)
+
+        ell = torch.log(A + eps)
+        r = ell - center
+        s = r / (1.0 + torch.abs(r))
+        M = torch.exp(-logx * s)
+        k_precond = k_i * M
+
+        S = S * g_i[..., None].exp()
+        S = S + torch.einsum('b h k, b h v -> b h k v', beta_i[..., None] * k_precond, v_i - (k_i[..., None] * S).sum(-2))
+        o[:, i] = torch.einsum('b h k, b h k v -> b h v', q_i, S)
+
+    if not output_final_state:
+        S = None
+        A = None
+    return o.to(dtype), S, A

--- a/fla/ops/precond_kda/wy_fast.py
+++ b/fla/ops/precond_kda/wy_fast.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.op import exp2
+from fla.utils import autotune_cache_kwargs
+
+
+@triton.heuristics({
+    'STORE_QG': lambda args: args['qg'] is not None,
+    'STORE_KG': lambda args: args['kg'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def recompute_w_u_fwd_kernel(
+    q,
+    k,
+    k_precond,
+    qg,
+    kg,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    gk,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    STORE_QG: tl.constexpr,
+    STORE_KG: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    DOT_PRECISION: tl.constexpr = 'tf32x3',
+):
+    """
+    Asymmetric WY representation:
+    - w = A @ (k * beta * exp(gk)) - uses original k for read/correction
+    - kg = k_precond * exp(gn - gk) - uses k_precond for write/h update
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    p_b = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_b = tl.load(p_b, boundary_check=(0,))
+
+    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    # u computation (unchanged)
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_u = tl.make_block_ptr(u + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
+        b_u = tl.dot(b_A, b_vb, input_precision=DOT_PRECISION)
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_w = tl.make_block_ptr(w + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        # Use original k for w (read/correction)
+        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = b_k * b_b[:, None]
+
+        p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_kb *= exp2(b_gk)
+
+        if STORE_QG:
+            p_q = tl.make_block_ptr(q + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_qg = tl.make_block_ptr(qg + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_qg = b_q * exp2(b_gk)
+            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
+
+        if STORE_KG:
+            # Use k_precond for kg (write/h update) - ASYMMETRIC
+            p_kp = tl.make_block_ptr(k_precond + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            b_kp = tl.load(p_kp, boundary_check=(0, 1))
+
+            last_idx = min(i_t * BT + BT, T) - 1
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            b_gn = tl.load(gk + ((bos + last_idx) * H + i_h) * K + o_k, mask=m_k, other=0.)
+            # kg uses k_precond, not original k
+            b_kg = b_kp * tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], exp2(b_gn[None, :] - b_gk), 0)
+            p_kg = tl.make_block_ptr(kg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+
+        # w uses original k
+        b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    k_precond: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    gk: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    q: torch.Tensor | None = None,
+    output_qg: bool = False,
+    output_kg: bool = True,
+):
+    """
+    Compute WY representation for preconditioned KDA.
+
+    Args:
+        k: [B, T, H, K] - original k (for w computation)
+        k_precond: [B, T, H, K] - preconditioned k (for kg computation)
+        v: [B, T, H, V] - values
+        beta: [B, T, H] - beta scaling
+        A: [B, T, H, BT] - inverse of Akk
+        gk: [B, T, H, K] - cumsum of gates
+
+    Returns:
+        w: [B, T, H, K] - A @ (k * beta * exp(gk))
+        u: [B, T, H, V] - A @ (v * beta)
+        qg: [B, T, H, K] or None - q * exp(gk)
+        kg: [B, T, H, K] or None - k_precond * exp(gn - gk) for h update
+    """
+    B, T, H, K = k.shape
+    V = v.shape[-1]
+    BT = A.shape[-1]
+    BK = 64
+    BV = 64
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    w = torch.empty_like(k)
+    u = torch.empty_like(v)
+    qg = torch.empty_like(q) if output_qg and q is not None else None
+    kg = torch.empty_like(k_precond) if output_kg else None
+
+    grid = (NT, B * H)
+    recompute_w_u_fwd_kernel[grid](
+        q=q,
+        k=k,
+        k_precond=k_precond,
+        qg=qg,
+        kg=kg,
+        v=v,
+        beta=beta,
+        w=w,
+        u=u,
+        A=A,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+    )
+    return w, u, qg, kg

--- a/fla/ops/precond_kda/wy_fast.py
+++ b/fla/ops/precond_kda/wy_fast.py
@@ -60,11 +60,11 @@ def recompute_w_u_fwd_kernel(
     - w = A @ (k * beta * exp(gk)) - uses original k for read/correction
     - kg = k_precond * exp(gn - gk) - uses k_precond for write/h update
     """
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T

--- a/fla/ops/precond_kda/wy_fast.py
+++ b/fla/ops/precond_kda/wy_fast.py
@@ -69,56 +69,62 @@ def recompute_w_u_fwd_kernel(
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_b = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_b = tl.load(beta + bos*H + i_h + o_t*H, mask=m_t, other=0.0)
+
+    o_A = tl.arange(0, BT)
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    b_A = tl.load(p_A, mask=m_t[:, None] & (o_A[None, :] < BT), other=0.0)
 
     # u computation (unchanged)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_u = u + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb, input_precision=DOT_PRECISION)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(u.dtype.element_ty), mask=m_tv)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_w = tl.make_block_ptr(w + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_tk = m_t[:, None] & m_k[None, :]
+        p_w = w + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
         # Use original k for w (read/correction)
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
         b_kb = b_k * b_b[:, None]
 
-        p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        p_gk = gk + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_gk = tl.load(p_gk, mask=m_tk, other=0.0)
         b_kb *= exp2(b_gk)
 
         if STORE_QG:
-            p_q = tl.make_block_ptr(q + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            p_qg = tl.make_block_ptr(qg + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            p_q = q + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+            p_qg = qg + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+            b_q = tl.load(p_q, mask=m_tk, other=0.0)
             b_qg = b_q * exp2(b_gk)
-            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_qg, b_qg.to(qg.dtype.element_ty), mask=m_tk)
 
         if STORE_KG:
             # Use k_precond for kg (write/h update) - ASYMMETRIC
-            p_kp = tl.make_block_ptr(k_precond + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            b_kp = tl.load(p_kp, boundary_check=(0, 1))
+            p_kp = k_precond + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+            b_kp = tl.load(p_kp, mask=m_tk, other=0.0)
 
             last_idx = min(i_t * BT + BT, T) - 1
-            o_k = i_k * BK + tl.arange(0, BK)
-            m_k = o_k < K
             b_gn = tl.load(gk + ((bos + last_idx) * H + i_h) * K + o_k, mask=m_k, other=0.)
             # kg uses k_precond, not original k
             b_kg = b_kp * tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], exp2(b_gn[None, :] - b_gk), 0)
-            p_kg = tl.make_block_ptr(kg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+            p_kg = kg + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+            tl.store(p_kg, b_kg.to(kg.dtype.element_ty), mask=m_tk)
 
         # w uses original k
         b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(w.dtype.element_ty), mask=m_tk)
 
 
 def recompute_w_u_fwd(

--- a/tests/models/test_modeling_precond_gated_deltanet.py
+++ b/tests/models/test_modeling_precond_gated_deltanet.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+# Copyright (c) 2023-2025
+# Tests for PrecondGatedDeltaNet model
+
+import pytest
+import torch
+
+from fla.layers.precond_gated_deltanet import PrecondGatedDeltaNet
+from fla.models import PrecondGatedDeltaNetConfig
+from fla.utils import device
+
+from .test_modeling_base import run_test_generation, run_test_model_forward_backward
+
+
+# ===================================================================================
+# Model-level Tests (Forward/Backward Pass)
+# ===================================================================================
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'use_l2warp', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-use_l2warp{}-{}".format(*test))
+        for test in [
+            (4, 4, 1024, 4, 64, True, torch.bfloat16),
+            (4, 4, 1024, 4, 64, False, torch.bfloat16),
+        ]
+    ],
+)
+def test_modeling(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    use_l2warp: bool,
+    dtype: torch.dtype,
+):
+    run_test_model_forward_backward(L, B, T, H, D, PrecondGatedDeltaNetConfig, use_l2warp=use_l2warp, dtype=dtype)
+
+
+# ===================================================================================
+# Model-level Tests (Generation)
+# ===================================================================================
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 4, 2000, 8, 64, torch.float16),
+        ]
+    ],
+)
+def test_generation(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    run_test_generation(L, B, T, H, D, PrecondGatedDeltaNetConfig, dtype)
+
+
+# ===================================================================================
+# Layer-level Tests
+# ===================================================================================
+@pytest.mark.parametrize(
+    ['B', 'T', 'H', 'D', 'dtype'],
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 256, 4, 64, torch.bfloat16),
+            (2, 512, 4, 64, torch.bfloat16),
+        ]
+    ],
+)
+def test_layer(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    """Test that the layer works with forward and backward passes."""
+    hidden_size = H * D
+
+    layer = PrecondGatedDeltaNet(
+        hidden_size=hidden_size,
+        num_heads=H,
+        head_dim=D,
+        expand_v=1,
+        mode='chunk',
+    ).to(device).to(dtype)
+
+    # Forward pass
+    hidden_states = torch.randn(B, T, hidden_size, dtype=dtype, device=device, requires_grad=True)
+    output, _, _ = layer(hidden_states)
+
+    assert output.shape == hidden_states.shape, f"Output shape mismatch: {output.shape} vs {hidden_states.shape}"
+
+    # Backward pass
+    loss = output.sum()
+    loss.backward()
+
+    assert hidden_states.grad is not None, "hidden_states.grad is None"
+    assert hidden_states.grad.shape == hidden_states.shape
+
+    # Check that ATK parameters have gradients
+    assert layer.a_atk_proj.weight.grad is not None, "a_atk_proj.weight.grad is None"
+    assert layer.b_atk_proj.weight.grad is not None, "b_atk_proj.weight.grad is None"
+    assert layer.A_log_atk.grad is not None, "A_log_atk.grad is None"
+    assert layer.dt_bias_atk.grad is not None, "dt_bias_atk.grad is None"

--- a/tests/models/test_modeling_precond_kda.py
+++ b/tests/models/test_modeling_precond_kda.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.models import PrecondKDAConfig
+
+from .test_modeling_base import run_test_generation, run_test_model_forward_backward
+
+
+# ===================================================================================
+# Test for Modeling (Forward/Backward Pass)
+# ===================================================================================
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (4, 4, 1024, 4, 64, torch.bfloat16),
+        ]
+    ],
+)
+def test_modeling(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    run_test_model_forward_backward(L, B, T, H, D, PrecondKDAConfig, use_l2warp=False, dtype=dtype)
+
+
+# ===================================================================================
+# Test for Generation
+# ===================================================================================
+@pytest.mark.parametrize(
+    ['L', 'B', 'T', 'H', 'D', 'dtype'],
+    [
+        pytest.param(*test, id="L{}-B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 4, 2000, 8, 64, torch.float16),
+        ]
+    ],
+)
+def test_generation(
+    L: int,
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    run_test_generation(L, B, T, H, D, PrecondKDAConfig, dtype)

--- a/tests/ops/test_precond_gated_delta.py
+++ b/tests/ops/test_precond_gated_delta.py
@@ -1,0 +1,596 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+# Tests for preconditioned gated delta rule kernel
+
+import os
+
+import pytest
+import torch
+import torch.nn.functional as F
+from einops import repeat
+
+from fla.ops.precond_gated_delta_rule import (
+    chunk_precond_gated_delta_rule,
+    fused_recurrent_precond_gated_delta_rule,
+)
+from fla.ops.precond_gated_delta_rule.naive import naive_recurrent_precond_gated_delta_rule
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HV', 'D', 'gate_logit_normalizer', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HV{}-D{}-gln{}-{}".format(*test))
+        for test in [
+            (1, 63, 1, 1, 64, 1, torch.float),
+            (2, 500, 4, 4, 60, 1, torch.float),
+            (2, 1000, 2, 8, 128, 0.1, torch.float),
+            (3, 1024, 2, 2, 128, 1, torch.float),
+            (4, 1024, 3, 3, 128, 10, torch.float),
+            (4, 2048, 4, 4, 64, 1, torch.float),
+            (2, 1024, 4, 4, 128, 0.1, torch.float16),
+            (2, 1024, 4, 8, 128, 10, torch.float16),
+        ]
+    ],
+)
+def test_fused_recurrent(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    x = 1.5
+
+    q = torch.randn(B, T, H, D, dtype=torch.float32)
+    k = torch.randn(B, T, H, D, dtype=torch.float32)
+    v = torch.randn(B, T, HV, D, dtype=dtype)
+    beta_atk = torch.rand(B, T, HV, dtype=dtype).sigmoid()
+    beta = torch.rand(B, T, HV, dtype=dtype).sigmoid()
+    g_atk = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32)) / gate_logit_normalizer
+    g = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32)) / gate_logit_normalizer
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
+    A0 = torch.zeros(B, HV, D, dtype=torch.float32)
+
+    log_atk_scale = torch.rand(HV, dtype=torch.float32) - 1.0
+
+    q, k, v, beta_atk, beta, g_atk, g, h0, A0, log_atk_scale = map(
+        lambda t: t.to(device).requires_grad_(False),
+        (q, k, v, beta_atk, beta, g_atk, g, h0, A0, log_atk_scale)
+    )
+
+    # Reference implementation: manually L2 normalize + repeat q/k to HV heads
+    ref, ref_ht, _ = naive_recurrent_precond_gated_delta_rule(
+        q=F.normalize(repeat(q.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1).to(dtype),
+        k=F.normalize(repeat(k.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1).to(dtype),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+        initial_state=h0.clone(),
+        initial_A_state=A0.clone(),
+        output_final_state=True,
+    )
+
+    # Kernel implementation: L2 norm done inside kernel
+    tri, tri_ht, _ = fused_recurrent_precond_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        initial_state=h0.clone(),
+        initial_A_state=A0.clone(),
+        use_qk_l2norm_in_kernel=True,
+        output_final_state=True,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    assert_close('o', ref, tri, 0.002)
+    assert_close('ht', ref_ht, tri_ht, 0.002)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-D{}-scale{}-gln{}-mask_p{}-qk_l2norm{}-{}".format(*test),
+        )
+        for test in [
+            (2, 75, 4, 64, 1, 0.01, 0, False, torch.float16),
+            (2, 500, 3, 60, 1, 1, 0, False, torch.float16),
+            (2, 1000, 3, 64, 0.1, 1, 0.5, False, torch.float16),
+            (3, 1024, 4, 100, 1, 0.1, 0, False, torch.float16),
+            (4, 1024, 4, 128, 0.1, 1, 0, False, torch.float16),
+            (4, 1024, 4, 128, 0.1, 1, 0, True, torch.float16),
+            (2, 1500, 4, 128, 0.1, 10, 0, False, torch.float16),
+            (4, 2048, 8, 64, 0.1, 1, 0, False, torch.float16),
+        ]
+    ],
+)
+def test_chunk(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    mask_p: float,
+    use_qk_l2norm_in_kernel: bool,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    x = 1.5
+
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, H, D, dtype=dtype)
+    beta_atk = torch.rand(B, T, H, dtype=torch.float).sigmoid()
+    beta = torch.rand(B, T, H, dtype=torch.float).sigmoid()
+    g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    g_atk = g_atk / gate_logit_normalizer
+    g_atk = g_atk * (torch.rand_like(g_atk) > mask_p)
+    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    g = g / gate_logit_normalizer
+    g = g * (torch.rand_like(g) > mask_p)
+    h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
+
+    log_atk_scale = torch.rand(H, dtype=torch.float32) - 1.0
+
+    q, k, v, beta_atk, beta, g_atk, g, h0 = map(
+        lambda t: t.to(device).requires_grad_(True),
+        (q, k, v, beta_atk, beta, g_atk, g, h0)
+    )
+    log_atk_scale = log_atk_scale.to(device).requires_grad_(True)
+
+    tri, tri_ht_h, _ = chunk_precond_gated_delta_rule(
+        q=q.clone() if use_qk_l2norm_in_kernel else F.normalize(q.clone(), p=2, dim=-1),
+        k=k.clone() if use_qk_l2norm_in_kernel else F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        log_atk_scale=log_atk_scale.clone(),
+        x=x,
+    )
+
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+    ((tri * do).sum() + (tri_ht_h * dht).sum()).backward(retain_graph=True)
+
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dbeta_atk, tri_dbeta = beta_atk.grad, beta.grad
+    tri_dg_atk, tri_dg = g_atk.grad, g.grad
+    tri_dh0 = h0.grad
+    tri_d_log_atk_scale = log_atk_scale.grad
+
+    q.grad = k.grad = v.grad = beta_atk.grad = beta.grad = None
+    g_atk.grad = g.grad = h0.grad = None
+    log_atk_scale.grad = None
+
+    ref, ref_ht, _ = naive_recurrent_precond_gated_delta_rule(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+    )
+
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
+
+    ref_dq, ref_dk, ref_dv = q.grad, k.grad, v.grad
+    ref_dbeta_atk, ref_dbeta = beta_atk.grad, beta.grad
+    ref_dg_atk, ref_dg = g_atk.grad, g.grad
+    ref_dh0 = h0.grad
+    ref_d_log_atk_scale = log_atk_scale.grad
+
+    assert_close('o', ref, tri, 0.005)
+    assert_close('ht', ref_ht, tri_ht_h, 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.008)
+    assert_close('dk', ref_dk, tri_dk, 0.008)
+    assert_close('dv', ref_dv, tri_dv, 0.008)
+    assert_close('dbeta_atk', ref_dbeta_atk, tri_dbeta_atk, 0.02)
+    assert_close('dg_atk', ref_dg_atk, tri_dg_atk, 0.02)
+    assert_close('dbeta', ref_dbeta, tri_dbeta, 0.02)
+    assert_close('dg', ref_dg, tri_dg, 0.02)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.008)
+    assert_close('d_log_atk_scale', ref_d_log_atk_scale, tri_d_log_atk_scale, 0.02)
+
+
+@pytest.mark.parametrize(
+    ('H', 'D', 'mask_p', 'cu_seqlens'),
+    [
+        pytest.param(*test, id=f"H{test[0]}-D{test[1]}-mask{test[2]}-seqs{len(test[3])-1}")
+        for test in [
+            (4, 60, 0, [0, 15]),
+            (4, 64, 0, [0, 256, 500, 1000]),
+            (4, 64, 0.5, [0, 256, 500, 1000]),
+            (4, 100, 0, [0, 15, 100, 300, 1200, 2000]),
+        ]
+    ],
+)
+def test_chunk_varlen(
+    H: int,
+    D: int,
+    mask_p: float,
+    cu_seqlens: list[int],
+):
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    dtype = torch.float16
+    x = 1.5
+
+    cu_seqlens_t = torch.LongTensor(cu_seqlens).to(device)
+    T = cu_seqlens[-1]
+    N = len(cu_seqlens) - 1
+
+    q = torch.rand((1, T, H, D), dtype=dtype)
+    k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
+    v = torch.rand((1, T, H, D), dtype=dtype)
+    beta_atk = torch.rand(1, T, H, dtype=dtype).sigmoid()
+    beta = torch.rand(1, T, H, dtype=dtype).sigmoid()
+    g_atk = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32)) * 0.5
+    g_atk = g_atk * (torch.rand_like(g_atk) > mask_p)
+    g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32)) * 0.5
+    g = g * (torch.rand_like(g) > mask_p)
+    h0 = torch.zeros((N, H, D, D), dtype=torch.float32)
+
+    log_atk_scale = torch.rand(H, dtype=torch.float32) - 1.0
+
+    q, k, v, beta_atk, beta, g_atk, g, h0 = map(
+        lambda t: t.to(device).requires_grad_(True),
+        (q, k, v, beta_atk, beta, g_atk, g, h0)
+    )
+    log_atk_scale = log_atk_scale.to(device).requires_grad_(True)
+
+    do = torch.randn_like(v)
+    dht = torch.rand_like(h0)
+
+    # Kernel forward
+    tri, tri_ht_h, _ = chunk_precond_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens_t,
+        log_atk_scale=log_atk_scale.clone(),
+        x=x,
+    )
+
+    # Backward
+    ((tri * do).sum() + (tri_ht_h * dht).sum()).backward(retain_graph=True)
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dbeta_atk, tri_dbeta = beta_atk.grad, beta.grad
+    tri_dg_atk, tri_dg = g_atk.grad, g.grad
+    tri_dh0 = h0.grad
+    tri_d_log_atk_scale = log_atk_scale.grad
+
+    # Clear gradients
+    q.grad = k.grad = v.grad = beta_atk.grad = beta.grad = None
+    g_atk.grad = g.grad = h0.grad = None
+    log_atk_scale.grad = None
+
+    # Reference: process each segment separately
+    ref_list = []
+    ref_ht_list = []
+    for i in range(N):
+        start, end = cu_seqlens[i], cu_seqlens[i + 1]
+        ref_i, ref_ht_i, _ = naive_recurrent_precond_gated_delta_rule(
+            q=q[:, start:end],
+            k=k[:, start:end],
+            v=v[:, start:end],
+            g_atk=g_atk[:, start:end],
+            g=g[:, start:end],
+            beta_atk=beta_atk[:, start:end],
+            beta=beta[:, start:end],
+            x=x,
+            log_atk_scale=log_atk_scale.clone(),
+            initial_state=h0[i],
+            output_final_state=True,
+        )
+        ref_list.append(ref_i)
+        ref_ht_list.append(ref_ht_i)
+
+    ref = torch.cat(ref_list, 1)
+    ref_ht = torch.cat(ref_ht_list, 0)
+
+    # Reference backward
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
+    ref_dq, ref_dk, ref_dv = q.grad, k.grad, v.grad
+    ref_dbeta_atk, ref_dbeta = beta_atk.grad, beta.grad
+    ref_dg_atk, ref_dg = g_atk.grad, g.grad
+    ref_dh0 = h0.grad
+    ref_d_log_atk_scale = log_atk_scale.grad
+
+    # Assertions
+    assert_close('o', ref, tri, 0.005)
+    assert_close('ht', ref_ht, tri_ht_h, 0.005)
+    assert_close('dq', ref_dq, tri_dq, 0.007)
+    assert_close('dk', ref_dk, tri_dk, 0.008)
+    assert_close('dv', ref_dv, tri_dv, 0.007)
+    assert_close('dbeta_atk', ref_dbeta_atk, tri_dbeta_atk, 0.015)
+    assert_close('dg_atk', ref_dg_atk, tri_dg_atk, 0.015)
+    assert_close('dbeta', ref_dbeta, tri_dbeta, 0.015)
+    assert_close('dg', ref_dg, tri_dg, 0.015)
+    assert_close('dh0', ref_dh0, tri_dh0, 0.007)
+    assert_close('d_log_atk_scale', ref_d_log_atk_scale, tri_d_log_atk_scale, 0.02)
+
+
+@pytest.mark.parametrize(
+    ('H', 'D', 'mask_p', 'cu_seqlens', 'dtype'),
+    [pytest.param(*test, id=f"H{test[0]}-D{test[1]}-mask{test[2]}-seqs{len(test[3]) - 1}-{test[4]}")
+     for test in [
+         (4, 60, 0, [0, 8192], torch.float16),
+         (4, 60, 0, [0, 15], torch.float16),
+         (4, 64, 0, [0, 256, 500, 1000], torch.float16),
+         (4, 64, 0.5, [0, 256, 500, 1000], torch.float16),
+         (4, 100, 0, [0, 15, 100, 300, 1200, 2000], torch.float16),
+    ]],
+)
+@torch.inference_mode()
+def test_chunk_varlen_prefill(
+    H: int,
+    D: int,
+    mask_p: float,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    x = 1.5
+
+    cu_seqlens_t = torch.LongTensor(cu_seqlens).to(device)
+    T = cu_seqlens[-1]
+    N = len(cu_seqlens) - 1
+
+    q = torch.randn((1, T, H, D), dtype=dtype).to(device)
+    k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype).to(device)
+    v = torch.randn((1, T, H, D), dtype=dtype).to(device)
+    beta_atk = torch.rand(1, T, H, dtype=dtype).sigmoid().to(device)
+    beta = torch.rand(1, T, H, dtype=dtype).sigmoid().to(device)
+    g_atk = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32)).to(device) * 0.5
+    g_atk = g_atk * (torch.rand_like(g_atk) > mask_p)
+    g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32)).to(device) * 0.5
+    g = g * (torch.rand_like(g) > mask_p)
+    h0 = torch.randn((N, H, D, D), dtype=torch.float32).to(device)
+    log_atk_scale = (torch.rand(H, dtype=torch.float32) - 1.0).to(device)
+
+    tri, tri_ht, _ = chunk_precond_gated_delta_rule(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens_t,
+        log_atk_scale=log_atk_scale.clone(),
+        x=x,
+    )
+
+    ref_list = []
+    ref_ht_list = []
+    for i in range(N):
+        start, end = cu_seqlens[i], cu_seqlens[i + 1]
+        ref_i, ref_ht_i, _ = naive_recurrent_precond_gated_delta_rule(
+            q=q[:, start:end],
+            k=k[:, start:end],
+            v=v[:, start:end],
+            g_atk=g_atk[:, start:end],
+            g=g[:, start:end],
+            beta_atk=beta_atk[:, start:end],
+            beta=beta[:, start:end],
+            x=x,
+            log_atk_scale=log_atk_scale.clone(),
+            initial_state=h0[i],
+            output_final_state=True,
+        )
+        ref_list.append(ref_i)
+        ref_ht_list.append(ref_ht_i)
+
+    ref = torch.cat(ref_list, 1)
+    ref_ht = torch.cat(ref_ht_list, 0)
+
+    assert_close('o', ref, tri, 0.005)
+    assert_close('ht', ref_ht, tri_ht, 0.005)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'scale', 'gate_logit_normalizer', 'dtype'),
+    [pytest.param(*test, id="B{}-T{}-H{}-D{}-scale{}-gln{}-{}".format(*test))
+     for test in [
+         (1, 63, 1, 64, 1, 1, torch.float16),
+         (2, 500, 3, 60, 1, 1, torch.float16),
+         (3, 1024, 4, 128, 0.1, 1, torch.float16),
+         (4, 2048, 8, 64, 0.1, 1, torch.float16),
+    ]],
+)
+def test_chunk_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    x = 1.5
+
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, H, D, dtype=dtype)
+    beta_atk = torch.rand(B, T, H, dtype=dtype).sigmoid()
+    beta = torch.rand(B, T, H, dtype=dtype).sigmoid()
+    g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32)) / gate_logit_normalizer
+    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32)) / gate_logit_normalizer
+    log_atk_scale = torch.rand(H, dtype=torch.float32) - 1.0
+    # Non-zero initial state to exercise the transpose load path
+    h0_kv = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+
+    q, k, v, beta_atk, beta, g_atk, g, log_atk_scale, h0_kv, h0_vk = map(
+        lambda t: t.to(device).requires_grad_(True),
+        (q, k, v, beta_atk, beta, g_atk, g, log_atk_scale, h0_kv, h0_vk)
+    )
+
+    do = torch.randn_like(v)
+    dht_vk = torch.randn(B, H, D, D, dtype=torch.float32, device=device)
+    dht_kv = dht_vk.transpose(-1, -2).contiguous()
+
+    # transposed layout
+    tri, tri_ht, _ = chunk_precond_gated_delta_rule(
+        q=q.clone(), k=k.clone(), v=v.clone(),
+        g_atk=g_atk.clone(), g=g.clone(),
+        beta_atk=beta_atk.clone(), beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_vk.clone(),
+        output_final_state=True,
+        log_atk_scale=log_atk_scale.clone(),
+        x=x,
+        transpose_state_layout=True,
+    )
+    ((tri * do).sum() + (tri_ht * dht_vk).sum()).backward(retain_graph=True)
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dbeta_atk, tri_dbeta = beta_atk.grad, beta.grad
+    tri_dg_atk, tri_dg = g_atk.grad, g.grad
+    tri_d_log_atk_scale = log_atk_scale.grad
+    tri_dh0 = h0_vk.grad
+    q.grad = k.grad = v.grad = beta_atk.grad = beta.grad = None
+    g_atk.grad = g.grad = log_atk_scale.grad = h0_vk.grad = None
+
+    # standard layout (reference)
+    ref, ref_ht, _ = chunk_precond_gated_delta_rule(
+        q=q.clone(), k=k.clone(), v=v.clone(),
+        g_atk=g_atk.clone(), g=g.clone(),
+        beta_atk=beta_atk.clone(), beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_kv.clone(),
+        output_final_state=True,
+        log_atk_scale=log_atk_scale.clone(),
+        x=x,
+        transpose_state_layout=False,
+    )
+    ((ref * do).sum() + (ref_ht * dht_kv).sum()).backward(retain_graph=True)
+    ref_dq, ref_dk, ref_dv = q.grad, k.grad, v.grad
+    ref_dbeta_atk, ref_dbeta = beta_atk.grad, beta.grad
+    ref_dg_atk, ref_dg = g_atk.grad, g.grad
+    ref_d_log_atk_scale = log_atk_scale.grad
+    ref_dh0 = h0_kv.grad
+
+    # Tolerance is 1e-3 rather than 1e-4 (upstream GDN uses 1e-4). The transposed and
+    # non-transposed code paths exercise different tile orderings in the chunk backward,
+    # and fp16 accumulation in the ATK-extended reductions amplifies tiny per-tile rounding
+    # differences that upstream GDN's simpler backward avoids. Observed worst ratios under
+    # 1e-4 are ~6.6e-4 (dh0) and ~2e-4 (dg); 1e-3 gives headroom.
+    assert_close('o', ref, tri, 1e-3)
+    assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 1e-3)
+    assert_close('dq', ref_dq, tri_dq, 1e-3)
+    assert_close('dk', ref_dk, tri_dk, 1e-3)
+    assert_close('dv', ref_dv, tri_dv, 1e-3)
+    assert_close('dbeta_atk', ref_dbeta_atk, tri_dbeta_atk, 1e-3)
+    assert_close('dbeta', ref_dbeta, tri_dbeta, 1e-3)
+    assert_close('dg_atk', ref_dg_atk, tri_dg_atk, 1e-3)
+    assert_close('dg', ref_dg, tri_dg, 1e-3)
+    assert_close('d_log_atk_scale', ref_d_log_atk_scale, tri_d_log_atk_scale, 1e-3)
+    assert_close('dh0', ref_dh0, tri_dh0.transpose(-1, -2), 1e-3)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'gate_logit_normalizer', 'dtype'),
+    [pytest.param(*test, id="B{}-T{}-H{}-D{}-gln{}-{}".format(*test))
+     for test in [
+         (1, 63, 1, 64, 1, torch.float32),
+         (2, 500, 4, 60, 1, torch.float32),
+         (2, 1000, 2, 128, 0.1, torch.float32),
+         (3, 1024, 2, 128, 1, torch.float32),
+    ]],
+)
+def test_fused_recurrent_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    x = 1.5
+
+    q = torch.randn(B, T, H, D, dtype=dtype)
+    k = torch.randn(B, T, H, D, dtype=dtype)
+    v = torch.randn(B, T, H, D, dtype=dtype)
+    beta_atk = torch.rand(B, T, H, dtype=dtype).sigmoid()
+    beta = torch.rand(B, T, H, dtype=dtype).sigmoid()
+    g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32)) / gate_logit_normalizer
+    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32)) / gate_logit_normalizer
+    log_atk_scale = torch.rand(H, dtype=torch.float32) - 1.0
+    h0_kv = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+    A0 = torch.zeros(B, H, D, dtype=torch.float32)
+
+    q, k, v, beta_atk, beta, g_atk, g, log_atk_scale, h0_kv, h0_vk, A0 = map(
+        lambda t: t.to(device).requires_grad_(False),
+        (q, k, v, beta_atk, beta, g_atk, g, log_atk_scale, h0_kv, h0_vk, A0)
+    )
+
+    ref, ref_ht, _ = fused_recurrent_precond_gated_delta_rule(
+        q=q.clone(), k=k.clone(), v=v.clone(),
+        g_atk=g_atk.clone(), g=g.clone(),
+        beta_atk=beta_atk.clone(), beta=beta.clone(),
+        initial_state=h0_kv.clone(),
+        initial_A_state=A0.clone(),
+        output_final_state=True,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+        transpose_state_layout=False,
+    )
+
+    tri, tri_ht, _ = fused_recurrent_precond_gated_delta_rule(
+        q=q.clone(), k=k.clone(), v=v.clone(),
+        g_atk=g_atk.clone(), g=g.clone(),
+        beta_atk=beta_atk.clone(), beta=beta.clone(),
+        initial_state=h0_vk.clone(),
+        initial_A_state=A0.clone(),
+        output_final_state=True,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+        transpose_state_layout=True,
+    )
+
+    assert_close('o', ref, tri, 1e-4)
+    assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 1e-4)

--- a/tests/ops/test_precond_gated_delta.py
+++ b/tests/ops/test_precond_gated_delta.py
@@ -12,7 +12,6 @@ import os
 import pytest
 import torch
 import torch.nn.functional as F
-from einops import repeat
 
 from fla.ops.precond_gated_delta_rule import (
     chunk_precond_gated_delta_rule,
@@ -53,24 +52,26 @@ def test_fused_recurrent(
     q = torch.randn(B, T, H, D, dtype=torch.float32)
     k = torch.randn(B, T, H, D, dtype=torch.float32)
     v = torch.randn(B, T, HV, D, dtype=dtype)
-    beta_atk = torch.rand(B, T, HV, dtype=dtype).sigmoid()
+    # ATK preconditions the keys: all ATK-side tensors carry H (key) heads
+    beta_atk = torch.rand(B, T, H, dtype=dtype).sigmoid()
     beta = torch.rand(B, T, HV, dtype=dtype).sigmoid()
-    g_atk = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32)) / gate_logit_normalizer
+    g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32)) / gate_logit_normalizer
     g = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32)) / gate_logit_normalizer
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
-    A0 = torch.zeros(B, HV, D, dtype=torch.float32)
+    A0 = torch.zeros(B, H, D, dtype=torch.float32)
 
-    log_atk_scale = torch.rand(HV, dtype=torch.float32) - 1.0
+    log_atk_scale = torch.rand(H, dtype=torch.float32) - 1.0
 
     q, k, v, beta_atk, beta, g_atk, g, h0, A0, log_atk_scale = map(
         lambda t: t.to(device).requires_grad_(False),
         (q, k, v, beta_atk, beta, g_atk, g, h0, A0, log_atk_scale)
     )
 
-    # Reference implementation: manually L2 normalize + repeat q/k to HV heads
+    # Reference implementation: manually L2 normalize; the naive reference
+    # applies the GVA repeat internally when HV > H
     ref, ref_ht, _ = naive_recurrent_precond_gated_delta_rule(
-        q=F.normalize(repeat(q.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1).to(dtype),
-        k=F.normalize(repeat(k.clone(), 'b t h d -> b t (h g) d', g=HV // H), p=2, dim=-1).to(dtype),
+        q=F.normalize(q.clone(), p=2, dim=-1).to(dtype),
+        k=F.normalize(k.clone(), p=2, dim=-1).to(dtype),
         v=v.clone(),
         g_atk=g_atk.clone(),
         g=g.clone(),
@@ -594,3 +595,208 @@ def test_fused_recurrent_transpose_state(
 
     assert_close('o', ref, tri, 1e-4)
     assert_close('ht', ref_ht, tri_ht.transpose(-1, -2), 1e-4)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HV', 'D', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HV{}-D{}-{}".format(*test))
+        for test in [
+            (2, 500, 2, 4, 64, torch.float16),
+            (2, 1024, 2, 8, 128, torch.float16),
+            (3, 1000, 4, 8, 100, torch.float16),
+        ]
+    ],
+)
+def test_chunk_gva(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    """GVA (HV > H): chunk kernel against the naive reference, forward and backward."""
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    x = 1.5
+    scale = D ** -0.5
+
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, HV, D, dtype=dtype)
+    # ATK preconditions the keys: all ATK-side tensors carry H (key) heads
+    beta_atk = torch.rand(B, T, H, dtype=torch.float).sigmoid()
+    beta = torch.rand(B, T, HV, dtype=torch.float).sigmoid()
+    g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    g = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32))
+    h0 = torch.zeros(B, HV, D, D, dtype=torch.float32)
+    log_atk_scale = torch.rand(H, dtype=torch.float32) - 1.0
+
+    q, k, v, beta_atk, beta, g_atk, g, h0, log_atk_scale = map(
+        lambda t: t.to(device).requires_grad_(True),
+        (q, k, v, beta_atk, beta, g_atk, g, h0, log_atk_scale)
+    )
+
+    tri, tri_ht, _ = chunk_precond_gated_delta_rule(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
+
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dbeta_atk, tri_dbeta = beta_atk.grad, beta.grad
+    tri_dg_atk, tri_dg = g_atk.grad, g.grad
+    tri_dh0 = h0.grad
+    tri_d_log_atk_scale = log_atk_scale.grad
+
+    q.grad = k.grad = v.grad = beta_atk.grad = beta.grad = None
+    g_atk.grad = g.grad = h0.grad = None
+    log_atk_scale.grad = None
+
+    # the naive reference applies the GVA repeat internally when HV > H
+    ref, ref_ht, _ = naive_recurrent_precond_gated_delta_rule(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+    )
+
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
+
+    assert_close('o', ref, tri, 0.005)
+    assert_close('ht', ref_ht, tri_ht, 0.005)
+    assert_close('dq', q.grad, tri_dq, 0.008)
+    assert_close('dk', k.grad, tri_dk, 0.008)
+    assert_close('dv', v.grad, tri_dv, 0.008)
+    assert_close('dbeta_atk', beta_atk.grad, tri_dbeta_atk, 0.02)
+    assert_close('dg_atk', g_atk.grad, tri_dg_atk, 0.02)
+    assert_close('dbeta', beta.grad, tri_dbeta, 0.02)
+    assert_close('dg', g.grad, tri_dg, 0.02)
+    assert_close('dh0', h0.grad, tri_dh0, 0.008)
+    assert_close('d_log_atk_scale', log_atk_scale.grad, tri_d_log_atk_scale, 0.02)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (2, 500, 3, 64, torch.float16),
+            (2, 1024, 4, 128, torch.float16),
+        ]
+    ],
+)
+def test_chunk_A_state(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    """End-to-end A-state: nonzero initial_A_state, the returned `at` is asserted,
+    and the gradient flowing in through `at` (dat) is checked against the naive
+    reference together with `dh0_atk`."""
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    x = 1.5
+    scale = D ** -0.5
+
+    q = torch.rand(B, T, H, D, dtype=dtype)
+    k = torch.rand(B, T, H, D, dtype=dtype)
+    v = torch.rand(B, T, H, D, dtype=dtype)
+    beta_atk = torch.rand(B, T, H, dtype=torch.float).sigmoid()
+    beta = torch.rand(B, T, H, dtype=torch.float).sigmoid()
+    g_atk = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
+    A0 = torch.rand(B, H, D, dtype=torch.float32)
+    log_atk_scale = torch.rand(H, dtype=torch.float32) - 1.0
+
+    q, k, v, beta_atk, beta, g_atk, g, h0, A0, log_atk_scale = map(
+        lambda t: t.to(device).requires_grad_(True),
+        (q, k, v, beta_atk, beta, g_atk, g, h0, A0, log_atk_scale)
+    )
+
+    tri, tri_ht, tri_at = chunk_precond_gated_delta_rule(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        initial_A_state=A0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+    dat = torch.randn(B, H, D, dtype=torch.float32, device=device)
+    ((tri * do).sum() + (tri_ht * dht).sum() + (tri_at.float() * dat).sum()).backward(retain_graph=True)
+
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dbeta_atk, tri_dg_atk = beta_atk.grad, g_atk.grad
+    tri_dh0, tri_dA0 = h0.grad, A0.grad
+    tri_d_log_atk_scale = log_atk_scale.grad
+
+    q.grad = k.grad = v.grad = beta_atk.grad = beta.grad = None
+    g_atk.grad = g.grad = h0.grad = A0.grad = None
+    log_atk_scale.grad = None
+
+    ref, ref_ht, ref_at = naive_recurrent_precond_gated_delta_rule(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g_atk=g_atk.clone(),
+        g=g.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+        initial_state=h0.clone(),
+        initial_A_state=A0.clone(),
+        output_final_state=True,
+    )
+
+    ((ref * do).sum() + (ref_ht * dht).sum() + (ref_at.float() * dat).sum()).backward(retain_graph=True)
+
+    assert_close('o', ref, tri, 0.005)
+    assert_close('ht', ref_ht, tri_ht, 0.005)
+    assert_close('at', ref_at, tri_at, 0.005)
+    assert_close('dq', q.grad, tri_dq, 0.008)
+    assert_close('dk', k.grad, tri_dk, 0.008)
+    assert_close('dv', v.grad, tri_dv, 0.008)
+    assert_close('dbeta_atk', beta_atk.grad, tri_dbeta_atk, 0.02)
+    assert_close('dg_atk', g_atk.grad, tri_dg_atk, 0.02)
+    assert_close('dh0', h0.grad, tri_dh0, 0.008)
+    assert_close('dh0_atk', A0.grad, tri_dA0, 0.02)
+    assert_close('d_log_atk_scale', log_atk_scale.grad, tri_d_log_atk_scale, 0.02)

--- a/tests/ops/test_precond_kda.py
+++ b/tests/ops/test_precond_kda.py
@@ -1,0 +1,823 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from fla.ops.kda.gate import fused_kda_gate, naive_kda_gate
+from fla.ops.precond_kda import chunk_precond_kda, fused_recurrent_precond_kda
+from fla.ops.precond_kda.naive import naive_recurrent_precond_kda
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "K", "V", "scale", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-K{}-V{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
+        )
+        for test in [
+            (1, 64, 1, 64, 64, 1, 1, torch.float),
+            (2, 512, 3, 60, 60, 1, 1, torch.float),
+            (4, 1024, 4, 128, 128, 0.1, 1, torch.float),
+            (4, 1024, 4, 128, 128, 1, 10, torch.float),
+        ]
+    ],
+)
+def test_naive_chunk(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    """Test chunk forward pass against naive recurrent reference."""
+    torch.manual_seed(42)
+
+    q = torch.rand(B, T, H, K, dtype=dtype)
+    k = torch.rand(B, T, H, K, dtype=dtype)
+    v = torch.rand(B, T, H, V, dtype=dtype)
+    gk = F.logsigmoid(torch.randn(B, T, H, K, dtype=torch.float)) / gate_logit_normalizer
+    g_atk = F.logsigmoid(torch.randn(B, T, H, dtype=torch.float))
+    beta_atk = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32)
+    h0 = torch.randn(B, H, K, V, dtype=torch.float32)
+
+    q, k, v, gk, g_atk, beta_atk, beta, h0, log_atk_scale = map(
+        lambda x: x.to(device).requires_grad_(True) if x.requires_grad else x.to(device),
+        (q, k, v, gk, g_atk, beta_atk, beta, h0, log_atk_scale)
+    )
+    q, k, v, gk, g_atk, beta_atk, beta, h0 = map(
+        lambda x: x.requires_grad_(True),
+        (q, k, v, gk, g_atk, beta_atk, beta, h0)
+    )
+
+    ref, ref_ht, ref_at = naive_recurrent_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    tri, tri_ht, tri_at = chunk_precond_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    assert_close("o", ref, tri, 0.005)
+    if tri_ht is not None:
+        assert_close("ht", ref_ht, tri_ht, 0.005)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "K", "V", "scale", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-K{}-V{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
+        )
+        for test in [
+            (1, 64, 1, 64, 64, 1, 1, torch.float),
+            (2, 512, 3, 60, 60, 1, 1, torch.float),
+            (3, 1000, 4, 100, 100, 0.1, 1, torch.float),
+            (4, 1024, 4, 128, 128, 0.1, 1, torch.float),
+        ]
+    ],
+)
+def test_fused_recurrent(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    """Test fused_recurrent forward against naive recurrent reference."""
+    torch.manual_seed(42)
+
+    q = torch.rand(B, T, H, K, dtype=dtype)
+    k = torch.rand(B, T, H, K, dtype=dtype)
+    v = torch.rand(B, T, H, V, dtype=dtype)
+    gk = F.logsigmoid(torch.randn(B, T, H, K, dtype=torch.float)) / gate_logit_normalizer
+    g_atk = F.logsigmoid(torch.randn(B, T, H, dtype=torch.float))
+    beta_atk = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32)
+    h0 = torch.randn(B, H, K, V, dtype=torch.float32)
+
+    q, k, v, gk, g_atk, beta_atk, beta, log_atk_scale, h0 = map(
+        lambda x: x.to(device).requires_grad_(False),
+        (q, k, v, gk, g_atk, beta_atk, beta, log_atk_scale, h0)
+    )
+
+    ref, ref_ht, ref_at = naive_recurrent_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    tri, tri_ht, tri_at = fused_recurrent_precond_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    assert_close("o", ref, tri, 0.005)
+    if tri_ht is not None:
+        assert_close("ht", ref_ht, tri_ht, 0.005)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "K", "V", "scale", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-K{}-V{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
+        )
+        for test in [
+            (1, 64, 1, 64, 64, 1, 1, torch.float),
+            (2, 512, 3, 60, 60, 1, 1, torch.float),
+            (3, 1000, 4, 100, 100, 0.1, 1, torch.float),
+            (4, 1024, 4, 128, 128, 0.1, 1, torch.float),
+        ]
+    ],
+)
+def test_fused_recurrent_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    """Test fused_recurrent with transpose_state_layout=True vs False."""
+    torch.manual_seed(42)
+    q = torch.rand(B, T, H, K, dtype=dtype)
+    k = torch.rand(B, T, H, K, dtype=dtype)
+    v = torch.rand(B, T, H, V, dtype=dtype)
+    gk = F.logsigmoid(torch.randn(B, T, H, K, dtype=torch.float)) / gate_logit_normalizer
+    g_atk = F.logsigmoid(torch.randn(B, T, H, dtype=torch.float))
+    beta_atk = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32)
+    h0_kv = torch.randn(B, H, K, V, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+
+    q, k, v, gk, g_atk, beta_atk, beta, h0_kv, h0_vk, log_atk_scale = map(
+        lambda x: x.to(device),
+        (q, k, v, gk, g_atk, beta_atk, beta, h0_kv, h0_vk, log_atk_scale)
+    )
+
+    ref, ref_ht, _ = fused_recurrent_precond_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_kv.clone(),
+        output_final_state=True,
+        transpose_state_layout=False,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+    tri, tri_ht, _ = fused_recurrent_precond_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_vk.clone(),
+        output_final_state=True,
+        transpose_state_layout=True,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+    assert_close("o", ref, tri, 1e-4)
+    assert_close("ht", ref_ht, tri_ht.transpose(-1, -2), 1e-4)
+
+
+@pytest.mark.parametrize(
+    (
+        "B",
+        "T",
+        "H",
+        "K",
+        "V",
+        "scale",
+        "mask_p",
+        "use_qk_l2norm_in_kernel",
+        "use_gate_in_kernel",
+        "solve_tril_precision",
+        "dtype",
+    ),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-K{}-V{}-scale{}-mask_p{}-qk_l2norm{}-gate{}-solve_tril{}-{}".format(*test),
+        )
+        for test in [
+            (1, 63, 1, 64, 64, 1, 0, False, False, 'tf32x3', torch.float),
+            (2, 500, 3, 60, 60, 1, 0, False, False, 'tf32x3', torch.float16),
+            (2, 1000, 3, 64, 64, 0.1, 0.5, False, False, 'tf32', torch.float16),
+            (3, 1024, 4, 100, 100, 1, 0, False, False, 'tf32', torch.float16),
+            (4, 1024, 4, 128, 128, 0.1, 0, False, False, 'tf32x3', torch.float16),
+            (4, 1024, 4, 128, 128, 0.1, 0, True, False, 'tf32', torch.bfloat16),
+            (2, 1500, 4, 128, 128, 0.1, 0, False, True, 'tf32x3', torch.float16),
+            (4, 2048, 8, 64, 64, 0.1, 0, False, True, 'tf32', torch.float16),
+            # High masking + gate: mirrors the failing varlen config in non-varlen form
+            (2, 1000, 4, 64, 64, 0.1, 0.9, False, True, 'tf32x3', torch.float16),
+        ]
+    ],
+)
+def test_chunk(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    scale: float,
+    mask_p: float,
+    use_qk_l2norm_in_kernel: bool,
+    use_gate_in_kernel: bool,
+    solve_tril_precision: str,
+    dtype: torch.dtype,
+):
+    """Test chunk forward + backward against naive reference."""
+    torch.manual_seed(42)
+
+    q = torch.rand(B, T, H, K, dtype=dtype)
+    k = torch.rand(B, T, H, K, dtype=dtype)
+    v = torch.rand(B, T, H, V, dtype=dtype)
+    gk = torch.randn(B, T, H, K, dtype=torch.float if not use_gate_in_kernel else dtype)
+    if use_gate_in_kernel:
+        A_log = torch.randn(H, dtype=torch.float)
+        dt_bias = torch.randn(H * K, dtype=torch.float)
+        if mask_p > 0:
+            # Mask gk to -1000 for strong decay (matches varlen test behavior for gate_in_kernel=True)
+            mask = torch.rand_like(gk) > mask_p
+            gk = gk * mask + (~mask).float() * (-1000)
+    else:
+        gk = F.logsigmoid(gk)
+        gk = gk * (torch.rand_like(gk) > mask_p)
+    g_atk = F.logsigmoid(torch.randn(B, T, H, dtype=torch.float))
+    beta_atk = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32)
+    h0 = torch.randn(B, H, K, V, dtype=torch.float32)
+
+    if use_gate_in_kernel:
+        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
+    q, k, v, gk, g_atk, beta_atk, beta, h0, log_atk_scale = map(
+        lambda x: x.to(device).requires_grad_(True),
+        (q, k, v, gk, g_atk, beta_atk, beta, h0, log_atk_scale)
+    )
+
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    # Naive reference: manually L2 normalize q, k
+    ref, ref_ht, ref_at = naive_recurrent_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=(naive_kda_gate(gk, A_log, dt_bias) if use_gate_in_kernel else gk.clone()),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
+    if use_gate_in_kernel:
+        ref_dA, A_log.grad = A_log.grad, None
+        ref_dbias, dt_bias.grad = dt_bias.grad, None
+    ref_dq, ref_dk, ref_dv = q.grad, k.grad, v.grad
+    ref_dg, ref_dg_atk = gk.grad, g_atk.grad
+    ref_dbeta_atk, ref_dbeta = beta_atk.grad, beta.grad
+    ref_dlog_atk_scale = log_atk_scale.grad
+    ref_dh0 = h0.grad
+    q.grad = k.grad = v.grad = gk.grad = g_atk.grad = None
+    beta_atk.grad = beta.grad = h0.grad = log_atk_scale.grad = None
+
+    tri, tri_ht, tri_at = chunk_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone(),
+        k=F.normalize(k.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        A_log=(A_log.clone() if use_gate_in_kernel else None),
+        dt_bias=(dt_bias.clone() if use_gate_in_kernel else None),
+        scale=scale,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_gate_in_kernel=use_gate_in_kernel,
+        solve_tril_precision=solve_tril_precision,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
+    if use_gate_in_kernel:
+        tri_dA, A_log.grad = A_log.grad, None
+        tri_dbias, dt_bias.grad = dt_bias.grad, None
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dg, tri_dg_atk = gk.grad, g_atk.grad
+    tri_dbeta_atk, tri_dbeta = beta_atk.grad, beta.grad
+    tri_dlog_atk_scale = log_atk_scale.grad
+    tri_dh0 = h0.grad
+
+    assert_close("o", ref, tri, 0.005)
+    assert_close("ht", ref_ht, tri_ht, 0.005)
+    assert_close("dq", ref_dq, tri_dq, 0.008)
+    assert_close("dk", ref_dk, tri_dk, 0.008)
+    assert_close("dv", ref_dv, tri_dv, 0.008)
+    assert_close("dg", ref_dg, tri_dg, 0.02)
+    assert_close("dg_atk", ref_dg_atk, tri_dg_atk, 0.02)
+    assert_close("dbeta_atk", ref_dbeta_atk, tri_dbeta_atk, 0.02)
+    assert_close("dbeta", ref_dbeta, tri_dbeta, 0.02)
+    if use_gate_in_kernel:
+        assert_close("dA", ref_dA, tri_dA, 0.003, warning=True)
+        assert_close("dbias", ref_dbias, tri_dbias, 0.008)
+    if tri_dlog_atk_scale is not None and ref_dlog_atk_scale is not None:
+        assert_close("dlog_atk_scale", ref_dlog_atk_scale, tri_dlog_atk_scale, 0.02)
+    assert_close("dh0", ref_dh0, tri_dh0, 0.008)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "K", "V", "scale", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-K{}-V{}-scale{}-gate_logit_normalizer{}-{}".format(*test),
+        )
+        for test in [
+            (1, 63, 1, 64, 64, 1, 1, torch.float16),
+            (2, 500, 3, 60, 60, 1, 1, torch.float16),
+            (3, 1024, 4, 128, 128, 0.1, 1, torch.float16),
+            (4, 2048, 8, 64, 64, 0.1, 1, torch.float16),
+        ]
+    ],
+)
+def test_chunk_transpose_state(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    scale: float,
+    gate_logit_normalizer: float,
+    dtype: torch.dtype,
+):
+    """Test chunk with transpose_state_layout=True vs False."""
+    torch.manual_seed(42)
+    q = torch.rand(B, T, H, K, dtype=dtype)
+    k = torch.rand(B, T, H, K, dtype=dtype)
+    v = torch.rand(B, T, H, V, dtype=dtype)
+    gk = F.logsigmoid(torch.randn(B, T, H, K, dtype=torch.float)) / gate_logit_normalizer
+    g_atk = F.logsigmoid(torch.randn(B, T, H, dtype=torch.float))
+    beta_atk = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    beta = torch.randn(B, T, H, dtype=dtype).sigmoid()
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32)
+    h0_kv = torch.randn(B, H, K, V, dtype=torch.float32)
+    h0_vk = h0_kv.transpose(-1, -2).contiguous()
+
+    q, k, v, gk, g_atk, beta_atk, beta, h0_kv, h0_vk, log_atk_scale = map(
+        lambda x: x.to(device).requires_grad_(True),
+        (q, k, v, gk, g_atk, beta_atk, beta, h0_kv, h0_vk, log_atk_scale)
+    )
+
+    do = torch.randn_like(v)
+    dht_vk = torch.randn(B, H, K, V, dtype=torch.float32, device=device)
+    dht_kv = dht_vk.transpose(-1, -2).contiguous()
+
+    tri, tri_ht, _ = chunk_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_vk.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        transpose_state_layout=True,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+    ((tri * do).sum() + (tri_ht * dht_vk).sum()).backward(retain_graph=True)
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dg, tri_dg_atk = gk.grad, g_atk.grad
+    tri_dbeta_atk, tri_dbeta = beta_atk.grad, beta.grad
+    tri_dh0 = h0_vk.grad
+    q.grad = k.grad = v.grad = gk.grad = g_atk.grad = None
+    beta_atk.grad = beta.grad = h0_vk.grad = log_atk_scale.grad = None
+
+    ref, ref_ht, _ = chunk_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0_kv.clone(),
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        transpose_state_layout=False,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+    ((ref * do).sum() + (ref_ht * dht_kv).sum()).backward(retain_graph=True)
+    ref_dq, ref_dk, ref_dv = q.grad, k.grad, v.grad
+    ref_dg, ref_dg_atk = gk.grad, g_atk.grad
+    ref_dbeta_atk, ref_dbeta = beta_atk.grad, beta.grad
+    ref_dh0 = h0_kv.grad
+
+    assert_close("o", ref, tri, 1e-4)
+    assert_close("ht", ref_ht, tri_ht.transpose(-1, -2), 1e-4)
+    assert_close("dq", ref_dq, tri_dq, 1e-4)
+    assert_close("dk", ref_dk, tri_dk, 1e-4)
+    assert_close("dv", ref_dv, tri_dv, 1e-4)
+    assert_close("dg", ref_dg, tri_dg, 1e-4)
+    assert_close("dg_atk", ref_dg_atk, tri_dg_atk, 1e-4)
+    assert_close("dbeta_atk", ref_dbeta_atk, tri_dbeta_atk, 1e-4)
+    assert_close("dbeta", ref_dbeta, tri_dbeta, 1e-4)
+    assert_close("dh0", ref_dh0, tri_dh0.transpose(-1, -2), 1e-4)
+
+
+@pytest.mark.parametrize(
+    ("H", "K", "V", "mask_p", "cu_seqlens", "dtype", "use_gate_in_kernel", "solve_tril_precision", "safe_gate", "disable_recompute"),
+    [
+        pytest.param(*test, id="H{}-K{}-V{}-mask_p{}-cu_seqlens{}-{}-gate{}-solve_tril{}-safe_gate{}-disable_recompute{}".format(*test))
+        for test in [
+            (4, 60, 60, 0.1, [0, 15], torch.float16, True, 'tf32x3', False, False),
+            (4, 64, 64, 0.9, [0, 256, 500, 1000], torch.float16, True, 'tf32', False, False),
+            (4, 128, 128, 0.5, [0, 256, 500, 1000], torch.float16, False, 'tf32x3', False, False),
+            (4, 100, 100, 0, [0, 15, 100, 300, 1200, 2000], torch.float16, True, 'tf32', False, False),
+            (4, 64, 64, 0, [0, 100, 300, 1200, 3000, 4096], torch.float16, False, 'tf32x3', True, True),
+        ]
+    ],
+)
+def test_chunk_varlen(
+    H: int,
+    K: int,
+    V: int,
+    mask_p: float,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+    use_gate_in_kernel: bool,
+    solve_tril_precision: str,
+    safe_gate: bool,
+    disable_recompute: bool,
+):
+    """Test chunk with variable length sequences."""
+    torch.manual_seed(42)
+    cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
+    T = cu_seqlens[-1]
+    N = len(cu_seqlens) - 1
+
+    q = torch.rand((1, T, H, K), dtype=dtype)
+    k = F.normalize(torch.randn(1, T, H, K, dtype=torch.float32), p=2, dim=-1).to(dtype)
+    v = torch.rand((1, T, H, V), dtype=dtype)
+    gk = torch.randn(1, T, H, K, dtype=torch.float if not use_gate_in_kernel else dtype)
+    if use_gate_in_kernel:
+        A_log = torch.log(torch.randn(1, 1, H, 1, dtype=torch.float32, device=device).uniform_(1, 16))
+        dt_bias = torch.randn(H * K, dtype=torch.float32, device=device)
+    else:
+        gk = F.logsigmoid(gk)
+        gk = gk * (torch.rand_like(gk) > mask_p)
+    mask = torch.rand_like(gk) > mask_p
+    gk = gk * mask + (~mask) * (-1000)
+    if safe_gate:
+        assert not use_gate_in_kernel
+        gk = gk.clamp(-5, 0)
+
+    g_atk = F.logsigmoid(torch.randn(1, T, H, dtype=torch.float))
+    beta_atk = torch.rand(1, T, H, dtype=dtype).sigmoid()
+    beta = torch.rand(1, T, H, dtype=dtype).sigmoid()
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32)
+    h0 = torch.randn((N, H, K, V), dtype=torch.float32)
+
+    q, k, v, gk, g_atk, beta_atk, beta, h0, log_atk_scale = map(
+        lambda x: x.to(device).requires_grad_(True),
+        (q, k, v, gk, g_atk, beta_atk, beta, h0, log_atk_scale)
+    )
+    if use_gate_in_kernel:
+        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(), (A_log, dt_bias))
+    do = torch.randn_like(v)
+    dht = torch.rand_like(h0)
+
+    tri, tri_ht, tri_at = chunk_precond_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        A_log=(A_log.clone() if use_gate_in_kernel else None),
+        dt_bias=(dt_bias.clone() if use_gate_in_kernel else None),
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_gate_in_kernel=use_gate_in_kernel,
+        safe_gate=safe_gate,
+        disable_recompute=disable_recompute,
+        solve_tril_precision=solve_tril_precision,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dg, tri_dg_atk = gk.grad, g_atk.grad
+    tri_dbeta_atk, tri_dbeta = beta_atk.grad, beta.grad
+    tri_dh0 = h0.grad
+    tri_dlog_atk_scale = log_atk_scale.grad
+    q.grad = k.grad = v.grad = gk.grad = g_atk.grad = None
+    beta_atk.grad = beta.grad = h0.grad = log_atk_scale.grad = None
+    if use_gate_in_kernel:
+        tri_dA, A_log.grad = A_log.grad, None
+        tri_dbias, dt_bias.grad = dt_bias.grad, None
+
+    ref = []
+    ref_ht = []
+    for i in range(N):
+        ref_i, ref_ht_i, ref_at_i = naive_recurrent_precond_kda(
+            q=F.normalize(q[:, cu_seqlens[i]: cu_seqlens[i + 1]], p=2, dim=-1),
+            k=F.normalize(k[:, cu_seqlens[i]: cu_seqlens[i + 1]], p=2, dim=-1),
+            v=v[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            g=(naive_kda_gate(
+                gk[:, cu_seqlens[i]: cu_seqlens[i + 1]].to(torch.float),
+                A_log.to(torch.float),
+                dt_bias.to(torch.float)
+            ) if use_gate_in_kernel else gk[:, cu_seqlens[i]: cu_seqlens[i + 1]]),
+            g_atk=g_atk[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            beta_atk=beta_atk[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            beta=beta[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            initial_state=h0[i],
+            output_final_state=True,
+            x=1.5,
+            log_atk_scale=log_atk_scale.clone(),
+        )
+        ref.append(ref_i)
+        ref_ht.append(ref_ht_i.squeeze(0))
+    ref = torch.cat(ref, 1)
+    ref_ht = torch.stack(ref_ht, 0)
+
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
+    ref_dq, ref_dk, ref_dv = q.grad, k.grad, v.grad
+    ref_dg, ref_dg_atk = gk.grad, g_atk.grad
+    ref_dbeta_atk, ref_dbeta = beta_atk.grad, beta.grad
+    ref_dh0 = h0.grad
+    ref_dlog_atk_scale = log_atk_scale.grad
+    if use_gate_in_kernel:
+        ref_dA, A_log.grad = A_log.grad, None
+        ref_dbias, dt_bias.grad = dt_bias.grad, None
+
+    assert_close("o", ref, tri, 0.005)
+    assert_close("ht", ref_ht, tri_ht, 0.005)
+    assert_close("dq", ref_dq, tri_dq, 0.007)
+    assert_close("dk", ref_dk, tri_dk, 0.008)
+    assert_close("dv", ref_dv, tri_dv, 0.007)
+    assert_close("dg", ref_dg, tri_dg, 0.015)
+    assert_close("dg_atk", ref_dg_atk, tri_dg_atk, 0.015)
+    assert_close("dbeta_atk", ref_dbeta_atk, tri_dbeta_atk, 0.015)
+    assert_close("dbeta", ref_dbeta, tri_dbeta, 0.015)
+    assert_close("dh0", ref_dh0, tri_dh0, 0.007)
+    if tri_dlog_atk_scale is not None and ref_dlog_atk_scale is not None:
+        assert_close("d_log_atk_scale", ref_dlog_atk_scale, tri_dlog_atk_scale, 0.02)
+    if use_gate_in_kernel:
+        # dA/dbias tolerance is looser than KDA (0.005) because the asymmetric k_precond
+        # backward (b_dk2 * k - b_dkt * k_precond vs KDA's (b_dk2 - b_dkt) * k) accumulates
+        # more fp16 rounding error under extreme masking with sparse gradient signal.
+        assert_close("dA", ref_dA, tri_dA, 0.025, warning=True)
+        assert_close("dbias", ref_dbias, tri_dbias, 0.02)
+
+
+@pytest.mark.parametrize(
+    ("H", "K", "V", "mask_p", "cu_seqlens", "dtype", "use_gate_in_kernel", "safe_gate", "disable_recompute"),
+    [
+        pytest.param(*test, id="H{}-K{}-V{}-mask_p{}-cu_seqlens{}-{}-gate{}-safe_gate{}-disable_recompute{}".format(*test))
+        for test in [
+            (4, 60, 60, 0.1, [0, 8192], torch.float16, True, False, False),
+            (4, 64, 64, 0.9, [0, 256, 500, 1000], torch.float16, True, False, False),
+            (4, 128, 128, 0.5, [0, 256, 500, 1000], torch.float16, False, False, False),
+            (4, 100, 100, 0, [0, 15, 100, 300, 1200, 2000], torch.float16, True, False, False),
+            (4, 64, 64, 0, [0, 100, 300, 1200, 3000, 4096], torch.float16, False, True, True),
+        ]
+    ],
+)
+@torch.inference_mode()
+def test_chunk_varlen_prefill(
+    H: int,
+    K: int,
+    V: int,
+    mask_p: float,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+    use_gate_in_kernel: bool,
+    safe_gate: bool,
+    disable_recompute: bool,
+):
+    """Test chunk varlen inference (forward only, no backward)."""
+    torch.manual_seed(42)
+    cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
+    T = cu_seqlens[-1]
+    N = len(cu_seqlens) - 1
+
+    q = torch.randn((1, T, H, K), dtype=dtype).to(device)
+    k = F.normalize(torch.randn(1, T, H, K, dtype=torch.float32), p=2, dim=-1).to(dtype).to(device)
+    v = torch.randn((1, T, H, V), dtype=dtype).to(device)
+    gk = torch.randn(1, T, H, K, dtype=torch.float if not use_gate_in_kernel else dtype).to(device)
+    if use_gate_in_kernel:
+        A_log = torch.log(torch.randn(1, 1, H, 1, dtype=torch.float32, device=device).uniform_(1, 16)).to(device)
+        dt_bias = torch.randn(H * K, dtype=torch.float32, device=device).to(device)
+    else:
+        gk = F.logsigmoid(gk)
+        gk = gk * (torch.rand_like(gk) > mask_p)
+    mask = torch.rand_like(gk) > mask_p
+    gk = gk * mask + (~mask) * (-1000)
+    if safe_gate:
+        assert not use_gate_in_kernel
+        gk = gk.clamp(-5, 0)
+
+    g_atk = F.logsigmoid(torch.randn(1, T, H, dtype=torch.float)).to(device)
+    beta_atk = torch.rand(1, T, H, dtype=dtype).sigmoid().to(device)
+    beta = torch.rand(1, T, H, dtype=dtype).sigmoid().to(device)
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32).to(device)
+    h0 = torch.randn((N, H, K, V), dtype=torch.float32).to(device)
+
+    tri, tri_ht, _ = chunk_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        A_log=(A_log.clone() if use_gate_in_kernel else None),
+        dt_bias=(dt_bias.clone() if use_gate_in_kernel else None),
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_gate_in_kernel=use_gate_in_kernel,
+        safe_gate=safe_gate,
+        disable_recompute=disable_recompute,
+        x=1.5,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    ref = []
+    ref_ht = []
+    for i in range(N):
+        ref_i, ref_ht_i, _ = naive_recurrent_precond_kda(
+            q=F.normalize(q[:, cu_seqlens[i]: cu_seqlens[i + 1]], p=2, dim=-1),
+            k=k[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            v=v[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            g=(naive_kda_gate(
+                gk[:, cu_seqlens[i]: cu_seqlens[i + 1]].to(torch.float),
+                A_log.to(torch.float),
+                dt_bias.to(torch.float)
+            ) if use_gate_in_kernel else gk[:, cu_seqlens[i]: cu_seqlens[i + 1]]),
+            g_atk=g_atk[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            beta_atk=beta_atk[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            beta=beta[:, cu_seqlens[i]: cu_seqlens[i + 1]],
+            initial_state=h0[i],
+            output_final_state=True,
+            x=1.5,
+            log_atk_scale=log_atk_scale.clone(),
+        )
+        ref.append(ref_i)
+        ref_ht.append(ref_ht_i.squeeze(0))
+    ref = torch.cat(ref, 1)
+    ref_ht = torch.stack(ref_ht, 0)
+
+    assert_close("o", ref, tri, 0.005)
+    assert_close("ht", ref_ht, tri_ht, 0.005)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "K", "HAS_BIAS"),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-K{}-bias{}".format(*test))
+        for test in [
+            (1, 2, 2, 12, False),
+            (1, 32, 2, 16, False),
+            (2, 64, 4, 32, False),
+            (4, 128, 8, 64, False),
+            (4, 128, 8, 128, False),
+            (1, 2, 2, 12, True),
+            (1, 32, 2, 16, True),
+            (2, 64, 4, 32, True),
+            (4, 128, 8, 64, True),
+            (4, 128, 8, 128, True),
+        ]
+    ],
+)
+def test_gate(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    HAS_BIAS: bool,
+):
+    """Test gate forward + backward."""
+    torch.manual_seed(42)
+    g = torch.randn(B, T, H, K, dtype=torch.float32) * 10
+    A_log = torch.log(torch.randn(1, 1, H, 1, dtype=torch.float32).uniform_(1, 16))
+    dt_bias = torch.randn(H * K, dtype=torch.float32) if HAS_BIAS else None
+    g, A_log = map(lambda x: x.to(device).requires_grad_(True), (g, A_log))
+    if dt_bias is not None:
+        dt_bias = dt_bias.to(device).requires_grad_(True)
+    do = torch.randn_like(g).view(B, T, H, K)
+
+    ref = naive_kda_gate(
+        g.clone(), A_log.clone(), dt_bias.clone() if dt_bias is not None else None,
+    )
+    tri = fused_kda_gate(
+        g.clone(), A_log.clone(), dt_bias.clone() if dt_bias is not None else None,
+    )
+    (ref * do).sum().backward(retain_graph=True)
+
+    ref_dg, ref_dA = g.grad, A_log.grad
+    ref_dbias = dt_bias.grad if dt_bias is not None else None
+    g.grad = A_log.grad = None
+    if dt_bias is not None:
+        dt_bias.grad = None
+
+    ((tri * do).sum()).backward(retain_graph=True)
+    tri_dg, tri_dA = g.grad, A_log.grad
+    tri_dbias = dt_bias.grad if dt_bias is not None else None
+    g.grad = A_log.grad = None
+    if dt_bias is not None:
+        dt_bias.grad = None
+
+    assert_close("o", ref, tri, 1e-4)
+    assert_close("dg", ref_dg, tri_dg, 1e-4)
+    assert_close("dA", ref_dA, tri_dA, 1e-4)
+    if HAS_BIAS:
+        assert_close("dbias", ref_dbias, tri_dbias, 1e-4)

--- a/tests/ops/test_precond_kda.py
+++ b/tests/ops/test_precond_kda.py
@@ -821,3 +821,107 @@ def test_gate(
     assert_close("dA", ref_dA, tri_dA, 1e-4)
     if HAS_BIAS:
         assert_close("dbias", ref_dbias, tri_dbias, 1e-4)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "K", "V", "dtype"),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-K{}-V{}-{}".format(*test))
+        for test in [
+            (2, 500, 3, 64, 64, torch.float16),
+            (2, 1024, 4, 128, 128, torch.float16),
+        ]
+    ],
+)
+def test_chunk_A_state(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+):
+    """End-to-end A-state: nonzero initial_A_state, the returned `at` is asserted,
+    and the gradient flowing in through `at` (dat) is checked against the naive
+    reference together with `dh0_atk`."""
+    torch.manual_seed(42)
+    scale = K ** -0.5
+    x = 1.5
+
+    q = torch.rand(B, T, H, K, dtype=dtype)
+    k = torch.rand(B, T, H, K, dtype=dtype)
+    v = torch.rand(B, T, H, V, dtype=dtype)
+    gk = F.logsigmoid(torch.randn(B, T, H, K, dtype=torch.float))
+    g_atk = F.logsigmoid(torch.randn(B, T, H, dtype=torch.float))
+    beta_atk = torch.randn(B, T, H, dtype=torch.float).sigmoid()
+    beta = torch.randn(B, T, H, dtype=torch.float).sigmoid()
+    log_atk_scale = torch.full((H,), -0.2, dtype=torch.float32)
+    h0 = torch.randn(B, H, K, V, dtype=torch.float32)
+    A0 = torch.rand(B, H, K, dtype=torch.float32)
+
+    q, k, v, gk, g_atk, beta_atk, beta, h0, A0, log_atk_scale = map(
+        lambda t: t.to(device).requires_grad_(True),
+        (q, k, v, gk, g_atk, beta_atk, beta, h0, A0, log_atk_scale)
+    )
+
+    tri, tri_ht, tri_at = chunk_precond_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        initial_A_state=A0.clone(),
+        output_final_state=True,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+    dat = torch.randn(B, H, K, dtype=torch.float32, device=device)
+    ((tri * do).sum() + (tri_ht * dht).sum() + (tri_at.float() * dat).sum()).backward(retain_graph=True)
+
+    tri_dq, tri_dk, tri_dv = q.grad, k.grad, v.grad
+    tri_dg, tri_dg_atk = gk.grad, g_atk.grad
+    tri_dbeta_atk = beta_atk.grad
+    tri_dh0, tri_dA0 = h0.grad, A0.grad
+    tri_dlog_atk_scale = log_atk_scale.grad
+
+    q.grad = k.grad = v.grad = gk.grad = None
+    g_atk.grad = beta_atk.grad = beta.grad = None
+    h0.grad = A0.grad = log_atk_scale.grad = None
+
+    ref, ref_ht, ref_at = naive_recurrent_precond_kda(
+        q=F.normalize(q.clone(), p=2, dim=-1),
+        k=F.normalize(k.clone(), p=2, dim=-1),
+        v=v.clone(),
+        g=gk.clone(),
+        g_atk=g_atk.clone(),
+        beta_atk=beta_atk.clone(),
+        beta=beta.clone(),
+        scale=scale,
+        initial_state=h0.clone(),
+        initial_A_state=A0.clone(),
+        output_final_state=True,
+        x=x,
+        log_atk_scale=log_atk_scale.clone(),
+    )
+
+    ((ref * do).sum() + (ref_ht * dht).sum() + (ref_at.float() * dat).sum()).backward(retain_graph=True)
+
+    assert_close("o", ref, tri, 0.005)
+    assert_close("ht", ref_ht, tri_ht, 0.005)
+    assert_close("at", ref_at, tri_at, 0.005)
+    assert_close("dq", q.grad, tri_dq, 0.008)
+    assert_close("dk", k.grad, tri_dk, 0.008)
+    assert_close("dv", v.grad, tri_dv, 0.008)
+    assert_close("dg", gk.grad, tri_dg, 0.02)
+    assert_close("dg_atk", g_atk.grad, tri_dg_atk, 0.02)
+    assert_close("dbeta_atk", beta_atk.grad, tri_dbeta_atk, 0.02)
+    assert_close("dh0", h0.grad, tri_dh0, 0.008)
+    assert_close("dh0_atk", A0.grad, tri_dA0, 0.02)
+    assert_close("d_log_atk_scale", log_atk_scale.grad, tri_dlog_atk_scale, 0.02)


### PR DESCRIPTION
## Summary

Adds curvature-aware **preconditioned** variants of Gated DeltaNet and KDA from
*Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences*
([arXiv:2604.21100](https://arxiv.org/abs/2604.21100), ICML 2026).

Reference implementation / training code (paper repo): https://github.com/ntumm120/preconditioned-deltanet

**Ops**
- `fla/ops/atk/` — shared ATK preconditioner kernels (fwd/bwd)
- `fla/ops/precond_gated_delta_rule/` — PGDN chunk + fused_recurrent
- `fla/ops/precond_kda/` — PKDA chunk (+ intra) + fused_recurrent

**Layers** — `fla/layers/precond_gated_deltanet.py`, `fla/layers/precond_kda.py`
**Models** — `fla/models/precond_gated_deltanet/`, `fla/models/precond_kda/`
**Tests** — op + model tests for both

Registered in `fla/{__init__,layers/__init__,models/__init__,ops/__init__}.py` and the
README model table, following existing conventions (cf. #939).

All kernels are written with manual pointer arithmetic + masks (no `tl.make_block_ptr`),
matching the current upstream KDA/GDN kernels so they build against Triton main.

### Note on `FLACache`

`FLACache`/`FLALayer` gain an **optional, backward-compatible** `A_state` field
(`fla/models/utils.py`) to carry the preconditioner's auxiliary recurrent state during
generation. It defaults to `None` and is a no-op for all existing models.

### Backends

Kernels are **Triton-only**. The shared `chunk_bwd_dqkwg` path reuses the existing backend
dispatch, so PGDN inherits the same Hopper/tilelang requirement as baseline GDN/KDA (#640).
FlashKDA/TileLang precond backends are possible follow-ups.

## Test plan

Full precond op + model suite on A100 (`FLA_DISABLE_BACKEND_DISPATCH=1`):

```
pytest tests/ops/test_precond_kda.py tests/ops/test_precond_gated_delta.py
pytest tests/models/test_modeling_precond_kda.py tests/models/test_modeling_precond_gated_deltanet.py
```

→ **78 op tests + 7 model tests pass, 0 failed** (dense + varlen + prefill, `safe_gate` on/off,
transpose-state, `disable_recompute`, fp16/bf16/fp32). GVA (`num_v_heads > num_heads`) path stays
finite in loss and gradients. `ruff` clean.

## Benchmark (kernel changes only)

A100-80GB, bf16, `B=4, T=4096, H=4, D=128`. "baseline" is the non-preconditioned op
(`chunk_kda` / `chunk_gated_delta_rule`); "precond" is the new op — the ratio is the cost of the
added curvature-aware preconditioning step, which is the intended overhead:

| op          | shape  | pass    | baseline | precond | ratio |
|-------------|--------|---------|---------:|--------:|------:|
| precond_kda | dense  | fwd     | 0.874 ms | 1.397 ms | 1.60x |
| precond_kda | dense  | fwd+bwd | 4.796 ms | 6.784 ms | 1.41x |
| precond_kda | varlen | fwd     | 0.868 ms | 1.746 ms | 2.01x |
| precond_kda | varlen | fwd+bwd | 5.029 ms | 7.456 ms | 1.48x |
| precond_gdn | dense  | fwd     | 0.634 ms | 1.188 ms | 1.87x |
| precond_gdn | dense  | fwd+bwd | 2.944 ms | 5.068 ms | 1.72x |
| precond_gdn | varlen | fwd     | 0.681 ms | 1.582 ms | 2.32x |
| precond_gdn | varlen | fwd+bwd | 3.369 ms | 6.377 ms | 1.89x |

Median of 50 runs after 10 warmups.

## Breaking changes

None. The only shared-code change is the optional `A_state` field on `FLACache`/`FLALayer`,
which defaults to `None` and does not affect any existing model.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
