### PR TITLE
[GDN] Restrict Blackwell fwd h kernel to 2 warps

### DIFF
--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -13,9 +13,20 @@ from fla.ops.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_HOPPER, USE_CUDA_GRAPH, autotune_cache_kwargs, check_shared_mem
+from fla.utils import (
+    IS_NVIDIA_BLACKWELL,
+    IS_NVIDIA_HOPPER,
+    USE_CUDA_GRAPH,
+    autotune_cache_kwargs,
+    check_shared_mem,
+)
 
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
+
+# TODO: Triton mainline fixes a Blackwell tl.dot recurrence race.
+# Keep this kernel on num_warps=2 for Blackwell until Triton 3.8 is released
+# and we re-validate the wider config space.
+GATED_DELTA_RULE_FWD_H_NUM_WARPS = [2] if IS_NVIDIA_BLACKWELL else [2, 4]
 
 
 @triton.heuristics({
@@ -29,7 +40,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
 @fla_cache_autotune(
     configs=[
         triton.Config({'BV': BV}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4]
+        for num_warps in GATED_DELTA_RULE_FWD_H_NUM_WARPS
         for num_stages in ([2, 3, 4] if check_shared_mem('ampere') else [2, 1])
         for BV in ([32, 64] if check_shared_mem('ada') else [32])
     ],

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -16,7 +16,23 @@ from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gat
 from fla.ops.gated_delta_rule.gate import fused_gdn_gate, naive_gdn_gate
 from fla.ops.gated_delta_rule.naive import naive_recurrent_gated_delta_rule
 from fla.ops.gated_delta_rule.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
-from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
+from fla.utils import IS_INTEL_ALCHEMIST, IS_NVIDIA_BLACKWELL, assert_close, device
+
+
+def _unwrap_autotuner(fn):
+    while not hasattr(fn, 'configs'):
+        fn = fn.fn
+    return fn
+
+
+def test_chunk_gated_delta_rule_fwd_h_blackwell_triton_guard():
+    if not IS_NVIDIA_BLACKWELL:
+        pytest.skip(reason='Blackwell guard is only active on Blackwell GPUs')
+
+    from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_fwd_kernel_h_blockdim64
+
+    tuner = _unwrap_autotuner(chunk_gated_delta_rule_fwd_kernel_h_blockdim64)
+    assert {config.num_warps for config in tuner.configs} == {2}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Guard `chunk_gated_delta_rule_fwd_kernel_h_blockdim64` autotune configs on Blackwell to `num_warps=2` to avoid non-deterministic forward `h` / `v_new` outputs.
- Add a config-space test for the Blackwell guard.

## Test plan
- `pytest tests/ops/test_gdn.py::test_chunk_gated_delta_rule_fwd_h_blackwell_triton_guard -v`

## Breaking changes
- None

Closes #945
