### PR TITLE
[Misc] Clean up feature_map type hints and add tests

### DIFF
--- a/fla/modules/feature_map.py
+++ b/fla/modules/feature_map.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import functools
 import math
 
 import torch
@@ -18,24 +19,31 @@ from fla.modules.layernorm import layer_norm
 from fla.utils import checkpoint
 
 
-@checkpoint
-def flatten_diag_outer_product(x, y):
-    z = torch.einsum("...i,...j->...ij", x, y)
-    N = z.size(-1)
-    indicies = torch.triu_indices(N, N)
-    return z[..., indicies[0], indicies[1]]
+@functools.cache
+def _triu_indices(n: int, offset: int, device: torch.device) -> torch.Tensor:
+    # cache the upper-triangular gather indices per (size, offset, device) to avoid rebuilding
+    # them and copying host -> device on every forward
+    return torch.triu_indices(n, n, offset, device=device)
 
 
 @checkpoint
-def flatten_diag_outer_product_off1(x, y):
+def flatten_diag_outer_product(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     z = torch.einsum("...i,...j->...ij", x, y)
     N = z.size(-1)
-    indicies = torch.triu_indices(N, N, 1)
-    indices2 = torch.arange(0, N)
-    return z[..., indicies[0], indicies[1]], z[..., indices2, indices2]
+    indices = _triu_indices(N, 0, z.device)
+    return z[..., indices[0], indices[1]]
 
 
-def is_power_of_2(n):
+@checkpoint
+def flatten_diag_outer_product_off1(x: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    z = torch.einsum("...i,...j->...ij", x, y)
+    N = z.size(-1)
+    indices = _triu_indices(N, 1, z.device)
+    diag = torch.arange(N, device=z.device)
+    return z[..., indices[0], indices[1]], z[..., diag, diag]
+
+
+def is_power_of_2(n: int) -> bool:
     return (n & (n - 1) == 0) and n != 0
 
 
@@ -49,7 +57,7 @@ class HedgehogFeatureMap(nn.Module):
     def __init__(
         self,
         head_dim: int,
-    ) -> HedgehogFeatureMap:
+    ) -> None:
         super().__init__()
         # Trainable map
         self.layer = nn.Linear(head_dim, head_dim)
@@ -57,14 +65,13 @@ class HedgehogFeatureMap(nn.Module):
 
     def init_weights_(self):
         """Initialize trainable map as identity"""
-        with torch.no_grad():
-            identity = torch.eye(*self.layer.weight.shape[-2:], dtype=torch.float)
-            self.layer.weight.copy_(identity.to(self.layer.weight))
+        nn.init.eye_(self.layer.weight)
         nn.init.zeros_(self.layer.bias)
 
-    def forward(self, x: torch.Tensor):
-        x = self.layer(x)  # shape b, h, l, d
-        return torch.cat([2*x, -2*x], dim=-1).softmax(-1)
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.layer(x)  # b, h, l, d
+        y = 2 * x
+        return torch.cat([y, -y], dim=-1).softmax(-1)
 
 
 class T2RFeatureMap(nn.Module):
@@ -77,9 +84,9 @@ class T2RFeatureMap(nn.Module):
     def __init__(
         self,
         head_dim: int,
-        dot_dim: int = None,
+        dot_dim: int | None = None,
         bias: bool | None = False,
-    ) -> T2RFeatureMap:
+    ) -> None:
         super().__init__()
         # Trainable map
         if dot_dim is None:
@@ -94,7 +101,7 @@ class T2RFeatureMap(nn.Module):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(head_dim={self.head_dim}, dot_dim={self.dot_dim}, bias={self.bias})"
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.layer(x).relu()
 
 
@@ -109,12 +116,13 @@ class DPFPFeatureMap(nn.Module):
         self,
         head_dim: int,
         nu: int = 4,
-    ) -> DPFPFeatureMap:
+    ) -> None:
         super().__init__()
         self.nu = nu
 
-    def forward(self, x: torch.Tensor):
-        x = torch.cat([x.relu(), -x.relu()], dim=-1)
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        relu = x.relu()
+        x = torch.cat([relu, -relu], dim=-1)
         x_rolled = torch.cat([x.roll(shifts=j, dims=-1) for j in range(1, self.nu+1)], dim=-1)
         x_repeat = torch.cat([x] * self.nu, dim=-1)
         return x_repeat * x_rolled
@@ -124,13 +132,13 @@ class HadamardFeatureMap(nn.Module):
     def __init__(
         self,
         head_dim: int,
-    ) -> HadamardFeatureMap:
+    ) -> None:
         super().__init__()
         # Trainable map
         self.layer1 = nn.Linear(head_dim, head_dim)
         self.layer2 = nn.Linear(head_dim, head_dim)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.layer1(x) * self.layer2(x)
 
 
@@ -139,14 +147,14 @@ class LearnableOuterProductFeatureMap(nn.Module):
         self,
         head_dim: int,
         feature_dim: int,
-    ) -> LearnableOuterProductFeatureMap:
+    ) -> None:
         super().__init__()
         # Trainable map
         self.layer1 = nn.Linear(head_dim, feature_dim, bias=False)
         self.layer2 = nn.Linear(head_dim, feature_dim, bias=False)
         self.normalizer = feature_dim ** -0.5
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return flatten_diag_outer_product(self.layer1(x), self.layer2(x))
 
 
@@ -157,13 +165,16 @@ class LearnablePolySketchNonNegativeFeatureMap(nn.Module):
         head_dim: int,
         sketch_size: int | None = None,
         degree: int | None = 2,
-    ) -> LearnablePolySketchNonNegativeFeatureMap:
+    ) -> None:
         super().__init__()
 
         assert is_power_of_2(degree) and degree >= 2, f"The degree {degree} must be a power of 2"
 
+        if sketch_size is None:
+            sketch_size = head_dim
+
         self.head_dim = head_dim
-        self.sketch_size = sketch_size if sketch_size is not None else head_dim
+        self.sketch_size = sketch_size
         self.degree = degree
 
         self.gamma = nn.Parameter(torch.ones(head_dim))
@@ -179,7 +190,7 @@ class LearnablePolySketchNonNegativeFeatureMap(nn.Module):
             *[nn.Linear(sketch_size, sketch_size, bias=False) for _ in range(int(math.log2(self.degree)) - 2)],
         ])
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Section 2.1
         x = layer_norm(x, self.gamma, self.beta)
         # first map the input to sketch size with learnable parameters
@@ -195,14 +206,14 @@ class TaylorFeatureMap(nn.Module):
     def __init__(
         self,
         head_dim: int,
-    ) -> TaylorFeatureMap:
+    ) -> None:
         super().__init__()
         self.head_dim = head_dim
         self.r2 = math.sqrt(2)
         self.rd = math.sqrt(self.head_dim)
         self.rrd = math.sqrt(self.rd)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x2_1, x2_2 = flatten_diag_outer_product_off1(x, x)
         return torch.cat([torch.ones_like(x[..., 0:1]), x / self.rrd, x2_2 / (self.rd * self.r2), x2_1 / self.rd], dim=-1)
 
@@ -215,7 +226,7 @@ class RebasedFeatureMap(nn.Module):
         use_gamma: bool | None = True,
         use_beta: bool | None = True,
         normalize: bool | None = True,
-    ) -> RebasedFeatureMap:
+    ) -> None:
         super().__init__()
 
         self.head_dim = head_dim
@@ -230,7 +241,7 @@ class RebasedFeatureMap(nn.Module):
         if use_beta:
             self.beta = nn.Parameter(torch.zeros(head_dim))
 
-    def forward(self, x: torch.Tensor, flatten: bool | None = True):
+    def forward(self, x: torch.Tensor, flatten: bool | None = True) -> torch.Tensor:
         if self.use_beta and self.use_gamma and self.normalize:
             x = layer_norm(x, self.gamma, self.beta)
         elif self.normalize:
@@ -241,7 +252,7 @@ class RebasedFeatureMap(nn.Module):
             x = x.mul(self.gamma)
         else:
             raise RuntimeError(f"Not supported combination of `use_gamma`, `use_beta` and `normalize`, "
-                               f"which is currentlt set as (`{self.use_gamma}`, `{self.use_beta}`, `{self.normalize}`)")
+                               f"which is currently set as (`{self.use_gamma}`, `{self.use_beta}`, `{self.normalize}`)")
         if not flatten:
             return x
         x2_1, x2_2 = flatten_diag_outer_product_off1(x, x)
@@ -253,10 +264,10 @@ class ReLUFeatureMap(nn.Module):
 
     def __init__(
         self,
-    ) -> ReLUFeatureMap:
+    ) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return F.relu(x)
 
 
@@ -264,10 +275,10 @@ class SquaredReLUFeatureMap(nn.Module):
 
     def __init__(
         self,
-    ) -> SquaredReLUFeatureMap:
+    ) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return sqrelu(x)
 
 
@@ -275,10 +286,10 @@ class GELUFeatureMap(nn.Module):
 
     def __init__(
         self,
-    ) -> GELUFeatureMap:
+    ) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return fast_gelu_impl(x)
 
 
@@ -286,10 +297,10 @@ class SwishFeatureMap(nn.Module):
 
     def __init__(
         self,
-    ) -> SwishFeatureMap:
+    ) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return swish(x)
 
 
@@ -297,8 +308,8 @@ class SigmoidFeatureMap(nn.Module):
 
     def __init__(
         self,
-    ) -> SigmoidFeatureMap:
+    ) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return sigmoid(x)

--- a/tests/modules/test_feature_map.py
+++ b/tests/modules/test_feature_map.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.modules.feature_map import (
+    DPFPFeatureMap,
+    GELUFeatureMap,
+    HadamardFeatureMap,
+    HedgehogFeatureMap,
+    LearnableOuterProductFeatureMap,
+    LearnablePolySketchNonNegativeFeatureMap,
+    RebasedFeatureMap,
+    ReLUFeatureMap,
+    SigmoidFeatureMap,
+    SquaredReLUFeatureMap,
+    SwishFeatureMap,
+    T2RFeatureMap,
+    TaylorFeatureMap,
+    flatten_diag_outer_product,
+    flatten_diag_outer_product_off1,
+)
+from fla.utils import device
+
+# (constructor, kwargs, output last-dim given head_dim D) for every feature map
+FEATURE_MAPS = [
+    (HedgehogFeatureMap, {"head_dim": 16}, 32),
+    (T2RFeatureMap, {"head_dim": 16}, 16),
+    (T2RFeatureMap, {"head_dim": 16, "dot_dim": 8}, 8),
+    (DPFPFeatureMap, {"head_dim": 16, "nu": 4}, 16 * 2 * 4),
+    (HadamardFeatureMap, {"head_dim": 16}, 16),
+    (LearnableOuterProductFeatureMap, {"head_dim": 16, "feature_dim": 8}, 8 * 9 // 2),
+    (LearnablePolySketchNonNegativeFeatureMap, {"head_dim": 16}, 16 * 17 // 2),
+    (TaylorFeatureMap, {"head_dim": 16}, 1 + 16 + 16 + 16 * 15 // 2),
+    (RebasedFeatureMap, {"head_dim": 16}, 16 + 16 * 15 // 2),
+    (ReLUFeatureMap, {}, 16),
+    (SquaredReLUFeatureMap, {}, 16),
+    (GELUFeatureMap, {}, 16),
+    (SwishFeatureMap, {}, 16),
+    (SigmoidFeatureMap, {}, 16),
+]
+
+
+@pytest.mark.parametrize("dtype", [torch.float32])
+@pytest.mark.parametrize(("fmap", "kwargs", "expected_dim"), FEATURE_MAPS)
+def test_feature_map_forward(fmap, kwargs: dict, expected_dim: int, dtype: torch.dtype):
+    torch.manual_seed(42)
+
+    x = torch.randn(2, 4, 8, 16, device=device, dtype=dtype)
+    fm = fmap(**kwargs).to(device=device, dtype=dtype)
+    out = fm(x)
+
+    assert out.shape[:-1] == x.shape[:-1]
+    assert out.shape[-1] == expected_dim
+    assert torch.isfinite(out).all()
+
+
+def test_hedgehog_identity_init():
+    # the trainable map is initialized to identity with zero bias
+    torch.manual_seed(42)
+    fm = HedgehogFeatureMap(head_dim=16).to(device)
+
+    assert torch.allclose(fm.layer.weight, torch.eye(16, device=device))
+    assert fm.layer.bias.abs().sum() == 0
+
+
+def test_flatten_diag_outer_product():
+    # the helper gathers the upper triangle (incl. diagonal) of the outer product
+    torch.manual_seed(42)
+    x = torch.randn(2, 4, 8, 6, device=device)
+    y = torch.randn(2, 4, 8, 6, device=device)
+
+    z = torch.einsum("...i,...j->...ij", x, y)
+    idx = torch.triu_indices(6, 6, device=device)
+    diag = torch.arange(6, device=device)
+
+    flat = flatten_diag_outer_product(x, y)
+    assert torch.equal(flat, z[..., idx[0], idx[1]])
+
+    off1, on_diag = flatten_diag_outer_product_off1(x, y)
+    idx1 = torch.triu_indices(6, 6, 1, device=device)
+    assert torch.equal(off1, z[..., idx1[0], idx1[1]])
+    assert torch.equal(on_diag, z[..., diag, diag])


### PR DESCRIPTION
## Summary

Housekeeping pass over `fla/modules/feature_map.py`, which had no test coverage despite being used by the based / rebased / raven / linear_attn / gsa layers. The changes are behavior-preserving except for one latent crash fix.

**Type hints (conform to FLA style)**
- Every `__init__` was annotated `-> <ClassName>`, which is wrong — `__init__` returns `None`. Corrected all ~13 classes to `-> None`.
- `T2RFeatureMap.dot_dim: int = None` → `int | None = None`.
- Added `-> torch.Tensor` return hints to the `forward` methods and the module-level helpers.

**Bug fix**
- `LearnablePolySketchNonNegativeFeatureMap` crashed when constructed with the default `sketch_size=None`: the attribute was normalized to `head_dim` but the raw `None` was still passed into `nn.Linear`. Normalize `sketch_size` before building the sketch layers (same pattern as `T2RFeatureMap.dot_dim`).

**Minor optimizations (behavior-preserving)**
- Cache the upper-triangular gather indices on the input device in `flatten_diag_outer_product` / `_off1`, avoiding a fresh `triu_indices` build and an implicit host→device copy on every forward.
- Dedup the doubled `relu()` in `DPFPFeatureMap` and the doubled `2 * x` in `HedgehogFeatureMap`; use `nn.init.eye_` for the Hedgehog identity init.
- Fix a `currentlt` → `currently` typo and the `indicies` → `indices` spelling.

**Tests**
- Add `tests/modules/test_feature_map.py`: forward shape/finiteness for every feature map, the Hedgehog identity init, the PolySketch default-arg regression, and `flatten_diag_outer_product*` equivalence against a reference gather.

## Test plan

- `pytest tests/modules/test_feature_map.py -v` → **16 passed** on H100 (torch 2.11).
- `pre-commit run --files fla/modules/feature_map.py tests/modules/test_feature_map.py` clean.

## Breaking changes

None.