### PR TITLE
[Ops] Add naive PyTorch reference for DeepSeek Sparse Attention (DSA)

### DIFF
--- a/fla/ops/dsa/README.md
+++ b/fla/ops/dsa/README.md
@@ -23,10 +23,8 @@ Every method builds `S_t` the same way — **score all candidates with a cheap p
 attend** — because scoring with full attention would cost the `O(T²)` you are trying to avoid. So the
 proxy is the whole game, and it is fixed by **two choices**:
 
-- **Granularity** — score/select individual **tokens** (precise, scattered reads) or contiguous
-  **blocks** (coarser, but contiguous, tensor-core- and KV-cache-friendly).
-- **Scoring proxy** — rank by **pooled existing keys** (free, no new params, lossy) or by a
-  **separate learned indexer** (expressive, but extra params that must be trained).
+- **Granularity** — score and select individual **tokens**, or contiguous **blocks** of keys.
+- **Scoring proxy** — rank candidates by **pooled existing keys**, or by a **separate learned indexer**.
 
 Those two choices place the four methods in a 2×2:
 
@@ -35,18 +33,27 @@ Those two choices place the four methods in a 2×2:
 | **block** | NSA, MoBA                       | MSA                              |
 | **token** | —                               | DSA                              |
 
-The scoring choice also decides the **hard part — training.** `top-k` is non-differentiable, so the
-score must be learned some other way:
+Each axis has one consequence.
 
-- **Pooled keys** (NSA, MoBA) get gradient *for free*: the same keys feed the attention output, so
-  the language-model loss trains them. No extra machinery.
+**Granularity sets the quality–speed trade-off.**
+Token-level selection is the ideal:
+each query picks its own `top-k` tokens, the closest sparse match to full attention.
+But token reads are scattered and memory-bound.
+Blocks fix that — contiguous, tensor-core- and KV-cache-friendly — at the cost of coarser selection.
+So the axis runs **DSA → NSA/MSA → MoBA**, most precise to fastest.
+
+**Scoring sets the training difficulty.**
+`top-k` is non-differentiable, so the score has to be learned some other way:
+
+- **Pooled keys** (NSA, MoBA) get gradient *for free*:
+  the same keys feed the output, so the LM loss trains them.
 - **A separate indexer** (DSA, MSA) feeds *only* selection, never the output, so it gets no gradient.
-  It must be trained by **distilling it to the full attention** (KL loss: indexer = student, attention
-  = teacher).
+  It must be **distilled to the full attention** (KL loss: indexer = student, attention = teacher).
 
-Two structural patterns are near-universal: a **local + global** split (a cheap local path plus the
-sparse global one), and a **prefill/decode asymmetry** (a method sparse in training may still go dense
-at generation, as MoBA does).
+**Beyond the two axes,** two patterns recur.
+One is a **local + global** split: a cheap local path next to the sparse global one.
+The other is a **prefill/decode asymmetry**:
+a method sparse in training may still go dense at generation, as MoBA does.
 
 ---
 
@@ -79,11 +86,13 @@ Paper: [arXiv:2502.11089](https://arxiv.org/abs/2502.11089) — *block · pooled
 - **No separate scorer** — selection reuses the compression scores `I_t`, so one coarse pass both
   adds context *and* steers selection (the gradient-free proxy).
 
-**Hardware-aligned core — why GQA is mandatory.** Selection is *per KV head, not per query head*, so
-all `G = H_Q/H_KV` query heads in a group share one block list. The kernel makes this a GEMM: load the
-group's queries once as `[G, d]`, then for each selected block load its KV tile `[d, B_S]` from HBM
-**once** and matmul against all `G` rows. Group sharing amortizes each KV read over `G` heads, and block-level reads stay contiguous — together
-they restore the arithmetic intensity that scattered, memory-bound sparse attention throws away.
+**Hardware-aligned core — why GQA is mandatory.**
+Selection is *per KV head, not per query head*,
+so all `G = H_Q/H_KV` query heads in a group share one block list.
+The kernel makes this a GEMM: load the group's queries once as `[G, d]`,
+then for each selected block load its KV tile `[d, B_S]` from HBM **once** and matmul against all `G` rows.
+Group sharing amortizes each KV read over `G` heads, and block-level reads stay contiguous —
+together they restore the arithmetic intensity that scattered, memory-bound sparse attention throws away.
 
 ### MoBA — Mixture of Block Attention
 

--- a/fla/ops/dsa/__init__.py
+++ b/fla/ops/dsa/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+from .naive import naive_dsa
+
+__all__ = [
+    'naive_dsa',
+]

--- a/fla/ops/dsa/naive.py
+++ b/fla/ops/dsa/naive.py
@@ -111,8 +111,12 @@ def naive_dsa(
     r"""
     Naive reference for DeepSeek Sparse Attention (DSA).
 
-    The lightning indexer scores every causal key for each query, the top-k keys are selected, and
-    attention is computed over the selected keys only. The selection is shared across all query heads.
+    DSA scores every causal key with a lightweight indexer, keeps the top-k per query,
+    and attends over those keys only. The selection is shared across all query heads.
+
+    Reference:
+        DeepSeek-V3.2 (https://arxiv.org/abs/2512.02556);
+        TileLang `examples/deepseek_v32` (https://github.com/tile-ai/tilelang/tree/main/examples/deepseek_v32).
 
     Args:
         q (torch.Tensor):

--- a/fla/ops/dsa/naive.py
+++ b/fla/ops/dsa/naive.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import warnings
+
+import torch
+import torch.nn.functional as F
+from einops import repeat
+
+
+def naive_dsa_indexer(
+    q_idx: torch.Tensor,
+    k_idx: torch.Tensor,
+    w_idx: torch.Tensor | None = None,
+    topk: int = 2048,
+    scale: float | None = None,
+    activation: str | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> torch.LongTensor:
+    r"""
+    Lightning indexer of DeepSeek Sparse Attention (DSA), scoring causal keys and selecting the top-k.
+
+    For a query at position `t` and a preceding token at position `s`,
+    the index score is the weighted sum of head-wise similarities (MQA: a single index key is shared across heads):
+
+        I[t, s] = \sum_j w_idx[t, j] * act(scale * q_idx[t, j] . k_idx[s])
+
+    The `topk` highest-scoring causal keys are then kept per query.
+    A positive `scale`, a monotone `activation`, and the weights do not change the ranking,
+    so they only matter when the raw scores are consumed directly rather than for selection.
+
+    Args:
+        q_idx (torch.Tensor):
+            Index queries of shape `[B, T, HI, DI]`, where `HI` is the number of indexer heads.
+        k_idx (torch.Tensor):
+            Index keys of shape `[B, T, DI]`. A single key per token is shared across all heads.
+        w_idx (torch.Tensor, Optional):
+            Per-head index weights of shape `[B, T, HI]`. If `None`, heads are summed with equal weight. Default: `None`.
+        topk (int, Optional):
+            Number of keys selected per query. Default: `2048`.
+        scale (float, Optional):
+            Scale factor applied to the dot product. If `None`, defaults to `1 / sqrt(DI)`. Default: `None`.
+        activation (str, Optional):
+            Name of the activation (a `torch.nn.functional` name) applied to head-wise similarities before aggregation,
+            e.g. `'relu'`. If `None`, no activation is applied. Default: `None`.
+        cu_seqlens (torch.LongTensor, Optional):
+            Cumulative sequence lengths of shape `[N+1]` for variable-length inputs.
+            When provided, the batch size must be 1. Default: `None`.
+
+    Returns:
+        indices (torch.LongTensor):
+            Selected key indices of shape `[B, T, topk]`, padded with `-1`.
+            For varlen inputs, the indices are local offsets within each sequence.
+    """
+    if scale is None:
+        scale = q_idx.shape[-1] ** -0.5
+    q_idx, k_idx = q_idx.float(), k_idx.float()
+    if w_idx is not None:
+        w_idx = w_idx.float()
+
+    def select(q_b, k_b, w_b):
+        # q_b: [T, HI, DI], k_b: [T, DI], w_b: [T, HI] or None -> indices [T, topk]
+        T = q_b.shape[0]
+        # [HI, T, T]
+        score = torch.einsum('m h d, n d -> h m n', q_b, k_b) * scale
+        if activation is not None:
+            score = getattr(F, activation)(score)
+        # aggregate over indexer heads -> [T, T]
+        logits = score.sum(0) if w_b is None else torch.einsum('h m n, m h -> m n', score, w_b)
+        i_t = torch.arange(T, device=q_b.device)
+        logits = logits.masked_fill(i_t[:, None] < i_t[None, :], float('-inf'))
+        S = min(topk, T)
+        values, indices = torch.topk(logits, S, dim=-1)
+        # drop slots backed by invisible (`-inf`) positions, then pad up to `topk`
+        indices = indices.masked_fill(torch.isinf(values), -1)
+        if topk > S:
+            indices = torch.cat([indices, indices.new_full((T, topk - S), -1)], dim=-1)
+        return indices
+
+    if cu_seqlens is None:
+        indices = torch.stack([
+            select(q_idx[i], k_idx[i], None if w_idx is None else w_idx[i]) for i in range(q_idx.shape[0])
+        ], 0)
+    else:
+        assert q_idx.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
+        indices = q_idx.new_full((1, q_idx.shape[1], topk), -1, dtype=torch.long)
+        for i in range(len(cu_seqlens) - 1):
+            bos, eos = cu_seqlens[i], cu_seqlens[i + 1]
+            w_b = None if w_idx is None else w_idx[0, bos:eos]
+            indices[0, bos:eos] = select(q_idx[0, bos:eos], k_idx[0, bos:eos], w_b)
+    return indices
+
+
+def naive_dsa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_idx: torch.Tensor,
+    k_idx: torch.Tensor,
+    w_idx: torch.Tensor | None = None,
+    indices: torch.LongTensor | None = None,
+    topk: int = 2048,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    return_indices: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.LongTensor]:
+    r"""
+    Naive reference for DeepSeek Sparse Attention (DSA).
+
+    The lightning indexer scores every causal key for each query, the top-k keys are selected, and
+    attention is computed over the selected keys only. The selection is shared across all query heads.
+
+    Args:
+        q (torch.Tensor):
+            Queries of shape `[B, T, HQ, K]`.
+        k (torch.Tensor):
+            Keys of shape `[B, T, H, K]`. GQA is supported with group size `G = HQ // H`.
+        v (torch.Tensor):
+            Values of shape `[B, T, H, V]`.
+        q_idx (torch.Tensor):
+            Index queries of shape `[B, T, HI, DI]`.
+        k_idx (torch.Tensor):
+            Index keys of shape `[B, T, DI]`, shared across indexer heads.
+        w_idx (torch.Tensor, Optional):
+            Per-head index weights of shape `[B, T, HI]`.
+            If `None`, indexer heads are summed with equal weight. Default: `None`.
+        indices (torch.LongTensor, Optional):
+            Precomputed selection of shape `[B, T, topk]`, padded with `-1`.
+            If provided, the indexer is skipped and `q_idx`/`k_idx`/`w_idx` are ignored. Default: `None`.
+        topk (int, Optional):
+            Number of keys selected per query. Default: `2048`.
+        scale (float, Optional):
+            Scale factor for attention scores. If `None`, defaults to `1 / sqrt(K)`. Default: `None`.
+        cu_seqlens (torch.LongTensor, Optional):
+            Cumulative sequence lengths of shape `[N+1]` for variable-length inputs, consistent with the FlashAttention API.
+            When provided, the batch size must be 1. Default: `None`.
+        return_indices (bool, Optional):
+            Whether to also return the selected indices. Default: `False`.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, HQ, V]`.
+            When `return_indices=True`, also returns the selected indices of shape `[B, T, topk]`.
+    """
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    if cu_seqlens is not None:
+        assert q.shape[0] == 1, "batch size must be 1 when cu_seqlens are provided"
+
+    dtype = q.dtype
+    G = q.shape[2] // k.shape[2]
+    q, k, v = (x.float() for x in (q, k, v))
+    k, v = (repeat(x, 'b t h d -> b t (h g) d', g=G) for x in (k, v))
+
+    if indices is None:
+        indices = naive_dsa_indexer(q_idx, k_idx, w_idx, topk, activation='relu', cu_seqlens=cu_seqlens)
+    elif q_idx is not None:
+        warnings.warn("`indices` is provided, the lightning indexer is skipped")
+
+    def attend(q_b, k_b, v_b, i_b):
+        T = q_b.shape[0]
+        # scatter selection into a boolean mask, with the dummy column `T` absorbing `-1` padding
+        mask = q_b.new_zeros(T, T + 1, dtype=torch.bool)
+        mask.scatter_(1, i_b.masked_fill(i_b < 0, T), True)
+        mask = mask[:, :T]
+        i_t = torch.arange(T, device=q_b.device)
+        mask = mask & (i_t[:, None] >= i_t[None, :])
+        # [HQ, T, T]
+        score = torch.einsum('m h d, n h d -> h m n', q_b, k_b) * scale
+        score = score.masked_fill(~mask[None], float('-inf'))
+        p = torch.softmax(score, dim=-1)
+        return torch.einsum('h m n, n h d -> m h d', p, v_b)
+
+    o = torch.empty_like(v)
+    if cu_seqlens is None:
+        for i in range(q.shape[0]):
+            o[i] = attend(q[i], k[i], v[i], indices[i])
+    else:
+        for i in range(len(cu_seqlens) - 1):
+            bos, eos = cu_seqlens[i], cu_seqlens[i + 1]
+            o[0, bos:eos] = attend(q[0, bos:eos], k[0, bos:eos], v[0, bos:eos], indices[0, bos:eos])
+
+    o = o.to(dtype)
+    return (o, indices) if return_indices else o

--- a/fla/ops/dsa/naive.py
+++ b/fla/ops/dsa/naive.py
@@ -115,8 +115,7 @@ def naive_dsa(
     and attends over those keys only. The selection is shared across all query heads.
 
     Reference:
-        DeepSeek-V3.2 (https://arxiv.org/abs/2512.02556);
-        TileLang `examples/deepseek_v32` (https://github.com/tile-ai/tilelang/tree/main/examples/deepseek_v32).
+        DeepSeek-V3.2 (https://arxiv.org/abs/2512.02556).
 
     Args:
         q (torch.Tensor):


### PR DESCRIPTION
## Summary

Adds `fla/ops/dsa`, a pure-PyTorch reference for **DeepSeek Sparse Attention (DSA)**, the token-granular, learned-indexer sparse attention from DeepSeek-V3.2. It mirrors the TileLang `examples/deepseek_v32` reference and serves as the ground-truth for future optimized kernels.

The pipeline is the standard *score → top-k → attend*:

- **`naive_dsa_indexer`** — the lightning indexer. MQA scoring (one shared key per token, multiple query heads) with optional per-head weights and activation, then returns the causal top-k key indices `[B, T, topk]`. Activation/weights/scale are optional since, being monotone, they don't affect the selection ranking.
- **`naive_dsa`** — softmax attention over the selected (and causal) keys only, shared across query heads. Supports GQA, variable-length inputs (`cu_seqlens`), precomputed `indices`, and `return_indices`.

Also relocates the sparse-attention design-space README from `nsa/` to `dsa/` and adds a high-level note framing granularity as the quality–speed dial (DSA → NSA/MSA → MoBA).

## Test plan

- CPU equivalence checks: indexer matches an independent einsum; `topk ≥ T` degenerates to dense causal GQA attention (~1e-6); varlen matches per-sequence; `-1` padding and causal constraints hold.
- `flake8` + `ruff` clean on the new module.