### PR TITLE
[Perf] Generalize fused q/k/v short convolution across layers

### DIFF
--- a/fla/layers/abc.py
+++ b/fla/layers/abc.py
@@ -17,6 +17,7 @@ from einops import rearrange
 from fla.layers.utils import get_layer_cache, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, RotaryEmbedding, ShortConvolution
 from fla.modules.activations import swiglu, swish
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.abc.chunk import chunk_abc
 
 if TYPE_CHECKING:
@@ -157,11 +158,27 @@ class ABCAttention(nn.Module):
         cu_seqlens = kwargs.get('cu_seqlens')
         if cu_seqlens is not None:
             raise NotImplementedError("Training with cu_seqlens is not supported yet for ABCAttention")
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_mask = attention_mask[:, -hidden_states.shape[1]:] if attention_mask is not None else None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+                mask=conv_mask,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
-            conv_mask = attention_mask[:, -hidden_states.shape[1]:] if attention_mask is not None else None
             q, conv_state_q = self.q_conv1d(
                 x=self.q_proj(hidden_states),
                 mask=conv_mask,

--- a/fla/layers/comba.py
+++ b/fla/layers/comba.py
@@ -18,6 +18,7 @@ from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.comba import chunk_comba, fused_recurrent_comba
 
 if TYPE_CHECKING:
@@ -237,8 +238,23 @@ class Comba(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/delta_net.py
+++ b/fla/layers/delta_net.py
@@ -17,6 +17,7 @@ from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.delta_rule import chunk_delta_rule, fused_recurrent_delta_rule
 
 if TYPE_CHECKING:
@@ -194,8 +195,23 @@ class DeltaNet(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -18,7 +18,7 @@ from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
-from fla.modules.convolution import causal_conv1d
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
 
 if TYPE_CHECKING:
@@ -199,23 +199,6 @@ class GatedDeltaNet(nn.Module):
             self.o_norm = RMSNorm(self.head_v_dim, eps=norm_eps, dtype=torch.float32)
         self.o_proj = nn.Linear(self.value_dim, hidden_size, bias=False)
 
-    def _use_fused_qkv_conv(
-        self,
-        last_state: dict | None,
-        use_cache: bool | None,
-        cu_seqlens: torch.Tensor | None,
-    ) -> bool:
-        # The dense no-cache q/k/v short convolutions can collapse into a single
-        # causal_conv1d only when there is no cache/varlen state and the three convs
-        # share the same backend, activation, and kernel size.
-        if not (self.use_short_conv and last_state is None and not use_cache and cu_seqlens is None):
-            return False
-        return (
-            self.q_conv1d.backend == self.k_conv1d.backend == self.v_conv1d.backend and
-            self.q_conv1d.activation == self.k_conv1d.activation == self.v_conv1d.activation and
-            self.q_conv1d.kernel_size == self.k_conv1d.kernel_size == self.v_conv1d.kernel_size
-        )
-
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -246,35 +229,21 @@ class GatedDeltaNet(nn.Module):
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
         conv_state_q, conv_state_k, conv_state_v = None, None, None
-        if self._use_fused_qkv_conv(last_state, use_cache, cu_seqlens):
-            qkv = torch.cat(
-                [
-                    self.q_proj(hidden_states),
-                    self.k_proj(hidden_states),
-                    self.v_proj(hidden_states),
-                ],
-                dim=-1,
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
             )
-            qkv_weight = torch.cat(
-                [
-                    self.q_conv1d.weight.squeeze(1),
-                    self.k_conv1d.weight.squeeze(1),
-                    self.v_conv1d.weight.squeeze(1),
-                ],
-                dim=0,
-            )
-            if self.conv_bias:
-                qkv_bias = torch.cat([self.q_conv1d.bias, self.k_conv1d.bias, self.v_conv1d.bias], dim=0)
-            else:
-                qkv_bias = None
-            qkv, _ = causal_conv1d(
-                x=qkv,
-                weight=qkv_weight,
-                bias=qkv_bias,
-                activation=self.q_conv1d.activation,
-                backend=self.q_conv1d.backend,
-            )
-            q, k, v = torch.split(qkv, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
         elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']

--- a/fla/layers/gated_deltaproduct.py
+++ b/fla/layers/gated_deltaproduct.py
@@ -18,6 +18,7 @@ from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.gated_delta_product import chunk_gated_delta_product
 from fla.ops.gated_delta_rule import fused_recurrent_gated_delta_rule
 
@@ -190,8 +191,23 @@ class GatedDeltaProduct(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/gdn2.py
+++ b/fla/layers/gdn2.py
@@ -24,6 +24,7 @@ from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.gdn2 import chunk_gdn2, fused_recurrent_gdn2
 
 if TYPE_CHECKING:
@@ -224,8 +225,23 @@ class GatedDeltaNet2(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state["conv_state"]
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/gla.py
+++ b/fla/layers/gla.py
@@ -17,6 +17,7 @@ from einops import rearrange, repeat
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.modules.activations import ACT2FN
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.gla import chunk_gla, fused_chunk_gla, fused_recurrent_gla
 
 if TYPE_CHECKING:
@@ -200,8 +201,23 @@ class GatedLinearAttention(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/gsa.py
+++ b/fla/layers/gsa.py
@@ -17,6 +17,7 @@ from einops import rearrange, repeat
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import RMSNorm, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.modules.feature_map import ReLUFeatureMap, SwishFeatureMap, T2RFeatureMap
 from fla.modules.layernorm import rms_norm_linear
 from fla.ops.gsa import chunk_gsa, fused_recurrent_gsa
@@ -155,8 +156,23 @@ class GatedSlotAttention(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/kda.py
+++ b/fla/layers/kda.py
@@ -17,6 +17,7 @@ from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.kda import chunk_kda, fused_recurrent_kda
 
 if TYPE_CHECKING:
@@ -220,8 +221,23 @@ class KimiDeltaAttention(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state["conv_state"]
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/lightnet.py
+++ b/fla/layers/lightnet.py
@@ -18,6 +18,7 @@ from einops import rearrange
 
 from fla.layers.utils import get_layer_cache, update_layer_cache
 from fla.modules import FusedRMSNormGated, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.modules.fused_norm_gate import rms_norm_swish_gate_linear
 from fla.ops.gla import chunk_gla, fused_recurrent_gla
 
@@ -131,11 +132,27 @@ class LightNetAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_mask = attention_mask[:, -hidden_states.shape[1]:] if attention_mask is not None else None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+                mask=conv_mask,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
-            conv_mask = attention_mask[:, -hidden_states.shape[1]:] if attention_mask is not None else None
             q, conv_state_q = self.q_conv1d(
                 x=self.q_proj(hidden_states),
                 mask=conv_mask,

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -16,6 +16,7 @@ from transformers.activations import ACT2FN
 
 from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.modules.rotary import RotaryEmbedding
 from fla.ops.retention import chunk_retention, fused_chunk_retention, fused_recurrent_retention, parallel_retention
 from fla.ops.utils.index import prepare_lens_from_mask
@@ -194,8 +195,23 @@ class MultiScaleRetention(nn.Module):
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
             q, conv_state_q = self.q_conv1d(

--- a/fla/layers/simple_gla.py
+++ b/fla/layers/simple_gla.py
@@ -17,6 +17,7 @@ from einops import rearrange, repeat
 from fla.layers.utils import get_layer_cache, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.modules.activations import ACT2FN
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
 from fla.ops.simple_gla import chunk_simple_gla, fused_recurrent_simple_gla
 
 if TYPE_CHECKING:
@@ -182,11 +183,27 @@ class SimpleGatedLinearAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        if self.use_short_conv:
-            conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_state_q, conv_state_k, conv_state_v = None, None, None
+        conv_mask = attention_mask[:, -hidden_states.shape[1]:] if attention_mask is not None else None
+        if (
+            self.use_short_conv
+            and last_state is None
+            and not use_cache
+            and cu_seqlens is None
+            and can_fuse_qkv_short_conv(self.q_conv1d, self.k_conv1d, self.v_conv1d)
+        ):
+            q, k, v = fused_qkv_short_conv(
+                self.q_proj(hidden_states),
+                self.k_proj(hidden_states),
+                self.v_proj(hidden_states),
+                self.q_conv1d,
+                self.k_conv1d,
+                self.v_conv1d,
+                mask=conv_mask,
+            )
+        elif self.use_short_conv:
             if last_state is not None:
                 conv_state_q, conv_state_k, conv_state_v = last_state['conv_state']
-            conv_mask = attention_mask[:, -hidden_states.shape[1]:] if attention_mask is not None else None
             q, conv_state_q = self.q_conv1d(
                 x=self.q_proj(hidden_states),
                 mask=conv_mask,

--- a/fla/modules/__init__.py
+++ b/fla/modules/__init__.py
@@ -5,7 +5,13 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-from fla.modules.convolution import ImplicitLongConvolution, LongConvolution, ShortConvolution
+from fla.modules.convolution import (
+    ImplicitLongConvolution,
+    LongConvolution,
+    ShortConvolution,
+    can_fuse_qkv_short_conv,
+    fused_qkv_short_conv,
+)
 from fla.modules.fused_bitlinear import BitLinear, FusedBitLinear
 from fla.modules.fused_cross_entropy import FusedCrossEntropyLoss
 from fla.modules.fused_kl_div import FusedKLDivLoss
@@ -49,4 +55,6 @@ __all__ = [
     'RotaryEmbedding',
     'ShortConvolution',
     'TokenShift',
+    'can_fuse_qkv_short_conv',
+    'fused_qkv_short_conv',
 ]

--- a/fla/modules/conv/short_conv.py
+++ b/fla/modules/conv/short_conv.py
@@ -157,7 +157,9 @@ class ShortConvolution(nn.Conv1d):
         if mask is not None:
             if cu_seqlens is not None:
                 raise ValueError("`mask` and `cu_seqlens` cannot be provided at the same time")
-            x = x.mul_(mask.unsqueeze(-1))
+            # Out-of-place: in-place `mul_` breaks autograd when `x` is a leaf
+            # tensor that requires grad (e.g. the fused q/k/v short-conv path).
+            x = x * mask.unsqueeze(-1)
 
         # in decoding phase, the cache (if provided) is updated inplace
         if B * T == N:

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -76,7 +76,8 @@ def fused_qkv_short_conv(
     """
     qkv = torch.cat([q, k, v], dim=-1)
     if mask is not None:
-        qkv.mul_(mask.unsqueeze(-1))
+        # Out-of-place for autograd safety (mirrors ShortConvolution.forward).
+        qkv = qkv * mask.unsqueeze(-1)
     qkv_weight = torch.cat(
         [
             q_conv.weight.squeeze(1),

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -5,6 +5,10 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+from __future__ import annotations
+
+import torch
+
 from fla.modules.conv import (
     ImplicitLongConvolution,
     LongConvolution,
@@ -23,6 +27,81 @@ from fla.modules.conv.triton import (
     causal_conv1d_update_states,
 )
 
+
+def can_fuse_qkv_short_conv(
+    q_conv: ShortConvolution,
+    k_conv: ShortConvolution,
+    v_conv: ShortConvolution,
+) -> bool:
+    """Whether the q/k/v short convolutions can collapse into a single call.
+
+    The three depthwise convolutions can only be merged when they share the
+    same backend, activation, and kernel size, so that one `causal_conv1d`
+    over the concatenated channels is exactly equivalent to running them
+    separately. Layers should additionally gate this on the dense no-cache
+    path (no `last_state`, no `use_cache`, no `cu_seqlens`) before calling
+    `fused_qkv_short_conv`.
+    """
+    return (
+        q_conv.backend == k_conv.backend == v_conv.backend
+        and q_conv.activation == k_conv.activation == v_conv.activation
+        and q_conv.kernel_size == k_conv.kernel_size == v_conv.kernel_size
+    )
+
+
+def fused_qkv_short_conv(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_conv: ShortConvolution,
+    k_conv: ShortConvolution,
+    v_conv: ShortConvolution,
+    mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the q/k/v short convolutions as a single `causal_conv1d`.
+
+    This is the dense, cache-less fast path shared by all q/k/v short-conv
+    layers. It concatenates the projected q/k/v along the channel dimension,
+    concatenates the depthwise weights (and biases, when present) in the same
+    order, and issues one convolution before splitting the result back into
+    q/k/v. The split sizes are read from the convolution weights, so grouped
+    (GQA) and multi-householder channel counts are handled transparently.
+
+    It mirrors `ShortConvolution.forward` for the dense path: an optional
+    attention mask zeroes out padded positions before the convolution, and the
+    convs' shared activation/backend are applied inside `causal_conv1d`. Any
+    layer-specific post-activation (for example an extra `F.silu`) stays in the
+    layer. Callers must guard this with `can_fuse_qkv_short_conv` and only
+    invoke it when there is no cache or variable-length state.
+    """
+    qkv = torch.cat([q, k, v], dim=-1)
+    if mask is not None:
+        qkv.mul_(mask.unsqueeze(-1))
+    qkv_weight = torch.cat(
+        [
+            q_conv.weight.squeeze(1),
+            k_conv.weight.squeeze(1),
+            v_conv.weight.squeeze(1),
+        ],
+        dim=0,
+    )
+    qkv_bias = None
+    if q_conv.bias is not None:
+        qkv_bias = torch.cat([q_conv.bias, k_conv.bias, v_conv.bias], dim=0)
+    qkv, _ = causal_conv1d(
+        x=qkv,
+        weight=qkv_weight,
+        bias=qkv_bias,
+        activation=q_conv.activation,
+        backend=q_conv.backend,
+    )
+    return torch.split(
+        qkv,
+        [q_conv.weight.shape[0], k_conv.weight.shape[0], v_conv.weight.shape[0]],
+        dim=-1,
+    )
+
+
 __all__ = [
     'CausalConv1dFunction',
     'CausalConv1dFunctionCP',
@@ -31,6 +110,7 @@ __all__ = [
     'LongConvolution',
     'PositionalEmbedding',
     'ShortConvolution',
+    'can_fuse_qkv_short_conv',
     'causal_conv1d',
     'causal_conv1d_bwd',
     'causal_conv1d_cp',
@@ -39,4 +119,5 @@ __all__ = [
     'causal_conv1d_update_states',
     'fast_causal_conv1d_fn',
     'fft_conv',
+    'fused_qkv_short_conv',
 ]

--- a/tests/layers/test_gated_deltanet.py
+++ b/tests/layers/test_gated_deltanet.py
@@ -60,7 +60,7 @@ def test_gated_deltanet_fused_qkv_conv_matches_fallback(B: int, T: int, D: int, 
         # input, so the three q/k/v convs run as separate calls.
         x_sep = x.detach().clone().requires_grad_(True)
         conv_calls['n'] = 0
-        with mock.patch.object(GatedDeltaNet, '_use_fused_qkv_conv', return_value=False):
+        with mock.patch('fla.layers.gated_deltanet.can_fuse_qkv_short_conv', return_value=False):
             y_sep = layer(x_sep)[0]
         sep_calls = conv_calls['n']
         (y_sep * do).sum().backward()

--- a/tests/modules/test_fused_qkv_short_conv.py
+++ b/tests/modules/test_fused_qkv_short_conv.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from unittest import mock
+
+import pytest
+import torch
+
+from fla.modules import ShortConvolution
+from fla.modules.convolution import can_fuse_qkv_short_conv, fused_qkv_short_conv
+from fla.utils import assert_close, device
+
+
+def _as_input(x: torch.Tensor) -> torch.Tensor:
+    # `ShortConvolution.forward` applies the mask in-place (`x.mul_`), so the
+    # tensors we pass in must be non-leaf to avoid PyTorch's leaf-inplace error.
+    x = x * 1.0
+    x.requires_grad_(True)
+    return x
+
+
+def _make_convs(
+    dq: int,
+    dk: int,
+    dv: int,
+    kernel_size: int,
+    bias: bool,
+    activation: str | None,
+    dtype: torch.dtype,
+    backend: str = 'triton',
+) -> tuple[ShortConvolution, ShortConvolution, ShortConvolution]:
+    def _build(d: int) -> ShortConvolution:
+        return ShortConvolution(
+            hidden_size=d,
+            kernel_size=kernel_size,
+            bias=bias,
+            activation=activation,
+            backend=backend,
+        ).to(device=device, dtype=dtype)
+    return _build(dq), _build(dk), _build(dv)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'dq', 'dk', 'dv', 'bias', 'activation', 'use_mask', 'dtype'),
+    [
+        pytest.param(*case, id="B{}-T{}-q{}k{}v{}-bias{}-{}-mask{}-{}".format(*case))
+        for case in [
+            # Equal q/k/v channel counts (DeltaNet / GDN / KDA / Comba style).
+            (2, 128, 128, 128, 256, False, 'silu', False, torch.bfloat16),
+            (2, 100, 128, 128, 256, True, 'silu', False, torch.float16),
+            # Grouped (GQA) channel counts (GLA / GSA / multiscale retention style).
+            (2, 128, 128, 64, 256, False, 'silu', False, torch.bfloat16),
+            (2, 96, 128, 64, 256, True, 'silu', False, torch.float16),
+            # No in-conv activation (LightNet style, silu is applied post-conv).
+            (2, 128, 128, 128, 256, False, None, False, torch.bfloat16),
+            # Masked dense path (ABC / SimpleGLA / LightNet style).
+            (2, 128, 128, 128, 256, False, 'silu', True, torch.bfloat16),
+            (1, 64, 128, 64, 256, True, None, True, torch.float16),
+        ]
+    ],
+)
+def test_fused_qkv_short_conv_matches_separate(
+    B: int,
+    T: int,
+    dq: int,
+    dk: int,
+    dv: int,
+    bias: bool,
+    activation: str | None,
+    use_mask: bool,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    q_conv, k_conv, v_conv = _make_convs(dq, dk, dv, 4, bias, activation, dtype)
+    q_conv.train()
+    k_conv.train()
+    v_conv.train()
+
+    q_base = torch.randn(B, T, dq, device=device, dtype=dtype)
+    k_base = torch.randn(B, T, dk, device=device, dtype=dtype)
+    v_base = torch.randn(B, T, dv, device=device, dtype=dtype)
+    mask = None
+    if use_mask:
+        mask = torch.randint(0, 2, (B, T), device=device, dtype=dtype)
+    do = (
+        torch.randn(B, T, dq, device=device, dtype=dtype),
+        torch.randn(B, T, dk, device=device, dtype=dtype),
+        torch.randn(B, T, dv, device=device, dtype=dtype),
+    )
+
+    # Count calls into the ShortConvolution modules: the fused path bypasses
+    # them and issues a single `causal_conv1d`, the separate path calls all three.
+    conv_calls = {'n': 0}
+
+    def bump(*_):
+        conv_calls['n'] += 1
+    handles = [m.register_forward_hook(bump) for m in (q_conv, k_conv, v_conv)]
+    try:
+        # Reference: three separate short convolutions.
+        q, k, v = _as_input(q_base), _as_input(k_base), _as_input(v_base)
+        conv_calls['n'] = 0
+        q_ref, _ = q_conv(q, mask=mask)
+        k_ref, _ = k_conv(k, mask=mask)
+        v_ref, _ = v_conv(v, mask=mask)
+        sep_calls = conv_calls['n']
+        ((q_ref * do[0]).sum() + (k_ref * do[1]).sum() + (v_ref * do[2]).sum()).backward()
+        g_sep = dict(_named_params(q_conv, k_conv, v_conv))
+        dq_sep = (q.grad.detach().clone(), k.grad.detach().clone(), v.grad.detach().clone())
+        for m in (q_conv, k_conv, v_conv):
+            m.zero_grad(set_to_none=True)
+
+        # Fused: a single concatenated short convolution.
+        q, k, v = _as_input(q_base), _as_input(k_base), _as_input(v_base)
+        conv_calls['n'] = 0
+        q_fused, k_fused, v_fused = fused_qkv_short_conv(q, k, v, q_conv, k_conv, v_conv, mask=mask)
+        fused_calls = conv_calls['n']
+        ((q_fused * do[0]).sum() + (k_fused * do[1]).sum() + (v_fused * do[2]).sum()).backward()
+        g_fused = dict(_named_params(q_conv, k_conv, v_conv))
+        dq_fused = (q.grad.detach().clone(), k.grad.detach().clone(), v.grad.detach().clone())
+    finally:
+        for h in handles:
+            h.remove()
+
+    assert fused_calls == 0, f"fused path should bypass the conv modules, saw {fused_calls} call(s)"
+    assert sep_calls == 3, f"separate path should call all three conv modules, saw {sep_calls} call(s)"
+
+    assert_close('q', q_ref, q_fused, 0.0)
+    assert_close('k', k_ref, k_fused, 0.0)
+    assert_close('v', v_ref, v_fused, 0.0)
+    for name, ref, tri in zip(('dq', 'dk', 'dv'), dq_sep, dq_fused, strict=False):
+        assert_close(name, ref, tri, 1e-3)
+    # The fused path concatenates the q/k/v conv weights into one conv, which
+    # regroups the backward accumulation for those weights, so the conv-weight
+    # grads can differ by tiny accumulation-order noise.
+    for name in g_fused:
+        assert_close(f'd{name}', g_sep[name], g_fused[name], 5e-3)
+
+
+def _named_params(q_conv, k_conv, v_conv):
+    for prefix, module in (('q', q_conv), ('k', k_conv), ('v', v_conv)):
+        for name, param in module.named_parameters():
+            yield f'{prefix}.{name}', param.grad.detach().clone()
+
+
+def test_can_fuse_qkv_short_conv_predicate():
+    q_conv, k_conv, v_conv = _make_convs(128, 128, 256, 4, False, 'silu', torch.float32)
+    assert can_fuse_qkv_short_conv(q_conv, k_conv, v_conv)
+
+    # Mismatched activation blocks fusion (e.g. DeltaNet with non-silu q/k).
+    _, k_conv_mismatch, _ = _make_convs(128, 128, 256, 4, False, None, torch.float32)
+    assert not can_fuse_qkv_short_conv(q_conv, k_conv_mismatch, v_conv)
+
+    # Mismatched kernel size blocks fusion.
+    _, k_conv_mismatch, _ = _make_convs(128, 128, 256, 3, False, 'silu', torch.float32)
+    assert not can_fuse_qkv_short_conv(q_conv, k_conv_mismatch, v_conv)
+
+    # Mismatched backend blocks fusion. Set the attribute directly so the test
+    # does not require the optional CUDA `causal_conv1d` package.
+    k_conv_mismatch = mock.Mock(wraps=k_conv)
+    k_conv_mismatch.backend = 'cuda'
+    k_conv_mismatch.activation = k_conv.activation
+    k_conv_mismatch.kernel_size = k_conv.kernel_size
+    assert not can_fuse_qkv_short_conv(q_conv, k_conv_mismatch, v_conv)


### PR DESCRIPTION
## Summary
- Generalizes the dense no-cache q/k/v short-convolution fusion from #972 into a shared `fused_qkv_short_conv` helper (plus the `can_fuse_qkv_short_conv` guard) in `fla.modules.convolution`.
- Routes every q/k/v short-conv layer through the helper so they share one dense-path fusion instead of each carrying a copy.
- The helper reads the split sizes from the conv weights, so it transparently handles standard, grouped (GQA), and multi-householder channel counts, and accepts an optional attention mask that mirrors `ShortConvolution.forward`.
- Each layer keeps its own cache / varlen guard and any layer-specific post-activation, so the non-dense fallback and existing semantics are unchanged.

## Layers
Fused path added: GatedDeltaNet, GDN2, KDA, Comba, GatedDeltaProduct, DeltaNet, GLA, MultiscaleRetention, GSA, ABC, SimpleGLA, LightNet.

Intentionally left unchanged: MoM (varlen / single-kv path) and MesaNet (q/k only, no `v_conv`).

## Test
- New `tests/modules/test_fused_qkv_short_conv.py`: compares the fused helper against three separate `ShortConvolution` calls (forward and backward) across split / bias / activation / mask variants, and checks the `can_fuse_qkv_short_conv` predicate.
- Updated `tests/layers/test_gated_deltanet.py` to patch the new guard predicate.

Follow-up to #972.
