### PR TITLE
[Fix] Restrict delta_rule prepare_wy_repr_bwd to num_warps=2 on Hopper

### DIFF
--- a/fla/ops/delta_rule/wy_fast.py
+++ b/fla/ops/delta_rule/wy_fast.py
@@ -15,7 +15,11 @@ from fla.ops.utils.op import safe_dot
 from fla.ops.utils.solve_tril import solve_tril
 from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
 
-NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
+# Triton miscompiles `prepare_wy_repr_bwd_kernel` with num_warps=4 on Hopper
+# (sm_90) for BT=64: it produces incorrect dk/dbeta (and can raise an illegal
+# memory access), while num_warps=2 is correct (see #984). Restrict the Hopper
+# autotune configs to num_warps=2 until the upstream compiler issue is resolved.
+NUM_WARPS = [2] if IS_NVIDIA_HOPPER else [2, 4, 8]
 
 
 @triton.heuristics({


### PR DESCRIPTION
## Summary
Fixes #984.

`tests/ops/test_delta.py::test_chunk_with_chunk_size[...-chunk64]` failed on Hopper (H100) with a large `dk`/`dbeta` error (`dk@64 ratio ~0.53`). The root cause is a Triton compiler miscompilation: for `BT=64` on Hopper (sm_90), the `num_warps=4` autotune config of `prepare_wy_repr_bwd_kernel` produces incorrect `dk`/`dbeta` (and in some shapes raises an illegal memory access), while `num_warps=2` is correct.

## Fix
Restrict the Hopper autotune configs of `prepare_wy_repr_bwd_kernel` to `num_warps=2`:

```python
NUM_WARPS = [2] if IS_NVIDIA_HOPPER else [2, 4, 8]
```

This matches the existing Hopper-specific `NUM_WARPS` restriction already used by `gated_delta_rule/wy_fast.py`, `common/chunk_o.py`, etc. (those exclude `num_warps=8` on Hopper); here `num_warps=4` is also excluded for the delta_rule backward kernel.

## Root-cause validation
Per-config bisection of `prepare_wy_repr_bwd_kernel` on H100 (BT=64, Triton 3.7.1):

| num_warps | num_stages | result |
|---|---|---|
| 2 | 2 / 3 / 4 | correct (dk corr ≈ 1) |
| 4 | 2 / 3 / 4 | illegal memory access |

Cross-arch check on GB200 / Blackwell (Triton 3.6.0): `num_warps=4` is correct there, so the miscompilation is Hopper-specific and the fix is correctly scoped to `IS_NVIDIA_HOPPER`.

## Test plan
- [ ] CI: `tests/ops/test_delta.py` passes on H100 (the `chunk64` parametrization is the regression test for #984).