### PR TITLE
[NSA] Speed up parallel backward: gather+batch bwd_dkv

### DIFF
--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -524,14 +524,11 @@ def _nsa_post_init(inputs, B, T, H, D, HQ=None, S=16, block_size=64, **kw):
     inputs['block_size'] = block_size
 
 
-# Sweep T across the regime where the selective backward's tile-skip matters:
-# at short T every query selects nearly all its causal blocks (dense), the win
-# only appears once T >> S * block_size makes the selection sparse.
 _nsa_shapes = {
-    'B1_T8K_H1_HQ16_D128_S16':  {'B': 1, 'T': 8192,  'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
-    'B1_T16K_H1_HQ16_D128_S16': {'B': 1, 'T': 16384, 'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
-    'B1_T32K_H1_HQ16_D128_S16': {'B': 1, 'T': 32768, 'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
-    'B1_T64K_H1_HQ16_D128_S16': {'B': 1, 'T': 65536, 'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
+    'B1_T8K_H1_HQ32_D128_S16':  {'B': 1, 'T': 8192,  'H': 1, 'HQ': 32, 'D': 128, 'S': 16, 'block_size': 64},
+    'B1_T16K_H1_HQ64_D128_S16': {'B': 1, 'T': 16384, 'H': 1, 'HQ': 64, 'D': 128, 'S': 16, 'block_size': 64},
+    'B1_T32K_H1_HQ64_D256_S16': {'B': 1, 'T': 32768, 'H': 1, 'HQ': 64, 'D': 256, 'S': 16, 'block_size': 64},
+    'B1_T64K_H1_HQ128_D256_S16': {'B': 1, 'T': 65536, 'H': 1, 'HQ': 128, 'D': 256, 'S': 16, 'block_size': 64},
 }
 
 register_op(OpConfig(

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -59,6 +59,13 @@ def shape_LBTD(B, T, H, D, L=None, **kw):
     return (L, B, T, D)
 
 
+def shape_q_hq(B, T, H, D, HQ=None, **kw):
+    """q with HQ query heads (GQA); k/v keep H heads. Used by NSA."""
+    if HQ is None:
+        raise ValueError("shape_q_hq requires the 'HQ' (query-head) shape config key")
+    return (B, T, HQ, D)
+
+
 # ---------------------------------------------------------------------------
 # Transform helpers
 # ---------------------------------------------------------------------------
@@ -259,7 +266,7 @@ def generate_inputs(
 # Op registrations
 # ===========================================================================
 
-# --- A: Simple qkv (no extra inputs) ---
+# --- Simple qkv (no extra inputs) ---
 
 _simple_qkv = {
     'q': TensorSpec(shape_BTHD),
@@ -281,7 +288,7 @@ register_op(OpConfig(
     category='simple_qkv',
 ))
 
-# --- B: +elem gate (g=[B,T,H,D] with logsigmoid_clamp) ---
+# --- +elem gate (g=[B,T,H,D] with logsigmoid_clamp) ---
 
 register_op(OpConfig(
     name='chunk_gla',
@@ -293,7 +300,7 @@ register_op(OpConfig(
     category='elem_gate',
 ))
 
-# --- C: +beta (beta=[B,T,H] with sigmoid) ---
+# --- +beta (beta=[B,T,H] with sigmoid) ---
 
 register_op(OpConfig(
     name='chunk_delta_rule',
@@ -306,7 +313,7 @@ register_op(OpConfig(
     test_file='tests/ops/test_delta.py',
 ))
 
-# --- D: +gate + beta ---
+# --- +gate + beta ---
 
 register_op(OpConfig(
     name='chunk_gdn',
@@ -334,7 +341,7 @@ register_op(OpConfig(
     category='gate_beta',
 ))
 
-# --- E: +head gate (g=[B,T,H] with logsigmoid) ---
+# --- +head gate (g=[B,T,H] with logsigmoid) ---
 
 register_op(OpConfig(
     name='chunk_simple_gla',
@@ -346,7 +353,7 @@ register_op(OpConfig(
     category='head_gate',
 ))
 
-# --- F: RWKV ---
+# --- RWKV ---
 
 
 def _rwkv7_post_init(inputs, B, T, H, D, **kw):
@@ -385,7 +392,7 @@ register_op(OpConfig(
     category='rwkv',
 ))
 
-# --- H: Comba ---
+# --- Comba ---
 
 register_op(OpConfig(
     name='chunk_comba',
@@ -400,7 +407,7 @@ register_op(OpConfig(
     category='comba',
 ))
 
-# --- I: HGRN (x, g only, no qkv) ---
+# --- HGRN (x, g only, no qkv) ---
 
 register_op(OpConfig(
     name='fused_recurrent_hgrn',
@@ -412,7 +419,7 @@ register_op(OpConfig(
     category='hgrn',
 ))
 
-# --- J: Generalized delta rule (DPLR) ---
+# --- Generalized delta rule (DPLR) ---
 
 register_op(OpConfig(
     name='chunk_dplr_delta_rule',
@@ -427,7 +434,7 @@ register_op(OpConfig(
     test_file='tests/ops/test_dplr_delta.py',
 ))
 
-# --- K: Lightning attention (needs layer_idx, num_layers) ---
+# --- Lightning attention (needs layer_idx, num_layers) ---
 
 register_op(OpConfig(
     name='chunk_lightning_attn',
@@ -437,7 +444,7 @@ register_op(OpConfig(
     category='lightning',
 ))
 
-# --- L: Attention baselines ---
+# --- Attention baselines ---
 
 register_op(OpConfig(
     name='parallel_attn',
@@ -458,7 +465,7 @@ register_op(OpConfig(
     category='flash_attn',
 ))
 
-# --- M: layer-axis residual aggregation (AttnRes, mHC, ...) ---
+# --- layer-axis residual aggregation (AttnRes, mHC, ...) ---
 # These ops attend / aggregate over an `L` axis of stacked residual sources.
 # Inputs and shape sweeps are shared so future ops (mHC etc.) can reuse them.
 
@@ -495,16 +502,10 @@ register_op(OpConfig(
     category='naive_attnres',
 ))
 
-# --- N: NSA (native sparse attention) — GQA + structured block selection ---
+# --- NSA (native sparse attention) — GQA + structured block selection ---
 # q carries HQ query heads while k/v carry H kv heads (GQA; HQ/H a power of two
 # and >= 16). block_indices is a causal random selection that must be built
 # explicitly — the generic randn/randint input factory cannot produce a valid one.
-
-
-def shape_q_hq(B, T, H, D, HQ=None, **kw):
-    if HQ is None:
-        raise ValueError("nsa shapes require an 'HQ' (query-head) key")
-    return (B, T, HQ, D)
 
 
 def _nsa_post_init(inputs, B, T, H, D, HQ=None, S=16, block_size=64, **kw):

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -494,3 +494,56 @@ register_op(OpConfig(
     default_shapes=_layer_default_shapes,
     category='naive_attnres',
 ))
+
+# --- N: NSA (native sparse attention) — GQA + structured block selection ---
+# q carries HQ query heads while k/v carry H kv heads (GQA; HQ/H a power of two
+# and >= 16). block_indices is a causal random selection that must be built
+# explicitly — the generic randn/randint input factory cannot produce a valid one.
+
+
+def shape_q_hq(B, T, H, D, HQ=None, **kw):
+    if HQ is None:
+        raise ValueError("nsa shapes require an 'HQ' (query-head) key")
+    return (B, T, HQ, D)
+
+
+def _nsa_post_init(inputs, B, T, H, D, HQ=None, S=16, block_size=64, **kw):
+    # build block_indices [B, T, H, S]: for each query t, pick S of the causal
+    # blocks (block i is selectable iff i <= t // block_size), -1-padded when
+    # fewer than S exist, then sorted — mirroring tests/ops/test_nsa.py.
+    device = inputs['q'].device
+    NS = (T + block_size - 1) // block_size
+    valid = (torch.arange(NS, device=device)[None, None, None, :]
+             <= (torch.arange(T, device=device) // block_size)[None, :, None, None])
+    scores = torch.rand(B, T, H, NS, device=device).masked_fill(~valid, float('-inf'))
+    topv, topi = scores.topk(min(S, NS), dim=-1)
+    block_indices = topi.masked_fill(topv == float('-inf'), -1).sort(-1)[0].to(torch.long)
+    inputs['block_indices'] = block_indices.contiguous()
+    inputs['block_counts'] = S
+    inputs['block_size'] = block_size
+
+
+# Sweep T across the regime where the selective backward's tile-skip matters:
+# at short T every query selects nearly all its causal blocks (dense), the win
+# only appears once T >> S * block_size makes the selection sparse.
+_nsa_shapes = {
+    'B1_T8K_H1_HQ16_D128_S16':  {'B': 1, 'T': 8192,  'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
+    'B1_T16K_H1_HQ16_D128_S16': {'B': 1, 'T': 16384, 'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
+    'B1_T32K_H1_HQ16_D128_S16': {'B': 1, 'T': 32768, 'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
+    'B1_T64K_H1_HQ16_D128_S16': {'B': 1, 'T': 65536, 'H': 1, 'D': 128, 'HQ': 16, 'S': 16, 'block_size': 64},
+}
+
+register_op(OpConfig(
+    name='parallel_nsa',
+    import_path='fla.ops.nsa',
+    inputs={
+        'q': TensorSpec(shape_q_hq),
+        'k': TensorSpec(shape_BTHD),
+        'v': TensorSpec(shape_BTHD),
+    },
+    post_init=_nsa_post_init,
+    output_is_tuple=False,
+    default_shapes=_nsa_shapes,
+    category='nsa',
+    test_file='tests/ops/test_nsa.py',
+))

--- a/fla/ops/nsa/README.md
+++ b/fla/ops/nsa/README.md
@@ -82,8 +82,7 @@ Paper: [arXiv:2502.11089](https://arxiv.org/abs/2502.11089) — *block · pooled
 **Hardware-aligned core — why GQA is mandatory.** Selection is *per KV head, not per query head*, so
 all `G = H_Q/H_KV` query heads in a group share one block list. The kernel makes this a GEMM: load the
 group's queries once as `[G, d]`, then for each selected block load its KV tile `[d, B_S]` from HBM
-**once** and matmul against all `G` rows. Group sharing amortizes each KV read over `G` heads (so the
-group must be a multiple of 16, the MMA tile height), and block-level reads stay contiguous — together
+**once** and matmul against all `G` rows. Group sharing amortizes each KV read over `G` heads, and block-level reads stay contiguous — together
 they restore the arithmetic intensity that scattered, memory-bound sparse attention throws away.
 
 ### MoBA — Mixture of Block Attention

--- a/fla/ops/nsa/compression.py
+++ b/fla/ops/nsa/compression.py
@@ -521,7 +521,7 @@ class ParallelNSACompressionFunction(torch.autograd.Function):
         ctx.token_indices = token_indices_q
         ctx.block_size = block_size
         ctx.scale = scale
-        # q/k cu_seqlens differ only in cached inference (Tq != Tk), where backward is not supported
+        # q/k cu_seqlens differ only in cached inference (TQ != TK), where backward is not supported
         ctx.tq_ne_tk = isinstance(cu_seqlens, tuple)
         return o.to(q.dtype), lse
 

--- a/fla/ops/nsa/naive.py
+++ b/fla/ops/nsa/naive.py
@@ -39,7 +39,7 @@ def naive_nsa_selection(
             queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a multiple of 16.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16 (it is a kernel tile dimension; Triton requires power-of-2 block shapes).
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         block_indices (torch.LongTensor):
@@ -326,7 +326,7 @@ def naive_nsa(
             Queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             Keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a multiple of 16.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16 (it is a kernel tile dimension; Triton requires power-of-2 block shapes).
         v (torch.Tensor):
             Values of shape `[B, T, H, V]`.
         g_cmp (torch.Tensor, Optional):

--- a/fla/ops/nsa/naive.py
+++ b/fla/ops/nsa/naive.py
@@ -39,7 +39,7 @@ def naive_nsa_selection(
             queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a multiple of 16.
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         block_indices (torch.LongTensor):
@@ -326,7 +326,7 @@ def naive_nsa(
             Queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             Keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a multiple of 16.
         v (torch.Tensor):
             Values of shape `[B, T, H, V]`.
         g_cmp (torch.Tensor, Optional):

--- a/fla/ops/nsa/naive.py
+++ b/fla/ops/nsa/naive.py
@@ -39,7 +39,8 @@ def naive_nsa_selection(
             queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16 (it is a kernel tile dimension; Triton requires power-of-2 block shapes).
+            GQA is enforced here: the ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >= 16.
+            This is a kernel tile dimension, which Triton requires to be a power-of-2 block shape.
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         block_indices (torch.LongTensor):
@@ -326,7 +327,8 @@ def naive_nsa(
             Queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             Keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16 (it is a kernel tile dimension; Triton requires power-of-2 block shapes).
+            GQA is enforced here: the ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >= 16.
+            This is a kernel tile dimension, which Triton requires to be a power-of-2 block shape.
         v (torch.Tensor):
             Values of shape `[B, T, H, V]`.
         g_cmp (torch.Tensor, Optional):
@@ -362,7 +364,8 @@ def naive_nsa(
         scale = k.shape[-1] ** -0.5
     if cu_seqlens is not None:
         assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
-    assert q.shape[2] % (k.shape[2] * 16) == 0, "Group size must be a multiple of 16 in NSA"
+    G = q.shape[2] // k.shape[2]
+    assert G >= 16 and (G & (G - 1)) == 0, "Group size (HQ/H) must be a power of 2 and >= 16 in NSA"
 
     if cu_seqlens is not None:
         if isinstance(cu_seqlens, tuple):

--- a/fla/ops/nsa/naive.py
+++ b/fla/ops/nsa/naive.py
@@ -77,12 +77,12 @@ def naive_nsa_selection(
     varlen = True
     if cu_seqlens is None:
         varlen = False
-        Tq = Tk = q.shape[1]
+        TQ = TK = q.shape[1]
         cu_q = torch.cat([
-            block_indices.new_tensor(range(0, B * Tq, Tq)), block_indices.new_tensor([B * Tq])
+            block_indices.new_tensor(range(0, B * TQ, TQ)), block_indices.new_tensor([B * TQ])
         ]).to(device=q.device)
         cu_k = torch.cat([
-            block_indices.new_tensor(range(0, B * Tk, Tk)), block_indices.new_tensor([B * Tk])
+            block_indices.new_tensor(range(0, B * TK, TK)), block_indices.new_tensor([B * TK])
         ]).to(device=q.device)
     else:
         if isinstance(cu_seqlens, tuple):
@@ -94,21 +94,21 @@ def naive_nsa_selection(
         if not varlen:
             q_b, k_b, v_b, i_b = q[i], k[i], v[i], block_indices[i]
         else:
-            Tq = cu_q[i+1] - cu_q[i]
-            Tk = cu_k[i+1] - cu_k[i]
+            TQ = cu_q[i+1] - cu_q[i]
+            TK = cu_k[i+1] - cu_k[i]
             q_b, k_b, v_b, i_b = (q[0][cu_q[i]:cu_q[i+1]], k[0][cu_k[i]:cu_k[i+1]],
                                   v[0][cu_k[i]:cu_k[i+1]], block_indices[0][cu_q[i]:cu_q[i+1]])
-        assert Tq == Tk, "TQ != TK case is not supported in naive_nsa_selection"
+        assert TQ == TK, "TQ != TK case is not supported in naive_nsa_selection"
         i_b = i_b.unsqueeze(-1) * BS + i_b.new_tensor(range(BS))
         # [T, S*BS, HQ]
-        i_b = i_b.view(Tq, block_indices.shape[2], -1).transpose(1, 2)
-        for i_q in range(Tq):
+        i_b = i_b.view(TQ, block_indices.shape[2], -1).transpose(1, 2)
+        for i_q in range(TQ):
             # [HQ, D]
             q_i = q_b[i_q] * scale
             # [S*BS, HQ]
             i_i = i_b[i_q]
             # [S*BS, HQ, -1]
-            k_i, v_i = map(lambda x: x.gather(0, i_i.clamp(0, Tk-1).unsqueeze(-1).expand(*i_i.shape, x.shape[-1])),
+            k_i, v_i = map(lambda x: x.gather(0, i_i.clamp(0, TK-1).unsqueeze(-1).expand(*i_i.shape, x.shape[-1])),
                            (k_b, v_b))
             # [S*BS, HQ]
             attn = torch.einsum('h d, n h d -> n h', q_i, k_i).masked_fill(

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -881,7 +881,7 @@ def parallel_nsa(
             queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a multiple of 16.
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         g_cmp (torch.Tensor):

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -8,7 +8,6 @@
 import warnings
 
 import torch
-import torch.nn.functional as F
 import triton
 import triton.language as tl
 
@@ -531,6 +530,126 @@ def parallel_nsa_bwd_kernel_dkv(
     tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
 
+def prepare_dkv_csr(block_mask, cu_seqlens, chunk_indices, block_size):
+    # Inverse index for gather-based dkv: per KV block (keyed by the same id the
+    # kernel decodes) the sorted list of *absolute* query positions selecting it,
+    # as CSR (q_idx values + q_ptr offsets). Lets bwd_dkv gather selecting queries
+    # and batch them into one MMA instead of scanning every query tile per block.
+    # Handles both dense (key = (b*H+h)*NS + block) and varlen (key = global-chunk
+    # * H + h, via cu_seqlens/chunk_offsets).
+    B, T, H, NS = block_mask.shape
+    nz = block_mask.nonzero(as_tuple=False)            # [P, 4] = (b, t, h, ns)
+    b_, t_, h_, ns_ = nz[:, 0], nz[:, 1], nz[:, 2], nz[:, 3]
+    if cu_seqlens is None:
+        q_abs = (b_ * T + t_).to(torch.int32)
+        gkey = (b_ * H + h_) * NS + ns_
+        n_keys = B * H * NS
+    else:
+        n_ = torch.searchsorted(cu_seqlens[1:].contiguous(), t_, right=True)   # sequence index
+        chunk_off = prepare_chunk_offsets(cu_seqlens, block_size)
+        gkey = (chunk_off[n_] + ns_) * H + h_
+        q_abs = t_.to(torch.int32)
+        n_keys = chunk_indices.shape[0] * H
+    order = (gkey.to(torch.int64) * (B * T) + q_abs).argsort()
+    q_idx = q_abs[order].contiguous()
+    counts = torch.bincount(gkey, minlength=n_keys)
+    q_ptr = torch.zeros(n_keys + 1, dtype=torch.int32, device=block_mask.device)
+    q_ptr[1:] = counts.cumsum(0)
+    return q_idx, q_ptr.contiguous()
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BG': BG}, num_warps=nw, num_stages=ns)
+        for BG in [1, 2, 4, 8]
+        for nw in [2, 4, 8]
+        for ns in [1, 2]
+    ],
+    key=['BS', 'BK', 'BV', 'G'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def parallel_nsa_bwd_kernel_dkv_gather(
+    q, k, v, lse, delta, do, dk, dv,
+    q_idx, q_ptr, cu_seqlens, chunk_indices,
+    scale,
+    T, NTOK,
+    B: tl.constexpr, H: tl.constexpr, HQ: tl.constexpr, G: tl.constexpr,
+    K: tl.constexpr, V: tl.constexpr, NS: tl.constexpr,
+    BS: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr, BG: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_blk = tl.program_id(0), tl.program_id(1)
+    # decode the program into this KV block's head and absolute key start; all
+    # address arithmetic in int64 (NTOK*HQ*K overflows int32 at long seq / big heads).
+    if IS_VARLEN:
+        i_c, i_h = i_blk // H, i_blk % H
+        i_n = tl.load(chunk_indices + i_c * 2).to(tl.int32)
+        i_sl = tl.load(chunk_indices + i_c * 2 + 1).to(tl.int32)
+        kbos = tl.load(cu_seqlens + i_n).to(tl.int64)
+        keos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        key_abs = kbos + i_sl * BS + tl.arange(0, BS)
+    else:
+        i_s = i_blk % NS
+        bh = i_blk // NS
+        i_b, i_h = bh // H, bh % H
+        key_abs = (i_b * T).to(tl.int64) + i_s * BS + tl.arange(0, BS)
+        keos = (i_b + 1) * T
+
+    start = tl.load(q_ptr + i_blk).to(tl.int32)
+    end = tl.load(q_ptr + i_blk + 1).to(tl.int32)
+    cnt = end - start
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_g = i_h * G + tl.arange(0, G)
+    r_m, k_m, v_m = key_abs < keos, o_k < K, o_v < V
+
+    # K/V tile for this block: k/v[key_abs, i_h, :]
+    b_k = tl.load(k + key_abs[:, None] * (H * K) + i_h * K + o_k[None, :], mask=r_m[:, None] & k_m[None, :], other=0.)
+    b_v = tl.load(v + key_abs[:, None] * (H * V) + i_h * V + o_v[None, :], mask=r_m[:, None] & v_m[None, :], other=0.)
+    b_dk = tl.zeros([BS, BK], dtype=tl.float32)
+    b_dv = tl.zeros([BS, BV], dtype=tl.float32)
+
+    for it in range(0, tl.cdiv(cnt, BG)):
+        offs = it * BG + tl.arange(0, BG)
+        m_j = offs < cnt
+        q_pos = tl.load(q_idx + start + offs, mask=m_j, other=0).to(tl.int64)         # [BG] absolute
+
+        base = q_pos[:, None, None] * (HQ * K) + o_g[None, :, None] * K + o_k[None, None, :]
+        b_q = tl.load(q + base, mask=m_j[:, None, None] & k_m[None, None, :], other=0.).to(tl.float32)
+        b_q = tl.reshape(b_q * scale, [BG * G, BK]).to(b_k.dtype)
+
+        based = q_pos[:, None, None] * (HQ * V) + o_g[None, :, None] * V + o_v[None, None, :]
+        b_do = tl.load(do + based, mask=m_j[:, None, None] & v_m[None, None, :], other=0.)
+        b_do = tl.reshape(b_do, [BG * G, BV])
+
+        ld = q_pos[:, None] * HQ + o_g[None, :]
+        b_lse = tl.reshape(tl.load(lse + ld, mask=m_j[:, None], other=0.), [BG * G])
+        b_del = tl.reshape(tl.load(delta + ld, mask=m_j[:, None], other=0.), [BG * G])
+
+        col_valid = tl.reshape(tl.broadcast_to(m_j[:, None], [BG, G]), [BG * G])
+        qpos_rep = tl.reshape(tl.broadcast_to(q_pos[:, None], [BG, G]), [BG * G])
+
+        b_s = tl.dot(b_k, tl.trans(b_q))                                              # [BS, BG*G]
+        b_p = exp(b_s - b_lse[None, :])
+        keep = (qpos_rep[None, :] >= key_abs[:, None]) & col_valid[None, :]
+        b_p = tl.where(keep, b_p, 0.)
+
+        b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
+        b_dp = tl.dot(b_v, tl.trans(b_do))
+        b_ds = b_p * (b_dp.to(tl.float32) - b_del[None, :])
+        b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
+
+    dk_off = (i_v * NTOK + key_abs)[:, None] * (H * K) + i_h * K + o_k[None, :]
+    dv_off = key_abs[:, None] * (H * V) + i_h * V + o_v[None, :]
+    tl.store(dk + dk_off, b_dk.to(dk.dtype.element_ty), mask=r_m[:, None] & k_m[None, :])
+    tl.store(dv + dv_off, b_dv.to(dv.dtype.element_ty), mask=r_m[:, None] & v_m[None, :])
+
+
 @contiguous
 def parallel_nsa_topk(
     q: torch.Tensor,
@@ -745,43 +864,21 @@ def parallel_nsa_bwd(
     # [B, T, H, M] block_mask, plus q_last[b, h, s] = furthest query that selected
     # KV block s (fused into the mask kernel), so dkv stops its scan there instead
     # of at eos. Used on the dense path only (varlen falls back via HAS_Q_LAST off).
-    block_mask, q_last = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
+    block_mask, _ = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
     M = block_mask.shape[-1]
-    # skip_mask[t] = OR of block_mask over a BQ-query tile, so dkv can skip whole tiles
-    # of queries that selected nothing in a KV block
-    mask = F.pad(block_mask.reshape(B * T, H, M), (0, 0, 0, 0, 0, (-(B * T)) % BQ))
-    skip_mask = mask.view(-1, BQ, H, M).any(dim=1).contiguous()
     dk = torch.empty(NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device)
     dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)
 
-    grid = (NV, NS, B * H)
-    parallel_nsa_bwd_kernel_dkv[grid](
-        q=q,
-        k=k,
-        v=v,
-        lse=lse,
-        delta=delta,
-        do=do,
-        dk=dk,
-        dv=dv,
-        block_mask=block_mask,
-        skip_mask=skip_mask,
-        q_last=q_last,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-        scale=scale,
-        T=T,
-        B=B,
-        H=H,
-        HQ=HQ,
-        G=G,
-        K=K,
-        V=V,
-        M=M,
-        BS=BS,
-        BK=BK,
-        BV=BV,
-        BQ=BQ,
+    # gather the queries selecting each KV block (CSR inverse index) and batch them
+    # into one MMA — far fewer, far larger matmuls than scanning every query tile.
+    # Works for dense and varlen (the kernel decodes the block via chunk_indices).
+    q_idx, q_ptr = prepare_dkv_csr(block_mask, cu_seqlens, chunk_indices, block_size)
+    n_blk = chunk_indices.shape[0] * H if cu_seqlens is not None else B * H * M
+    grid = (NV, n_blk)
+    parallel_nsa_bwd_kernel_dkv_gather[grid](
+        q, k, v, lse, delta, do, dk, dv, q_idx, q_ptr, cu_seqlens, chunk_indices,
+        scale, T, B * T,
+        B=B, H=H, HQ=HQ, G=G, K=K, V=V, NS=M, BS=BS, BK=BK, BV=BV,
     )
     dk = dk.sum(0)
     return dq, dk, dv

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -881,7 +881,7 @@ def parallel_nsa(
             queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a multiple of 16.
+            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16 (it is a kernel tile dimension; Triton requires power-of-2 block shapes).
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         g_cmp (torch.Tensor):

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -14,7 +14,7 @@ import triton.language as tl
 from fla.ops.attn.parallel import parallel_attn_bwd_preprocess
 from fla.ops.nsa.compression import parallel_nsa_compression
 from fla.ops.nsa.utils import _bitonic_merge
-from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets, prepare_lens, prepare_token_indices
+from fla.ops.utils import prepare_block_csr, prepare_chunk_indices, prepare_chunk_offsets, prepare_lens, prepare_token_indices
 from fla.ops.utils.op import exp, log
 from fla.ops.utils.pooling import mean_pooling
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, check_shared_mem, contiguous
@@ -279,34 +279,6 @@ def parallel_nsa_fwd_kernel(
 
 
 @triton.heuristics({
-    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
-})
-@triton.jit(do_not_specialize=['T'])
-def parallel_nsa_kernel_mask(
-    block_indices,
-    block_counts,
-    block_mask,
-    T,
-    H: tl.constexpr,
-    S: tl.constexpr,
-    BS: tl.constexpr,
-    NS: tl.constexpr,
-    USE_BLOCK_COUNTS: tl.constexpr,
-):
-    i_t, i_b, i_hs = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_h, i_s = i_hs // S, i_hs % S
-
-    b_i = tl.load(block_indices + i_b * T * H * S + i_t * H * S + i_h * S + i_s)
-    if USE_BLOCK_COUNTS:
-        b_m = b_i * BS <= i_t and i_s < tl.load(block_counts + i_b * T * H + i_t * H + i_h)
-    else:
-        b_m = b_i * BS <= i_t
-
-    if b_i < NS and b_i >= 0:
-        tl.store(block_mask + i_b * T * H * NS + i_t * H * NS + i_h * NS + b_i, b_m.to(block_mask.dtype.element_ty))
-
-
-@triton.heuristics({
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
     'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
 })
@@ -416,124 +388,126 @@ def parallel_nsa_bwd_kernel_dq(
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
 
 
-def prepare_dkv_csr(block_mask, cu_seqlens, chunk_indices, block_size):
-    # Inverse index for gather-based dkv: per KV block (keyed by the same id the
-    # kernel decodes) the sorted list of *absolute* query positions selecting it,
-    # as CSR (q_idx values + q_ptr offsets). Lets bwd_dkv gather selecting queries
-    # and batch them into one MMA instead of scanning every query tile per block.
-    # Handles both dense (key = (b*H+h)*NS + block) and varlen (key = global-chunk
-    # * H + h, via cu_seqlens/chunk_offsets).
-    B, T, H, NS = block_mask.shape
-    nz = block_mask.nonzero(as_tuple=False)            # [P, 4] = (b, t, h, ns)
-    b_, t_, h_, ns_ = nz[:, 0], nz[:, 1], nz[:, 2], nz[:, 3]
-    if cu_seqlens is None:
-        q_abs = (b_ * T + t_).to(torch.int32)
-        gkey = (b_ * H + h_) * NS + ns_
-        n_keys = B * H * NS
-    else:
-        n_ = torch.searchsorted(cu_seqlens[1:].contiguous(), t_, right=True)   # sequence index
-        chunk_off = prepare_chunk_offsets(cu_seqlens, block_size)
-        gkey = (chunk_off[n_] + ns_) * H + h_
-        q_abs = t_.to(torch.int32)
-        n_keys = chunk_indices.shape[0] * H
-    order = (gkey.to(torch.int64) * (B * T) + q_abs).argsort()
-    q_idx = q_abs[order].contiguous()
-    counts = torch.bincount(gkey, minlength=n_keys)
-    q_ptr = torch.zeros(n_keys + 1, dtype=torch.int32, device=block_mask.device)
-    q_ptr[1:] = counts.cumsum(0)
-    return q_idx, q_ptr.contiguous()
-
-
 @triton.heuristics({
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.autotune(
     configs=[
-        triton.Config({'BG': BG}, num_warps=nw, num_stages=ns)
+        triton.Config({'BG': BG}, num_warps=num_warps, num_stages=num_stages)
         for BG in [1, 2, 4, 8]
-        for nw in [4, 8]
-        for ns in [1, 2]
+        for num_warps in [4, 8]
+        for num_stages in [1, 2]
     ],
     key=['BS', 'BK', 'BV', 'G'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
-def parallel_nsa_bwd_kernel_dkv_gather(
-    q, k, v, lse, delta, do, dk, dv,
-    q_idx, q_ptr, cu_seqlens, chunk_indices,
+def parallel_nsa_bwd_kernel_dkv(
+    q,
+    k,
+    v,
+    lse,
+    delta,
+    do,
+    dk,
+    dv,
     scale,
-    T, NTOK,
-    B: tl.constexpr, H: tl.constexpr, HQ: tl.constexpr, G: tl.constexpr,
-    K: tl.constexpr, V: tl.constexpr, NS: tl.constexpr,
-    BS: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr, BG: tl.constexpr,
+    csr_indices,
+    csr_offsets,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HQ: tl.constexpr,
+    G: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    TC: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    BG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_blk = tl.program_id(0), tl.program_id(1)
-    # decode the program into this KV block's head and absolute key start; all
-    # address arithmetic in int64 (NTOK*HQ*K overflows int32 at long seq / big heads).
+    i_q0, i_q1 = tl.load(csr_offsets + i_blk).to(tl.int64), tl.load(csr_offsets + i_blk + 1).to(tl.int64)
+    all = B * T
     if IS_VARLEN:
         i_c, i_h = i_blk // H, i_blk % H
         i_n = tl.load(chunk_indices + i_c * 2).to(tl.int32)
-        i_sl = tl.load(chunk_indices + i_c * 2 + 1).to(tl.int32)
-        kbos = tl.load(cu_seqlens + i_n).to(tl.int64)
-        keos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        key_abs = kbos + i_sl * BS + tl.arange(0, BS)
+        i_s = tl.load(chunk_indices + i_c * 2 + 1).to(tl.int32)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     else:
-        i_s = i_blk % NS
-        bh = i_blk // NS
-        i_b, i_h = bh // H, bh % H
-        key_abs = (i_b * T).to(tl.int64) + i_s * BS + tl.arange(0, BS)
-        keos = (i_b + 1) * T
-
-    start = tl.load(q_ptr + i_blk).to(tl.int32)
-    end = tl.load(q_ptr + i_blk + 1).to(tl.int32)
-    cnt = end - start
-
+        i_s = i_blk % TC
+        i_b, i_h = (i_blk // TC) // H, (i_blk // TC) % H
+        bos = (i_b * T).to(tl.int64)
+        eos = bos + T
+    o_t = bos + i_s * BS + tl.arange(0, BS)
     o_k = tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
-    o_g = i_h * G + tl.arange(0, G)
-    r_m, k_m, v_m = key_abs < keos, o_k < K, o_v < V
+    o_g = tl.arange(0, G)
+    m_t, m_k, m_v = o_t < eos, o_k < K, o_v < V
 
-    # K/V tile for this block: k/v[key_abs, i_h, :]
-    b_k = tl.load(k + key_abs[:, None] * (H * K) + i_h * K + o_k[None, :], mask=r_m[:, None] & k_m[None, :], other=0.)
-    b_v = tl.load(v + key_abs[:, None] * (H * V) + i_h * V + o_v[None, :], mask=r_m[:, None] & v_m[None, :], other=0.)
+    NQ = i_q1 - i_q0
+
+    q += i_h * G*K
+    do += i_h * G*V
+    lse += i_h * G
+    delta += i_h * G
+    k += i_h * K
+    v += i_h * V
+    dk += i_h * K
+    dv += i_h * V
+
+    # [BS, BK] / [BS, BV] k/v tile for this kv block
+    b_k = tl.load(k + o_t[:, None] * H*K + o_k[None, :], mask=m_t[:, None] & m_k[None, :], other=0.)
+    b_v = tl.load(v + o_t[:, None] * H*V + o_v[None, :], mask=m_t[:, None] & m_v[None, :], other=0.)
     b_dk = tl.zeros([BS, BK], dtype=tl.float32)
     b_dv = tl.zeros([BS, BV], dtype=tl.float32)
 
-    for it in range(0, tl.cdiv(cnt, BG)):
-        offs = it * BG + tl.arange(0, BG)
-        m_j = offs < cnt
-        q_pos = tl.load(q_idx + start + offs, mask=m_j, other=0).to(tl.int64)         # [BG] absolute
+    for i in range(tl.cdiv(NQ, BG)):
+        o_j = i * BG + tl.arange(0, BG)
+        m_j = o_j < NQ
+        # [BG] absolute positions of the queries selecting this block
+        i_q = tl.load(csr_indices + i_q0 + o_j, mask=m_j, other=0).to(tl.int64)
 
-        base = q_pos[:, None, None] * (HQ * K) + o_g[None, :, None] * K + o_k[None, None, :]
-        b_q = tl.load(q + base, mask=m_j[:, None, None] & k_m[None, None, :], other=0.).to(tl.float32)
+        # gather q/do/lse/delta for the BG queries over their G group heads -> [BG*G, *]
+        o_q = i_q[:, None, None] * HQ*K + o_g[None, :, None] * K + o_k[None, None, :]
+        b_q = tl.load(q + o_q, mask=m_j[:, None, None] & m_k[None, None, :], other=0.).to(tl.float32)
         b_q = tl.reshape(b_q * scale, [BG * G, BK]).to(b_k.dtype)
 
-        based = q_pos[:, None, None] * (HQ * V) + o_g[None, :, None] * V + o_v[None, None, :]
-        b_do = tl.load(do + based, mask=m_j[:, None, None] & v_m[None, None, :], other=0.)
+        o_do = i_q[:, None, None] * HQ*V + o_g[None, :, None] * V + o_v[None, None, :]
+        b_do = tl.load(do + o_do, mask=m_j[:, None, None] & m_v[None, None, :], other=0.)
         b_do = tl.reshape(b_do, [BG * G, BV])
 
-        ld = q_pos[:, None] * HQ + o_g[None, :]
-        b_lse = tl.reshape(tl.load(lse + ld, mask=m_j[:, None], other=0.), [BG * G])
-        b_del = tl.reshape(tl.load(delta + ld, mask=m_j[:, None], other=0.), [BG * G])
+        o_ld = i_q[:, None] * HQ + o_g[None, :]
+        b_lse = tl.reshape(tl.load(lse + o_ld, mask=m_j[:, None], other=0.), [BG * G])
+        b_delta = tl.reshape(tl.load(delta + o_ld, mask=m_j[:, None], other=0.), [BG * G])
 
-        col_valid = tl.reshape(tl.broadcast_to(m_j[:, None], [BG, G]), [BG * G])
-        qpos_rep = tl.reshape(tl.broadcast_to(q_pos[:, None], [BG, G]), [BG * G])
+        # broadcast per-query validity and position over the G group heads
+        m_col = tl.reshape(tl.broadcast_to(m_j[:, None], [BG, G]), [BG * G])
+        o_pos = tl.reshape(tl.broadcast_to(i_q[:, None], [BG, G]), [BG * G])
 
-        b_s = tl.dot(b_k, tl.trans(b_q))                                              # [BS, BG*G]
+        # [BS, BK] @ [BK, BG*G] -> [BS, BG*G]
+        b_s = tl.dot(b_k, tl.trans(b_q))
         b_p = exp(b_s - b_lse[None, :])
-        keep = (qpos_rep[None, :] >= key_abs[:, None]) & col_valid[None, :]
-        b_p = tl.where(keep, b_p, 0.)
+        # causal: a key contributes only to queries at or after its position
+        b_p = tl.where((o_pos[None, :] >= o_t[:, None]) & m_col[None, :], b_p, 0.)
 
+        # [BS, BG*G] @ [BG*G, BV] -> [BS, BV]
         b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
+        # [BS, BV] @ [BV, BG*G] -> [BS, BG*G]
         b_dp = tl.dot(b_v, tl.trans(b_do))
-        b_ds = b_p * (b_dp.to(tl.float32) - b_del[None, :])
+        b_ds = b_p * (b_dp.to(tl.float32) - b_delta[None, :])
+        # [BS, BG*G] @ [BG*G, BK] -> [BS, BK]
         b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
 
-    dk_off = (i_v * NTOK + key_abs)[:, None] * (H * K) + i_h * K + o_k[None, :]
-    dv_off = key_abs[:, None] * (H * V) + i_h * V + o_v[None, :]
-    tl.store(dk + dk_off, b_dk.to(dk.dtype.element_ty), mask=r_m[:, None] & k_m[None, :])
-    tl.store(dv + dv_off, b_dv.to(dv.dtype.element_ty), mask=r_m[:, None] & v_m[None, :])
+    o_dk = (i_v * all + o_t)[:, None] * H*K + o_k[None, :]
+    o_dv = o_t[:, None] * H*V + o_v[None, :]
+    tl.store(dk + o_dk, b_dk.to(dk.dtype.element_ty), mask=m_t[:, None] & m_k[None, :])
+    tl.store(dv + o_dv, b_dv.to(dv.dtype.element_ty), mask=m_t[:, None] & m_v[None, :])
 
 
 @contiguous
@@ -611,8 +585,8 @@ def parallel_nsa_fwd(
     cu_seqlens_k: torch.LongTensor | None = None,
     token_indices_q: torch.LongTensor | None = None,
 ):
-    B, T_kv, H, K, V, S = *k.shape, v.shape[-1], block_indices.shape[-1]
-    _, T_q, HQ, _ = q.shape
+    B, TK, H, K, V, S = *k.shape, v.shape[-1], block_indices.shape[-1]
+    _, TQ, HQ, _ = q.shape
     G = HQ // H
     BS = block_size
     if check_shared_mem('hopper', q.device.index):
@@ -625,9 +599,9 @@ def parallel_nsa_fwd(
     NV = triton.cdiv(V, BV)
     assert NK == 1, "The key dimension can not be larger than 256"
 
-    grid = (T_q, NV, B * H)
-    o = torch.empty(B, T_q, HQ, V, dtype=v.dtype, device=q.device)
-    lse = torch.empty(B, T_q, HQ, dtype=torch.float, device=q.device)
+    grid = (TQ, NV, B * H)
+    o = torch.empty(B, TQ, HQ, V, dtype=v.dtype, device=q.device)
+    lse = torch.empty(B, TQ, HQ, dtype=torch.float, device=q.device)
 
     parallel_nsa_fwd_kernel[grid](
         q=q,
@@ -641,8 +615,8 @@ def parallel_nsa_fwd(
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
         token_indices_q=token_indices_q,
-        TQ=T_q,
-        TK=T_kv,
+        TQ=TQ,
+        TK=TK,
         H=H,
         HQ=HQ,
         G=G,
@@ -654,33 +628,6 @@ def parallel_nsa_fwd(
         BV=BV,
     )
     return o, lse
-
-
-def parallel_nsa_block_mask(
-    block_indices: torch.LongTensor,
-    block_counts: torch.LongTensor | int,
-    cu_seqlens: torch.LongTensor,
-    block_size: int,
-):
-    B, T, H, S = block_indices.shape
-    BS = block_size
-    if cu_seqlens is not None:
-        NS = triton.cdiv(prepare_lens(cu_seqlens).max().item(), BS)
-    else:
-        NS = triton.cdiv(T, BS)
-    block_mask = torch.zeros(B, T, H, NS, dtype=torch.bool, device=block_indices.device)
-
-    parallel_nsa_kernel_mask[(T, B, H*S)](
-        block_indices=block_indices,
-        block_counts=block_counts,
-        block_mask=block_mask,
-        T=T,
-        H=H,
-        S=S,
-        BS=BS,
-        NS=NS,
-    )
-    return block_mask
 
 
 def parallel_nsa_bwd(
@@ -740,23 +687,47 @@ def parallel_nsa_bwd(
     if cu_seqlens is not None and chunk_indices is None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BS)
 
-    # [B, T, H, M] block_mask: which KV blocks each query selects (causal + count
-    # valid); prepare_dkv_csr inverts it into the per-block list of selecting queries.
-    block_mask = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
-    M = block_mask.shape[-1]
+    M = triton.cdiv(T, BS) if cu_seqlens is None else triton.cdiv(prepare_lens(cu_seqlens).max().item(), BS)
     dk = torch.empty(NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device)
     dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)
 
-    # gather the queries selecting each KV block (CSR inverse index) and batch them
-    # into one MMA — far fewer, far larger matmuls than scanning every query tile.
-    # Works for dense and varlen (the kernel decodes the block via chunk_indices).
-    q_idx, q_ptr = prepare_dkv_csr(block_mask, cu_seqlens, chunk_indices, block_size)
-    n_blk = chunk_indices.shape[0] * H if cu_seqlens is not None else B * H * M
-    grid = (NV, n_blk)
-    parallel_nsa_bwd_kernel_dkv_gather[grid](
-        q, k, v, lse, delta, do, dk, dv, q_idx, q_ptr, cu_seqlens, chunk_indices,
-        scale, T, B * T,
-        B=B, H=H, HQ=HQ, G=G, K=K, V=V, NS=M, BS=BS, BK=BK, BV=BV,
+    # invert the selection into the per-block list of selecting queries (CSR), so the kernel
+    # gathers and batches them into one MMA instead of scanning every query tile.
+    csr_indices, csr_offsets = prepare_block_csr(
+        block_indices=block_indices,
+        block_counts=block_counts,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        num_blocks=M,
+        block_size=block_size,
+    )
+    NB = chunk_indices.shape[0] * H if cu_seqlens is not None else B * H * M
+    grid = (NV, NB)
+    parallel_nsa_bwd_kernel_dkv[grid](
+        q=q,
+        k=k,
+        v=v,
+        lse=lse,
+        delta=delta,
+        do=do,
+        dk=dk,
+        dv=dv,
+        scale=scale,
+        csr_indices=csr_indices,
+        csr_offsets=csr_offsets,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        HQ=HQ,
+        G=G,
+        K=K,
+        V=V,
+        TC=M,
+        BS=BS,
+        BK=BK,
+        BV=BV,
     )
     dk = dk.sum(0)
     return dq, dk, dv
@@ -856,7 +827,8 @@ def parallel_nsa(
             queries of shape `[B, TQ, HQ, K]`.
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
-            GQA is enforced here. The ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >=16 (it is a kernel tile dimension; Triton requires power-of-2 block shapes).
+            GQA is enforced here: the ratio of query heads (HQ) to key/value heads (H) must be a power of 2 and >= 16.
+            This is a kernel tile dimension, which Triton requires to be a power-of-2 block shape.
         v (torch.Tensor):
             values of shape `[B, T, H, V]`.
         g_cmp (torch.Tensor):
@@ -898,7 +870,8 @@ def parallel_nsa(
             f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`. "
             f"Please flatten variable-length inputs before processing.",
         )
-    assert q.shape[2] % (k.shape[2] * 16) == 0, "Group size must be a multiple of 16 in NSA"
+    G = q.shape[2] // k.shape[2]
+    assert G >= 16 and (G & (G - 1)) == 0, "Group size (HQ/H) must be a power of 2 and >= 16 in NSA"
 
     if cu_seqlens is not None:
         if isinstance(cu_seqlens, tuple):

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -737,12 +737,8 @@ def parallel_nsa_bwd(
     )
     dq = dq.sum(0)
 
-    if cu_seqlens is not None:
-        if chunk_indices is None:
-            chunk_indices = prepare_chunk_indices(cu_seqlens, BS)
-        NS = len(chunk_indices)
-    else:
-        NS = triton.cdiv(T, BS)
+    if cu_seqlens is not None and chunk_indices is None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BS)
 
     # [B, T, H, M] block_mask: which KV blocks each query selects (causal + count
     # valid); prepare_dkv_csr inverts it into the per-block list of selecting queries.

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -542,8 +542,7 @@ def parallel_nsa_topk(
     scale: float = None,
     cu_seqlens: torch.LongTensor | tuple[torch.LongTensor, torch.LongTensor] | None = None,
 ) -> torch.LongTensor:
-    B, TQ, HQ, K = q.shape
-    _, TC, H, _ = k.shape
+    B, TQ, HQ, K, H = *q.shape, k.shape[2]
 
     assert k.shape[0] == q.shape[0] and k.shape[-1] == q.shape[-1], "The last dimension of k and q must match"
     assert lse is None or lse.shape == (B, TQ, HQ), "The shape of lse must be (B, TQ, HQ)"
@@ -830,7 +829,7 @@ class ParallelNSAFunction(torch.autograd.Function):
         ctx.token_indices = token_indices_q
         ctx.block_size = block_size
         ctx.scale = scale
-        # q/k cu_seqlens differ only in cached inference (Tq != Tk), where backward is not supported
+        # q/k cu_seqlens differ only in cached inference (TQ != TK), where backward is not supported
         ctx.tq_ne_tk = isinstance(cu_seqlens, tuple)
         return o.to(q.dtype)
 

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -423,8 +423,8 @@ def parallel_nsa_bwd_kernel_dq(
 
 
 @triton.heuristics({
+    'HAS_Q_LAST': lambda args: args['cu_seqlens'] is None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-    'USE_QMAX': lambda args: args['cu_seqlens'] is None,
 })
 @triton.autotune(
     configs=[
@@ -463,8 +463,8 @@ def parallel_nsa_bwd_kernel_dkv(
     BK: tl.constexpr,
     BV: tl.constexpr,
     BQ: tl.constexpr,
+    HAS_Q_LAST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    USE_QMAX: tl.constexpr,
 ):
     i_v, i_s, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
@@ -495,7 +495,7 @@ def parallel_nsa_bwd_kernel_dkv(
     # stop scanning past the furthest query that selected this block (dense only);
     # q_last holds that position, so the all-empty tail is never iterated.
     q_hi = eos
-    if USE_QMAX:
+    if HAS_Q_LAST:
         q_hi = tl.minimum(eos, bos + tl.load(q_last + (i_b * H + i_h) * M + i_s) + 1)
     for i_t in range(q_min // BQ * BQ, q_hi, BQ):
         if tl.load(skip_mask + (i_t // BQ) * H*M + i_h * M + i_s):
@@ -744,7 +744,7 @@ def parallel_nsa_bwd(
 
     # [B, T, H, M] block_mask, plus q_last[b, h, s] = furthest query that selected
     # KV block s (fused into the mask kernel), so dkv stops its scan there instead
-    # of at eos. Used on the dense path only (varlen falls back via USE_QMAX off).
+    # of at eos. Used on the dense path only (varlen falls back via HAS_Q_LAST off).
     block_mask, q_last = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
     M = block_mask.shape[-1]
     # skip_mask[t] = OR of block_mask over a BQ-query tile, so dkv can skip whole tiles

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -286,7 +286,6 @@ def parallel_nsa_kernel_mask(
     block_indices,
     block_counts,
     block_mask,
-    q_last,
     T,
     H: tl.constexpr,
     S: tl.constexpr,
@@ -305,10 +304,6 @@ def parallel_nsa_kernel_mask(
 
     if b_i < NS and b_i >= 0:
         tl.store(block_mask + i_b * T * H * NS + i_t * H * NS + i_h * NS + b_i, b_m.to(block_mask.dtype.element_ty))
-        # furthest query that actually selects this block — lets bwd_dkv stop its
-        # scan here instead of at eos. Fused in (one atomic) so it costs ~nothing.
-        if b_m:
-            tl.atomic_max(q_last + i_b * H * NS + i_h * NS + b_i, i_t)
 
 
 @triton.heuristics({
@@ -421,115 +416,6 @@ def parallel_nsa_bwd_kernel_dq(
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'HAS_Q_LAST': lambda args: args['cu_seqlens'] is None,
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=nw, num_stages=ns)
-        for nw in [1, 2, 4, 8]
-        for ns in [1, 2, 3]
-    ],
-    key=['BS', 'BK', 'BV'],
-    **autotune_cache_kwargs,
-)
-@triton.jit(do_not_specialize=['T'])
-def parallel_nsa_bwd_kernel_dkv(
-    q,
-    k,
-    v,
-    lse,
-    delta,
-    do,
-    dk,
-    dv,
-    block_mask,
-    skip_mask,
-    q_last,
-    cu_seqlens,
-    chunk_indices,
-    scale,
-    T,
-    B: tl.constexpr,
-    H: tl.constexpr,
-    HQ: tl.constexpr,
-    G: tl.constexpr,
-    K: tl.constexpr,
-    V: tl.constexpr,
-    M: tl.constexpr,
-    BS: tl.constexpr,
-    BK: tl.constexpr,
-    BV: tl.constexpr,
-    BQ: tl.constexpr,
-    HAS_Q_LAST: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-):
-    i_v, i_s, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_b, i_h = i_bh // H, i_bh % H
-
-    all = B * T
-    if IS_VARLEN:
-        i_n, i_s = tl.load(chunk_indices + i_s * 2).to(tl.int32), tl.load(chunk_indices + i_s * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
-    else:
-        bos, eos = i_b * T, i_b * T + T
-
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_s * BS, 0), (BS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s * BS, i_v * BV), (BS, BV), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (i_v * all * H + bos * H + i_h) * K, (T, K), (H*K, 1), (i_s * BS, 0), (BS, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s * BS, i_v * BV), (BS, BV), (1, 0))
-
-    # [BS, BK]
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_dk = tl.zeros([BS, BK], dtype=tl.float32)
-    # [BS, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_dv = tl.zeros([BS, BV], dtype=tl.float32)
-
-    # skip query tiles where no query selected this KV block: skip_mask ORs block_mask
-    # over BQ-query tiles, absolute-aligned (bos may not be BQ-aligned under varlen)
-    q_min = bos + i_s * BS
-    # stop scanning past the furthest query that selected this block (dense only);
-    # q_last holds that position, so the all-empty tail is never iterated.
-    q_hi = eos
-    if HAS_Q_LAST:
-        q_hi = tl.minimum(eos, bos + tl.load(q_last + (i_b * H + i_h) * M + i_s) + 1)
-    for i_t in range(q_min // BQ * BQ, q_hi, BQ):
-        if tl.load(skip_mask + (i_t // BQ) * H*M + i_h * M + i_s):
-            for i in range(tl.maximum(i_t, q_min), tl.minimum(i_t + BQ, eos)):
-                if tl.load(block_mask + i * H*M + i_h * M + i_s):
-                    p_q = tl.make_block_ptr(q + i * HQ*K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
-                    # [G, BK]
-                    b_q = tl.load(p_q, boundary_check=(0, 1))
-                    b_q = (b_q * scale).to(b_q.dtype)
-
-                    p_do = tl.make_block_ptr(do + i * HQ*V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
-                    p_lse = lse + i * HQ + i_h * G + tl.arange(0, G)
-                    p_delta = delta + i * HQ + i_h * G + tl.arange(0, G)
-                    # [G, BV]
-                    b_do = tl.load(p_do, boundary_check=(0, 1))
-                    # [G]
-                    b_lse = tl.load(p_lse)
-                    b_delta = tl.load(p_delta)
-                    # [BS, G]
-                    b_s = tl.dot(b_k, tl.trans(b_q))
-                    b_p = exp(b_s - b_lse[None, :])
-                    b_p = tl.where((i >= q_min + tl.arange(0, BS))[:, None], b_p, 0)
-                    # [BS, G] @ [G, BV] -> [BS, BV]
-                    b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
-                    # [BS, BV] @ [BV, G] -> [BS, G]
-                    b_dp = tl.dot(b_v, tl.trans(b_do))
-                    # [BS, G]
-                    b_ds = b_p * (b_dp - b_delta[None, :])
-                    # [BS, G] @ [G, BK] -> [BS, BK]
-                    b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
-
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-
-
 def prepare_dkv_csr(block_mask, cu_seqlens, chunk_indices, block_size):
     # Inverse index for gather-based dkv: per KV block (keyed by the same id the
     # kernel decodes) the sorted list of *absolute* query positions selecting it,
@@ -565,7 +451,7 @@ def prepare_dkv_csr(block_mask, cu_seqlens, chunk_indices, block_size):
     configs=[
         triton.Config({'BG': BG}, num_warps=nw, num_stages=ns)
         for BG in [1, 2, 4, 8]
-        for nw in [2, 4, 8]
+        for nw in [4, 8]
         for ns in [1, 2]
     ],
     key=['BS', 'BK', 'BV', 'G'],
@@ -783,20 +669,18 @@ def parallel_nsa_block_mask(
     else:
         NS = triton.cdiv(T, BS)
     block_mask = torch.zeros(B, T, H, NS, dtype=torch.bool, device=block_indices.device)
-    q_last = torch.full((B, H, NS), -1, dtype=torch.int32, device=block_indices.device)
 
     parallel_nsa_kernel_mask[(T, B, H*S)](
         block_indices=block_indices,
         block_counts=block_counts,
         block_mask=block_mask,
-        q_last=q_last,
         T=T,
         H=H,
         S=S,
         BS=BS,
         NS=NS,
     )
-    return block_mask, q_last
+    return block_mask
 
 
 def parallel_nsa_bwd(
@@ -820,7 +704,6 @@ def parallel_nsa_bwd(
     BS = block_size
     BK = max(triton.next_power_of_2(K), 16)
     BV = min(128, max(triton.next_power_of_2(v.shape[-1]), 16))
-    BQ = 16
     NV = triton.cdiv(V, BV)
 
     delta = parallel_attn_bwd_preprocess(o, do)
@@ -861,10 +744,9 @@ def parallel_nsa_bwd(
     else:
         NS = triton.cdiv(T, BS)
 
-    # [B, T, H, M] block_mask, plus q_last[b, h, s] = furthest query that selected
-    # KV block s (fused into the mask kernel), so dkv stops its scan there instead
-    # of at eos. Used on the dense path only (varlen falls back via HAS_Q_LAST off).
-    block_mask, _ = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
+    # [B, T, H, M] block_mask: which KV blocks each query selects (causal + count
+    # valid); prepare_dkv_csr inverts it into the per-block list of selecting queries.
+    block_mask = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
     M = block_mask.shape[-1]
     dk = torch.empty(NV, *k.shape, dtype=k.dtype if NV == 1 else torch.float, device=q.device)
     dv = torch.empty(v.shape, dtype=v.dtype, device=q.device)

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -287,6 +287,7 @@ def parallel_nsa_kernel_mask(
     block_indices,
     block_counts,
     block_mask,
+    q_last,
     T,
     H: tl.constexpr,
     S: tl.constexpr,
@@ -305,6 +306,10 @@ def parallel_nsa_kernel_mask(
 
     if b_i < NS and b_i >= 0:
         tl.store(block_mask + i_b * T * H * NS + i_t * H * NS + i_h * NS + b_i, b_m.to(block_mask.dtype.element_ty))
+        # furthest query that actually selects this block — lets bwd_dkv stop its
+        # scan here instead of at eos. Fused in (one atomic) so it costs ~nothing.
+        if b_m:
+            tl.atomic_max(q_last + i_b * H * NS + i_h * NS + b_i, i_t)
 
 
 @triton.heuristics({
@@ -419,6 +424,7 @@ def parallel_nsa_bwd_kernel_dq(
 
 @triton.heuristics({
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+    'USE_QMAX': lambda args: args['cu_seqlens'] is None,
 })
 @triton.autotune(
     configs=[
@@ -441,6 +447,7 @@ def parallel_nsa_bwd_kernel_dkv(
     dv,
     block_mask,
     skip_mask,
+    q_last,
     cu_seqlens,
     chunk_indices,
     scale,
@@ -457,6 +464,7 @@ def parallel_nsa_bwd_kernel_dkv(
     BV: tl.constexpr,
     BQ: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_QMAX: tl.constexpr,
 ):
     i_v, i_s, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
@@ -484,7 +492,12 @@ def parallel_nsa_bwd_kernel_dkv(
     # skip query tiles where no query selected this KV block: skip_mask ORs block_mask
     # over BQ-query tiles, absolute-aligned (bos may not be BQ-aligned under varlen)
     q_min = bos + i_s * BS
-    for i_t in range(q_min // BQ * BQ, eos, BQ):
+    # stop scanning past the furthest query that selected this block (dense only);
+    # q_last holds that position, so the all-empty tail is never iterated.
+    q_hi = eos
+    if USE_QMAX:
+        q_hi = tl.minimum(eos, bos + tl.load(q_last + (i_b * H + i_h) * M + i_s) + 1)
+    for i_t in range(q_min // BQ * BQ, q_hi, BQ):
         if tl.load(skip_mask + (i_t // BQ) * H*M + i_h * M + i_s):
             for i in range(tl.maximum(i_t, q_min), tl.minimum(i_t + BQ, eos)):
                 if tl.load(block_mask + i * H*M + i_h * M + i_s):
@@ -652,18 +665,20 @@ def parallel_nsa_block_mask(
     else:
         NS = triton.cdiv(T, BS)
     block_mask = torch.zeros(B, T, H, NS, dtype=torch.bool, device=block_indices.device)
+    q_last = torch.full((B, H, NS), -1, dtype=torch.int32, device=block_indices.device)
 
     parallel_nsa_kernel_mask[(T, B, H*S)](
         block_indices=block_indices,
         block_counts=block_counts,
         block_mask=block_mask,
+        q_last=q_last,
         T=T,
         H=H,
         S=S,
         BS=BS,
         NS=NS,
     )
-    return block_mask
+    return block_mask, q_last
 
 
 def parallel_nsa_bwd(
@@ -728,8 +743,10 @@ def parallel_nsa_bwd(
     else:
         NS = triton.cdiv(T, BS)
 
-    # [B, T, H, M]
-    block_mask = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
+    # [B, T, H, M] block_mask, plus q_last[b, h, s] = furthest query that selected
+    # KV block s (fused into the mask kernel), so dkv stops its scan there instead
+    # of at eos. Used on the dense path only (varlen falls back via USE_QMAX off).
+    block_mask, q_last = parallel_nsa_block_mask(block_indices, block_counts, cu_seqlens, block_size)
     M = block_mask.shape[-1]
     # skip_mask[t] = OR of block_mask over a BQ-query tile, so dkv can skip whole tiles
     # of queries that selected nothing in a KV block
@@ -750,6 +767,7 @@ def parallel_nsa_bwd(
         dv=dv,
         block_mask=block_mask,
         skip_mask=skip_mask,
+        q_last=q_last,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         scale=scale,

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -422,8 +422,9 @@ def parallel_nsa_bwd_kernel_dq(
 })
 @triton.autotune(
     configs=[
-        triton.Config({}, num_warps=num_warps)
-        for num_warps in [1, 2, 4]
+        triton.Config({}, num_warps=nw, num_stages=ns)
+        for nw in [1, 2, 4, 8]
+        for ns in [1, 2, 3]
     ],
     key=['BS', 'BK', 'BV'],
     **autotune_cache_kwargs,

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -393,8 +393,8 @@ def parallel_nsa_bwd_kernel_dq(
 })
 @triton.autotune(
     configs=[
-        triton.Config({'BG': BG}, num_warps=num_warps, num_stages=num_stages)
-        for BG in [1, 2, 4, 8]
+        triton.Config({'BQ': BQ}, num_warps=num_warps, num_stages=num_stages)
+        for BQ in [1, 2, 4, 8]
         for num_warps in [4, 8]
         for num_stages in [1, 2]
     ],
@@ -427,11 +427,10 @@ def parallel_nsa_bwd_kernel_dkv(
     BS: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
-    BG: tl.constexpr,
+    BQ: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_blk = tl.program_id(0), tl.program_id(1)
-    i_q0, i_q1 = tl.load(csr_offsets + i_blk).to(tl.int64), tl.load(csr_offsets + i_blk + 1).to(tl.int64)
     all = B * T
     if IS_VARLEN:
         i_c, i_h = i_blk // H, i_blk % H
@@ -445,68 +444,63 @@ def parallel_nsa_bwd_kernel_dkv(
         bos = (i_b * T).to(tl.int64)
         eos = bos + T
     o_t = bos + i_s * BS + tl.arange(0, BS)
-    o_k = tl.arange(0, BK)
+    o_d = tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
-    o_g = tl.arange(0, G)
-    m_t, m_k, m_v = o_t < eos, o_k < K, o_v < V
+    o_h = tl.arange(0, BQ * G) % G
+    m_t, m_d, m_v = o_t < eos, o_d < K, o_v < V
 
+    # this block's CSR slice: the queries that selected it
+    i_q0, i_q1 = tl.load(csr_offsets + i_blk).to(tl.int64), tl.load(csr_offsets + i_blk + 1).to(tl.int64)
     NQ = i_q1 - i_q0
 
     q += i_h * G*K
-    do += i_h * G*V
-    lse += i_h * G
-    delta += i_h * G
     k += i_h * K
     v += i_h * V
+    lse += i_h * G
+    delta += i_h * G
+    do += i_h * G*V
     dk += i_h * K
     dv += i_h * V
 
     # [BS, BK] / [BS, BV] k/v tile for this kv block
-    b_k = tl.load(k + o_t[:, None] * H*K + o_k[None, :], mask=m_t[:, None] & m_k[None, :], other=0.)
+    b_k = tl.load(k + o_t[:, None] * H*K + o_d[None, :], mask=m_t[:, None] & m_d[None, :], other=0.)
     b_v = tl.load(v + o_t[:, None] * H*V + o_v[None, :], mask=m_t[:, None] & m_v[None, :], other=0.)
     b_dk = tl.zeros([BS, BK], dtype=tl.float32)
     b_dv = tl.zeros([BS, BV], dtype=tl.float32)
 
-    for i in range(tl.cdiv(NQ, BG)):
-        o_j = i * BG + tl.arange(0, BG)
-        m_j = o_j < NQ
-        # [BG] absolute positions of the queries selecting this block
-        i_q = tl.load(csr_indices + i_q0 + o_j, mask=m_j, other=0).to(tl.int64)
+    for i in range(tl.cdiv(NQ, BQ)):
+        # BQ queries x G group heads flattened to [BQ*G] columns; row r -> query slot i*BQ + r//G, head o_h[r]
+        o_q = i * BQ + tl.arange(0, BQ * G) // G
+        m_q = o_q < NQ
+        o_q = tl.load(csr_indices + i_q0 + o_q, mask=m_q, other=0).to(tl.int64)
 
-        # gather q/do/lse/delta for the BG queries over their G group heads -> [BG*G, *]
-        o_q = i_q[:, None, None] * HQ*K + o_g[None, :, None] * K + o_k[None, None, :]
-        b_q = tl.load(q + o_q, mask=m_j[:, None, None] & m_k[None, None, :], other=0.).to(tl.float32)
-        b_q = tl.reshape(b_q * scale, [BG * G, BK]).to(b_k.dtype)
+        # gather q/do/lse/delta for the [BQ*G] (query, group-head) columns
+        # [BQ*G, BK]
+        b_q = tl.load(q + o_q[:, None] * HQ*K + o_h[:, None] * K + o_d[None, :], mask=m_q[:, None] & m_d[None, :], other=0.)
+        b_q = (b_q * scale).to(b_k.dtype)
+        # [BQ*G, BV]
+        b_do = tl.load(do + o_q[:, None] * HQ*V + o_h[:, None] * V + o_v[None, :], mask=m_q[:, None] & m_v[None, :], other=0.)
+        # [BQ*G]
+        b_lse = tl.load(lse + o_q * HQ + o_h, mask=m_q, other=0.)
+        b_delta = tl.load(delta + o_q * HQ + o_h, mask=m_q, other=0.)
 
-        o_do = i_q[:, None, None] * HQ*V + o_g[None, :, None] * V + o_v[None, None, :]
-        b_do = tl.load(do + o_do, mask=m_j[:, None, None] & m_v[None, None, :], other=0.)
-        b_do = tl.reshape(b_do, [BG * G, BV])
-
-        o_ld = i_q[:, None] * HQ + o_g[None, :]
-        b_lse = tl.reshape(tl.load(lse + o_ld, mask=m_j[:, None], other=0.), [BG * G])
-        b_delta = tl.reshape(tl.load(delta + o_ld, mask=m_j[:, None], other=0.), [BG * G])
-
-        # broadcast per-query validity and position over the G group heads
-        m_col = tl.reshape(tl.broadcast_to(m_j[:, None], [BG, G]), [BG * G])
-        o_pos = tl.reshape(tl.broadcast_to(i_q[:, None], [BG, G]), [BG * G])
-
-        # [BS, BK] @ [BK, BG*G] -> [BS, BG*G]
+        # [BS, BK] @ [BK, BQ*G] -> [BS, BQ*G]
         b_s = tl.dot(b_k, tl.trans(b_q))
         b_p = exp(b_s - b_lse[None, :])
         # causal: a key contributes only to queries at or after its position
-        b_p = tl.where((o_pos[None, :] >= o_t[:, None]) & m_col[None, :], b_p, 0.)
+        b_p = tl.where((o_q[None, :] >= o_t[:, None]) & m_q[None, :], b_p, 0.)
 
-        # [BS, BG*G] @ [BG*G, BV] -> [BS, BV]
+        # [BS, BQ*G] @ [BQ*G, BV] -> [BS, BV]
         b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
-        # [BS, BV] @ [BV, BG*G] -> [BS, BG*G]
+        # [BS, BV] @ [BV, BQ*G] -> [BS, BQ*G]
         b_dp = tl.dot(b_v, tl.trans(b_do))
         b_ds = b_p * (b_dp.to(tl.float32) - b_delta[None, :])
-        # [BS, BG*G] @ [BG*G, BK] -> [BS, BK]
+        # [BS, BQ*G] @ [BQ*G, BK] -> [BS, BK]
         b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
 
-    o_dk = (i_v * all + o_t)[:, None] * H*K + o_k[None, :]
+    o_dk = (i_v * all + o_t)[:, None] * H*K + o_d[None, :]
     o_dv = o_t[:, None] * H*V + o_v[None, :]
-    tl.store(dk + o_dk, b_dk.to(dk.dtype.element_ty), mask=m_t[:, None] & m_k[None, :])
+    tl.store(dk + o_dk, b_dk.to(dk.dtype.element_ty), mask=m_t[:, None] & m_d[None, :])
     tl.store(dv + o_dv, b_dv.to(dv.dtype.element_ty), mask=m_t[:, None] & m_v[None, :])
 
 

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -388,6 +388,14 @@ def parallel_nsa_bwd_kernel_dq(
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
 
 
+def _prune_dkv_bq(configs, nargs, **kwargs):
+    # the gather stacks BQ queries x G group heads into a [BQ*G]-wide tile; past ~1024 columns the
+    # Triton compiler fails outright (which autotune cannot catch), so cap BQ*G here. Shared-memory
+    # fit is left to autotune, which prunes configs that don't fit the device. Always keep BQ=1.
+    G = {**(nargs or {}), **kwargs}.get('G', 1)
+    return [c for c in configs if c.kwargs['BQ'] == 1 or c.kwargs['BQ'] * G <= 256]
+
+
 @triton.heuristics({
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
@@ -399,6 +407,7 @@ def parallel_nsa_bwd_kernel_dq(
         for num_stages in [1, 2]
     ],
     key=['BS', 'BK', 'BV', 'G'],
+    prune_configs_by={'early_config_prune': _prune_dkv_bq},
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/fla/ops/utils/__init__.py
+++ b/fla/ops/utils/__init__.py
@@ -5,6 +5,7 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+from .csr import prepare_block_csr
 from .cumsum import (
     chunk_global_cumsum,
     chunk_global_cumsum_scalar,
@@ -46,6 +47,7 @@ __all__ = [
     "matmul",
     "mean_pooling",
     "pack_sequence",
+    "prepare_block_csr",
     "prepare_chunk_indices",
     "prepare_chunk_offsets",
     "prepare_cu_seqlens_from_lens",

--- a/fla/ops/utils/csr.py
+++ b/fla/ops/utils/csr.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.index import prepare_chunk_offsets, prepare_token_indices
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+    'USE_BLOCK_COUNTS': lambda args: isinstance(args['block_counts'], torch.Tensor),
+})
+@triton.jit(do_not_specialize=['T'])
+def prepare_block_csr_kernel(
+    block_indices,
+    block_counts,
+    csr_indices,
+    csr_offsets,
+    cursor,
+    cu_seqlens,
+    token_indices,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BS: tl.constexpr,
+    TC: tl.constexpr,
+    COUNT_ONLY: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_BLOCK_COUNTS: tl.constexpr,
+):
+    # one program per (batch, kv-head, query); scan its selected blocks and, for each valid one,
+    # count it (pass 1) or scatter it (pass 2) into the selected block's CSR segment
+    i_q, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_qh = ((i_b * T).to(tl.int64) + i_q) * H + i_h
+    if IS_VARLEN:
+        # block_base = global block base of this query's sequence (as in the fwd/topk kernels)
+        i_n = tl.load(token_indices + i_q * 2).to(tl.int32)
+        block_base = tl.load(chunk_offsets + i_n).to(tl.int64)
+
+    block_indices += i_qh * S
+    NS = tl.load(block_counts + i_qh) if USE_BLOCK_COUNTS else block_counts
+    for i in range(NS):
+        i_s = tl.load(block_indices + i).to(tl.int64)
+        if (i_s >= 0) and (i_s < TC) and (i_s * BS <= i_q):
+            block_id = (block_base + i_s) * H + i_h if IS_VARLEN else (i_b * H + i_h) * TC + i_s
+            if COUNT_ONLY:
+                tl.atomic_add(csr_offsets + block_id + 1, 1)
+            else:
+                dst = tl.load(csr_offsets + block_id).to(tl.int64) + tl.atomic_add(cursor + block_id, 1)
+                tl.store(csr_indices + dst, i_b * T + i_q)
+
+
+def prepare_block_csr(
+    block_indices: torch.LongTensor,
+    block_counts: torch.LongTensor | int,
+    cu_seqlens: torch.LongTensor | None,
+    chunk_indices: torch.LongTensor | None,
+    num_blocks: int,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""
+    Invert a per-query block selection into CSR (compressed sparse row) form.
+
+    `block_indices[b, t, h, :]` lists the blocks query `t` (kv-head `h`) selects.
+    The inverse maps each block to the queries that selected it,
+    which a block-parallel backward (e.g. NSA `bwd_dkv`) needs.
+    The result is CSR over a `[block, query]` matrix: `csr_indices` holds the selecting query positions grouped by block,
+    and `csr_offsets` holds the per-block row offsets,
+    so block `i` owns `csr_indices[csr_offsets[i]:csr_offsets[i + 1]]`.
+
+    Block ids follow the launching kernel's program-id layout:
+    `(b * H + h) * num_blocks + s` for dense, `(global_block + s) * H + h` for varlen.
+    The varlen block base is read from the standard `token_indices` / `chunk_offsets` (as in the fwd/topk kernels).
+    Counting then scattering avoids a comparison sort,
+    and `csr_indices` is over-allocated to its upper bound, so its length need not be read back to the host.
+
+    Example (dense, B = H = 1, block_size = 1 so block b covers token b; causal needs b <= t):
+
+        # input: each query lists the blocks it selects, -1 is padding
+        block_indices[0, :, 0, :] =
+            [[ 0, -1],   # query 0 selects block 0
+             [ 0,  1],   # query 1 selects blocks 0, 1
+             [ 1,  2],   # query 2 selects blocks 1, 2
+             [ 0,  3]]   # query 3 selects blocks 0, 3
+
+        # invert -> which queries selected each block:
+        #   block 0: queries 0, 1, 3
+        #   block 1: queries 1, 2
+        #   block 2: query 2
+        #   block 3: query 3
+
+        csr_indices = [0, 1, 3,  1, 2,  2,  3]   # 7 selections, grouped by block (order within a block is arbitrary)
+        csr_offsets = [0, 3, 5, 6, 7]            # block i's queries = csr_indices[csr_offsets[i]:csr_offsets[i+1]]
+
+    Args:
+        block_indices (torch.LongTensor):
+            Selected block ids of shape `[B, T, H, S]`, padded with `-1`.
+        block_counts (torch.LongTensor or int):
+            Number of valid slots per query, a `[B, T, H]` tensor or an int.
+        cu_seqlens (torch.LongTensor, Optional):
+            Cumulative sequence lengths for variable-length packing. Default: `None` (dense).
+        chunk_indices (torch.LongTensor):
+            Per-chunk `(sequence, local-block)` index pairs; read only to size the varlen block-id space.
+        num_blocks (int):
+            Number of blocks per `(batch, head)`, i.e. the dense kernel's `TC`.
+        block_size (int):
+            Selected block size, used for the causal check and varlen block ids.
+
+    Returns:
+        csr_indices (torch.Tensor):
+            `int32` selecting query positions, grouped by block; absolute (`b * T + t`).
+        csr_offsets (torch.Tensor):
+            `int32` CSR row offsets of shape `[NB + 1]`, one per block plus a final end offset.
+    """
+    B, T, H, S = block_indices.shape
+    device = block_indices.device
+    NB = B * H * num_blocks if cu_seqlens is None else chunk_indices.shape[0] * H
+    token_indices = prepare_token_indices(cu_seqlens) if cu_seqlens is not None else None
+    chunk_offsets = prepare_chunk_offsets(cu_seqlens, block_size) if cu_seqlens is not None else None
+
+    cursor = torch.zeros(NB, dtype=torch.int32, device=device)
+    csr_offsets = torch.zeros(NB + 1, dtype=torch.int32, device=device)
+    csr_indices = torch.empty(B * T * H * S, dtype=torch.int32, device=device)
+
+    grid = (T, B * H)
+
+    # counting sort over blocks. it takes two kernel launches, not one: the scatter places each
+    # query at csr_offsets[block] + cursor, and csr_offsets is the prefix sum over ALL blocks'
+    # counts -- a global dependency one grid launch can't satisfy (no cross-program barrier).
+    def launch(count_only):
+        prepare_block_csr_kernel[grid](
+            block_indices=block_indices,
+            block_counts=block_counts,
+            csr_indices=csr_indices,
+            csr_offsets=csr_offsets,
+            cursor=cursor,
+            cu_seqlens=cu_seqlens,
+            token_indices=token_indices,
+            chunk_offsets=chunk_offsets,
+            T=T,
+            H=H,
+            S=S,
+            BS=block_size,
+            TC=num_blocks,
+            COUNT_ONLY=count_only,
+        )
+
+    # pass 1: tally each block's query count into csr_offsets[block + 1]
+    launch(count_only=True)
+    # prefix sum in place: per-block tallies -> CSR start offsets
+    csr_offsets.cumsum_(0)
+    # pass 2: scatter each query into its block's segment
+    launch(count_only=False)
+    return csr_indices, csr_offsets

--- a/tests/ops/utils/test_csr.py
+++ b/tests/ops/utils/test_csr.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.csr import prepare_block_csr
+from fla.utils import device
+
+
+def ref_block_csr(block_indices, block_counts, cu_seqlens, num_blocks, block_size):
+    # reference: same validity, but CSR built with unique() (sorted within each block)
+    B, T, H, S = block_indices.shape
+    BS = block_size
+    dev = block_indices.device
+    bi = block_indices
+    b = torch.arange(B, device=dev).view(B, 1, 1, 1)
+    t = torch.arange(T, device=dev).view(1, T, 1, 1)
+    h = torch.arange(H, device=dev).view(1, 1, H, 1)
+    slot = torch.arange(S, device=dev).view(1, 1, 1, S)
+    quota = block_counts.unsqueeze(-1) if torch.is_tensor(block_counts) else block_counts
+    valid = (bi >= 0) & (bi < num_blocks) & (bi * BS <= t) & (slot < quota)
+    b, t, h, bi = (x.expand_as(block_indices)[valid] for x in (b, t, h, bi))
+    if cu_seqlens is None:
+        block_id = (b * H + h) * num_blocks + bi
+        q_pos = b * T + t
+        n_blocks = B * H * num_blocks
+    else:
+        lens = cu_seqlens[1:] - cu_seqlens[:-1]
+        chunk_offsets = torch.cat([cu_seqlens.new_zeros(1), ((lens + BS - 1) // BS).cumsum(0)])
+        seq = torch.searchsorted(cu_seqlens[1:].contiguous(), t, right=True)
+        block_id = (chunk_offsets[seq] + bi) * H + h
+        q_pos = t
+        n_blocks = int(chunk_offsets[-1]) * H
+    key = torch.unique(block_id * (B * T) + q_pos)
+    csr_indices = (key % (B * T)).to(torch.int32)
+    csr_offsets = torch.zeros(n_blocks + 1, dtype=torch.int32, device=dev)
+    csr_offsets[1:] = torch.bincount(key // (B * T), minlength=n_blocks).cumsum(0)
+    return csr_indices, csr_offsets
+
+
+def gen_block_indices(B, T, H, S, num_blocks, block_size):
+    # distinct, causal block ids per query (mirrors top-k selection); -1 pads short tails
+    g = torch.Generator().manual_seed(42)
+    bi = torch.full((B, T, H, S), -1, dtype=torch.long)
+    for b in range(B):
+        for t in range(T):
+            hi = min(num_blocks, t // block_size + 1)
+            for h in range(H):
+                k = min(S, hi)
+                if k > 0:
+                    bi[b, t, h, :k] = torch.randperm(hi, generator=g)[:k]
+    return bi.to(device)
+
+
+def assert_csr_match(out, ref):
+    (qi, qo), (rqi, rqo) = out, ref
+    # offsets (per-block counts) must match exactly
+    torch.testing.assert_close(qo.long(), rqo.long())
+    qi, qo, rqi, rqo = qi.cpu(), qo.cpu(), rqi.cpu(), rqo.cpu()
+    # within a block the scatter order is arbitrary, so compare the query sets
+    for i in range(qo.numel() - 1):
+        got = set(qi[qo[i]:qo[i + 1]].tolist())
+        exp = set(rqi[rqo[i]:rqo[i + 1]].tolist())
+        assert got == exp, f"block {i}: {got} != {exp}"
+
+
+def make_block_counts(B, T, H, S, kind):
+    if kind == "int":
+        return S
+    g = torch.Generator().manual_seed(0)
+    return torch.randint(0, S + 1, (B, T, H), generator=g).to(device)
+
+
+@pytest.mark.parametrize("counts_kind", ["int", "tensor"])
+@pytest.mark.parametrize(
+    ("B", "T", "H", "S", "block_size"),
+    [(1, 64, 1, 8, 16), (2, 100, 2, 4, 16), (1, 60, 4, 8, 32)],
+)
+def test_block_csr(B, T, H, S, block_size, counts_kind):
+    num_blocks = (T + block_size - 1) // block_size
+    block_indices = gen_block_indices(B, T, H, S, num_blocks, block_size)
+    block_counts = make_block_counts(B, T, H, S, counts_kind)
+    out = prepare_block_csr(block_indices, block_counts, None, None, num_blocks, block_size)
+    ref = ref_block_csr(block_indices, block_counts, None, num_blocks, block_size)
+    assert_csr_match(out, ref)
+
+
+@pytest.mark.parametrize("counts_kind", ["int", "tensor"])
+@pytest.mark.parametrize("seqlens", [[15, 49], [30, 1, 33, 64], [100]])
+@pytest.mark.parametrize(("H", "S", "block_size"), [(1, 8, 16), (4, 8, 16)])
+def test_block_csr_varlen(seqlens, H, S, block_size, counts_kind):
+    cu_seqlens = torch.tensor([0, *torch.tensor(seqlens).cumsum(0).tolist()], dtype=torch.int32, device=device)
+    T = int(cu_seqlens[-1])
+    num_blocks = (max(seqlens) + block_size - 1) // block_size
+    block_indices = gen_block_indices(1, T, H, S, num_blocks, block_size)
+    block_counts = make_block_counts(1, T, H, S, counts_kind)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, block_size)
+    out = prepare_block_csr(block_indices, block_counts, cu_seqlens, chunk_indices, num_blocks, block_size)
+    ref = ref_block_csr(block_indices, block_counts, cu_seqlens, num_blocks, block_size)
+    assert_csr_match(out, ref)


### PR DESCRIPTION
## What

Speeds up NSA's `bwd_dkv` (the dk/dv backward), and factors its core index transform into a reusable utility.

- **Gather + batch `bwd_dkv`.** Each program owns one KV block and accumulates from all the queries that selected it in a few large matmuls, replacing the previous per-query scan over the causal range (tiny per-query matmuls gated by selection masks).
- **`fla.ops.utils.prepare_block_csr`.** A counting-sort Triton kernel that inverts the per-query block selection (`block_indices`) into CSR form — for each KV block, the list of queries that selected it. Reusable across the NSA family (MoBA/MSA); replaces the old dense block-mask machinery.
- Tighten the GQA group-size constraint to a power of 2 and ≥ 16 (it is a matmul tile dimension), across the kernel, the naive reference and the README.
- Add `tests/ops/utils/test_csr.py`.

## Where the speedup comes from

For each KV block the backward sums contributions from every query that selected it. Two compounding levers:

1. **Batching the queries (primary).** The old kernel did one matmul per selecting query, with the matmul's free dimension equal to the GQA group size `G`. For typical GQA (many KV heads → small `G`) that is far below what the tensor cores need. Stacking `BQ` queries × their `G` group-heads into one `BQ*G`-wide matmul restores utilization, and the gain grows as `G` shrinks.
2. **CSR inversion (enabler + structural).** The selecting queries are scattered, so batching them requires the per-block inverse list; building it once as a CSR also replaces the scan's per-tile/per-query mask loads and branch divergence with a compact loop — a benefit that grows with sequence length.

The two compound: the win is largest at small `G` and long sequences, and tapers toward neutral as `G` grows (the matmul is already wide, so batching saturates). `BQ` is autotuned with `BQ*G` capped (and `BQ=1` always available) so the gather tile stays within compiler and shared-memory limits across group sizes, head dims and devices.
