### PR TITLE
[NSA] Skip sliding-window tests when flash-attn is unavailable

### DIFF
--- a/tests/ops/test_nsa.py
+++ b/tests/ops/test_nsa.py
@@ -5,6 +5,7 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+import importlib.util
 import os
 import warnings
 
@@ -21,6 +22,9 @@ from fla.ops.nsa.parallel import parallel_nsa, parallel_nsa_fwd, parallel_nsa_to
 from fla.ops.utils import prepare_chunk_offsets, prepare_token_indices  # noqa: E402
 from fla.ops.utils.pooling import mean_pooling  # noqa: E402
 from fla.utils import assert_close, device  # noqa: E402
+
+# The sliding-window branch of NSA is backed by Flash Attention, so window_size > 0 cases are skipped when absent.
+_FLASH_ATTN_AVAILABLE = importlib.util.find_spec("flash_attn") is not None
 
 
 def build_block_indices(B, T, H, S, block_size, seq_indices=None):
@@ -452,6 +456,8 @@ def test_parallel_decode(
         window_size: int,
         dtype: torch.dtype,
 ):
+    if window_size > 0 and not _FLASH_ATTN_AVAILABLE:
+        pytest.skip("Flash Attention is required for the sliding-window branch")
     torch.manual_seed(42)
 
     q = (torch.rand((B, T, HQ, D), dtype=dtype, device=device) * 3 - 2).requires_grad_(True)
@@ -841,6 +847,8 @@ def test_parallel_varlen_decode(
         q_lens,
         dtype: torch.dtype,
 ):
+    if window_size > 0 and not _FLASH_ATTN_AVAILABLE:
+        pytest.skip("Flash Attention is required for the sliding-window branch")
     torch.manual_seed(42)
 
     T = cu_seqlens[-1]


### PR DESCRIPTION
## What

Guard the `window_size > 0` cases in `test_parallel_decode` and `test_parallel_varlen_decode` behind a flash-attn availability check, skipping them when flash-attn is not installed.

## Why

The new PyTorch 2.12 H100 CI job fails with:

```
fla/ops/nsa/naive.py:417: TypeError: 'NoneType' object is not callable
    o_swa = flash_attn_func(q, k, v, causal=True, window_size=(window_size-1, 0))
```

The sliding-window branch of NSA (both the naive reference and the production `parallel_nsa`) is backed by `flash_attn`. The PyTorch 2.12 CI environment does not ship `flash_attn` (CI never installs it and no 2.12 wheel exists yet), so `flash_attn_func` is `None` and every `window_size > 0` case crashes.

This mirrors the existing convention in the repo: `deltaformer`/`moba` treat flash-attn as a hard dependency, and `test_kda.py` skips when the optional backend is missing.

## Testing

Validated on an H100 with flash-attn **present** — all affected cases (including `W64`/`W128`) still pass, so the flash-attn path is unchanged:

```
12 passed, 35 deselected in 652.75s
```

In environments without flash-attn, the `window_size > 0` cases are now skipped instead of erroring.