### PR TITLE
[NSA] Use int64 addressing to avoid int32 overflow at large T

### DIFF
--- a/fla/ops/nsa/compression.py
+++ b/fla/ops/nsa/compression.py
@@ -56,14 +56,14 @@ def parallel_nsa_compression_fwd_kernel(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int32)
-        bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int32), tl.load(cu_seqlens_q + i_n + 1).to(tl.int32)
-        bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int32), tl.load(cu_seqlens_k + i_n + 1).to(tl.int32)
-        TQ = eos_q - bos_q
-        TK = eos_k - bos_k
+        bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int64), tl.load(cu_seqlens_q + i_n + 1).to(tl.int64)
+        bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int64), tl.load(cu_seqlens_k + i_n + 1).to(tl.int64)
+        TQ = (eos_q - bos_q).to(tl.int32)
+        TK = (eos_k - bos_k).to(tl.int32)
         TC = tl.cdiv(TK, BS)
         boc = tl.load(chunk_offsets + i_n).to(tl.int32)
     else:
-        bos_q, eos_q = i_b * TQ, i_b * TQ + TQ
+        bos_q, eos_q = (i_b * TQ).to(tl.int64), (i_b * TQ + TQ).to(tl.int64)
         TC = tl.cdiv(TK, BS)
         boc = i_b * TC
 
@@ -162,11 +162,11 @@ def parallel_nsa_compression_bwd_kernel_dq(
     all = B * T
     if IS_VARLEN:
         i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
         boc = tl.load(chunk_offsets + i_n).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
         boc = i_b * tl.cdiv(T, BS)
 
     q += (bos + i_t) * HQ*K
@@ -269,13 +269,13 @@ def parallel_nsa_compression_bwd_kernel_dkv(
 
     if IS_VARLEN:
         i_n, i_c = tl.load(chunk_indices + i_c * 2).to(tl.int32), tl.load(chunk_indices + i_c * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
         # the number of compression representations in total
         TC = tl.cdiv(T, BS)
         boc = tl.load(chunk_offsets + i_n).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
         boc = i_b * tl.cdiv(T, BS)
 
     p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (TC, K), (H*K, 1), (i_c * BC, 0), (BC, BK), (1, 0))

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -68,14 +68,14 @@ def parallel_nsa_kernel_topk(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int32)
-        bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int32), tl.load(cu_seqlens_q + i_n + 1).to(tl.int32)
-        bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int32), tl.load(cu_seqlens_k + i_n + 1).to(tl.int32)
-        TQ = eos_q - bos_q
-        TK = eos_k - bos_k
+        bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int64), tl.load(cu_seqlens_q + i_n + 1).to(tl.int64)
+        bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int64), tl.load(cu_seqlens_k + i_n + 1).to(tl.int64)
+        TQ = (eos_q - bos_q).to(tl.int32)
+        TK = (eos_k - bos_k).to(tl.int32)
         TC = tl.cdiv(TK, BS)
         boc = tl.load(chunk_offsets + i_n).to(tl.int32)
     else:
-        bos_q, eos_q = i_b * TQ, i_b * TQ + TQ
+        bos_q, eos_q = (i_b * TQ).to(tl.int64), (i_b * TQ + TQ).to(tl.int64)
         TC = tl.cdiv(TK, BS)
         boc = i_b * TC
     # boc is the start of the current sequence at [B, TC] dimensions
@@ -213,13 +213,13 @@ def parallel_nsa_fwd_kernel(
     if IS_VARLEN:
         # token_indices_q maps a flattened query to its (sequence index, in-sequence position)
         i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int32)
-        bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int32), tl.load(cu_seqlens_q + i_n + 1).to(tl.int32)
-        bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int32), tl.load(cu_seqlens_k + i_n + 1).to(tl.int32)
-        TQ = eos_q - bos_q
-        TK = eos_k - bos_k
+        bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int64), tl.load(cu_seqlens_q + i_n + 1).to(tl.int64)
+        bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int64), tl.load(cu_seqlens_k + i_n + 1).to(tl.int64)
+        TQ = (eos_q - bos_q).to(tl.int32)
+        TK = (eos_k - bos_k).to(tl.int32)
     else:
-        bos_q, eos_q = i_b * TQ, i_b * TQ + TQ
-        bos_k, eos_k = i_b * TK, i_b * TK + TK
+        bos_q, eos_q = (i_b * TQ).to(tl.int64), (i_b * TQ + TQ).to(tl.int64)
+        bos_k, eos_k = (i_b * TK).to(tl.int64), (i_b * TK + TK).to(tl.int64)
 
     # q tokens are assumed to be the last TQ tokens of the sequence (cached decoding)
     Q_OFFSET = TK - TQ
@@ -324,10 +324,10 @@ def parallel_nsa_bwd_kernel_dq(
     all = B * T
     if IS_VARLEN:
         i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
 
     q += (bos + i_t) * HQ*K
     do += (bos + i_t) * HQ*V


### PR DESCRIPTION
## What
Make address arithmetic int64-safe across all NSA kernels (selected + compression), so long sequences no longer overflow int32.

## Why
With `T=64K, HQ=128, D=256`, the per-token base offset `(bos + i_t)·HQ·K` and the dq output offset `(i_v·all + bos + i_t)·HQ·K` reach ~2³¹, overflowing int32 and triggering an illegal memory access in the backward pass. (Forward sits just under the limit and happened to survive.) `bwd_dkv` was already int64; the other kernels were not.

## Change
Cast `bos`/`eos` to int64 at assignment in `topk`, `fwd`, `bwd_dq` (`parallel.py`) and `fwd`, `bwd_dq`, `bwd_dkv` (`compression.py`), while keeping sequence lengths (`T/TQ/TK/TC`) int32 for block-pointer shapes — the same int64-base / int32-length split already used by `bwd_dkv` and the chunk kernels (kda/gdn2/cp).

## Validation
- `tests/ops/test_nsa.py`: **47 passed** (GB200, torch 2.11/cu132, Triton 3.6).
- `T=64K, HQ=128, D=256` fwd+bwd: **crash → 270 ms**; smaller shapes unchanged.
