### PR TITLE
[CI] Run op tests one file per process to avoid runner OOM

### DIFF
--- a/.github/workflows/reusable-ci-tests.yml
+++ b/.github/workflows/reusable-ci-tests.yml
@@ -93,7 +93,15 @@ jobs:
         env:
           FLA_DISABLE_BACKEND_DISPATCH: "1"
         run: |
-          $CONDA_BIN_PATH/pytest -s -v --exitfirst ${{ steps.find-ops-tests.outputs.test_files }}
+          # Run each test file in its own pytest process (single concurrency).
+          # The op suite accumulates Triton JIT caches, PyTorch allocator state
+          # and Python objects in a single process until it exceeds the runner's
+          # ~15GB RAM and gets OOM-killed (exit 137). One file per process
+          # releases all memory between files. --exitfirst still stops a file at
+          # its first failure.
+          for f in ${{ steps.find-ops-tests.outputs.test_files }}; do
+            $CONDA_BIN_PATH/pytest -s -v --exitfirst "$f" || exit 1
+          done
 
       - name: Run pytest on ops test files (dispatch ENABLED, backend coverage)
         if: steps.find-ops-tests.outputs.test_files && steps.setup.outputs.skip_tests == 'false' && steps.check-dispatch.outputs.dispatch_changed == 'true'
@@ -101,8 +109,13 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          $CONDA_BIN_PATH/pytest -s -v --exitfirst ${{ steps.find-ops-tests.outputs.test_files }} 2>&1 | tee /tmp/fla-dispatch-coverage.log
-          exit ${PIPESTATUS[0]}
+          # Same per-file splitting as the baseline batch above (avoid runner OOM).
+          # Append each file's output to the coverage log.
+          : > /tmp/fla-dispatch-coverage.log
+          for f in ${{ steps.find-ops-tests.outputs.test_files }}; do
+            $CONDA_BIN_PATH/pytest -s -v --exitfirst "$f" 2>&1 | tee -a /tmp/fla-dispatch-coverage.log
+            test ${PIPESTATUS[0]} -eq 0 || exit 1
+          done
 
       - name: Comment on PR when dispatch coverage fails
         if: steps.dispatch-coverage.outcome == 'failure' && github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

The H100 self-hosted runner has ~15GB RAM. Running the whole op test suite in a **single pytest process** accumulates Triton JIT caches, PyTorch allocator state and Python objects until it exceeds the limit and gets **OOM-killed (exit 137)**, e.g. in `tests/ops/test_kda.py`. This hits any PR that triggers the full op suite, regardless of the actual code change (observed on multiple PRs).

Run each test file in its **own pytest process** (single concurrency) so all memory is released between files. `--exitfirst` is preserved per process.

## Changes

- `.github/workflows/reusable-ci-tests.yml`: both op-test steps (dispatch DISABLED baseline and dispatch ENABLED coverage) now loop over the selected test files and run one `pytest` per file.
- The dispatch-coverage batch still appends to `/tmp/fla-dispatch-coverage.log` so the PR comment keeps working.

## Validation

On the H100 runner, the heaviest single file (`tests/ops/test_kda.py`, the one that OOM'd in the full-suite run) peaks at **~2.4GB RSS**, well under the 15GB limit. With one file per process, cumulative growth across files is eliminated.

## Notes

- This branch is based on `fix/gla-bwd-autotune-prune` (#989) so that CI can demonstrate the OOM fix without the unrelated GLA illegal-memory-access failure masking it. It should be rebased onto `main` after #989 lands (GitHub will retarget automatically).
- Out of scope: `tests/ops/test_kda.py::test_chunk` shows pre-existing fp16 numerical flakiness (autotune config-selection dependent); it is unrelated to this change and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)