### PR TITLE
[Fix] Prune oversized autotune configs in GLA chunk backward

### DIFF
--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -21,6 +21,35 @@ BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
 
 
+def _prune_gla_bwd_configs(configs, named_args, **kwargs):
+    """Drop configs whose block exceeds the tensor dims.
+
+    Triton's software-pipelined ``make_block_ptr`` can emit an out-of-bounds
+    prefetch when a block is larger than the tensor along a dimension (e.g.
+    ``BV=128`` for ``V=64``), even with ``boundary_check``. ``K`` and ``V`` are
+    kernel ``constexpr`` and are not forwarded to ``early_config_prune``, so we
+    recover them from the last dimension of the ``k``/``q`` and ``v``/``do``
+    tensors. Keep only configs whose block fits within ``K`` and ``V`` so
+    autotune never benchmarks those oversized configs. Always keep at least one
+    config.
+    """
+    K = V = None
+    for name in ('k', 'q'):
+        t = named_args.get(name)
+        if t is not None:
+            K = t.shape[-1]
+            break
+    for name in ('v', 'do', 'dv'):
+        t = named_args.get(name)
+        if t is not None:
+            V = t.shape[-1]
+            break
+    if K is None or V is None:
+        return configs
+    pruned = [c for c in configs if c.kwargs['BK'] <= K and c.kwargs['BV'] <= V]
+    return pruned or [min(configs, key=lambda c: (c.kwargs['BK'], c.kwargs['BV']))]
+
+
 @triton.heuristics({
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
@@ -585,7 +614,8 @@ def chunk_gla_bwd_kernel_dA(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'STATE_V_FIRST'],
+    key=['BT', 'STATE_V_FIRST', 'K', 'V'],
+    prune_configs_by={'early_config_prune': _prune_gla_bwd_configs},
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -668,7 +698,8 @@ def chunk_gla_bwd_kernel_dv(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'STATE_V_FIRST'],
+    key=['BT', 'STATE_V_FIRST', 'K', 'V'],
+    prune_configs_by={'early_config_prune': _prune_gla_bwd_configs},
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -21,33 +21,19 @@ BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
 
 
-def _prune_gla_bwd_configs(configs, named_args, **kwargs):
-    """Drop configs whose block exceeds the tensor dims.
-
-    Triton's software-pipelined ``make_block_ptr`` can emit an out-of-bounds
-    prefetch when a block is larger than the tensor along a dimension (e.g.
-    ``BV=128`` for ``V=64``), even with ``boundary_check``. ``K`` and ``V`` are
-    kernel ``constexpr`` and are not forwarded to ``early_config_prune``, so we
-    recover them from the last dimension of the ``k``/``q`` and ``v``/``do``
-    tensors. Keep only configs whose block fits within ``K`` and ``V`` so
-    autotune never benchmarks those oversized configs. Always keep at least one
-    config.
-    """
-    K = V = None
-    for name in ('k', 'q'):
-        t = named_args.get(name)
-        if t is not None:
-            K = t.shape[-1]
-            break
-    for name in ('v', 'do', 'dv'):
-        t = named_args.get(name)
-        if t is not None:
-            V = t.shape[-1]
-            break
-    if K is None or V is None:
-        return configs
-    pruned = [c for c in configs if c.kwargs['BK'] <= K and c.kwargs['BV'] <= V]
-    return pruned or [min(configs, key=lambda c: (c.kwargs['BK'], c.kwargs['BV']))]
+def _prune_gla_bwd_configs(configs, nargs, **kwargs):
+    # Keep a tile only if it leaves headroom below its dim, or is the smallest
+    # option (so small dims still autotune); this avoids a software-pipelined
+    # make_block_ptr prefetching past the tensor. K/V arrive as launch kwargs.
+    args = {**(nargs or {}), **kwargs}
+    K, V = args['K'], args['V']
+    min_bk = min(c.kwargs['BK'] for c in configs)
+    min_bv = min(c.kwargs['BV'] for c in configs)
+    return [
+        c for c in configs
+        if (c.kwargs['BK'] < K or c.kwargs['BK'] == min_bk)
+        and (c.kwargs['BV'] < V or c.kwargs['BV'] == min_bv)
+    ]
 
 
 @triton.heuristics({


### PR DESCRIPTION
## Summary

Fix an illegal memory access in the GLA varlen backward pass
(`chunk_gla_bwd_kernel_dv` / `chunk_gla_bwd_kernel_inter`) on Hopper,
exposed in #977.

## Root cause

The two kernels autotune over `BK ∈ {32, 64}` and `BV ∈ {64, 128}`.
For a small head dim (e.g. the GLA test shape K=32, V=64), a config
like `BV=128` makes the `make_block_ptr` block twice the tensor size.
Triton's software-pipelined `boundary_check` then emits an out-of-bounds
prefetch and the run aborts with an IMA.

This was latent on main: `find_dependent_tests.py` skips
`test_modeling_gla.py` on main (GLA files unchanged), so the kernel is
never exercised there. #977 touched `fla/layers/gla.py`, which selected
the test and surfaced it.

## Fix

Add an `early_config_prune` that drops any config whose block exceeds
the actual K/V, so autotune never benchmarks the oversized configs. K/V
are kernel `constexpr` and are not forwarded to the prune hook, so they
are recovered from the last dimension of the `k`/`q` and `v`/`do`
tensors. K/V are also added to the autotune key so different head dims
get separate cache entries — otherwise a config tuned for one K/V could
be reused for another where it is oversized.

## Test

- [ ] `tests/models/test_modeling_gla.py` passes on Hopper
  (`L4-B4-T1024-H4-D64-...-bfloat16` previously IMA'd here).
