### PR TITLE
[Agents] Add correctness-gated kernel optimization loop workflow

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -2,8 +2,7 @@
 
 Repository-local agent configuration lives here.
 
-Keep shared rules in `AGENTS.md`. Put optional task-specific workflows under
-`skills/`.
+Keep shared rules in `AGENTS.md`. Put optional task-specific workflows under `skills/`.
 
 ## Repo-local skills
 
@@ -15,14 +14,14 @@ Skills are self-contained workflow guides stored as:
 
 Current skills:
 
-| Skill | Purpose |
-|-------|---------|
-| `fla-nvidia-performance` | NVIDIA GPU kernel / Triton / Gluon / TileLang / CUDA backend performance work |
-| `fla-kda` | KDA-specific gate, intra/inter, backend, and test workflow |
-| `fla-dispatch-backends` | `@dispatch` decorator and backend registry workflow |
-| `fla-correctness-coverage` | Kernel correctness testing and coverage for `fla/ops/**` |
-| `fla-mr-readiness` | Preparing MR/PR, test plans, and contribution compliance |
+| Skill                      | Purpose                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| `fla-optimization-loop`    | Correctness-gated kernel optimization loop (contract, phases, iteration, traps) |
+| `fla-nvidia-performance`   | NVIDIA GPU kernel / Triton / Gluon / TileLang / CUDA backend performance work   |
+| `fla-kda`                  | KDA-specific gate, intra/inter, backend, and test workflow                      |
+| `fla-dispatch-backends`    | `@dispatch` decorator and backend registry workflow                             |
+| `fla-correctness-coverage` | Kernel correctness testing and coverage for `fla/ops/**`                        |
+| `fla-mr-readiness`         | Preparing MR/PR, test plans, and contribution compliance                        |
 
-To add a new skill, create a directory under `skills/` containing `SKILL.md`
-and optional `references/` files. Do not add redundant `README.md` files inside
-skill directories.
+To add a new skill, create a directory under `skills/` containing `SKILL.md` and optional `references/` files.
+Do not add redundant `README.md` files inside skill directories.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -6,18 +6,17 @@ Add reusable workflows as:
 .agents/skills/<skill-name>/SKILL.md
 ```
 
-Each skill should be self-contained and task-specific. Include YAML frontmatter
-with `name` and `description`. If a skill needs reference files, place them in a
-`references/` subdirectory inside the skill folder. Symlinks to public repo docs
+Each skill should be self-contained and task-specific. Include YAML frontmatter with `name` and `description`. If a skill
+needs reference files, place them in a `references/` subdirectory inside the skill folder. Symlinks to public repo docs
 are allowed when the referenced file is already tracked in this repository.
 
-Do not add a `README.md` inside individual skill directories; the canonical
-entry point is `SKILL.md`.
+Do not add a `README.md` inside individual skill directories; the canonical entry point is `SKILL.md`.
 
 ## Current skills
 
 | Skill | Purpose |
 |-------|---------|
+| `fla-optimization-loop` | Disciplined, reproducible kernel optimization loop (task contract, three phases, iteration protocol, trap catalog) anchored on the frozen pytest correctness gate |
 | `fla-nvidia-performance` | NVIDIA GPU kernel performance workflow for Triton, Gluon, TileLang, CUDA backends, hardware baselines, and MR-ready profiling evidence |
 | `fla-kda` | KDA-specific gate, intra/inter, backend, and test workflow |
 | `fla-dispatch-backends` | `@dispatch` decorator and backend registry workflow |

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -14,11 +14,11 @@ Do not add a `README.md` inside individual skill directories; the canonical entr
 
 ## Current skills
 
-| Skill | Purpose |
-|-------|---------|
-| `fla-optimization-loop` | Disciplined, reproducible kernel optimization loop (task contract, three phases, iteration protocol, trap catalog) anchored on the frozen pytest correctness gate |
-| `fla-nvidia-performance` | NVIDIA GPU kernel performance workflow for Triton, Gluon, TileLang, CUDA backends, hardware baselines, and MR-ready profiling evidence |
-| `fla-kda` | KDA-specific gate, intra/inter, backend, and test workflow |
-| `fla-dispatch-backends` | `@dispatch` decorator and backend registry workflow |
-| `fla-correctness-coverage` | Coverage matrix and test guidance for `fla/ops/**` kernels |
-| `fla-mr-readiness` | MR/PR preparation checklist, test plan, and PR body structure |
+| Skill                      | Purpose                                                                                                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fla-optimization-loop`    | Disciplined, reproducible kernel optimization loop (task contract, three phases, iteration protocol, trap catalog) anchored on the frozen pytest correctness gate |
+| `fla-nvidia-performance`   | NVIDIA GPU kernel performance workflow for Triton, Gluon, TileLang, CUDA backends, hardware baselines, and MR-ready profiling evidence                            |
+| `fla-kda`                  | KDA-specific gate, intra/inter, backend, and test workflow                                                                                                        |
+| `fla-dispatch-backends`    | `@dispatch` decorator and backend registry workflow                                                                                                               |
+| `fla-correctness-coverage` | Coverage matrix and test guidance for `fla/ops/**` kernels                                                                                                        |
+| `fla-mr-readiness`         | MR/PR preparation checklist, test plan, and PR body structure                                                                                                     |

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -6,9 +6,10 @@ Add reusable workflows as:
 .agents/skills/<skill-name>/SKILL.md
 ```
 
-Each skill should be self-contained and task-specific. Include YAML frontmatter with `name` and `description`. If a skill
-needs reference files, place them in a `references/` subdirectory inside the skill folder. Symlinks to public repo docs
-are allowed when the referenced file is already tracked in this repository.
+Each skill should be self-contained and task-specific.
+Include YAML frontmatter with `name` and `description`.
+If a skill needs reference files, place them in a `references/` subdirectory inside the skill folder.
+Symlinks to public repo docs are allowed when the referenced file is already tracked in this repository.
 
 Do not add a `README.md` inside individual skill directories; the canonical entry point is `SKILL.md`.
 

--- a/.agents/skills/fla-nvidia-performance/SKILL.md
+++ b/.agents/skills/fla-nvidia-performance/SKILL.md
@@ -1,31 +1,26 @@
 ---
 name: fla-nvidia-performance
 description: >
-  Guidelines for NVIDIA GPU kernel / Triton / Gluon / TileLang / CUDA backend
-  performance work in the FLA repo. Covers profiling workflow, hardware baselines,
-  and MR-ready performance evidence requirements. Uses an installed
-  ncu-report-skill when a task needs detailed Nsight Compute collection and
-  diagnosis.
+  Guidelines for NVIDIA GPU kernel / Triton / Gluon / TileLang / CUDA backend performance work in the FLA repo.
+  Covers profiling workflow, hardware baselines, and MR-ready performance evidence requirements.
+  Uses an installed ncu-report-skill when a task needs detailed Nsight Compute collection and diagnosis.
 ---
 
 # FLA NVIDIA Performance Skill
 
-Use this skill when working on Triton, Gluon, TileLang, CUDA, or other NVIDIA GPU
-kernel optimizations, backend tuning, or any change that could affect throughput
-or latency in `fla/ops/` or related modules.
+Use this skill when working on Triton, Gluon, TileLang, CUDA, or other NVIDIA GPU kernel optimizations,
+backend tuning, or any change that could affect throughput or latency in `fla/ops/` or related modules.
 
 ## Hardware baseline
 
 - **Minimum effective baseline**: datacenter NVIDIA GPUs with sm_90 or newer; H100 / H20 are accepted.
 - **Preferred targets**: datacenter NVIDIA GPUs with sm_100 or sm_103.
-- **Reference only**: A100 (sm_80), pre-sm_80 GPUs, and all consumer cards
-  (including sm_86, sm_89, and sm_120).
+- **Reference only**: A100 (sm_80), pre-sm_80 GPUs, and all consumer cards (including sm_86, sm_89, and sm_120).
   Do not use these numbers as the only MR performance conclusion.
 
 ## Detailed NCU workflow
 
-This repo intentionally does **not** vendor `ncu-report-skill`, add it as a
-submodule, or auto-clone it during agent work.
+This repo intentionally does **not** vendor `ncu-report-skill`, add it as a submodule, or auto-clone it during agent work.
 
 If a user-level `ncu-report-skill` is available, use it for:
 
@@ -34,9 +29,9 @@ If a user-level `ncu-report-skill` is available, use it for:
 - report parsing helpers and diagnosis playbooks;
 - the final profiling report structure.
 
-If it is not available, use the minimal NCU commands in this skill and state in
-the MR notes that the external helper skill was unavailable. Do not create
-untracked external clones inside this repo unless the user explicitly asks.
+If it is not available, use the minimal NCU commands in this skill and state in the MR notes
+that the external helper skill was unavailable.
+Do not create untracked external clones inside this repo unless the user explicitly asks.
 
 ## Day-to-day development
 
@@ -47,16 +42,15 @@ untracked external clones inside this repo unless the user explicitly asks.
 
 ## Before opening an MR (performance evidence)
 
-An agent-authored MR that touches kernel code must include **complete
-performance evidence**:
+An agent-authored MR that touches kernel code must include **complete performance evidence**:
 
 1. **Before / after benchmark**
    - Run the same benchmark script with the same workload on the same hardware.
    - Report throughput (tokens/s or iters/s) and, if relevant, peak memory.
 
 2. **NCU profile**
-   - Run `ncu` with both `--set full` and `--set source` for a representative
-     changed kernel when Nsight Compute is available.
+   - Run `ncu` with both `--set full` and `--set source` for a representative changed kernel
+     when Nsight Compute is available.
    - Capture the `.ncu-rep` locally; do **not** commit it to the repo.
    - In the MR description, paste a short summary of key metrics
      (e.g., memory throughput %, SOL, occupancy, top hot instructions).

--- a/.agents/skills/fla-optimization-loop/SKILL.md
+++ b/.agents/skills/fla-optimization-loop/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: fla-optimization-loop
 description: >
-  Disciplined, reproducible loop for making an FLA kernel faster (Triton, Gluon, TileLang, CuTe) without ever breaking
-  or gaming correctness. Synthesizes the task-contract / three-phase / iteration-protocol / silent-bug-catalog discipline
-  of agent kernel-optimization frameworks (KDA, the MLSys FlashInfer contest workflow, AKO4ALL/AKO4X) and anchors all of
-  it on FLA's frozen pytest (forward AND backward, under NaN poisoning) as the immutable correctness gate. Use when
-  iterating on `fla/ops/**` performance over multiple rounds.
+  Disciplined, reproducible loop for making an FLA kernel faster (Triton, Gluon, TileLang, CuTe)
+  without ever breaking or gaming correctness.
+  Synthesizes the task-contract / three-phase / iteration-protocol / silent-bug-catalog discipline
+  of agent kernel-optimization frameworks (KDA, the MLSys FlashInfer contest workflow, AKO4ALL/AKO4X),
+  and anchors all of it on FLA's frozen pytest (forward AND backward, under NaN poisoning) as the immutable correctness gate.
+  Use when iterating on `fla/ops/**` performance over multiple rounds.
 ---
 
 # FLA Optimization Loop Skill
 
 Use this when you are making an existing `fla/ops/**` kernel faster — or bringing a new kernel from correct to fast —
-across more than one iteration, in any FLA backend language (Triton, Gluon, TileLang, CuTe DSL). This skill is the
-**search discipline** that ties the other skills together; it does not replace them:
+across more than one iteration, in any FLA backend language (Triton, Gluon, TileLang, CuTe DSL).
+This skill is the **search discipline** that ties the other skills together; it does not replace them:
 
 - **`fla-nvidia-performance`** — how to profile (NCU), hardware baselines, MR-ready perf evidence.
 - **`fla-correctness-coverage`** — how to design the test coverage matrix for an op.
@@ -22,9 +23,10 @@ This skill covers the loop *around* those: what to lock, how to iterate, what to
 
 ## 0. The inviolable rule: the test file is a frozen contract
 
-The op's `tests/ops/test_<op>.py` and its `fla/ops/<op>/naive.py` reference are **frozen** for the entire optimization
-loop. The whole point of "faster" only means something if correctness — forward **and** backward, under the conftest
-NaN-memory poisoning — is held fixed. During a perf loop you may **not**:
+The op's `tests/ops/test_<op>.py` and its `fla/ops/<op>/naive.py` reference are **frozen** for the entire optimization loop.
+The whole point of "faster" only means something if correctness — forward **and** backward,
+under the conftest NaN-memory poisoning — is held fixed.
+During a perf loop you may **not**:
 
 - edit the test file, or its `naive.py` reference;
 - loosen an `assert_close` tolerance, or widen `rms_eps` / dtype to make a diff pass;
@@ -38,8 +40,9 @@ Run the gate with the unmodified test, every iteration:
 python -m benchmarks.ops.verify --op <op> [--gate-k <subset>]
 ```
 
-`verify.py` runs the pytest file as a black box and **refuses to report a speedup on a red gate**. `--gate-k` only
-*selects* a shape subset for a fast signal — it never edits the test; promote only on a full (no `-k`) green gate.
+`verify.py` runs the pytest file as a black box and **refuses to report a speedup on a red gate**.
+`--gate-k` only *selects* a shape subset for a fast signal — it never edits the test;
+promote only on a full (no `-k`) green gate.
 
 **Banned vs. allowed implementation (anti-reward-hacking):**
 
@@ -49,8 +52,8 @@ python -m benchmarks.ops.verify --op <op> [--gate-k <subset>]
 | Returning uninitialized / partially-written outputs that happen to pass | Fully initialized outputs (NaN poisoning will catch partial writes) |
 | Stream tricks / monkey-patching the bench to dodge timing | Genuine latency reduction measured by `verify.py` / `run.py` |
 
-If you genuinely believe a test is **wrong**, that is a **separate PR** with its own justification — never bundled into a
-perf change. Stop and ask the user.
+If you genuinely believe a test is **wrong**, that is a **separate PR** with its own justification —
+never bundled into a perf change. Stop and ask the user.
 
 ## 1. Write the task contract first (before any code)
 
@@ -71,14 +74,14 @@ Do not start editing kernels until the draft exists. (Borrowed from KDA: plan, t
 Run these in order; repeat 2 and 3 with progressively higher targets.
 
 - **Phase 1 — correct baseline.** Confirm the current kernel passes the full gate, and record baseline numbers:
-  `python -m benchmarks.ops.verify --op <op> --base main`. For a brand-new kernel, get the gate green first; performance
-  is secondary here.
-- **Phase 2 — profile-guided optimization.** Use `fla-nvidia-performance` for NCU evidence. Enumerate candidate
-  directions, rank them by expected benefit vs. implementation risk, and explore each for at most a few iterations. Keep,
-  revise, or reject each with evidence — don't optimize blindly.
-- **Phase 3 — shape specialization.** Only when profiling shows *different* bottlenecks across shape regimes (short vs.
-  long `T`, small vs. large `D`), add dispatch / specialized paths. Justify the added complexity with the measured win;
-  validate on the full shape set, not the one you tuned on.
+  `python -m benchmarks.ops.verify --op <op> --base main`.
+  For a brand-new kernel, get the gate green first; performance is secondary here.
+- **Phase 2 — profile-guided optimization.** Use `fla-nvidia-performance` for NCU evidence.
+  Enumerate candidate directions, rank them by expected benefit vs. implementation risk,
+  and explore each for at most a few iterations. Keep, revise, or reject each with evidence — don't optimize blindly.
+- **Phase 3 — shape specialization.** Only when profiling shows *different* bottlenecks across shape regimes
+  (short vs. long `T`, small vs. large `D`), add dispatch / specialized paths.
+  Justify the added complexity with the measured win; validate on the full shape set, not the one you tuned on.
 
 ## 3. Iteration protocol
 
@@ -88,33 +91,37 @@ Every iteration is exactly three steps, in order, with no telescoping into the n
 2. Run `verify.py` — gate must stay green; record the bench number.
 3. Append one row to `OPT_LOG.md` (see `references/opt-log-template.md`) and `git commit`.
 
-A failed or no-change iteration is still an iteration: log it and commit before debugging the next direction. (Borrowed
-from AKO4ALL: bench → log → commit, the most-skipped step in practice.)
+A failed or no-change iteration is still an iteration: log it and commit before debugging the next direction.
+(Borrowed from AKO4ALL: bench → log → commit, the most-skipped step in practice.)
 
-**Stall handling.** After 3 consecutive iterations with no improvement (≥ a few % over current best, above noise), stop
-and re-assess: re-profile, re-read `OPT_LOG.md` for which axes you've already tried, and search for known techniques for
-this op family before picking a new direction.
+**Stall handling.** After 3 consecutive iterations with no improvement (≥ a few % over current best, above noise),
+stop and re-assess: re-profile, re-read `OPT_LOG.md` for which axes you've already tried,
+and search for known techniques for this op family before picking a new direction.
 
-**When to stop.** A user-set iteration cap is reached; or re-assessment produces hard evidence of a floor (bandwidth-bound
-at HBM limit, launch-overhead dominated, timer-resolution limited — cite it in `OPT_LOG.md`); or you've documented ≥3
-distinct directions tried with evidence. Don't stop silently because a tool (e.g. NCU) was unavailable — that's a
-re-assessment input.
+**When to stop.** A user-set iteration cap is reached;
+or re-assessment produces hard evidence of a floor (bandwidth-bound at HBM limit, launch-overhead dominated,
+timer-resolution limited — cite it in `OPT_LOG.md`);
+or you've documented ≥3 distinct directions tried with evidence.
+Don't stop silently because a tool (e.g. NCU) was unavailable — that's a re-assessment input.
 
 ## 4. Reproducibility
 
 - **Seed** — the tests already pin `torch.manual_seed(42)`; don't undermine it.
-- **Environment** — `verify.py` prints GPU / CUDA / PyTorch / Triton / commit SHA; paste that line into `OPT_LOG.md` so a
-  number is interpretable later.
+- **Environment** — `verify.py` prints GPU / CUDA / PyTorch / Triton / commit SHA;
+  paste that line into `OPT_LOG.md` so a number is interpretable later.
 - **Full-shape verdict before promotion** — a `--gate-k` subset is a signal only.
-- **Rank by the solution's own runtime** for fast iteration signal; pay for the full `--base main` comparison only at the
-  verdict. Clock noise on unlocked GPUs can swing absolute speedup — see `references/TRAPS.md`.
+- **Rank by the solution's own runtime** for fast iteration signal;
+  pay for the full `--base main` comparison only at the verdict.
+  Clock noise on unlocked GPUs can swing absolute speedup — see `references/TRAPS.md`.
 
 ## 5. Silent-bug & measurement traps
 
-Read `references/TRAPS.md` before trusting any number. It catalogs FLA-specific traps (NaN poisoning on partial writes,
-TF32 inflating fp32 reference diffs, `assert_close` relative tolerance, autotune-cache staleness across edits, `int64`
-address arithmetic, implausible speedups that signal a silently-skipped path). When you hit a new one, add it there with
-**Fact / Why / How to apply** so the next session doesn't re-learn it. (Borrowed from AKO4X's `TRAPS.md`.)
+Read `references/TRAPS.md` before trusting any number.
+It catalogs FLA-specific traps (NaN poisoning on partial writes, TF32 inflating fp32 reference diffs,
+`assert_close` relative tolerance, autotune-cache staleness across edits, `int64` address arithmetic,
+implausible speedups that signal a silently-skipped path).
+When you hit a new one, add it there with **Fact / Why / How to apply** so the next session doesn't re-learn it.
+(Borrowed from AKO4X's `TRAPS.md`.)
 
 ## 6. Evidence records (scratch workspace)
 
@@ -128,15 +135,15 @@ profile/<op>-opt/
   trace/              # torch.profiler / NCU artifacts (kept out of git)
 ```
 
-Each kept candidate's `kernel` gets a short header (Identity / Delta / Lessons / Dead-ends / Open-directions) per
-`references/opt-log-template.md`, so a later session can see what was tried and why.
+Each kept candidate's `kernel` gets a short header (Identity / Delta / Lessons / Dead-ends / Open-directions)
+per `references/opt-log-template.md`, so a later session can see what was tried and why.
 
 ## 7. Promotion → MR
 
 A candidate is promotable only on a **full green gate** plus a measured, repeatable win on the target shapes. Then:
 
-- Keep the diff minimal — change only what the win needs, plus light cleanups (CONTRIBUTING "Protect battle-tested paths;
-  keep diffs minimal").
+- Keep the diff minimal — change only what the win needs,
+  plus light cleanups (CONTRIBUTING "Protect battle-tested paths; keep diffs minimal").
 - Collect perf evidence per `fla-nvidia-performance` (before/after, NCU summary, dense + varlen coverage).
 - Package the PR per `fla-mr-readiness`.
 

--- a/.agents/skills/fla-optimization-loop/SKILL.md
+++ b/.agents/skills/fla-optimization-loop/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: fla-optimization-loop
+description: >
+  Disciplined, reproducible loop for making an FLA kernel faster (Triton, Gluon, TileLang, CuTe) without ever breaking
+  or gaming correctness. Synthesizes the task-contract / three-phase / iteration-protocol / silent-bug-catalog discipline
+  of agent kernel-optimization frameworks (KDA, the MLSys FlashInfer contest workflow, AKO4ALL/AKO4X) and anchors all of
+  it on FLA's frozen pytest (forward AND backward, under NaN poisoning) as the immutable correctness gate. Use when
+  iterating on `fla/ops/**` performance over multiple rounds.
+---
+
+# FLA Optimization Loop Skill
+
+Use this when you are making an existing `fla/ops/**` kernel faster — or bringing a new kernel from correct to fast —
+across more than one iteration, in any FLA backend language (Triton, Gluon, TileLang, CuTe DSL). This skill is the
+**search discipline** that ties the other skills together; it does not replace them:
+
+- **`fla-nvidia-performance`** — how to profile (NCU), hardware baselines, MR-ready perf evidence.
+- **`fla-correctness-coverage`** — how to design the test coverage matrix for an op.
+- **`fla-mr-readiness`** — how to package the promoted change into a PR.
+
+This skill covers the loop *around* those: what to lock, how to iterate, what to record, and when to stop.
+
+## 0. The inviolable rule: the test file is a frozen contract
+
+The op's `tests/ops/test_<op>.py` and its `fla/ops/<op>/naive.py` reference are **frozen** for the entire optimization
+loop. The whole point of "faster" only means something if correctness — forward **and** backward, under the conftest
+NaN-memory poisoning — is held fixed. During a perf loop you may **not**:
+
+- edit the test file, or its `naive.py` reference;
+- loosen an `assert_close` tolerance, or widen `rms_eps` / dtype to make a diff pass;
+- drop, narrow, or `skip` parametrized shapes;
+- special-case the kernel on values it only sees in the test;
+- cache module-level tensors so trials reuse warm/identical data.
+
+Run the gate with the unmodified test, every iteration:
+
+```bash
+python -m benchmarks.ops.verify --op <op> [--gate-k <subset>]
+```
+
+`verify.py` runs the pytest file as a black box and **refuses to report a speedup on a red gate**. `--gate-k` only
+*selects* a shape subset for a fast signal — it never edits the test; promote only on a full (no `-k`) green gate.
+
+**Banned vs. allowed implementation (anti-reward-hacking):**
+
+| Banned | Allowed |
+|--------|---------|
+| Making the op a thin wrapper that delegates the whole compute to a vendor lib (a plain `torch.matmul` / `F.scaled_dot_product_attention` standing in *as* the operator) just to win latency | Hand-written Triton / Gluon / TileLang / CuTe kernels; `torch` ops used as *glue* around a kernel you wrote |
+| Returning uninitialized / partially-written outputs that happen to pass | Fully initialized outputs (NaN poisoning will catch partial writes) |
+| Stream tricks / monkey-patching the bench to dodge timing | Genuine latency reduction measured by `verify.py` / `run.py` |
+
+If you genuinely believe a test is **wrong**, that is a **separate PR** with its own justification — never bundled into a
+perf change. Stop and ask the user.
+
+## 1. Write the task contract first (before any code)
+
+Put a short `docs/draft.md` in your scratch workspace (see §6) stating:
+
+- **Op + entry point** — e.g. `chunk_gla` in `fla.ops.gla`.
+- **Target** — which shapes (from `benchmarks/ops/registry.py` `SHAPE_CONFIGS`), and a target speedup vs. `main`.
+- **Allowed languages** — Triton / Gluon / TileLang / CuTe (state any constraint).
+- **Validation command** — `python -m benchmarks.ops.verify --op <op>` (the frozen gate).
+- **Benchmark command** — `python -m benchmarks.ops.verify --op <op> --base main`.
+- **Promotion criteria** — full green gate AND a measured, repeatable win on the target shapes.
+- **Frozen scope** — the test file, `naive.py`, and the public op signature.
+
+Do not start editing kernels until the draft exists. (Borrowed from KDA: plan, then execute.)
+
+## 2. Three phases
+
+Run these in order; repeat 2 and 3 with progressively higher targets.
+
+- **Phase 1 — correct baseline.** Confirm the current kernel passes the full gate, and record baseline numbers:
+  `python -m benchmarks.ops.verify --op <op> --base main`. For a brand-new kernel, get the gate green first; performance
+  is secondary here.
+- **Phase 2 — profile-guided optimization.** Use `fla-nvidia-performance` for NCU evidence. Enumerate candidate
+  directions, rank them by expected benefit vs. implementation risk, and explore each for at most a few iterations. Keep,
+  revise, or reject each with evidence — don't optimize blindly.
+- **Phase 3 — shape specialization.** Only when profiling shows *different* bottlenecks across shape regimes (short vs.
+  long `T`, small vs. large `D`), add dispatch / specialized paths. Justify the added complexity with the measured win;
+  validate on the full shape set, not the one you tuned on.
+
+## 3. Iteration protocol
+
+Every iteration is exactly three steps, in order, with no telescoping into the next iteration between them:
+
+1. Make **one** change to the kernel.
+2. Run `verify.py` — gate must stay green; record the bench number.
+3. Append one row to `OPT_LOG.md` (see `references/opt-log-template.md`) and `git commit`.
+
+A failed or no-change iteration is still an iteration: log it and commit before debugging the next direction. (Borrowed
+from AKO4ALL: bench → log → commit, the most-skipped step in practice.)
+
+**Stall handling.** After 3 consecutive iterations with no improvement (≥ a few % over current best, above noise), stop
+and re-assess: re-profile, re-read `OPT_LOG.md` for which axes you've already tried, and search for known techniques for
+this op family before picking a new direction.
+
+**When to stop.** A user-set iteration cap is reached; or re-assessment produces hard evidence of a floor (bandwidth-bound
+at HBM limit, launch-overhead dominated, timer-resolution limited — cite it in `OPT_LOG.md`); or you've documented ≥3
+distinct directions tried with evidence. Don't stop silently because a tool (e.g. NCU) was unavailable — that's a
+re-assessment input.
+
+## 4. Reproducibility
+
+- **Seed** — the tests already pin `torch.manual_seed(42)`; don't undermine it.
+- **Environment** — `verify.py` prints GPU / CUDA / PyTorch / Triton / commit SHA; paste that line into `OPT_LOG.md` so a
+  number is interpretable later.
+- **Full-shape verdict before promotion** — a `--gate-k` subset is a signal only.
+- **Rank by the solution's own runtime** for fast iteration signal; pay for the full `--base main` comparison only at the
+  verdict. Clock noise on unlocked GPUs can swing absolute speedup — see `references/TRAPS.md`.
+
+## 5. Silent-bug & measurement traps
+
+Read `references/TRAPS.md` before trusting any number. It catalogs FLA-specific traps (NaN poisoning on partial writes,
+TF32 inflating fp32 reference diffs, `assert_close` relative tolerance, autotune-cache staleness across edits, `int64`
+address arithmetic, implausible speedups that signal a silently-skipped path). When you hit a new one, add it there with
+**Fact / Why / How to apply** so the next session doesn't re-learn it. (Borrowed from AKO4X's `TRAPS.md`.)
+
+## 6. Evidence records (scratch workspace)
+
+Keep your search artifacts in a git-ignored directory — `profile/<op>-opt/` is already ignored:
+
+```text
+profile/<op>-opt/
+  docs/draft.md       # the task contract (§1)
+  OPT_LOG.md          # one row per iteration (template in references/)
+  TRAPS.md            # traps you hit this session (seed: references/TRAPS.md)
+  trace/              # torch.profiler / NCU artifacts (kept out of git)
+```
+
+Each kept candidate's `kernel` gets a short header (Identity / Delta / Lessons / Dead-ends / Open-directions) per
+`references/opt-log-template.md`, so a later session can see what was tried and why.
+
+## 7. Promotion → MR
+
+A candidate is promotable only on a **full green gate** plus a measured, repeatable win on the target shapes. Then:
+
+- Keep the diff minimal — change only what the win needs, plus light cleanups (CONTRIBUTING "Protect battle-tested paths;
+  keep diffs minimal").
+- Collect perf evidence per `fla-nvidia-performance` (before/after, NCU summary, dense + varlen coverage).
+- Package the PR per `fla-mr-readiness`.
+
+The scratch workspace under `profile/<op>-opt/` stays local; it is not part of the PR.

--- a/.agents/skills/fla-optimization-loop/references/TRAPS.md
+++ b/.agents/skills/fla-optimization-loop/references/TRAPS.md
@@ -1,9 +1,10 @@
 # FLA Optimization Traps
 
-A catalog of silent-bug and measurement traps specific to optimizing FLA kernels. Each entry has a **Fact**, a **Why**
-(so a future session can judge whether its context flips the fact), and a **How to apply**. This is a *seed* — when you
-hit a new trap during an optimization loop, copy it into your scratch `profile/<op>-opt/TRAPS.md` and, if it generalizes,
-propose adding it here.
+A catalog of silent-bug and measurement traps specific to optimizing FLA kernels.
+Each entry has a **Fact**, a **Why** (so a future session can judge whether its context flips the fact),
+and a **How to apply**.
+This is a *seed* — when you hit a new trap during an optimization loop,
+copy it into your scratch `profile/<op>-opt/TRAPS.md` and, if it generalizes, propose adding it here.
 
 ---
 
@@ -11,49 +12,50 @@ propose adding it here.
 
 ### Partially-initialized outputs pass in eager but are real bugs
 
-**Fact:** A kernel that writes only part of its output tensor (a masked tail, an unfilled boundary block) can pass a
-casual eager run yet be wrong.
+**Fact:** A kernel that writes only part of its output tensor (a masked tail, an unfilled boundary block)
+can pass a casual eager run yet be wrong.
 
-**Why:** `tests/conftest.py` replaces `torch.empty` / `empty_like` / `new_empty` with **NaN-filled** tensors for
-`tests/ops/` and `tests/modules/`. Uninitialized reads then surface as NaN in `assert_close`. Outside that guard the same
-memory is often coincidentally zero, hiding the bug.
+**Why:** `tests/conftest.py` replaces `torch.empty` / `empty_like` / `new_empty` with **NaN-filled** tensors
+for `tests/ops/` and `tests/modules/`. Uninitialized reads then surface as NaN in `assert_close`.
+Outside that guard the same memory is often coincidentally zero, hiding the bug.
 
-**How to apply:** Fully initialize every output element. If the gate fails with NaN but an ad-hoc script "passes", trust
-the gate — you have a partial-write bug.
+**How to apply:** Fully initialize every output element.
+If the gate fails with NaN but an ad-hoc script "passes", trust the gate — you have a partial-write bug.
 
 ### TF32 inflates the fp32 reference diff
 
-**Fact:** An fp32 correctness case can fail by a margin that is a measurement artifact, not a kernel bug, if TF32 matmuls
-are on in the reference path.
+**Fact:** An fp32 correctness case can fail by a margin that is a measurement artifact, not a kernel bug,
+if TF32 matmuls are on in the reference path.
 
-**Why:** cuBLAS TF32 has a 10-bit mantissa; an einsum/matmul backward in the naive reference then differs from a
-true-fp32 kernel by more than the tolerance. `tests/ops/test_attnres.py` explicitly sets
-`torch.backends.cuda.matmul.allow_tf32 = False` for exactly this reason.
+**Why:** cuBLAS TF32 has a 10-bit mantissa;
+an einsum/matmul backward in the naive reference then differs from a true-fp32 kernel by more than the tolerance.
+`tests/ops/test_attnres.py` explicitly sets `torch.backends.cuda.matmul.allow_tf32 = False` for exactly this reason.
 
-**How to apply:** Don't "fix" an fp32 diff by loosening tolerance. Check whether the *reference* is running TF32 first;
-the test, not your kernel, owns that choice — and it is frozen.
+**How to apply:** Don't "fix" an fp32 diff by loosening tolerance.
+Check whether the *reference* is running TF32 first; the test, not your kernel, owns that choice — and it is frozen.
 
 ### `assert_close` is a *relative* tolerance — never loosen it to pass
 
-**Fact:** The gate uses `fla.utils.assert_close` with a relative tolerance. Widening it to make a candidate pass converts
-a correctness regression into a silent one.
+**Fact:** The gate uses `fla.utils.assert_close` with a relative tolerance.
+Widening it to make a candidate pass converts a correctness regression into a silent one.
 
-**Why:** A "win" that only passes at a looser tolerance is usually a numerically degraded kernel (lower-precision
-accumulation, dropped correction term), not a faster correct one.
+**Why:** A "win" that only passes at a looser tolerance is usually a numerically degraded kernel
+(lower-precision accumulation, dropped correction term), not a faster correct one.
 
-**How to apply:** Tolerance is part of the frozen contract. If you think it's wrong, that's a separate PR with
-justification — ask the user.
+**How to apply:** Tolerance is part of the frozen contract.
+If you think it's wrong, that's a separate PR with justification — ask the user.
 
 ### Grid-derived indices must be `int64`
 
-**Fact:** Program IDs and grid-derived offsets multiplied by sizes/strides can silently overflow at large `T`, producing
-wrong results only on big shapes.
+**Fact:** Program IDs and grid-derived offsets multiplied by sizes/strides can silently overflow at large `T`,
+producing wrong results only on big shapes.
 
-**Why:** Triton program IDs and non-first grid dims can be narrow integers; the overflow is silent and shape-dependent
-(CONTRIBUTING → Triton Kernels). A kernel can pass small-shape cases and corrupt `T=8000+` ones.
+**Why:** Triton program IDs and non-first grid dims can be narrow integers;
+the overflow is silent and shape-dependent (CONTRIBUTING → Triton Kernels).
+A kernel can pass small-shape cases and corrupt `T=8000+` ones.
 
-**How to apply:** Cast to `tl.int64` before address arithmetic; keep all base/stride/offset math in `int64`. Always run
-the gate's large-`T` cases, not just the fast small ones.
+**How to apply:** Cast to `tl.int64` before address arithmetic; keep all base/stride/offset math in `int64`.
+Always run the gate's large-`T` cases, not just the fast small ones.
 
 ---
 
@@ -64,30 +66,31 @@ the gate's large-`T` cases, not just the fast small ones.
 **Fact:** A large speedup that doesn't match the structural change (e.g. you touched one reduction and latency halved)
 usually means a code path was skipped, a shape was filtered out of the run, or correctness silently degraded.
 
-**Why:** Optimizers reward-hack by accident — an early return, a wrong dispatch, a `dim_constraints` filter dropping the
-expensive shape. The contest/AKO harnesses flag implausible speedups for this reason.
+**Why:** Optimizers reward-hack by accident — an early return, a wrong dispatch,
+a `dim_constraints` filter dropping the expensive shape.
+The contest/AKO harnesses flag implausible speedups for this reason.
 
-**How to apply:** Before celebrating, confirm the gate is green on the *same* shapes you benchmarked, and that the shape
-was actually run (not skipped). If the number is too good, it is.
+**How to apply:** Before celebrating, confirm the gate is green on the *same* shapes you benchmarked,
+and that the shape was actually run (not skipped). If the number is too good, it is.
 
 ### Autotune cache can be stale across edits
 
-**Fact:** Triton autotune results are cached; after editing a kernel, the first timed run may reflect the *old* best
-config or an un-retuned path.
+**Fact:** Triton autotune results are cached;
+after editing a kernel, the first timed run may reflect the *old* best config or an un-retuned path.
 
 **Why:** Caching speeds iteration but pins config choices made before your edit.
 
-**How to apply:** `run.py` / `verify.py` warm up all shapes before timing — keep that. When a result looks off after a
-config-space change, clear/rewarm the autotune cache and re-measure.
+**How to apply:** `run.py` / `verify.py` warm up all shapes before timing — keep that.
+When a result looks off after a config-space change, clear/rewarm the autotune cache and re-measure.
 
 ### Clock-state drift moves absolute speedup
 
 **Fact:** The same unchanged kernel can report different absolute speedups across runs when GPU clocks are unlocked;
 cumulative AB deltas across separate runs do not compose.
 
-**Why:** Reference and solution timed in different clock states carry per-run noise; summing N independent deltas
-accumulates noise that can reverse sign.
+**Why:** Reference and solution timed in different clock states carry per-run noise;
+summing N independent deltas accumulates noise that can reverse sign.
 
-**How to apply:** For iteration *signal*, rank by the solution's own runtime in one run. For the *verdict*, run the full
-`--base main` compare in one session. Don't claim a cumulative win as the sum of prior separate measurements — re-measure
-directly against the baseline.
+**How to apply:** For iteration *signal*, rank by the solution's own runtime in one run.
+For the *verdict*, run the full `--base main` compare in one session.
+Don't claim a cumulative win as the sum of prior separate measurements — re-measure directly against the baseline.

--- a/.agents/skills/fla-optimization-loop/references/TRAPS.md
+++ b/.agents/skills/fla-optimization-loop/references/TRAPS.md
@@ -1,0 +1,93 @@
+# FLA Optimization Traps
+
+A catalog of silent-bug and measurement traps specific to optimizing FLA kernels. Each entry has a **Fact**, a **Why**
+(so a future session can judge whether its context flips the fact), and a **How to apply**. This is a *seed* — when you
+hit a new trap during an optimization loop, copy it into your scratch `profile/<op>-opt/TRAPS.md` and, if it generalizes,
+propose adding it here.
+
+---
+
+## Correctness traps
+
+### Partially-initialized outputs pass in eager but are real bugs
+
+**Fact:** A kernel that writes only part of its output tensor (a masked tail, an unfilled boundary block) can pass a
+casual eager run yet be wrong.
+
+**Why:** `tests/conftest.py` replaces `torch.empty` / `empty_like` / `new_empty` with **NaN-filled** tensors for
+`tests/ops/` and `tests/modules/`. Uninitialized reads then surface as NaN in `assert_close`. Outside that guard the same
+memory is often coincidentally zero, hiding the bug.
+
+**How to apply:** Fully initialize every output element. If the gate fails with NaN but an ad-hoc script "passes", trust
+the gate — you have a partial-write bug.
+
+### TF32 inflates the fp32 reference diff
+
+**Fact:** An fp32 correctness case can fail by a margin that is a measurement artifact, not a kernel bug, if TF32 matmuls
+are on in the reference path.
+
+**Why:** cuBLAS TF32 has a 10-bit mantissa; an einsum/matmul backward in the naive reference then differs from a
+true-fp32 kernel by more than the tolerance. `tests/ops/test_attnres.py` explicitly sets
+`torch.backends.cuda.matmul.allow_tf32 = False` for exactly this reason.
+
+**How to apply:** Don't "fix" an fp32 diff by loosening tolerance. Check whether the *reference* is running TF32 first;
+the test, not your kernel, owns that choice — and it is frozen.
+
+### `assert_close` is a *relative* tolerance — never loosen it to pass
+
+**Fact:** The gate uses `fla.utils.assert_close` with a relative tolerance. Widening it to make a candidate pass converts
+a correctness regression into a silent one.
+
+**Why:** A "win" that only passes at a looser tolerance is usually a numerically degraded kernel (lower-precision
+accumulation, dropped correction term), not a faster correct one.
+
+**How to apply:** Tolerance is part of the frozen contract. If you think it's wrong, that's a separate PR with
+justification — ask the user.
+
+### Grid-derived indices must be `int64`
+
+**Fact:** Program IDs and grid-derived offsets multiplied by sizes/strides can silently overflow at large `T`, producing
+wrong results only on big shapes.
+
+**Why:** Triton program IDs and non-first grid dims can be narrow integers; the overflow is silent and shape-dependent
+(CONTRIBUTING → Triton Kernels). A kernel can pass small-shape cases and corrupt `T=8000+` ones.
+
+**How to apply:** Cast to `tl.int64` before address arithmetic; keep all base/stride/offset math in `int64`. Always run
+the gate's large-`T` cases, not just the fast small ones.
+
+---
+
+## Measurement traps
+
+### A speedup implausible for the change you made signals a silent skip
+
+**Fact:** A large speedup that doesn't match the structural change (e.g. you touched one reduction and latency halved)
+usually means a code path was skipped, a shape was filtered out of the run, or correctness silently degraded.
+
+**Why:** Optimizers reward-hack by accident — an early return, a wrong dispatch, a `dim_constraints` filter dropping the
+expensive shape. The contest/AKO harnesses flag implausible speedups for this reason.
+
+**How to apply:** Before celebrating, confirm the gate is green on the *same* shapes you benchmarked, and that the shape
+was actually run (not skipped). If the number is too good, it is.
+
+### Autotune cache can be stale across edits
+
+**Fact:** Triton autotune results are cached; after editing a kernel, the first timed run may reflect the *old* best
+config or an un-retuned path.
+
+**Why:** Caching speeds iteration but pins config choices made before your edit.
+
+**How to apply:** `run.py` / `verify.py` warm up all shapes before timing — keep that. When a result looks off after a
+config-space change, clear/rewarm the autotune cache and re-measure.
+
+### Clock-state drift moves absolute speedup
+
+**Fact:** The same unchanged kernel can report different absolute speedups across runs when GPU clocks are unlocked;
+cumulative AB deltas across separate runs do not compose.
+
+**Why:** Reference and solution timed in different clock states carry per-run noise; summing N independent deltas
+accumulates noise that can reverse sign.
+
+**How to apply:** For iteration *signal*, rank by the solution's own runtime in one run. For the *verdict*, run the full
+`--base main` compare in one session. Don't claim a cumulative win as the sum of prior separate measurements — re-measure
+directly against the baseline.

--- a/.agents/skills/fla-optimization-loop/references/opt-log-template.md
+++ b/.agents/skills/fla-optimization-loop/references/opt-log-template.md
@@ -21,7 +21,7 @@ Target: <e.g. 1.2x on B4_T4096_H64_D128, full gate green>
 ## Summary
 
 | Iter | Direction (one line) | Gate | Bench (median ms) | vs best | Status |
-|------|----------------------|------|-------------------|---------|--------|
+| ---- | -------------------- | ---- | ----------------- | ------- | ------ |
 | 0    | baseline             | pass | 1.934             | —       | base   |
 | 1    | fuse gate mult       | pass | 1.701             | +12%    | keep   |
 | 2    | larger BT block      | pass | 1.770             | -4%     | revert |

--- a/.agents/skills/fla-optimization-loop/references/opt-log-template.md
+++ b/.agents/skills/fla-optimization-loop/references/opt-log-template.md
@@ -1,15 +1,16 @@
 # Optimization Log Templates
 
-Copy these into your scratch workspace `profile/<op>-opt/`. They keep an optimization loop auditable: a future reader (or
-session) should be able to reconstruct what was tried, what passed the gate, what was measured, and why a candidate was
-kept or dropped. Keep this workspace out of git (`profile/` is already ignored).
+Copy these into your scratch workspace `profile/<op>-opt/`.
+They keep an optimization loop auditable: a future reader (or session) should be able to reconstruct
+what was tried, what passed the gate, what was measured, and why a candidate was kept or dropped.
+Keep this workspace out of git (`profile/` is already ignored).
 
 ---
 
 ## `OPT_LOG.md` — one row per iteration
 
-Append a row after every iteration (including failed / no-change ones). Record the environment line `verify.py` prints
-once at the top so the numbers are interpretable later.
+Append a row after every iteration (including failed / no-change ones).
+Record the environment line `verify.py` prints once at the top so the numbers are interpretable later.
 
 ```markdown
 # Optimization log — <op>
@@ -33,15 +34,15 @@ Status values: keep / revert / drop / floor.
 Rules:
 - **Gate** is the frozen pytest result (`pass` / `fail`), not a hand check.
 - A `fail` row is benchmarked nothing — correctness comes first.
-- After 3 consecutive non-`keep` rows, stop and re-assess (re-profile, review this table for untried axes) before the
-  next iteration.
+- After 3 consecutive non-`keep` rows, stop and re-assess (re-profile, review this table for untried axes)
+  before the next iteration.
 
 ---
 
 ## Kept-candidate header
 
-When you keep a candidate worth returning to, put a short header at the top of its kernel file (in your scratch copy, not
-the repo) so its lineage is legible:
+When you keep a candidate worth returning to, put a short header at the top of its kernel file
+(in your scratch copy, not the repo) so its lineage is legible:
 
 ```markdown
 # Identity:  <op> / <which kernel> / iter-<N>, parent iter-<M>
@@ -51,6 +52,7 @@ the repo) so its lineage is legible:
 # Open:      <levers not yet attempted — forensic note for the next session>
 ```
 
-Keep provenance (specific iter numbers, exact ms, dates) in `OPT_LOG.md` and these headers — not in the promoted PR diff
-or the shared SKILL docs. The PR carries only the final minimal change plus the perf evidence (`fla-nvidia-performance`)
+Keep provenance (specific iter numbers, exact ms, dates) in `OPT_LOG.md` and these headers —
+not in the promoted PR diff or the shared SKILL docs.
+The PR carries only the final minimal change plus the perf evidence (`fla-nvidia-performance`)
 and PR structure (`fla-mr-readiness`).

--- a/.agents/skills/fla-optimization-loop/references/opt-log-template.md
+++ b/.agents/skills/fla-optimization-loop/references/opt-log-template.md
@@ -1,0 +1,56 @@
+# Optimization Log Templates
+
+Copy these into your scratch workspace `profile/<op>-opt/`. They keep an optimization loop auditable: a future reader (or
+session) should be able to reconstruct what was tried, what passed the gate, what was measured, and why a candidate was
+kept or dropped. Keep this workspace out of git (`profile/` is already ignored).
+
+---
+
+## `OPT_LOG.md` — one row per iteration
+
+Append a row after every iteration (including failed / no-change ones). Record the environment line `verify.py` prints
+once at the top so the numbers are interpretable later.
+
+```markdown
+# Optimization log — <op>
+
+Env: <paste the "Machine: ... | Triton ... | <branch>[sha]" line from verify.py>
+Baseline (main): <median ms on target shapes>
+Target: <e.g. 1.2x on B4_T4096_H64_D128, full gate green>
+
+## Summary
+
+| Iter | Direction (one line) | Gate | Bench (median ms) | vs best | Status |
+|------|----------------------|------|-------------------|---------|--------|
+| 0    | baseline             | pass | 1.934             | —       | base   |
+| 1    | fuse gate mult       | pass | 1.701             | +12%    | keep   |
+| 2    | larger BT block      | pass | 1.770             | -4%     | revert |
+| 3    | wider vectorized ld  | fail | —                 | —       | drop   |
+
+Status values: keep / revert / drop / floor.
+```
+
+Rules:
+- **Gate** is the frozen pytest result (`pass` / `fail`), not a hand check.
+- A `fail` row is benchmarked nothing — correctness comes first.
+- After 3 consecutive non-`keep` rows, stop and re-assess (re-profile, review this table for untried axes) before the
+  next iteration.
+
+---
+
+## Kept-candidate header
+
+When you keep a candidate worth returning to, put a short header at the top of its kernel file (in your scratch copy, not
+the repo) so its lineage is legible:
+
+```markdown
+# Identity:  <op> / <which kernel> / iter-<N>, parent iter-<M>
+# Delta:     <the one change vs. parent, in one sentence>
+# Lessons:   <what this iteration taught — mechanism, not just the number>
+# Dead-ends: <what you tried inside this direction that did not work, and why>
+# Open:      <levers not yet attempted — forensic note for the next session>
+```
+
+Keep provenance (specific iter numbers, exact ms, dates) in `OPT_LOG.md` and these headers — not in the promoted PR diff
+or the shared SKILL docs. The PR carries only the final minimal change plus the perf evidence (`fla-nvidia-performance`)
+and PR structure (`fla-mr-readiness`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Keep review/PR comments concise and natural — skip heavy `**1.** **2.**` scaff
 
 This repo provides task-specific workflow skills under `.agents/skills/*/SKILL.md`:
 
+- **`fla-optimization-loop`** — disciplined, reproducible kernel optimization loop with a frozen pytest correctness gate (`benchmarks/ops/verify.py`)
 - **`fla-nvidia-performance`** — NVIDIA GPU kernel / Triton / Gluon / TileLang / CUDA backend performance work
 - **`fla-kda`** — KDA-specific gate, intra/inter, backend, and test workflow
 - **`fla-dispatch-backends`** — `@dispatch` decorator and backend registry workflow

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -125,29 +125,25 @@ class OpConfig:
         extra_kwargs (dict[str, Any], Optional):
             Constant keyword arguments passed to the op. Default: `{}`.
         output_is_tuple (bool):
-            Whether the op returns a tuple whose first item is the tensor used
-            for `.backward()`. Default: `True`.
+            Whether the op returns a tuple whose first item is the tensor used for `.backward()`. Default: `True`.
         skip_backward (bool):
             Whether to skip forward-backward benchmark mode. Default: `False`.
         post_init (Callable, Optional):
-            Callback invoked as `post_init(inputs, B=B, T=T, H=H, D=D, **kw)`
-            for custom input mutation. Default: None.
+            Callback invoked as `post_init(inputs, B=B, T=T, H=H, D=D, **kw)` for custom input mutation. Default: None.
         category (str):
             Grouping label used in reports. Default: `''`.
         dim_constraints (dict, Optional):
-            Shape constraints, such as `{'D': [64, 128]}`. Shapes that do not
-            match are skipped. Default: None.
+            Shape constraints, such as `{'D': [64, 128]}`. Shapes that do not match are skipped. Default: None.
         default_shapes (dict[str, dict[str, int]], Optional):
             Per-op shape configs used instead of the global `SHAPE_CONFIGS`.
             This is useful when the op's shape semantics differ from `B/T/H/D`,
             for example when AttnRes uses an extra `L` residual-source axis.
             Default: None.
         test_file (str, Optional):
-            Path (relative to repo root) to the op's pytest file, used as the
-            frozen correctness gate by `benchmarks/ops/verify.py`. When None,
-            the gate is derived from `import_path`'s last segment, e.g.
-            `fla.ops.gla` -> `tests/ops/test_gla.py`. Set this only when the
-            derived path is wrong. Default: None.
+            Path (relative to repo root) to the op's pytest file,
+            used as the frozen correctness gate by `benchmarks/ops/verify.py`.
+            When None, the gate is derived from `import_path`'s last segment (e.g. `fla.ops.gla` -> `tests/ops/test_gla.py`).
+            Set this only when the derived path is wrong. Default: None.
     """
     name: str
     import_path: str

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -142,6 +142,12 @@ class OpConfig:
             This is useful when the op's shape semantics differ from `B/T/H/D`,
             for example when AttnRes uses an extra `L` residual-source axis.
             Default: None.
+        test_file (str, Optional):
+            Path (relative to repo root) to the op's pytest file, used as the
+            frozen correctness gate by `benchmarks/ops/verify.py`. When None,
+            the gate is derived from `import_path`'s last segment, e.g.
+            `fla.ops.gla` -> `tests/ops/test_gla.py`. Set this only when the
+            derived path is wrong. Default: None.
     """
     name: str
     import_path: str
@@ -154,6 +160,7 @@ class OpConfig:
     category: str = ''
     dim_constraints: dict | None = None
     default_shapes: dict[str, dict[str, int]] | None = None
+    test_file: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -300,6 +307,7 @@ register_op(OpConfig(
         'beta': TensorSpec(shape_BTH, transform=sigmoid_transform),
     },
     category='beta',
+    test_file='tests/ops/test_delta.py',
 ))
 
 # --- D: +gate + beta ---
@@ -315,6 +323,7 @@ register_op(OpConfig(
     func_name='chunk_gated_delta_rule',
     extra_kwargs={'use_qk_l2norm_in_kernel': True},
     category='gate_beta',
+    test_file='tests/ops/test_gdn.py',
 ))
 
 register_op(OpConfig(
@@ -419,6 +428,7 @@ register_op(OpConfig(
         'gk': TensorSpec(shape_BTHD, transform=logsigmoid),
     },
     category='gen_delta',
+    test_file='tests/ops/test_dplr_delta.py',
 ))
 
 # --- K: Lightning attention (needs layer_idx, num_layers) ---

--- a/benchmarks/ops/verify.py
+++ b/benchmarks/ops/verify.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""
+Correctness-gated benchmark driver for the kernel optimization loop.
+
+This ties the two halves of an optimization iteration into one reproducible
+command: it runs the op's **frozen pytest** as a correctness gate, and only if
+the gate is green does it measure performance. A speedup is never reported on a
+red gate. See ``.agents/skills/fla-optimization-loop/SKILL.md`` for the
+discipline this driver supports.
+
+Why a separate driver and not just ``run.py``? ``run.py`` measures latency but
+does not check correctness; the pytest suite checks correctness (forward AND
+backward, under NaN memory poisoning) but does not measure latency. During an
+optimization loop you need both, every iteration, and you must never let a fast
+kernel that silently broke gradients look like a win. This driver enforces that
+ordering. It reuses ``registry.py`` (inputs) and ``run.py`` (timing); the only
+correctness logic is "run the unmodified test file via pytest" — the test is a
+black box this tool may select from but never edit.
+
+Usage::
+
+    # Gate (full pytest) + benchmark vs. main
+    python -m benchmarks.ops.verify --op chunk_gla --base main
+
+    # Fast signal: gate on a shape subset (pytest -k selection, test unchanged)
+    python -m benchmarks.ops.verify --op chunk_gla --gate-k T15 --modes fwd
+
+    # Gate + benchmark + torch profiler trace
+    python -m benchmarks.ops.verify --op fused_attnres --profile
+
+    # Point the gate at an explicit test file (when the derived path is wrong)
+    python -m benchmarks.ops.verify --op chunk_gdn --test-file tests/ops/test_gdn.py
+
+    # Skip the gate entirely (loud warning; speedup is then unverified)
+    python -m benchmarks.ops.verify --op chunk_gla --no-gate
+
+    # List registered ops
+    python -m benchmarks.ops.verify --list
+
+``--gate-k`` is a pytest ``-k`` *selection* for fast iteration — it narrows
+which parametrized cases run, it does not modify the test. The full file is the
+promotion gate; a subset is only a signal. Promote a candidate only on a full
+green gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+import torch
+
+# Import sibling modules. Works both as a package (python -m benchmarks.ops.verify)
+# and standalone, matching run.py's import strategy.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from registry import SHAPE_CONFIGS, get_op, list_ops  # noqa: E402
+from run import (  # noqa: E402
+    _bench_at_ref,
+    _find_project_root,
+    _get_machine_info,
+    benchmark_op,
+    print_results_table,
+)
+
+
+def derive_test_file(op_name: str) -> str:
+    """Derive the gate test path from the registered op.
+
+    Priority: the op's explicit ``test_file`` field, else
+    ``tests/ops/test_<last-segment-of-import_path>.py``. The returned path is
+    repo-root-relative; the caller checks existence (some ops need an explicit
+    override because the op directory name and test name differ, e.g.
+    ``fla.ops.gated_delta_rule`` is tested by ``test_gdn.py``).
+    """
+    config = get_op(op_name)
+    if config.test_file:
+        return config.test_file
+    leaf = config.import_path.rstrip('.').split('.')[-1]
+    return os.path.join('tests', 'ops', f'test_{leaf}.py')
+
+
+def run_gate(op_name: str, test_file: str | None, gate_k: str | None) -> bool:
+    """Run the frozen pytest correctness gate for *op_name*.
+
+    Returns True iff pytest exits 0. The test file is run unmodified; ``gate_k``
+    only narrows selection via pytest ``-k``. Raises FileNotFoundError if the
+    resolved test file does not exist (caller should surface the override hint).
+    """
+    root = _find_project_root()
+    rel = test_file or derive_test_file(op_name)
+    abs_path = rel if os.path.isabs(rel) else os.path.join(root, rel)
+    if not os.path.isfile(abs_path):
+        raise FileNotFoundError(rel)
+
+    cmd = [sys.executable, '-m', 'pytest', abs_path, '-q']
+    if gate_k:
+        cmd += ['-k', gate_k]
+    scope = f" (-k {gate_k})" if gate_k else ' (full)'
+    print(f"\n{'=' * 78}\n  Correctness gate: {rel}{scope}\n{'=' * 78}")
+    result = subprocess.run(cmd, cwd=root)
+    return result.returncode == 0
+
+
+def profile_op(op_name: str, modes: list[str]) -> None:
+    """Dump a torch.profiler trace for one fwd(+bwd) call into profile/<op>-opt/.
+
+    A general (no-ncu) profiling entry point — the torch profiler the user
+    already reaches for, wired to the same registry inputs. Detailed Nsight
+    Compute collection lives in the fla-nvidia-performance skill.
+    """
+    import importlib
+
+    from registry import generate_inputs
+    from torch.profiler import ProfilerActivity, profile
+
+    config = get_op(op_name)
+    mod = importlib.import_module(config.import_path)
+    op_fn = getattr(mod, config.func_name or config.name)
+
+    shapes = config.default_shapes or SHAPE_CONFIGS
+    shape = next(iter(shapes.values()))
+    B, T, H, D = shape['B'], shape['T'], shape['H'], shape['D']
+    extra = {k: v for k, v in shape.items() if k not in ('B', 'T', 'H', 'D')}
+    inputs = generate_inputs(config, B, T, H, D, dtype=torch.bfloat16, device='cuda', **extra)
+
+    do_bwd = 'fwdbwd' in modes and not config.skip_backward
+    out = op_fn(**inputs, **config.extra_kwargs)
+    out_tensor = out[0] if config.output_is_tuple else out
+    do = torch.randn_like(out_tensor)
+
+    def step():
+        result = op_fn(**inputs, **config.extra_kwargs)
+        t = result[0] if config.output_is_tuple else result
+        if do_bwd:
+            t.backward(do)
+
+    for _ in range(3):  # warm autotune before profiling
+        step()
+    torch.cuda.synchronize()
+
+    out_dir = os.path.join(_find_project_root(), 'profile', f'{op_name}-opt')
+    os.makedirs(out_dir, exist_ok=True)
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True) as prof:
+        step()
+        torch.cuda.synchronize()
+
+    trace = os.path.join(out_dir, f'{op_name}_trace.json')
+    prof.export_chrome_trace(trace)
+    print(f"\n  Top CUDA ops for {op_name} @ {B}x{T}x{H}x{D} "
+          f"({'fwd+bwd' if do_bwd else 'fwd'}):")
+    print(prof.key_averages().table(sort_by='self_cuda_time_total', row_limit=10))
+    print(f"  Chrome trace: {trace}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Correctness-gated benchmark driver for the optimization loop',
+    )
+    parser.add_argument('--op', help='Registered op name (see --list)')
+    parser.add_argument(
+        '--kind', choices=['op', 'layer'], default='op',
+        help='Target kind. Only "op" is implemented; "layer" is a reserved '
+             'extension point. Default: op.',
+    )
+    parser.add_argument(
+        '--base', default=None,
+        help='Git ref for the baseline column (e.g. "main"); reuses run.py worktree compare.',
+    )
+    parser.add_argument(
+        '--modes', nargs='+', default=['fwd', 'fwdbwd'], choices=['fwd', 'fwdbwd'],
+        help='Benchmark modes. Default: fwd fwdbwd.',
+    )
+    parser.add_argument(
+        '--gate-k', default=None,
+        help='pytest -k selection for a fast signal gate (test file is NOT modified). '
+             'Promote only on a full (no -k) green gate.',
+    )
+    parser.add_argument(
+        '--test-file', default=None,
+        help='Explicit gate test path (repo-root relative). Overrides the derived path.',
+    )
+    parser.add_argument(
+        '--no-gate', action='store_true',
+        help='Skip the correctness gate. Speedup is then UNVERIFIED — never promote on this.',
+    )
+    parser.add_argument('--profile', action='store_true', help='Dump a torch.profiler trace.')
+    parser.add_argument('--list', action='store_true', help='List registered ops and exit.')
+    args = parser.parse_args()
+
+    if args.list:
+        ops = list_ops()
+        print(f"Registered ops ({len(ops)}):")
+        for name in ops:
+            cfg = get_op(name)
+            print(f"  {name:30s}  [{cfg.category}]  {cfg.import_path}")
+        return 0
+
+    if args.kind == 'layer':
+        raise NotImplementedError(
+            "verify.py currently covers ops only; the registry has no layer targets yet. "
+            "Layer support is a reserved extension point — register layer configs in "
+            "registry.py and add a layer input/reference path before using --kind layer."
+        )
+
+    if not args.op:
+        parser.error('--op is required (use --list to see available ops)')
+
+    # 1. Correctness gate (the frozen test, run unmodified). Never benchmark on a red gate.
+    if args.no_gate:
+        print("\n  *** WARNING: --no-gate set. Correctness is NOT verified; any "
+              "speedup below is meaningless for promotion. ***")
+    else:
+        try:
+            passed = run_gate(args.op, args.test_file, args.gate_k)
+        except FileNotFoundError as e:
+            print(
+                f"\n  Gate test not found: {e}\n"
+                f"  The op directory name may differ from its test name. Pass "
+                f"--test-file tests/ops/test_<name>.py, or set test_file=... in "
+                f"registry.py for '{args.op}'.",
+                file=sys.stderr,
+            )
+            return 2
+        if not passed:
+            print("\n  GATE FAILED — correctness regressed. Not benchmarking. "
+                  "Fix correctness before measuring speed.", file=sys.stderr)
+            return 1
+        print("\n  GATE PASSED.")
+
+    # 2. Performance measurement (reuses run.py). Baseline compare via git worktree.
+    machine_info = _get_machine_info()
+    print(f"\n  Machine: {machine_info.get('gpu_name', 'N/A')} | "
+          f"CUDA {machine_info.get('cuda_version', 'N/A')} | "
+          f"PyTorch {machine_info.get('pytorch_version', 'N/A')} | "
+          f"Triton {machine_info.get('triton_version', 'N/A')} | "
+          f"{machine_info.get('git_label', 'unknown')}")
+
+    results = benchmark_op(args.op, SHAPE_CONFIGS, modes=args.modes)
+    baseline, baseline_info = (None, None)
+    if args.base:
+        baseline, baseline_info = _bench_at_ref(args.base, [args.op], SHAPE_CONFIGS, args.modes)
+    print_results_table(results, machine_info, baseline=baseline, baseline_info=baseline_info)
+
+    # 3. Optional profiling.
+    if args.profile:
+        profile_op(args.op, args.modes)
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/benchmarks/ops/verify.py
+++ b/benchmarks/ops/verify.py
@@ -8,20 +8,20 @@
 """
 Correctness-gated benchmark driver for the kernel optimization loop.
 
-This ties the two halves of an optimization iteration into one reproducible
-command: it runs the op's **frozen pytest** as a correctness gate, and only if
-the gate is green does it measure performance. A speedup is never reported on a
-red gate. See ``.agents/skills/fla-optimization-loop/SKILL.md`` for the
-discipline this driver supports.
+This ties the two halves of an optimization iteration into one reproducible command:
+it runs the op's **frozen pytest** as a correctness gate, and only if the gate is green does it measure performance.
+A speedup is never reported on a red gate.
+See ``.agents/skills/fla-optimization-loop/SKILL.md`` for the discipline this driver supports.
 
-Why a separate driver and not just ``run.py``? ``run.py`` measures latency but
-does not check correctness; the pytest suite checks correctness (forward AND
-backward, under NaN memory poisoning) but does not measure latency. During an
-optimization loop you need both, every iteration, and you must never let a fast
-kernel that silently broke gradients look like a win. This driver enforces that
-ordering. It reuses ``registry.py`` (inputs) and ``run.py`` (timing); the only
-correctness logic is "run the unmodified test file via pytest" — the test is a
-black box this tool may select from but never edit.
+Why a separate driver and not just ``run.py``?
+``run.py`` measures latency but does not check correctness;
+the pytest suite checks correctness (forward AND backward, under NaN memory poisoning) but does not measure latency.
+During an optimization loop you need both, every iteration,
+and you must never let a fast kernel that silently broke gradients look like a win.
+This driver enforces that ordering.
+It reuses ``registry.py`` (inputs) and ``run.py`` (timing);
+the only correctness logic is "run the unmodified test file via pytest" —
+the test is a black box this tool may select from but never edit.
 
 Usage::
 
@@ -43,10 +43,10 @@ Usage::
     # List registered ops
     python -m benchmarks.ops.verify --list
 
-``--gate-k`` is a pytest ``-k`` *selection* for fast iteration — it narrows
-which parametrized cases run, it does not modify the test. The full file is the
-promotion gate; a subset is only a signal. Promote a candidate only on a full
-green gate.
+``--gate-k`` is a pytest ``-k`` *selection* for fast iteration — it narrows which parametrized cases run,
+it does not modify the test.
+The full file is the promotion gate; a subset is only a signal.
+Promote a candidate only on a full green gate.
 """
 
 from __future__ import annotations
@@ -74,11 +74,10 @@ from run import (  # noqa: E402
 def derive_test_file(op_name: str) -> str:
     """Derive the gate test path from the registered op.
 
-    Priority: the op's explicit ``test_file`` field, else
-    ``tests/ops/test_<last-segment-of-import_path>.py``. The returned path is
-    repo-root-relative; the caller checks existence (some ops need an explicit
-    override because the op directory name and test name differ, e.g.
-    ``fla.ops.gated_delta_rule`` is tested by ``test_gdn.py``).
+    Priority: the op's explicit ``test_file`` field, else ``tests/ops/test_<last-segment-of-import_path>.py``.
+    The returned path is repo-root-relative; the caller checks existence
+    (some ops need an explicit override because the op directory name and test name differ,
+    e.g. ``fla.ops.gated_delta_rule`` is tested by ``test_gdn.py``).
     """
     config = get_op(op_name)
     if config.test_file:
@@ -90,9 +89,9 @@ def derive_test_file(op_name: str) -> str:
 def run_gate(op_name: str, test_file: str | None, gate_k: str | None) -> bool:
     """Run the frozen pytest correctness gate for *op_name*.
 
-    Returns True iff pytest exits 0. The test file is run unmodified; ``gate_k``
-    only narrows selection via pytest ``-k``. Raises FileNotFoundError if the
-    resolved test file does not exist (caller should surface the override hint).
+    Returns True iff pytest exits 0.
+    The test file is run unmodified; ``gate_k`` only narrows selection via pytest ``-k``.
+    Raises FileNotFoundError if the resolved test file does not exist (caller should surface the override hint).
     """
     root = _find_project_root()
     rel = test_file or derive_test_file(op_name)
@@ -112,9 +111,9 @@ def run_gate(op_name: str, test_file: str | None, gate_k: str | None) -> bool:
 def profile_op(op_name: str, modes: list[str]) -> None:
     """Dump a torch.profiler trace for one fwd(+bwd) call into profile/<op>-opt/.
 
-    A general (no-ncu) profiling entry point — the torch profiler the user
-    already reaches for, wired to the same registry inputs. Detailed Nsight
-    Compute collection lives in the fla-nvidia-performance skill.
+    A general (no-ncu) profiling entry point — the torch profiler the user already reaches for,
+    wired to the same registry inputs.
+    Detailed Nsight Compute collection lives in the fla-nvidia-performance skill.
     """
     import importlib
 


### PR DESCRIPTION
## Summary

A disciplined, reproducible loop for optimizing FLA kernels where correctness is a hard gate, not an afterthought: speed is measured only once the op's existing forward+backward pytest passes, so a faster-but-wrong kernel can never look like a win.

It ships as a workflow skill plus a one-command driver, adapting the discipline of agent kernel-optimization frameworks (KDA, the MLSys FlashInfer contest, AKO) to FLA — anchored on its correctness gate rather than forward-latency alone.

## Test plan

Smoke-tested without a GPU; `pre-commit` clean.

## Breaking changes

None.
