### PR TITLE
[Fix] Uninitialized rotary output on left-padded batched generation

### DIFF
--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -180,7 +180,8 @@ def rotary_embedding_fwdbwd(
     else:
         assert seqlen_offsets + T <= TR
 
-    y = torch.empty_like(x) if not inplace else x
+    # zeros_like, not empty_like: the kernel does not write out-of-range rows (negative o_cs under left-padding), which must be defined so uninitialized memory cannot leak into attention.
+    y = torch.zeros_like(x) if not inplace else x
     if R2 < D and not inplace:
         y[..., R2:].copy_(x[..., R2:])
 

--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -180,7 +180,7 @@ def rotary_embedding_fwdbwd(
     else:
         assert seqlen_offsets + T <= TR
 
-    # zeros_like, not empty_like: the kernel does not write out-of-range rows (negative o_cs under left-padding), which must be defined so uninitialized memory cannot leak into attention.
+    # zeros_like: rows the kernel skips (negative o_cs under left-padding) must be defined, not uninitialized.
     y = torch.zeros_like(x) if not inplace else x
     if R2 < D and not inplace:
         y[..., R2:].copy_(x[..., R2:])

--- a/tests/modules/test_rotary.py
+++ b/tests/modules/test_rotary.py
@@ -181,7 +181,7 @@ def test_rotary_partial(B: int, T: int, H: int, D: int, rotary_dim: int, dtype: 
 @pytest.mark.parametrize("T", [2048])
 @pytest.mark.parametrize("H", [4])
 @pytest.mark.parametrize("D", [128])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_rotary_left_padding_no_uninit_leak(B: int, T: int, H: int, D: int, dtype: torch.dtype):
     # Regression guard for the uninitialized-output bug. Under left-padding the kernel
     # skips out-of-range rows, so an uninitialized output buffer leaks whatever was in

--- a/tests/modules/test_rotary.py
+++ b/tests/modules/test_rotary.py
@@ -132,7 +132,7 @@ def test_rotary_varlen(N: int, T: int, H: int, G: int, D: int, dtype: torch.dtyp
 @pytest.mark.parametrize("T", [2048, 4096])
 @pytest.mark.parametrize("H", [4])
 @pytest.mark.parametrize("D", [128, 256])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 def test_rotary_left_padding(B: int, T: int, H: int, D: int, dtype: torch.dtype):
     # Left-padding gives a NEGATIVE per-sequence seqlen_offset (real_len - T), as the
     # attention layer builds it for a padded batch. Existing tests cover only positive
@@ -160,7 +160,7 @@ def test_rotary_left_padding(B: int, T: int, H: int, D: int, dtype: torch.dtype)
 @pytest.mark.parametrize("H", [4])
 @pytest.mark.parametrize("D", [128, 256])
 @pytest.mark.parametrize("rotary_dim", [64])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 def test_rotary_partial(B: int, T: int, H: int, D: int, rotary_dim: int, dtype: torch.dtype):
     # Partial rotary (rotary_dim < head_dim): only [:rotary_dim] is rotated and the
     # non-rotated tail [rotary_dim:] is carried over from the input. Previously untested.
@@ -181,7 +181,7 @@ def test_rotary_partial(B: int, T: int, H: int, D: int, rotary_dim: int, dtype: 
 @pytest.mark.parametrize("T", [2048])
 @pytest.mark.parametrize("H", [4])
 @pytest.mark.parametrize("D", [128])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 def test_rotary_left_padding_no_uninit_leak(B: int, T: int, H: int, D: int, dtype: torch.dtype):
     # Regression guard for the uninitialized-output bug. Under left-padding the kernel
     # skips out-of-range rows, so an uninitialized output buffer leaks whatever was in

--- a/tests/modules/test_rotary.py
+++ b/tests/modules/test_rotary.py
@@ -126,3 +126,81 @@ def test_rotary_varlen(N: int, T: int, H: int, G: int, D: int, dtype: torch.dtyp
     assert_close(" k", ref_k, tri_k, ratio=1e-5)
     assert_close("dq", ref_dq, tri_dq, ratio=1e-5)
     assert_close("dk", ref_dk, tri_dk, ratio=1e-5)
+
+
+@pytest.mark.parametrize("B", [4])
+@pytest.mark.parametrize("T", [2048, 4096])
+@pytest.mark.parametrize("H", [4])
+@pytest.mark.parametrize("D", [128, 256])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_rotary_left_padding(B: int, T: int, H: int, D: int, dtype: torch.dtype):
+    # Left-padding gives a NEGATIVE per-sequence seqlen_offset (real_len - T), as the
+    # attention layer builds it for a padded batch. Existing tests cover only positive
+    # offsets; this checks the real (in-range) tokens are rotated correctly under it.
+    torch.manual_seed(42)
+    pads = torch.arange(B, device=device) * (T // (2 * B))   # 0, p, 2p, ... left-pad per sequence
+    seqlen_offset = -pads                                     # negative offset == left padding
+    q = torch.randn(B, T, H, D).to(device).to(dtype=dtype)
+    k = torch.randn(B, T, H, D).to(device).to(dtype=dtype)
+    rotary = RotaryEmbedding(D).to(device)
+
+    tri_q, tri_k = rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=T)
+
+    for i, pad in enumerate(pads.tolist()):
+        ref_q = rotary_embedding_ref(q[i:i+1, pad:].float(), rotary._cos_cached[:T-pad],
+                                     rotary._sin_cached[:T-pad]).to(dtype=dtype)
+        ref_k = rotary_embedding_ref(k[i:i+1, pad:].float(), rotary._cos_cached[:T-pad],
+                                     rotary._sin_cached[:T-pad]).to(dtype=dtype)
+        assert_close(f" q[{i}]", ref_q, tri_q[i:i+1, pad:], ratio=1e-5)
+        assert_close(f" k[{i}]", ref_k, tri_k[i:i+1, pad:], ratio=1e-5)
+
+
+@pytest.mark.parametrize("B", [2])
+@pytest.mark.parametrize("T", [256, 2048])
+@pytest.mark.parametrize("H", [4])
+@pytest.mark.parametrize("D", [128, 256])
+@pytest.mark.parametrize("rotary_dim", [64])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_rotary_partial(B: int, T: int, H: int, D: int, rotary_dim: int, dtype: torch.dtype):
+    # Partial rotary (rotary_dim < head_dim): only [:rotary_dim] is rotated and the
+    # non-rotated tail [rotary_dim:] is carried over from the input. Previously untested.
+    torch.manual_seed(42)
+    q = torch.randn(B, T, H, D).to(device).to(dtype=dtype)
+    k = torch.randn(B, T, H, D).to(device).to(dtype=dtype)
+    rotary = RotaryEmbedding(rotary_dim).to(device)
+
+    tri_q, tri_k = rotary(q, k)
+
+    ref_q = rotary_embedding_ref(q.float(), rotary._cos_cached[:T], rotary._sin_cached[:T]).to(dtype=dtype)
+    ref_k = rotary_embedding_ref(k.float(), rotary._cos_cached[:T], rotary._sin_cached[:T]).to(dtype=dtype)
+    assert_close(" q", ref_q, tri_q, ratio=1e-5)
+    assert_close(" k", ref_k, tri_k, ratio=1e-5)
+
+
+@pytest.mark.parametrize("B", [4])
+@pytest.mark.parametrize("T", [2048])
+@pytest.mark.parametrize("H", [4])
+@pytest.mark.parametrize("D", [128])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_rotary_left_padding_no_uninit_leak(B: int, T: int, H: int, D: int, dtype: torch.dtype):
+    # Regression guard for the uninitialized-output bug. Under left-padding the kernel
+    # skips out-of-range rows, so an uninitialized output buffer leaks whatever was in
+    # the reused allocation. We force the worst case by seeding the caching allocator's
+    # free list with NaN-filled, output-shaped blocks (after a warm-up so the next
+    # same-size allocation is the output buffer), then require the result to be finite.
+    # Fails on `torch.empty_like`; passes once the buffer is initialized.
+    torch.manual_seed(0)
+    pads = torch.arange(B, device=device) * (T // (2 * B))
+    seqlen_offset = -pads                                     # negative offset == left padding
+    q = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    k = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    rotary = RotaryEmbedding(D).to(device)
+
+    rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=T)   # warm up cos/sin cache + kernel
+    torch.cuda.synchronize()
+    junk = [torch.full_like(q, float("nan")) for _ in range(32)]   # poison the free list
+    del junk
+
+    tri_q, tri_k = rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=T)
+    assert torch.isfinite(tri_q).all(), "rotary leaked uninitialized memory into q under left-padding"
+    assert torch.isfinite(tri_k).all(), "rotary leaked uninitialized memory into k under left-padding"


### PR DESCRIPTION
rotary_embedding_fwdbwd allocated its output with torch.empty_like, but the Triton kernel only stores rows whose rotary position o_cs is in range (m_t = (o_t>=0)&(o_t<T)&(o_cs>=0)&(o_cs<TR)). Under left-padding the per-sequence seqlen_offset is negative, so padding rows get o_cs < 0, are masked out of the store, and keep uninitialized memory. That garbage then leaks into attention on paths that do not unpad (e.g. torch SDPA): when it is NaN/Inf it propagates across the batch and RoPE models emit empty generations. (The flash-attn varlen path unpads padding rows before attention, which is why it only surfaces without flash-attn.)

Fix: allocate the output with torch.zeros_like so the kernel-skipped rows are defined rather than uninitialized.

Tests (tests/modules/test_rotary.py):
- test_rotary_left_padding / test_rotary_partial: correctness on the negative-offset (left-padding) and partial-rotary paths, which were previously untested (existing tests cover only positive offsets); output is checked against rotary_embedding_ref.
- test_rotary_left_padding_no_uninit_leak: regression guard for this bug -- seeds the allocator free list with NaN blocks the output buffer would reuse, then requires the result to be finite. Fails on the empty_like version, passes with the fix.