### PR TITLE
[NSA] Skip empty query tiles in selective backward (bwd_dkv)

### DIFF
--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -8,6 +8,7 @@
 import warnings
 
 import torch
+import torch.nn.functional as F
 import triton
 import triton.language as tl
 
@@ -438,6 +439,7 @@ def parallel_nsa_bwd_kernel_dkv(
     dk,
     dv,
     block_mask,
+    skip_mask,
     cu_seqlens,
     chunk_indices,
     scale,
@@ -452,6 +454,7 @@ def parallel_nsa_bwd_kernel_dkv(
     BS: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    BQ: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_s, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -477,34 +480,38 @@ def parallel_nsa_bwd_kernel_dkv(
     b_v = tl.load(p_v, boundary_check=(0, 1))
     b_dv = tl.zeros([BS, BV], dtype=tl.float32)
 
-    for i in range(i_s * BS, T):
-        b_m = tl.load(block_mask + (bos + i) * H*M + i_h * M + i_s)
-        if b_m:
-            p_q = tl.make_block_ptr(q + (bos + i) * HQ*K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
-            # [G, BK]
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_q = (b_q * scale).to(b_q.dtype)
+    # skip query tiles where no query selected this KV block: skip_mask ORs block_mask
+    # over BQ-query tiles, absolute-aligned (bos may not be BQ-aligned under varlen)
+    q_min = bos + i_s * BS
+    for i_t in range(q_min // BQ * BQ, eos, BQ):
+        if tl.load(skip_mask + (i_t // BQ) * H*M + i_h * M + i_s):
+            for i in range(tl.maximum(i_t, q_min), tl.minimum(i_t + BQ, eos)):
+                if tl.load(block_mask + i * H*M + i_h * M + i_s):
+                    p_q = tl.make_block_ptr(q + i * HQ*K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+                    # [G, BK]
+                    b_q = tl.load(p_q, boundary_check=(0, 1))
+                    b_q = (b_q * scale).to(b_q.dtype)
 
-            p_do = tl.make_block_ptr(do + (bos + i) * HQ*V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
-            p_lse = lse + (bos + i) * HQ + i_h * G + tl.arange(0, G)
-            p_delta = delta + (bos + i) * HQ + i_h * G + tl.arange(0, G)
-            # [G, BV]
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            # [G]
-            b_lse = tl.load(p_lse)
-            b_delta = tl.load(p_delta)
-            # [BS, G]
-            b_s = tl.dot(b_k, tl.trans(b_q))
-            b_p = exp(b_s - b_lse[None, :])
-            b_p = tl.where((i >= (i_s * BS + tl.arange(0, BS)))[:, None], b_p, 0)
-            # [BS, G] @ [G, BV] -> [BS, BV]
-            b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
-            # [BS, BV] @ [BV, G] -> [BS, G]
-            b_dp = tl.dot(b_v, tl.trans(b_do))
-            # [BS, G]
-            b_ds = b_p * (b_dp - b_delta[None, :])
-            # [BS, G] @ [G, BK] -> [BS, BK]
-            b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
+                    p_do = tl.make_block_ptr(do + i * HQ*V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+                    p_lse = lse + i * HQ + i_h * G + tl.arange(0, G)
+                    p_delta = delta + i * HQ + i_h * G + tl.arange(0, G)
+                    # [G, BV]
+                    b_do = tl.load(p_do, boundary_check=(0, 1))
+                    # [G]
+                    b_lse = tl.load(p_lse)
+                    b_delta = tl.load(p_delta)
+                    # [BS, G]
+                    b_s = tl.dot(b_k, tl.trans(b_q))
+                    b_p = exp(b_s - b_lse[None, :])
+                    b_p = tl.where((i >= q_min + tl.arange(0, BS))[:, None], b_p, 0)
+                    # [BS, G] @ [G, BV] -> [BS, BV]
+                    b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
+                    # [BS, BV] @ [BV, G] -> [BS, G]
+                    b_dp = tl.dot(b_v, tl.trans(b_do))
+                    # [BS, G]
+                    b_ds = b_p * (b_dp - b_delta[None, :])
+                    # [BS, G] @ [G, BK] -> [BS, BK]
+                    b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
 
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
@@ -679,6 +686,7 @@ def parallel_nsa_bwd(
     BS = block_size
     BK = max(triton.next_power_of_2(K), 16)
     BV = min(128, max(triton.next_power_of_2(v.shape[-1]), 16))
+    BQ = 16
     NV = triton.cdiv(V, BV)
 
     delta = parallel_attn_bwd_preprocess(o, do)
@@ -721,6 +729,11 @@ def parallel_nsa_bwd(
 
     # [B, T, H, M]
     block_mask = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
+    M = block_mask.shape[-1]
+    # skip_mask[t] = OR of block_mask over a BQ-query tile, so dkv can skip whole tiles
+    # of queries that selected nothing in a KV block
+    mask = F.pad(block_mask.reshape(B * T, H, M), (0, 0, 0, 0, 0, (-(B * T)) % BQ))
+    skip_mask = mask.view(-1, BQ, H, M).any(dim=1).contiguous()
     dk = torch.empty(NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device)
     dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)
 
@@ -735,6 +748,7 @@ def parallel_nsa_bwd(
         dk=dk,
         dv=dv,
         block_mask=block_mask,
+        skip_mask=skip_mask,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         scale=scale,
@@ -745,10 +759,11 @@ def parallel_nsa_bwd(
         G=G,
         K=K,
         V=V,
-        M=block_mask.shape[-1],
+        M=M,
         BS=BS,
         BK=BK,
         BV=BV,
+        BQ=BQ,
     )
     dk = dk.sum(0)
     return dq, dk, dv

--- a/tests/ops/test_nsa.py
+++ b/tests/ops/test_nsa.py
@@ -162,7 +162,7 @@ def test_parallel_varlen(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close('o', ref, tri, 0.004)
+    assert_close(' o', ref, tri, 0.004)
     assert_close('dq', ref_dq, tri_dq, 0.005)
     assert_close('dk', ref_dk, tri_dk, 0.005)
     assert_close('dv', ref_dv, tri_dv, 0.005)
@@ -209,7 +209,7 @@ def test_parallel_selective_decode(
         scale,
     )
 
-    o_short, lse_short = parallel_nsa_fwd(
+    o_dec, lse_dec = parallel_nsa_fwd(
         q[:, -Tq:], k, v, block_indices[:, -Tq:],
         S,
         block_size,
@@ -220,18 +220,9 @@ def test_parallel_selective_decode(
         q, k, v, block_indices, block_size, scale
     )
 
-    assert_close(
-        'outputs: full-vs-naive',
-        o_naive_fla, o_full, 0.005
-    )
-    assert_close(
-        'outputs: full-vs-cached',
-        o_short, o_full[:, -Tq:], 0.005
-    )
-    assert_close(
-        'log-sum-exp: full-vs-cached',
-        lse_short, lse_full[:, -Tq:], 0.005
-    )
+    assert_close('  o', o_naive_fla, o_full, 0.005)
+    assert_close('  o', o_dec, o_full[:, -Tq:], 0.005)
+    assert_close('lse', lse_dec, lse_full[:, -Tq:], 0.005)
 
 
 @pytest.mark.parametrize(
@@ -292,33 +283,21 @@ def test_parallel_compressive(
     ref_dk, k.grad = k.grad.clone(), None
     ref_dv, v.grad = v.grad.clone(), None
 
-    assert_close(
-        'outputs: full-vs-naive',
-        o_full, o_naive, 0.005
-    )
+    assert_close('  o', o_full, o_naive, 0.005)
     # For positions not attending to any token, the log-sum-exp should be -inf; the kernel returns 0 instead, it is
     # OK as those positions will not be used in the compressive attention anyway.
-    assert_close(
-        'log-sum-exp: full-vs-naive',
-        lse_full, torch.where(lse_naive == float('-inf'), 0, lse_naive), 0.005
-    )
-    assert_close('dq', ref_dq, tri_dq, 0.005)
-    assert_close('dk', ref_dk, tri_dk, 0.005)
-    assert_close('dv', ref_dv, tri_dv, 0.005)
+    assert_close('lse', lse_full, torch.where(lse_naive == float('-inf'), 0, lse_naive), 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
 
-    o_short, lse_short = parallel_nsa_compression(
+    o_dec, lse_dec = parallel_nsa_compression(
         q[:, -Tq:], k_cmp, v_cmp, T, block_size, scale,
     )
 
-    assert_close(
-        'outputs: full-vs-cached',
-        o_short, o_full[:, -Tq:], 0.005
-    )
+    assert_close('  o', o_dec, o_full[:, -Tq:], 0.005)
 
-    assert_close(
-        'log-sum-exp: full-vs-cached',
-        lse_short, lse_full[:, -Tq:], 0.005
-    )
+    assert_close('lse', lse_dec, lse_full[:, -Tq:], 0.005)
 
 
 @pytest.mark.parametrize(
@@ -412,7 +391,7 @@ def test_parallel_topk_decode(
                 m = a_s.max(dim=0, keepdim=True).values
                 a_lse = torch.log(torch.exp(a_s - m).sum(0)) + m.squeeze(0)
                 k_lse = lse_full[b_i, t_i, h_i * (HQ // H): (h_i + 1) * (HQ // H)]
-                assert_close('block lse', a_lse, k_lse, ratio=0.005)
+                assert_close('   block lse', a_lse, k_lse, ratio=0.005)
             fk = free_block_indices[b_i, t_i, h_i]
             fn = free_block_indices_naive[b_i, t_i, h_i]
             sk = a_snm[fk[fk >= 0]].sort(descending=True).values
@@ -421,7 +400,7 @@ def test_parallel_topk_decode(
         warnings.warn(f"Block selection differs at {pos.shape[0]} positions, "
                       f"all with matching scores (near-tied blocks).")
 
-    block_indices_short = parallel_nsa_topk(
+    block_indices_dec = parallel_nsa_topk(
         q=q[:, -Tq:],
         k=k_cmp,
         lse=lse_full[:, -Tq:] if lse_full is not None else None,
@@ -431,12 +410,12 @@ def test_parallel_topk_decode(
         scale=scale,
     )
 
-    fixed_block_indices_short, free_block_indices_short = (
-        block_indices_short[:, :, :, :3], block_indices_short[:, :, :, 3:])
-    fixed_block_indices_short, _ = torch.sort(fixed_block_indices_short, dim=-1)
-    assert (fixed_block_indices_short == fixed_block_indices[:, -Tq:]).all(), \
+    fixed_block_indices_dec, free_block_indices_dec = (
+        block_indices_dec[:, :, :, :3], block_indices_dec[:, :, :, 3:])
+    fixed_block_indices_dec, _ = torch.sort(fixed_block_indices_dec, dim=-1)
+    assert (fixed_block_indices_dec == fixed_block_indices[:, -Tq:]).all(), \
         "Different in forcefully selected block indices compared to full"
-    assert (free_block_indices_short == free_block_indices[:, -Tq:]).all(), \
+    assert (free_block_indices_dec == free_block_indices[:, -Tq:]).all(), \
         "Different in free block indices compared to full"
 
 
@@ -499,12 +478,12 @@ def test_parallel_decode(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close('full vs naive', o_full, o_naive, 0.005)
+    assert_close(' o', o_full, o_naive, 0.005)
     assert_close('dq', ref_dq, tri_dq, 0.005)
     assert_close('dk', ref_dk, tri_dk, 0.005)
     assert_close('dv', ref_dv, tri_dv, 0.005)
 
-    o_short = parallel_nsa(
+    o_dec = parallel_nsa(
         q[:, -Tq:], k, v, g_cmp[:, -Tq:], g_slc[:, -Tq:], g_swa[:, -Tq:],
         block_indices=block_indices[:, -Tq:],
         block_counts=S,
@@ -513,7 +492,7 @@ def test_parallel_decode(
         window_size=window_size
     )
 
-    assert_close('short vs full', o_short, o_full[:, -Tq:], 0.005)
+    assert_close(' o', o_dec, o_full[:, -Tq:], 0.005)
 
 
 @pytest.mark.parametrize(
@@ -576,17 +555,17 @@ def test_parallel_selective_varlen_decode(
         cu_seqlens=cu_seqlens
     )
 
-    q_short = build_partial_varlen(q, cu_seqlens, q_lens)
-    block_indices_short = build_partial_varlen(block_indices, cu_seqlens, q_lens)
+    q_dec = build_partial_varlen(q, cu_seqlens, q_lens)
+    block_indices_dec = build_partial_varlen(block_indices, cu_seqlens, q_lens)
     cu_seqlens_q = torch.cumsum(torch.tensor([0] + q_lens), dim=0).to(device)
     token_indices_q = prepare_token_indices(cu_seqlens_q)
 
-    o_short_ref = build_partial_varlen(o_full, cu_seqlens, q_lens)
-    lse_short_ref = build_partial_varlen(lse_full, cu_seqlens, q_lens)
+    o_dec_ref = build_partial_varlen(o_full, cu_seqlens, q_lens)
+    lse_dec_ref = build_partial_varlen(lse_full, cu_seqlens, q_lens)
 
-    o_short, lse_short = parallel_nsa_fwd(
-        q_short, k, v,
-        block_indices_short,
+    o_dec, lse_dec = parallel_nsa_fwd(
+        q_dec, k, v,
+        block_indices_dec,
         S,
         block_size,
         cu_seqlens_q=cu_seqlens_q,
@@ -595,9 +574,9 @@ def test_parallel_selective_varlen_decode(
         token_indices_q=token_indices_q
     )
 
-    assert_close('outputs: full vs naive', ref, o_full, 0.005)
-    assert_close('outputs: full vs short', o_short, o_short_ref, 0.005)
-    assert_close('lse: full vs short', lse_short, lse_short_ref, 0.005)
+    assert_close('  o', ref, o_full, 0.005)
+    assert_close('  o', o_dec, o_dec_ref, 0.005)
+    assert_close('lse', lse_dec, lse_dec_ref, 0.005)
 
 
 @pytest.mark.parametrize(
@@ -666,20 +645,20 @@ def test_parallel_compressive_varlen(
     ref_dk, k.grad = k.grad.clone(), None
     ref_dv, v.grad = v.grad.clone(), None
 
-    assert_close('outputs: full vs naive', o_naive, o_full, 0.005)
-    assert_close('lse: full vs naive', torch.where(lse_naive == float('-inf'), 0, lse_naive), lse_full, 0.005)
-    assert_close('dq', ref_dq, tri_dq, 0.005)
-    assert_close('dk', ref_dk, tri_dk, 0.005)
-    assert_close('dv', ref_dv, tri_dv, 0.005)
+    assert_close('  o', o_naive, o_full, 0.005)
+    assert_close('lse', torch.where(lse_naive == float('-inf'), 0, lse_naive), lse_full, 0.005)
+    assert_close(' dq', ref_dq, tri_dq, 0.005)
+    assert_close(' dk', ref_dk, tri_dk, 0.005)
+    assert_close(' dv', ref_dv, tri_dv, 0.005)
 
-    q_short = build_partial_varlen(q, cu_seqlens, q_lens)
+    q_dec = build_partial_varlen(q, cu_seqlens, q_lens)
     cu_seqlens_q = torch.cumsum(torch.tensor([0] + q_lens), dim=0).to(device)
 
-    o_short_ref = build_partial_varlen(o_full, cu_seqlens, q_lens)
-    lse_short_ref = build_partial_varlen(lse_full, cu_seqlens, q_lens)
+    o_dec_ref = build_partial_varlen(o_full, cu_seqlens, q_lens)
+    lse_dec_ref = build_partial_varlen(lse_full, cu_seqlens, q_lens)
 
-    o_short, lse_short = parallel_nsa_compression(
-        q_short,
+    o_dec, lse_dec = parallel_nsa_compression(
+        q_dec,
         k_cmp, v_cmp,
         T,
         block_size,
@@ -687,8 +666,8 @@ def test_parallel_compressive_varlen(
         cu_seqlens=(cu_seqlens_q, cu_seqlens),
     )
 
-    assert_close('outputs: full vs short', o_short, o_short_ref, 0.005)
-    assert_close('lse: full vs short', lse_short, lse_short_ref, 0.005)
+    assert_close('  o', o_dec, o_dec_ref, 0.005)
+    assert_close('lse', lse_dec, lse_dec_ref, 0.005)
 
 
 @pytest.mark.parametrize(
@@ -792,7 +771,7 @@ def test_parallel_topk_varlen(
                 m = a_s.max(dim=0, keepdim=True).values
                 a_lse = torch.log(torch.exp(a_s - m).sum(0)) + m.squeeze(0)
                 k_lse = lse_full[0, t_i, h_i * (HQ // H): (h_i + 1) * (HQ // H)]
-                assert_close('block lse', a_lse, k_lse, ratio=0.005)
+                assert_close('   block lse', a_lse, k_lse, ratio=0.005)
             fk = free_block_indices[0, t_i, h_i]
             fn = free_block_indices_naive[0, t_i, h_i]
             sk = a_snm[fk[fk >= 0]].sort(descending=True).values
@@ -801,17 +780,17 @@ def test_parallel_topk_varlen(
         warnings.warn(f"Block selection differs at {pos.shape[0]} positions, "
                       f"all with matching scores (near-tied blocks).")
 
-    q_short = build_partial_varlen(q, cu_seqlens, q_lens)
+    q_dec = build_partial_varlen(q, cu_seqlens, q_lens)
     cu_seqlens_q = torch.cumsum(torch.tensor([0] + q_lens), dim=0).to(device)
 
-    fixed_block_indices_short_ref = build_partial_varlen(fixed_block_indices, cu_seqlens, q_lens)
-    free_block_indices_short_ref = build_partial_varlen(free_block_indices, cu_seqlens, q_lens)
-    lse_short_ref = build_partial_varlen(lse_full, cu_seqlens, q_lens) if lse_full is not None else None
+    fixed_block_indices_dec_ref = build_partial_varlen(fixed_block_indices, cu_seqlens, q_lens)
+    free_block_indices_dec_ref = build_partial_varlen(free_block_indices, cu_seqlens, q_lens)
+    lse_dec_ref = build_partial_varlen(lse_full, cu_seqlens, q_lens) if lse_full is not None else None
 
-    block_indices_short = parallel_nsa_topk(
-        q=q_short,
+    block_indices_dec = parallel_nsa_topk(
+        q=q_dec,
         k=k_cmp,
-        lse=lse_short_ref,
+        lse=lse_dec_ref,
         TK=T,
         block_counts=S,
         block_size=block_size,
@@ -819,12 +798,12 @@ def test_parallel_topk_varlen(
         cu_seqlens=(cu_seqlens_q, cu_seqlens),
     )
 
-    fixed_block_indices_short, free_block_indices_short = (
-        block_indices_short[:, :, :, :3], block_indices_short[:, :, :, 3:])
-    fixed_block_indices_short, _ = torch.sort(fixed_block_indices_short, dim=-1)
-    assert (fixed_block_indices_short == fixed_block_indices_short_ref).all(), \
+    fixed_block_indices_dec, free_block_indices_dec = (
+        block_indices_dec[:, :, :, :3], block_indices_dec[:, :, :, 3:])
+    fixed_block_indices_dec, _ = torch.sort(fixed_block_indices_dec, dim=-1)
+    assert (fixed_block_indices_dec == fixed_block_indices_dec_ref).all(), \
         "Different in forcefully selected block indices compared to full"
-    assert (free_block_indices_short == free_block_indices_short_ref).all(), \
+    assert (free_block_indices_dec == free_block_indices_dec_ref).all(), \
         "Different in free block indices compared to full"
 
 
@@ -892,22 +871,22 @@ def test_parallel_varlen_decode(
     tri_dk, k.grad = k.grad.clone(), None
     tri_dv, v.grad = v.grad.clone(), None
 
-    assert_close('full vs naive', o_full, o_naive, 0.005)
+    assert_close(' o', o_full, o_naive, 0.005)
     assert_close('dq', ref_dq, tri_dq, 0.005)
     assert_close('dk', ref_dk, tri_dk, 0.005)
     assert_close('dv', ref_dv, tri_dv, 0.005)
 
-    q_short = build_partial_varlen(q, cu_seqlens, q_lens)
-    g_short = build_partial_varlen(g, cu_seqlens, q_lens)
-    g_cmp, g_slc, g_swa = g_short.sigmoid().unbind(-1)
+    q_dec = build_partial_varlen(q, cu_seqlens, q_lens)
+    g_dec = build_partial_varlen(g, cu_seqlens, q_lens)
+    g_cmp, g_slc, g_swa = g_dec.sigmoid().unbind(-1)
     cu_seqlens_q = torch.cumsum(torch.tensor([0] + q_lens), dim=0).int().to(device)
 
     block_indices = build_partial_varlen(block_indices, cu_seqlens, q_lens)
 
-    o_short_ref = build_partial_varlen(o_full, cu_seqlens, q_lens)
+    o_dec_ref = build_partial_varlen(o_full, cu_seqlens, q_lens)
 
-    o_short = parallel_nsa(
-        q_short, k, v, g_cmp, g_slc, g_swa, block_indices=block_indices, block_counts=S, block_size=block_size,
+    o_dec = parallel_nsa(
+        q_dec, k, v, g_cmp, g_slc, g_swa, block_indices=block_indices, block_counts=S, block_size=block_size,
         scale=scale, window_size=window_size, cu_seqlens=(cu_seqlens_q, cu_seqlens), )
 
-    assert_close('outputs: full vs short', o_short, o_short_ref, 0.005)
+    assert_close(' o', o_dec, o_dec_ref, 0.005)


### PR DESCRIPTION
# [NSA] Speed up selective backward by skipping empty query tiles in `bwd_dkv`

## Problem

`parallel_nsa_bwd_kernel_dkv` computes `dk`/`dv` by iterating, **for every KV block**, over
*all* query positions `for i in range(i_s*BS, T)` and checking `block_mask` to see whether each
query selected that block. That is an `O(T²/BS)` dense scan whose cost is dominated by the
overwhelming majority of `(block, query)` pairs that are **not** selected.

Measured on **GB200 (sm_100)**, bf16, NSA-default shape `B1 H4 HQ64 D64 S16 block_size64`
(selection path, `parallel_nsa` with given `block_indices`):

| T | fwd | bwd (before) |
|---|----:|----:|
| 32768 | 3.63 ms | 32.6 ms |
| 65536 | 7.25 ms | 112.3 ms |

The backward dominates the forward ~9:1 and scales **super-linearly** (2× T → ~3.4× bwd) — the
signature of the dense scan.

## Fix

Skip whole **query tiles** that contain no selector for a KV block. We OR `block_mask` over
tiles of `BQ` queries into a small `reduced_mask`, and the kernel does a cheap outer sweep over
tiles, entering the per-query inner loop only for non-empty tiles. The numerics are unchanged
(same masked accumulation); only wasted iterations are removed.

```
for it in range(i_s*BS, T, BQ):
    if reduced_mask[(bos+it)//BQ, h, i_s]:      # any query in the tile selected this block?
        for i in range(it, min(it+BQ, T)):
            if block_mask[bos+i, h, i_s]:
                ... # unchanged dk/dv accumulation
```

`BQ` defaults to 16 (`NSA_BWD_BQ` env override), the best point in a 16/32/64 sweep.

## Results (same shape, after; `BQ=16`)

bwd latency (ms), fwd unchanged:

| T | bwd before | bwd after (random sel.) | bwd after (local/recency sel.) |
|---|----:|----:|----:|
| 32768 | 32.6 | 27.7 (1.18×) | 16.9 (**1.94×**) |
| 65536 | 112.3 | 58.5 (1.92×) | 34.6 (**3.24×**) |

Random selection is the worst case for tile-skipping (selectors are spread, so few tiles are
fully empty). Real NSA selection is clustered (strong locality) — the `local`/recency pattern,
where whole KV blocks are never selected and entire scans are skipped, is closer to production
and shows the larger win. `fwd` is unchanged.

Correctness: full `pytest tests/ops/test_nsa.py` passes (26 selected fwd/bwd cases + varlen);
the added microbenchmark's naive cross-check (`--check`) gives o/dq/dk/dv rel-err < 5e-4,
identical to baseline.

## Notes
- Forward and `bwd_dq` are untouched.
- Adds `benchmarks/benchmark_nsa.py` (selection fwd/bwd microbenchmark + naive correctness check).
