### PR TITLE
[Fix] Scale L2Wrap logits gradient by the upstream gradient

### DIFF
--- a/fla/modules/l2warp.py
+++ b/fla/modules/l2warp.py
@@ -16,13 +16,20 @@ class L2Wrap(torch.autograd.Function):
     This version is memory-optimized by not storing the full logits tensor.
     """
     @staticmethod
-    def forward(ctx, loss, logits, l2_penalty_factor=1e-4):
+    def forward(
+        ctx,
+        loss: torch.Tensor,
+        logits: torch.Tensor,
+        l2_penalty_factor: float = 1e-4,
+    ) -> torch.Tensor:
         """
-        Forward pass for L2 penalty.
         Args:
-            loss (torch.Tensor): The loss tensor.
-            logits (torch.Tensor): Shape[B, T, V] The logits tensor.
-            l2_penalty_factor (float): The factor for L2 penalty.
+            loss (torch.Tensor):
+                The already-reduced (scalar) loss to wrap.
+            logits (torch.Tensor):
+                The logits of shape `[B, T, V]`.
+            l2_penalty_factor (float, Optional):
+                The strength of the L2 penalty on the max logit. Default: 1e-4.
         """
         maxx, ids = torch.max(logits, dim=-1, keepdim=True)
         ctx.logits_shape = logits.shape
@@ -32,12 +39,13 @@ class L2Wrap(torch.autograd.Function):
         return loss
 
     @staticmethod
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output: torch.Tensor):
         maxx, ids = ctx.saved_tensors
-        glogits = torch.zeros(ctx.logits_shape, device=grad_output.device,
-                              dtype=grad_output.dtype)
-        glogits.scatter_(-1, ids, maxx)
-        return grad_output, glogits * grad_output, None
+        glogits = torch.zeros(ctx.logits_shape, device=grad_output.device, dtype=grad_output.dtype)
+        # an autograd.Function must scale its input gradients by the upstream gradient; fold the
+        # scalar grad_output into the sparse maxx to avoid a second full-size logits allocation
+        glogits.scatter_(-1, ids, maxx * grad_output)
+        return grad_output, glogits, None
 
 
 l2_warp = L2Wrap.apply

--- a/fla/modules/l2warp.py
+++ b/fla/modules/l2warp.py
@@ -37,7 +37,7 @@ class L2Wrap(torch.autograd.Function):
         glogits = torch.zeros(ctx.logits_shape, device=grad_output.device,
                               dtype=grad_output.dtype)
         glogits.scatter_(-1, ids, maxx)
-        return grad_output, glogits, None
+        return grad_output, glogits * grad_output, None
 
 
 l2_warp = L2Wrap.apply

--- a/tests/modules/test_l2warp.py
+++ b/tests/modules/test_l2warp.py
@@ -75,3 +75,28 @@ def test_fused_linear_cross_entropy_l2_warp(
     assert_close("dx", ref_x_grad, fused_x_grad, ratio)
     assert_close("dw", ref_w_grad, fused_w_grad, ratio)
     assert_close("db", ref_b_grad, fused_b_grad, ratio)
+
+
+@pytest.mark.parametrize("grad_scale", [3.0])
+@pytest.mark.skipif(
+    IS_INTEL_ALCHEMIST is True,
+    reason="Intel Triton Failure",
+)
+def test_l2_warp_grad_output_scaling(grad_scale: float):
+    # An autograd.Function must return input gradients that are linear in the upstream gradient.
+    # L2Wrap injects a logits gradient in backward, which must also be scaled by grad_output.
+    torch.manual_seed(42)
+
+    logits = torch.randn(2, 64, 100, device=device, requires_grad=True)
+    loss = torch.randn((), device=device, requires_grad=True)
+    wrapped = standalone_l2_warp(loss, logits, 1.0)
+
+    g_loss_1, g_logits_1 = torch.autograd.grad(
+        wrapped, (loss, logits), grad_outputs=torch.ones((), device=device), retain_graph=True
+    )
+    g_loss_k, g_logits_k = torch.autograd.grad(
+        wrapped, (loss, logits), grad_outputs=torch.full((), grad_scale, device=device)
+    )
+
+    assert_close("dloss", g_loss_k, grad_scale * g_loss_1, 1e-5)
+    assert_close("dlogits", g_logits_k, grad_scale * g_logits_1, 1e-5)

--- a/tests/modules/test_l2warp.py
+++ b/tests/modules/test_l2warp.py
@@ -15,12 +15,13 @@ from fla.modules.l2warp import l2_warp as standalone_l2_warp
 from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
 
 
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("B", [4, 8])
 @pytest.mark.parametrize("T", [1024])
 @pytest.mark.parametrize("H", [256])
 @pytest.mark.parametrize("V", [2000])
 @pytest.mark.parametrize("l2_penalty_factor", [1e-4, 1])
+@pytest.mark.parametrize("grad_scale", [1.0, 3.0])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 @pytest.mark.skipif(
     IS_INTEL_ALCHEMIST is True,
     reason="Intel Triton Failure",
@@ -31,6 +32,7 @@ def test_fused_linear_cross_entropy_l2_warp(
     H: int,
     V: int,
     l2_penalty_factor: float,
+    grad_scale: float,
     dtype: torch.dtype,
 ):
     torch.manual_seed(42)
@@ -49,7 +51,8 @@ def test_fused_linear_cross_entropy_l2_warp(
     ref_loss_ce = ref_criterion(ref_logits.view(B * T, V), shift_labels.view(-1))
     ref_loss = standalone_l2_warp(ref_loss_ce, ref_logits.view(B, T, V), l2_penalty_factor)
 
-    ref_loss.backward()
+    # scale the loss so backward sees a non-unit upstream gradient when grad_scale != 1
+    (grad_scale * ref_loss).backward()
     ref_x_grad = x.grad.clone()
     ref_w_grad = lm_head.weight.grad.clone()
     ref_b_grad = lm_head.bias.grad.clone()
@@ -64,12 +67,12 @@ def test_fused_linear_cross_entropy_l2_warp(
 
     fused_loss = fused_criterion(x, shift_labels, lm_head.weight, lm_head.bias)
 
-    fused_loss.backward()
+    (grad_scale * fused_loss).backward()
     fused_x_grad = x.grad.clone()
     fused_w_grad = lm_head.weight.grad.clone()
     fused_b_grad = lm_head.bias.grad.clone()
 
-    ratio = 4e-3 if dtype == torch.bfloat16 else 1e-3
+    ratio = 4e-3 if dtype == torch.float16 else 1e-3
 
     assert_close("Loss", ref_loss, fused_loss, ratio)
     assert_close("dx", ref_x_grad, fused_x_grad, ratio)
@@ -83,8 +86,8 @@ def test_fused_linear_cross_entropy_l2_warp(
     reason="Intel Triton Failure",
 )
 def test_l2_warp_grad_output_scaling(grad_scale: float):
-    # An autograd.Function must return input gradients that are linear in the upstream gradient.
-    # L2Wrap injects a logits gradient in backward, which must also be scaled by grad_output.
+    # an autograd.Function must return input gradients that are linear in the upstream gradient;
+    # L2Wrap injects a logits gradient in backward that must be scaled by grad_output too
     torch.manual_seed(42)
 
     logits = torch.randn(2, 64, 100, device=device, requires_grad=True)
@@ -92,11 +95,16 @@ def test_l2_warp_grad_output_scaling(grad_scale: float):
     wrapped = standalone_l2_warp(loss, logits, 1.0)
 
     g_loss_1, g_logits_1 = torch.autograd.grad(
-        wrapped, (loss, logits), grad_outputs=torch.ones((), device=device), retain_graph=True
+        wrapped,
+        (loss, logits),
+        grad_outputs=torch.ones((), device=device),
+        retain_graph=True,
     )
     g_loss_k, g_logits_k = torch.autograd.grad(
-        wrapped, (loss, logits), grad_outputs=torch.full((), grad_scale, device=device)
+        wrapped,
+        (loss, logits),
+        grad_outputs=torch.full((), grad_scale, device=device),
     )
 
-    assert_close("dloss", g_loss_k, grad_scale * g_loss_1, 1e-5)
+    assert_close("  dloss", g_loss_k, grad_scale * g_loss_1, 1e-5)
     assert_close("dlogits", g_logits_k, grad_scale * g_logits_1, 1e-5)


### PR DESCRIPTION

## Summary

`L2Wrap.backward` returns the logits gradient without multiplying it by the upstream gradient, so any non-unit upstream gradient under-scales the L2 penalty gradient on the logits.

An `autograd.Function` must return input gradients that are linear in the incoming `grad_output`. `L2Wrap.backward` does this for the loss input (`return grad_output, ...`) but returns `glogits` directly for the logits input:

```python
glogits.scatter_(-1, ids, maxx)
return grad_output, glogits, None   # glogits is not scaled by grad_output
```

So when the wrapped loss is scaled through autograd, `dloss` scales but `dlogits` does not. The common `loss.backward()` path uses an implicit upstream gradient of 1 and is unaffected, which is why this was not caught. It surfaces for gradient accumulation that scales the loss, custom loss weighting, `torch.autograd.grad(..., grad_outputs=k)`, or any outer fused loss wrapper. `use_l2warp` is a shared training option across the FLA causal LMs (and defaults to `True` for RWKV7), so the affected surface is broad.

The fused path already does the right thing: `fused_linear_cross_entropy_backward` multiplies the whole gradient, including the L2Warp contribution, by the upstream `do`, and #874 aligned its normalization with standalone `l2_warp`. The two paths are meant to be equivalent but only agree at upstream gradient 1; standalone `l2_warp` is the one missing the scaling.

The fix multiplies the logits gradient by `grad_output`. It is a scalar for the wrapped loss, so it broadcasts:

```python
return grad_output, glogits * grad_output, None
```

Minimal repro (an autograd.Function's input gradients must scale linearly with the upstream gradient):

```python
import torch
from fla.modules.l2warp import l2_warp

logits = torch.randn(2, 64, 100, requires_grad=True)
loss = torch.randn(())
wrapped = l2_warp(loss.requires_grad_(), logits, 1.0)

g_loss_1, g_logits_1 = torch.autograd.grad(wrapped, (loss, logits), grad_outputs=torch.ones(()), retain_graph=True)
g_loss_3, g_logits_3 = torch.autograd.grad(wrapped, (loss, logits), grad_outputs=torch.full((), 3.0))

print("loss grad ratio  :", (g_loss_3 / g_loss_1).item())                          # 3.0
print("logits grad ratio:", (g_logits_3.abs().max() / g_logits_1.abs().max()).item())
# before: 1.0  (logits gradient ignores the upstream gradient)
# after : 3.0  (matches the loss gradient and the fused path)
```

## Test plan

A regression test was added to `tests/modules/test_l2warp.py` (`test_l2_warp_grad_output_scaling`): for a non-unit upstream gradient, both `dloss` and `dlogits` from `l2_warp` must scale linearly. It fails before the fix (logits ratio ~2x off) and passes after.

- `pytest tests/modules/test_l2warp.py::test_l2_warp_grad_output_scaling -q` passes with the fix; without it the `dlogits` assertion fails.
- `pytest tests/modules/test_l2warp.py -q` still passes, including the existing standalone-vs-fused equivalence test `test_fused_linear_cross_entropy_l2_warp`.
- `pre-commit run --files fla/modules/l2warp.py tests/modules/test_l2warp.py` is clean.

## Breaking changes

None. 