### PR TITLE
[CI] Enable backend dispatch for model tests

### DIFF
--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -118,7 +118,6 @@ jobs:
     if: (success() || failure()) && inputs.skip_models_tests == false
     env:
       FLA_CI_ENV: 1
-      FLA_DISABLE_BACKEND_DISPATCH: "1"
 
     steps:
       - name: Check out repo
@@ -133,7 +132,7 @@ jobs:
           pytorch_version: ${{ inputs.pytorch_version }}
           gpu_type: ${{ inputs.gpu_type }}
           pytorch_cuda_version: ${{ inputs.pytorch_cuda_version }}
-          install_tilelang: "false"
+          install_tilelang: "true"
           skip_gpu_check: ${{ inputs.skip_gpu_check }}
 
       - name: Find dependent Model test files for Models


### PR DESCRIPTION
Model tests previously ran with FLA_DISABLE_BACKEND_DISPATCH=1, forcing the pure-Triton path. On Hopper with Triton >= 3.4.0 the gated chunk_bwd_dqkwg Triton path is guarded off (#640), so gated model tests had no runnable path there and failed at the guard with no backend fallback.

Enable dispatch (and install tilelang) for the test-models job so model tests exercise the same backend-dispatched path that production uses. This both restores gated-model coverage on H100 (via the tilelang backend) and ensures every backend stays compatible with the model-level dispatch path.