### PR TITLE
[Agents] Tighten fla-optimization-loop guardrails from KDA-Pilot

### DIFF
--- a/.agents/skills/fla-optimization-loop/SKILL.md
+++ b/.agents/skills/fla-optimization-loop/SKILL.md
@@ -51,6 +51,7 @@ promote only on a full (no `-k`) green gate.
 | Making the op a thin wrapper that delegates the whole compute to a vendor lib (a plain `torch.matmul` / `F.scaled_dot_product_attention` standing in *as* the operator) just to win latency | Hand-written Triton / Gluon / TileLang / CuTe kernels; `torch` ops used as *glue* around a kernel you wrote |
 | Returning uninitialized / partially-written outputs that happen to pass | Fully initialized outputs (NaN poisoning will catch partial writes) |
 | Stream tricks / monkey-patching the bench to dodge timing | Genuine latency reduction measured by `verify.py` / `run.py` |
+| One-sided numeric relaxation the baseline doesn't get — flipping `allow_tf32` on, dropping the fp32 accumulator to bf16/tf32, a config that quietly changes the numeric path | Same accumulation precision and numeric flags on both sides; speed comes from the kernel, not from computing something less accurate |
 
 If you genuinely believe a test is **wrong**, that is a **separate PR** with its own justification —
 never bundled into a perf change. Stop and ask the user.
@@ -64,7 +65,7 @@ Put a short `docs/draft.md` in your scratch workspace (see §6) stating:
 - **Allowed languages** — Triton / Gluon / TileLang / CuTe (state any constraint).
 - **Validation command** — `python -m benchmarks.ops.verify --op <op>` (the frozen gate).
 - **Benchmark command** — `python -m benchmarks.ops.verify --op <op> --base main`.
-- **Promotion criteria** — full green gate AND a measured, repeatable win on the target shapes.
+- **Promotion criteria** — full green gate, a measured repeatable win, and a profiler reading that explains it (§7).
 - **Frozen scope** — the test file, `naive.py`, and the public op signature.
 
 Do not start editing kernels until the draft exists. (Borrowed from KDA: plan, then execute.)
@@ -82,6 +83,8 @@ Run these in order; repeat 2 and 3 with progressively higher targets.
 - **Phase 3 — shape specialization.** Only when profiling shows *different* bottlenecks across shape regimes
   (short vs. long `T`, small vs. large `D`), add dispatch / specialized paths.
   Justify the added complexity with the measured win; validate on the full shape set, not the one you tuned on.
+  Record each bucket (condition / entry point / per-bucket latency + speedup / reason) in `dispatch.md`
+  (template in `references/opt-log-template.md`) — a specialized path without that evidence is unjustified complexity.
 
 ## 3. Iteration protocol
 
@@ -104,6 +107,11 @@ timer-resolution limited — cite it in `OPT_LOG.md`);
 or you've documented ≥3 distinct directions tried with evidence.
 Don't stop silently because a tool (e.g. NCU) was unavailable — that's a re-assessment input.
 
+**No-go bar.** If stopping means concluding there's no win to promote — a no-go — that verdict has its own bar:
+a first candidate losing doesn't clear it. A no-go needs a recorded baseline number, at least one reasoned
+candidate attempt (not a blind guess), the gate status, the bench evidence, and a *named* active bound or
+blocker (name which roofline/launch/timer limit, with the number). Without those five it's an unfinished loop.
+
 ## 4. Reproducibility
 
 - **Seed** — the tests already pin `torch.manual_seed(42)`; don't undermine it.
@@ -118,8 +126,8 @@ Don't stop silently because a tool (e.g. NCU) was unavailable — that's a re-as
 
 Read `references/TRAPS.md` before trusting any number.
 It catalogs FLA-specific traps (NaN poisoning on partial writes, TF32 inflating fp32 reference diffs,
-`assert_close` relative tolerance, autotune-cache staleness across edits, `int64` address arithmetic,
-implausible speedups that signal a silently-skipped path).
+`assert_close` relative tolerance, one-sided numeric-flag relaxation, autotune-cache staleness across edits,
+`int64` address arithmetic, implausible speedups that signal a silently-skipped path).
 When you hit a new one, add it there with **Fact / Why / How to apply** so the next session doesn't re-learn it.
 (Borrowed from AKO4X's `TRAPS.md`.)
 
@@ -131,6 +139,7 @@ Keep your search artifacts in a git-ignored directory — `profile/<op>-opt/` is
 profile/<op>-opt/
   docs/draft.md       # the task contract (§1)
   OPT_LOG.md          # one row per iteration (template in references/)
+  dispatch.md         # one row per shape bucket — only if Phase 3 specializes (template in references/)
   TRAPS.md            # traps you hit this session (seed: references/TRAPS.md)
   trace/              # torch.profiler / NCU artifacts (kept out of git)
 ```
@@ -140,11 +149,16 @@ per `references/opt-log-template.md`, so a later session can see what was tried 
 
 ## 7. Promotion → MR
 
-A candidate is promotable only on a **full green gate** plus a measured, repeatable win on the target shapes. Then:
+A candidate is promotable only on a **full green gate** plus a measured, repeatable win on the target shapes,
+**and** a profiler/roofline reading that *explains* the win (or, for a no-go, the blocker) —
+a speedup you can't account for is a silent-skip suspect, not a result (see §5). Then:
 
 - Keep the diff minimal — change only what the win needs,
   plus light cleanups (CONTRIBUTING "Protect battle-tested paths; keep diffs minimal").
-- Collect perf evidence per `fla-nvidia-performance` (before/after, NCU summary, dense + varlen coverage).
+- Collect perf evidence per `fla-nvidia-performance` — before/after, NCU summary, dense + varlen coverage,
+  and a full final-claim stats block (median/mean/std/min/p10/p90 per shape, equal-weight geomean speedup,
+  exact commands, baseline commit + candidate SHA, GPU id/model with idle-clock evidence —
+  the last guards the clock-drift trap in §5).
 - Package the PR per `fla-mr-readiness`.
 
 The scratch workspace under `profile/<op>-opt/` stays local; it is not part of the PR.

--- a/.agents/skills/fla-optimization-loop/references/TRAPS.md
+++ b/.agents/skills/fla-optimization-loop/references/TRAPS.md
@@ -45,7 +45,18 @@ Widening it to make a candidate pass converts a correctness regression into a si
 **How to apply:** Tolerance is part of the frozen contract.
 If you think it's wrong, that's a separate PR with justification — ask the user.
 
-### Grid-derived indices must be `int64`
+### Numeric flags must be symmetric across baseline and candidate
+
+**Fact:** A "win" can be a one-sided numeric relaxation — the candidate runs at a lower precision
+the baseline never gets — rather than a genuinely faster kernel.
+
+**Why:** `allow_tf32 = True`, a bf16/tf32 accumulator where the reference keeps fp32, or any flag that
+changes code generation makes the candidate compute *something cheaper but less accurate*.
+The gate may still pass within tolerance, so the speedup looks real while the comparison is rigged.
+
+**How to apply:** Keep accumulation precision and numeric flags identical on both sides;
+`verify.py` compares against `main`, so the win has to come from the kernel, not from the flag.
+If a precision change is genuinely the point, it is a separate, justified PR — not bundled into a perf number.
 
 **Fact:** Program IDs and grid-derived offsets multiplied by sizes/strides can silently overflow at large `T`,
 producing wrong results only on big shapes.

--- a/.agents/skills/fla-optimization-loop/references/opt-log-template.md
+++ b/.agents/skills/fla-optimization-loop/references/opt-log-template.md
@@ -56,3 +56,24 @@ Keep provenance (specific iter numbers, exact ms, dates) in `OPT_LOG.md` and the
 not in the promoted PR diff or the shared SKILL docs.
 The PR carries only the final minimal change plus the perf evidence (`fla-nvidia-performance`)
 and PR structure (`fla-mr-readiness`).
+
+---
+
+## `dispatch.md` — one row per shape bucket (only if Phase 3 specializes)
+
+A shape-specialized / dispatched kernel is justified only by evidence that buckets need *different* code.
+Record that evidence so the added complexity is auditable — one row per bucket:
+
+```markdown
+# Dispatch — <op>
+
+| Bucket condition | Entry point chosen  | Baseline ms | Candidate ms | Speedup | Why this path                          |
+| ---------------- | ------------------- | ----------- | ------------ | ------- | -------------------------------------- |
+| T <= 512         | `chunk_fwd_small`   | 0.42        | 0.31         | 1.35x   | launch-bound; smaller BT cuts overhead |
+| T > 512, D <= 64 | `chunk_fwd_default` | 1.93        | 1.70         | 1.14x   | compute-bound; default tiling wins     |
+```
+
+Rules:
+- A bucket earns a row only if profiler/bench evidence shows it needs a *different* path —
+  don't split a bucket the single kernel already serves best.
+- Every bucket's speedup is vs. the same frozen `main` baseline on *that bucket's* shapes.


### PR DESCRIPTION
## What

Sharpens five soft principles in the `fla-optimization-loop` skill into hard, executable guardrails, borrowed from [BBuf/KDA-Pilot](https://github.com/BBuf/KDA-Pilot)'s diffusion kernel rules. The skill already cites KDA for its overall discipline (frozen contract, three phases, bench→log→commit, TRAPS); this pass closes the gaps where KDA is more concrete than we were.

## Why

The loop's anti-reward-hacking and stop-condition language was principle-level ("justify the complexity", "cite a floor"). KDA encodes the same intent as checklist conditions an agent can't talk its way around. Tightening them makes the gate harder to game and a no-go harder to fake.

## Changes

- **Symmetric numerics** — new banned-table row + TRAPS entry: no one-sided `allow_tf32` / accumulator-precision relaxation the baseline doesn't get. A "win" from computing something less accurate is rigged, not faster.
- **No-go bar** (§3) — a first candidate losing is *not* a no-go. Declaring an op un-optimizable now requires baseline number + a reasoned attempt + gate status + bench evidence + a *named* active bound.
- **Profiler-explains-result** (§7) — promotion now requires a profiler/roofline reading that accounts for the win (or blocker); an unaccountable speedup is a silent-skip suspect.
- **Final-claim stats block** (§7) — cross-link to `fla-nvidia-performance` for the full report (median/mean/std/min/p10/p90, geomean, commands, baseline+candidate SHA, idle-clock evidence — the last guards the existing clock-drift trap).
- **`dispatch.md` template** — Phase 3 shape specialization now has a one-row-per-bucket evidence artifact; a specialized path without it is unjustified complexity.

Docs-only; scoped to `.agents/skills/fla-optimization-loop/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)