### PR TITLE
[CI] bump GitHub Actions to latest versions

### DIFF
--- a/.github/actions/setup-ci-env/action.yml
+++ b/.github/actions/setup-ci-env/action.yml
@@ -183,4 +183,4 @@ runs:
     - name: Get changed files
       if: steps.check_skip.outputs.skip_tests == 'false'
       id: changed-files
-      uses: tj-actions/changed-files@v47.0.0
+      uses: tj-actions/changed-files@v47.0.6

--- a/.github/workflows/amd-mi300.yml
+++ b/.github/workflows/amd-mi300.yml
@@ -26,7 +26,7 @@ jobs:
       FLA_CI_ENV: 1
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Install system dependencies
         run: apt-get update && apt-get install -y --no-install-recommends make git curl

--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Check NPU and CANN info
         run: |
@@ -73,7 +73,7 @@ jobs:
           npu-smi info
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
           path: artifacts
 
       - name: Post / update PR comments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/check-header.yml
+++ b/.github/workflows/check-header.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/issue-pytest-command.yml
+++ b/.github/workflows/issue-pytest-command.yml
@@ -40,7 +40,7 @@ jobs:
     needs: parse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9.0.0
         with:
           script: |
             github.rest.reactions.createForIssueComment({
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload pytest output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: pytest-output
           path: pytest_output.txt
@@ -148,13 +148,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download pytest output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:
           name: pytest-output
 
       - name: Post comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         env:
           PYTEST_ARGS: ${{ needs.parse.outputs.pytest_args }}
           PYTEST_STATUS: ${{ needs.run-pytest.outputs.status }}
@@ -178,7 +178,7 @@ jobs:
             const exitCode = process.env.PYTEST_EXIT_CODE || '';
             const args     = (process.env.PYTEST_ARGS || '').trim();
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `## ${status} — Pytest Results (H100 PyTorch 2.7)\n\n**Command:** \\`pytest ${args}\\`\n**Exit code:** ${exitCode}\n\n[View workflow run logs](${runUrl})\n\n<details><summary>Click to expand pytest output</summary>\n\n\\`\\`\\`\n${output}\n\\`\\`\\`\n\n</details>`;
+            const body = `## ${status} — Pytest Results (H100 PyTorch 2.7)\n\n**Command:** \`pytest ${args}\`\n**Exit code:** ${exitCode}\n\n[View workflow run logs](${runUrl})\n\n<details><summary>Click to expand pytest output</summary>\n\n\`\`\`\n${output}\n\`\`\`\n\n</details>`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v9.1.0
+    - uses: actions/stale@v10.3.0
       with:
         days-before-issue-stale: 30
         days-before-issue-close: 7

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.12']
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip
@@ -27,6 +27,6 @@ jobs:
           pre-commit install-hooks
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47.0.0
+        uses: tj-actions/changed-files@v47.0.6
       - name: Lint modified files
         run: pre-commit run --files ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Check eligibility and wait for PyTorch 2.12 H100 jobs
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.12'
     - name: Install dependencies

--- a/.github/workflows/reusable-ci-benchmarks.yml
+++ b/.github/workflows/reusable-ci-benchmarks.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Check out repo (full history for cross-commit comparison)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always() && steps.check_skip.outputs.skip_bench == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: benchmark-results-${{ inputs.runner }}
           path: |

--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup CI Environment
         id: setup
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup CI Environment
         id: setup

--- a/.github/workflows/update-year.yml
+++ b/.github/workflows/update-year.yml
@@ -18,10 +18,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.12'
 
@@ -44,7 +44,7 @@ jobs:
           START_YEAR: 2023
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           commit-message: "chore: bump copyright year to ${{ steps.year.outputs.value }}"
           title: "chore: bump copyright year to ${{ steps.year.outputs.value }}"


### PR DESCRIPTION
## Summary
- Bump GitHub Actions to current latest versions:
  - actions/checkout@v7.0.0
  - actions/setup-python@v6.2.0
  - actions/upload-artifact@v7.0.1
  - actions/download-artifact@v8.0.1
  - actions/github-script@v9.0.0
  - actions/stale@v10.3.0
  - tj-actions/changed-files@v47.0.6
  - peter-evans/create-pull-request@v8.1.1
- Fix the `Issue / PR pytest command` post-result template literal escaping that caused `SyntaxError: Unexpected identifier 'pytest'`.

## Validation
- Parsed all `.github` YAML files with PyYAML.
- Ran `node --check` on `github-script` blocks after replacing GitHub expressions with placeholders.
- Ran `git diff --check`.