### PR TITLE
[GDN] Re-enable Triton backend for Triton >= 3.7.1 on Hopper

### DIFF
--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -7,6 +7,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
   checks: read
 
 on:

--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -40,9 +40,6 @@ on:
 jobs:
   test-ops:
     runs-on: ${{ inputs.runner }}
-    permissions:
-      contents: read
-      issues: write
     env:
       FLA_CI_ENV: 1
 

--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -92,32 +92,51 @@ jobs:
 
       - name: Run pytest on ops test files (dispatch DISABLED, Triton baseline)
         if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false'
-        id: triton-baseline
-        continue-on-error: true
         shell: bash
         env:
           FLA_DISABLE_BACKEND_DISPATCH: "1"
         run: |
           $CONDA_BIN_PATH/pytest -s -v --exitfirst ${{ steps.find-ops-tests.outputs.test_files }}
 
-      - name: Comment on PR when Triton baseline fails
-        if: steps.triton-baseline.outcome == 'failure' && github.event_name == 'pull_request'
+      - name: Run pytest on ops test files (dispatch ENABLED, backend coverage)
+        if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false' && steps.check-dispatch.outputs.dispatch_changed == 'true'
+        id: dispatch-coverage
+        continue-on-error: true
+        shell: bash
+        run: |
+          $CONDA_BIN_PATH/pytest -s -v --exitfirst ${{ steps.find-ops-tests.outputs.test_files }} 2>&1 | tee /tmp/fla-dispatch-coverage.log
+          exit ${PIPESTATUS[0]}
+
+      - name: Comment on PR when dispatch coverage fails
+        if: steps.dispatch-coverage.outcome == 'failure' && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v9.0.0
         with:
           script: |
+            const fs = require('fs');
+            let tail = '(log unavailable)';
+            try {
+              const lines = fs.readFileSync('/tmp/fla-dispatch-coverage.log', 'utf8').trimEnd().split('\n');
+              tail = lines.slice(-40).join('\n');
+            } catch (e) {}
+            const body = [
+              '⚠️ **Dispatch coverage (backend) failed** while the Triton baseline passed.',
+              '',
+              'The dispatched backend (e.g. TileLang) disagrees with the Triton reference. CI is not blocked, but please review the backend changes.',
+              '',
+              '<details><summary>Last 40 lines of the failure log</summary>',
+              '',
+              '```text',
+              tail,
+              '```',
+              '</details>',
+            ].join('\n');
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ **Triton baseline (dispatch disabled) failed** on this runner.\n\nThe Triton backend produced incorrect results for at least one op (see #640). Dispatch coverage (e.g. TileLang) remains the gated path, so this does not block CI — please review the Triton kernel changes.'
+              body,
             });
-
-      - name: Run pytest on ops test files (dispatch ENABLED, backend coverage)
-        if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false' && steps.check-dispatch.outputs.dispatch_changed == 'true'
-        shell: bash
-        run: |
-          $CONDA_BIN_PATH/pytest -s -v --exitfirst ${{ steps.find-ops-tests.outputs.test_files }}
 
   test-models:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -40,6 +40,9 @@ on:
 jobs:
   test-ops:
     runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      issues: write
     env:
       FLA_CI_ENV: 1
 
@@ -87,27 +90,31 @@ jobs:
             echo "dispatch_changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Detect Triton baseline support
+      - name: Run pytest on ops test files (dispatch DISABLED, Triton baseline)
         if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false'
         id: triton-baseline
-        shell: bash
-        run: |
-          RUN_TRITON_BASELINE=$($CONDA_BIN_PATH/python -c "from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0; print('false' if IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 else 'true')")
-          echo "run=$RUN_TRITON_BASELINE" >> $GITHUB_OUTPUT
-          if [ "$RUN_TRITON_BASELINE" = "false" ]; then
-            echo "Skipping dispatch-disabled Triton baseline: gated chunk_bwd_dqkwg is blocked on Hopper with Triton >= 3.4.0 (#640)."
-          fi
-
-      - name: Run pytest on ops test files (dispatch DISABLED, Triton baseline)
-        if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false' && steps.triton-baseline.outputs.run == 'true'
+        continue-on-error: true
         shell: bash
         env:
           FLA_DISABLE_BACKEND_DISPATCH: "1"
         run: |
           $CONDA_BIN_PATH/pytest -s -v --exitfirst ${{ steps.find-ops-tests.outputs.test_files }}
 
+      - name: Comment on PR when Triton baseline fails
+        if: steps.triton-baseline.outcome == 'failure' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **Triton baseline (dispatch disabled) failed** on this runner.\n\nThe Triton backend produced incorrect results for at least one op (see #640). Dispatch coverage (e.g. TileLang) remains the gated path, so this does not block CI — please review the Triton kernel changes.'
+            });
+
       - name: Run pytest on ops test files (dispatch ENABLED, backend coverage)
-        if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false' && (steps.triton-baseline.outputs.run == 'false' || steps.check-dispatch.outputs.dispatch_changed == 'true')
+        if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false' && steps.check-dispatch.outputs.dispatch_changed == 'true'
         shell: bash
         run: |
           $CONDA_BIN_PATH/pytest -s -v --exitfirst ${{ steps.find-ops-tests.outputs.test_files }}

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -13,7 +13,13 @@ from fla.ops.common.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, autotune_cache_kwargs, check_shared_mem
+from fla.utils import (
+    IS_NVIDIA_HOPPER,
+    TRITON_ABOVE_3_4_0,
+    TRITON_ABOVE_3_7_1,
+    autotune_cache_kwargs,
+    check_shared_mem,
+)
 
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
@@ -674,11 +680,11 @@ def chunk_bwd_dqkwg(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    if g is not None and IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0:
+    if g is not None and IS_NVIDIA_HOPPER and TRITON_ABOVE_3_4_0 and not TRITON_ABOVE_3_7_1:
         raise RuntimeError(
-            "Triton >= 3.4.0 on Hopper GPUs produces incorrect results for "
-            "gated chunk_bwd_dqkwg (see #640). Please install tilelang: "
-            "`pip install tilelang`"
+            "Triton >= 3.4.0 and < 3.7.1 on Hopper GPUs produces incorrect results for "
+            "gated chunk_bwd_dqkwg (see #640). Please upgrade Triton to >= 3.7.1 or "
+            "install tilelang: `pip install tilelang`"
         )
 
     B, T, H, K, V, HV = *k.shape, v.shape[-1], v.shape[2]

--- a/fla/utils/__init__.py
+++ b/fla/utils/__init__.py
@@ -11,6 +11,7 @@ from ._compat import (  # noqa: F401
     SUPPORTS_AUTOTUNE_CACHE,
     TRITON_ABOVE_3_4_0,
     TRITON_ABOVE_3_5_1,
+    TRITON_ABOVE_3_7_1,
     autotune_cache_kwargs,
 )
 from ._config import (  # noqa: F401

--- a/fla/utils/_compat.py
+++ b/fla/utils/_compat.py
@@ -14,6 +14,7 @@ from ._config import FLA_CACHE_RESULTS
 
 TRITON_ABOVE_3_4_0 = package_version.parse(triton.__version__) >= package_version.parse("3.4.0")
 TRITON_ABOVE_3_5_1 = package_version.parse(triton.__version__) >= package_version.parse("3.5.1")
+TRITON_ABOVE_3_7_1 = package_version.parse(triton.__version__) >= package_version.parse("3.7.1")
 
 SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters
 autotune_cache_kwargs = {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}


### PR DESCRIPTION
## Summary
- The gated `chunk_bwd_dqkwg` precision bug (#640) is fixed in Triton 3.7.1, so stop blocking the Triton backend on Triton >= 3.7.1.
- Keep the guard only for the affected range `[3.4.0, 3.7.1)` on Hopper.
- CI: the dispatch-disabled **Triton baseline is now a hard gate** (it is the correctness reference); the **dispatch coverage (backend)** run is `continue-on-error` — when it fails, it posts a PR comment with the last 40 lines of the failure log instead of blocking CI.

## Changes
- `fla/utils`: add `TRITON_ABOVE_3_7_1`.
- `fla/ops/common/chunk_o.py`: raise only on `Hopper + 3.4.0 <= Triton < 3.7.1`; message suggests upgrading Triton.
- `.github/workflows/reusable-ci-tests.yml`: drop the "skip Triton baseline" gate; make the Triton baseline a hard gate; make dispatch coverage `continue-on-error` + comment the last 40 lines on failure.
- `.github/workflows/nvidia-h100.yml`: add `issues: write` so the PR-comment step can post.

## Known issue (not introduced here)
Re-enabling the Triton baseline surfaces a **pre-existing** `delta_rule` bug: `test_chunk_with_chunk_size[...-chunk64]` fails on Hopper + Triton >= 3.4 (`prepare_wy_repr_bwd` produces wrong `dk`/`dbeta` for BT=64). Tracked in **#984**; will be fixed in a follow-up PR.

## Test plan
- [ ] H100 CI (PyTorch 2.12 / Triton 3.7.1): Triton baseline runs and passes (except the known `delta_rule` case in #984); dispatch coverage unchanged.
- [ ] H100 CI (PyTorch 2.7 / Triton 3.3.1): unaffected.