### PR TITLE
[Fix] remove redundant decorators, add PowGlu kernel and pin the version of torch_npu to 2.7.1.post4 for npu.

### DIFF
--- a/fla/modules/activations.py
+++ b/fla/modules/activations.py
@@ -145,7 +145,6 @@ def sigmoid_bwd_kernel(
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def sigmoid_fwd(x: torch.Tensor, output_contiguous: bool = False) -> torch.Tensor:
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
@@ -162,7 +161,6 @@ def sigmoid_fwd(x: torch.Tensor, output_contiguous: bool = False) -> torch.Tenso
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def sigmoid_bwd(x: torch.Tensor, dy: torch.Tensor, output_contiguous: bool = False) -> torch.Tensor:
     x = _ensure_inner_contiguous(x)
     dy = _ensure_inner_contiguous(dy)
@@ -265,7 +263,6 @@ def logsigmoid_bwd_kernel(
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def logsigmoid_fwd(x: torch.Tensor, temperature: float = 1., output_contiguous: bool = False) -> torch.Tensor:
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
@@ -283,7 +280,6 @@ def logsigmoid_fwd(x: torch.Tensor, temperature: float = 1., output_contiguous: 
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def logsigmoid_bwd(
     x: torch.Tensor,
     dy: torch.Tensor,
@@ -388,7 +384,6 @@ def swish_bwd_kernel(
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def swish_fwd(x: torch.Tensor, output_contiguous: bool = False) -> torch.Tensor:
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
@@ -405,7 +400,6 @@ def swish_fwd(x: torch.Tensor, output_contiguous: bool = False) -> torch.Tensor:
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def swish_bwd(x: torch.Tensor, dy: torch.Tensor, output_contiguous: bool = False) -> torch.Tensor:
     x = _ensure_inner_contiguous(x)
     dy = _ensure_inner_contiguous(dy)
@@ -640,7 +634,6 @@ def swiglu_fwdbwd_kernel(
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def swiglu_fwd(x: torch.Tensor, y: torch.Tensor, output_contiguous: bool = False) -> torch.Tensor:
     assert x.shape == y.shape, f"swiglu_fwd: shape mismatch x={x.shape} y={y.shape}"
     x = _ensure_inner_contiguous(x)
@@ -661,7 +654,6 @@ def swiglu_fwd(x: torch.Tensor, y: torch.Tensor, output_contiguous: bool = False
 
 
 @dispatch('modules')
-@torch.compiler.disable
 def swiglu_fwdbwd(
     x: torch.Tensor,
     y: torch.Tensor,
@@ -1062,7 +1054,7 @@ def powglu_fwdbwd_kernel(
         tl.store(z + row * stride_z_row + col, b_z.to(z.dtype.element_ty), mask=mask)
 
 
-@torch.compiler.disable
+@dispatch('modules')
 def powglu_fwd(x: torch.Tensor, y: torch.Tensor, power: float = 3.0, output_contiguous: bool = False) -> torch.Tensor:
     assert x.shape == y.shape, f"powglu_fwd: shape mismatch x={x.shape} y={y.shape}"
     x = _ensure_inner_contiguous(x)
@@ -1083,7 +1075,7 @@ def powglu_fwd(x: torch.Tensor, y: torch.Tensor, power: float = 3.0, output_cont
     return z
 
 
-@torch.compiler.disable
+@dispatch('modules')
 def powglu_fwdbwd(
     x: torch.Tensor,
     y: torch.Tensor,
@@ -1190,6 +1182,7 @@ def powglu(x: torch.Tensor, y: torch.Tensor, power: float = 3.0) -> torch.Tensor
     return PowGLUFunction.apply(x, y, power)
 
 
+@dispatch('modules')
 def powglu_linear(
     x: torch.Tensor,
     y: torch.Tensor,

--- a/fla/modules/backends/triton_ascend/__init__.py
+++ b/fla/modules/backends/triton_ascend/__init__.py
@@ -188,6 +188,20 @@ class TritonAscendBackend(BaseBackend):
         from fla.modules.backends.triton_ascend.activations import sqrelu_bwd_npu
         return sqrelu_bwd_npu(g, x)
 
+    def powglu_fwd(self, x, y, power=3.0, output_contiguous=False):
+        from fla.modules.backends.triton_ascend.activations import powglu_fwd_npu
+        return powglu_fwd_npu(x, y, power=power, output_contiguous=output_contiguous)
+
+    def powglu_fwdbwd(self, x, y, g, power=3.0, use_weight=False, output_contiguous=False):
+        from fla.modules.backends.triton_ascend.activations import powglu_fwdbwd_npu
+        return powglu_fwdbwd_npu(
+            x, y, g, power=power, use_weight=use_weight, output_contiguous=output_contiguous,
+        )
+
+    def powglu_linear(self, x, y, weight, bias, power=3.0):
+        from fla.modules.backends.triton_ascend.activations import powglu_linear_npu
+        return powglu_linear_npu(x, y, weight, bias, power)
+
     def fused_kl_div_forward(
         self,
         x,

--- a/fla/modules/backends/triton_ascend/activations.py
+++ b/fla/modules/backends/triton_ascend/activations.py
@@ -694,3 +694,214 @@ class SwiGLULinearFunctionNPU(torch.autograd.Function):
 
 def swiglu_linear_npu(x, y, weight, bias):
     return SwiGLULinearFunctionNPU.apply(x, y, weight, bias)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'B': bs}, num_warps=num_warps)
+        for bs in [512, 1024, 2048, 4096, 8192]
+        for num_warps in NUM_WARPS_AUTOTUNE
+    ],
+    key=['D'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def powglu_fwd_kernel(
+    x, y, z,
+    stride_x_row,
+    stride_y_row,
+    stride_z_row,
+    m,
+    T,
+    D: tl.constexpr,
+    B: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64)
+    offs = i_n * B + tl.arange(0, B)
+    mask = offs < T
+    row = offs // D
+    col = offs % D
+    b_x = tl.load(x + row * stride_x_row + col, mask=mask, other=0.).to(tl.float32)
+    b_y = tl.load(y + row * stride_y_row + col, mask=mask, other=0.).to(tl.float32)
+    b_s = tl.sigmoid(b_x)
+    b_pos = b_x > 0
+    # feed only positive lanes to log/sqrt; masked lanes give x**p = 1 and are dropped by the where
+    b_xp = tl.where(b_pos, b_x, 1.0)
+    b_sqrt = tl.sqrt(b_xp)
+    b_p = m / (b_sqrt + 1.0)
+    b_pow = exp(b_p * log(b_xp))
+    b_g = tl.where(b_pos, b_pow * b_s, b_x * b_s)
+    b_z = b_g * b_y
+    tl.store(z + row * stride_z_row + col, b_z.to(z.dtype.element_ty), mask=mask)
+
+
+@triton.heuristics({
+    'HAS_WEIGHT': lambda args: args['z'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'B': bs}, num_warps=num_warps)
+        for bs in [512, 1024, 2048, 4096, 8192]
+        for num_warps in NUM_WARPS_AUTOTUNE
+    ],
+    key=['D'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def powglu_fwdbwd_kernel(
+    x, y, g, dx, dy, z,
+    stride_x_row,
+    stride_y_row,
+    stride_g_row,
+    stride_dx_row,
+    stride_dy_row,
+    stride_z_row,
+    m,
+    T,
+    D: tl.constexpr,
+    B: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64)
+    offs = i_n * B + tl.arange(0, B)
+    mask = offs < T
+    row = offs // D
+    col = offs % D
+    b_x = tl.load(x + row * stride_x_row + col, mask=mask, other=0.).to(tl.float32)
+    b_y = tl.load(y + row * stride_y_row + col, mask=mask, other=0.).to(tl.float32)
+    b_g = tl.load(g + row * stride_g_row + col, mask=mask, other=0.).to(tl.float32)
+
+    b_s = tl.sigmoid(b_x)
+    b_pos = b_x > 0
+    b_xp = tl.where(b_pos, b_x, 1.0)
+    b_sqrt = tl.sqrt(b_xp)
+    b_ln = log(b_xp)
+    b_p = m / (b_sqrt + 1.0)
+    b_pow = exp(b_p * b_ln)
+
+    b_gate_pos = b_pow * b_s
+    # d/dx of the exponent term: p' = -m / (2*sqrt(x)*(sqrt(x)+1)**2)
+    b_pprime = -m / (2.0 * b_sqrt * (b_sqrt + 1.0) * (b_sqrt + 1.0))
+    b_dgate_pos = b_gate_pos * (b_pprime * b_ln + b_p / b_xp + 1.0 - b_s)
+    b_gate_neg = b_x * b_s
+    b_dgate_neg = b_s * (1.0 + b_x * (1.0 - b_s))
+
+    b_gate = tl.where(b_pos, b_gate_pos, b_gate_neg)
+    b_dgate = tl.where(b_pos, b_dgate_pos, b_dgate_neg)
+
+    b_dx = b_g * b_y * b_dgate
+    b_dy = b_g * b_gate
+
+    tl.store(dx + row * stride_dx_row + col, b_dx.to(dx.dtype.element_ty), mask=mask)
+    tl.store(dy + row * stride_dy_row + col, b_dy.to(dy.dtype.element_ty), mask=mask)
+    if HAS_WEIGHT:
+        b_z = b_gate * b_y
+        tl.store(z + row * stride_z_row + col, b_z.to(z.dtype.element_ty), mask=mask)
+
+
+@torch.compiler.disable
+def powglu_fwd_npu(x: torch.Tensor, y: torch.Tensor, power: float = 3.0, output_contiguous: bool = False) -> torch.Tensor:
+    assert x.shape == y.shape, f"powglu_fwd: shape mismatch x={x.shape} y={y.shape}"
+    x = _ensure_inner_contiguous(x)
+    y = _ensure_inner_contiguous(y)
+    T, D = x.numel(), x.shape[-1]
+    z = _alloc_output(x, output_contiguous)
+    powglu_fwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+        x=x,
+        y=y,
+        z=z,
+        stride_x_row=_get_stride(x),
+        stride_y_row=_get_stride(y),
+        stride_z_row=_get_stride(z),
+        m=power,
+        T=T,
+        D=D,
+    )
+    return z
+
+
+@torch.compiler.disable
+def powglu_fwdbwd_npu(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    g: torch.Tensor,
+    power: float = 3.0,
+    use_weight: bool = False,
+    output_contiguous: bool = False,
+):
+    assert x.shape == y.shape == g.shape, f"powglu_fwdbwd: shape mismatch x={x.shape} y={y.shape} g={g.shape}"
+    x = _ensure_inner_contiguous(x)
+    y = _ensure_inner_contiguous(y)
+    g = _ensure_inner_contiguous(g)
+    T, D = x.numel(), x.shape[-1]
+    dx = _alloc_output(x, output_contiguous)
+    dy = _alloc_output(y, output_contiguous)
+    if use_weight:
+        z = _alloc_output(x, output_contiguous)
+    else:
+        z = None
+    powglu_fwdbwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+        x=x,
+        y=y,
+        g=g,
+        dx=dx,
+        dy=dy,
+        z=z,
+        stride_x_row=_get_stride(x),
+        stride_y_row=_get_stride(y),
+        stride_g_row=_get_stride(g),
+        stride_dx_row=_get_stride(dx),
+        stride_dy_row=_get_stride(dy),
+        stride_z_row=_get_stride(z) if z is not None else 0,
+        m=power,
+        T=T,
+        D=D,
+    )
+    if use_weight:
+        return dx, dy, z
+    return dx, dy
+
+
+class PowGLULinearFunctionNPU(torch.autograd.Function):
+    r"""
+    Power-Gated Linear Unit (PowGLU) function followed by a linear transformation.
+
+    .. math::
+        \text{PowGLULinear}(x, y, W, b) = (g(x) * y) W + b
+
+    This simple wrap discards the intermediate results of PowGLU(x, y) to save memory.
+    """
+
+    @staticmethod
+    @input_guard(no_guard_contiguous=True)
+    @autocast_custom_fwd
+    def forward(ctx, x, y, weight, bias, power):
+        z = powglu_fwd_npu(x, y, power, output_contiguous=True)
+        out = F.linear(z, weight, bias)
+        ctx.save_for_backward(x, y, weight)
+        ctx.linear_bias_is_none = bias is None
+        ctx.power = power
+        return out
+
+    @staticmethod
+    @input_guard(no_guard_contiguous=True)
+    @autocast_custom_bwd
+    def backward(ctx, dout, *args):
+        x, y, weight = ctx.saved_tensors
+        dout = dout.reshape(-1, dout.shape[-1])
+        dz = F.linear(dout, weight.t()).view_as(x)
+        dx, dy, z = powglu_fwdbwd_npu(x, y, dz, ctx.power, use_weight=True, output_contiguous=True)
+        z_flat = z.reshape(-1, z.shape[-1])
+        dlinear_weight = dout.t() @ z_flat
+        dlinear_bias = None if ctx.linear_bias_is_none else dout.sum(0)
+        return dx, dy, dlinear_weight, dlinear_bias, None
+
+
+def powglu_linear_npu(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    power: float = 3.0,
+) -> torch.Tensor:
+    return PowGLULinearFunctionNPU.apply(x, y, weight, bias, power)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ cuda = ["torch>=2.7.0", "triton>=3.3"]
 # on stable, triton-rocm on nightly, etc.).
 rocm = ["torch>=2.7.0"]
 xpu  = ["torch>=2.7.0"]
-npu  = ["torch==2.7.1", "torch_npu==2.7.1", "torchvision==0.22.1", "triton-ascend==3.2.1"]
+npu  = ["torch==2.7.1", "torch_npu==2.7.1.post4", "torchvision==0.22.1", "triton-ascend==3.2.1"]
 cpu  = ["torch>=2.7.0", "triton>=3.3"]
 tilelang = ["tilelang>=0.1.9"]
 conv1d = ["causal-conv1d>=1.4.0"]


### PR DESCRIPTION
## Summary
- Remove redundant `@torch.compiler.disable` decorators from dispatched activation functions (`sigmoid`, `logsigmoid`, `swish`, `swiglu`); the `@dispatch` wrapper already applies `torch.compiler.disable` centrally.
- Add PowGLU to the triton-ascend backend dispatch path: register `powglu_fwd`, `powglu_fwdbwd`, and `powglu_linear` with `@dispatch('modules')` and implement corresponding NPU Triton kernels, closing the coverage gap left by #973.
- Pin `torch_npu` to `2.7.1.post4` in the NPU optional dependency set for compatibility with CANN 9.0.0 and triton-ascend 3.2.1.
## Background
#973 expanded triton-ascend backends for most module activations but omitted PowGLU. Without dispatch registration, `powglu` / `powglu_linear` (used in PowGLU MLP layers) would fall through to the default CUDA Triton kernels on Ascend NPU and fail at runtime.
## Changes
### `fla/modules/activations.py`
- Remove duplicate `@torch.compiler.disable` from 8 dispatched functions.
- Add `@dispatch('modules')` to `powglu_fwd`, `powglu_fwdbwd`, and `powglu_linear`.
### `fla/modules/backends/triton_ascend/`
- Add `powglu_fwd_kernel`, `powglu_fwdbwd_kernel`, and fused `PowGLULinearFunctionNPU`.
- Register `powglu_fwd`, `powglu_fwdbwd`, `powglu_linear` on `TritonAscendBackend`.
### `pyproject.toml`
- Update NPU deps: `torch_npu==2.7.1` → `torch_npu==2.7.1.post4`.