### PR TITLE
[Conv] Chunk Ascend causal_conv1d launches for 65535 grid limit

### DIFF
--- a/fla/modules/backends/triton_ascend/causal_conv1d.py
+++ b/fla/modules/backends/triton_ascend/causal_conv1d.py
@@ -16,6 +16,8 @@ from fla.ops.utils import prepare_chunk_indices
 from fla.utils import input_guard
 
 STATIC_WARPS = 2
+# Ascend Triton rejects grids whose product exceeds 65535 (see fla/modules/token_shift.py).
+_NPU_MAX_TRITON_GRID = 65535
 
 
 def _npu_chunk_size(T: int, BT: int) -> int:
@@ -31,9 +33,18 @@ def _npu_chunk_size(T: int, BT: int) -> int:
 
 
 def _clamp_bd_for_grid(B: int, NT: int, D: int, BD: int) -> int:
-    while triton.cdiv(D, BD) * NT * B >= 65536 and BD < 64:
+    while triton.cdiv(D, BD) * NT * B > _NPU_MAX_TRITON_GRID and BD < 64:
         BD *= 2
     return BD
+
+
+def _npu_max_axis_chunks(grid_dim0: int, batch: int = 1) -> int:
+    denom = grid_dim0 * batch
+    if denom > _NPU_MAX_TRITON_GRID:
+        raise RuntimeError(
+            f'Ascend Triton grid dim0*batch={denom} exceeds {_NPU_MAX_TRITON_GRID}',
+        )
+    return max(1, _NPU_MAX_TRITON_GRID // max(denom, 1))
 
 
 def _npu_tile_config(
@@ -46,7 +57,9 @@ def _npu_tile_config(
     BT = _npu_chunk_size(T, BT)
     BD = 16
     if D >= 1024:
-        BD = 4
+        # BD=4 overflows Ascend UB on large-D forward; cap BT to limit NT.
+        BD = 8
+        BT = min(BT, 32)
     elif D >= 512:
         BD = 8
     if dtype == torch.float16 and initial_state is not None:
@@ -115,6 +128,7 @@ def causal_conv1d_fwd_kernel(
     HAS_BIAS: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    CHUNK_OFFSET: tl.constexpr,
 ):
     i_d, i_t, i_b = tl.program_id(0), tl.program_id(1), tl.program_id(2)
 
@@ -126,6 +140,7 @@ def causal_conv1d_fwd_kernel(
         p_y = y + bos * stride_y_t
     else:
         i_n = i_b
+        i_t = i_t + CHUNK_OFFSET
         bos = (i_b * T).to(tl.int64)
         p_x = x + tl.cast(i_b, tl.int64) * stride_x_n
         p_y = y + tl.cast(i_b, tl.int64) * stride_y_n
@@ -425,6 +440,8 @@ def causal_conv1d_bwd_kernel(
     USE_INITIAL_STATE: tl.constexpr,
     USE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    CHUNK_OFFSET: tl.constexpr,
+    NT: tl.constexpr,
 ):
     i_d, i_t, i_b = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     if IS_VARLEN:
@@ -436,7 +453,8 @@ def causal_conv1d_bwd_kernel(
         p_dy = dy + bos * stride_dy_t
         p_dx = dx + bos * stride_dx_t
     else:
-        i_tg = i_b * tl.num_programs(1) + i_t
+        i_t = i_t + CHUNK_OFFSET
+        i_tg = i_b * NT + i_t
         i_n = i_b
         p_x = x + tl.cast(i_b, tl.int64) * stride_x_n
         p_dy = dy + tl.cast(i_b, tl.int64) * stride_dy_n
@@ -543,8 +561,9 @@ def compute_dh0_kernel(
     BD: tl.constexpr,
     USE_ACTIVATION: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    CHUNK_OFFSET: tl.constexpr,
 ):
-    i_d, i_n = tl.program_id(0), tl.program_id(1)
+    i_d, i_n = tl.program_id(0), tl.program_id(1) + CHUNK_OFFSET
 
     if IS_VARLEN:
         bos = tl.load(cu_seqlens + i_n).to(tl.int64)
@@ -604,8 +623,9 @@ def causal_conv1d_states_fwd_kernel(
     BW: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    CHUNK_OFFSET: tl.constexpr,
 ):
-    i_d, i_n = tl.program_id(0), tl.program_id(1)
+    i_d, i_n = tl.program_id(0), tl.program_id(1) + CHUNK_OFFSET
 
     o_d = i_d * BD + tl.arange(0, BD)
     m_d = o_d < D
@@ -665,8 +685,9 @@ def causal_conv1d_update_kernel(
     BD: tl.constexpr,
     HAS_WEIGHT: tl.constexpr,
     HAS_BIAS: tl.constexpr,
+    CHUNK_OFFSET: tl.constexpr,
 ):
-    i_d, i_n = tl.program_id(0), tl.program_id(1)
+    i_d, i_n = tl.program_id(0), tl.program_id(1) + CHUNK_OFFSET
 
     o_d = i_d * BD + tl.arange(0, BD)
     m_d = o_d < D
@@ -738,15 +759,14 @@ def _launch_fwd_core(
     y = torch.zeros_like(x, memory_format=torch.contiguous_format)
     stride_y_n, stride_y_t, stride_y_d = y.stride()
 
-    grid = (triton.cdiv(D, BD), NT, B)
-    causal_conv1d_fwd_kernel[grid](
+    max_nt = _npu_max_axis_chunks(triton.cdiv(D, BD), B)
+    kernel_kwargs = dict(
         x=x,
         y=y,
         weight=weight,
         bias=bias,
         cu_seqlens=cu_seqlens,
         initial_state=initial_state,
-        chunk_indices=chunk_indices,
         B=B,
         T=T,
         D=D,
@@ -762,6 +782,16 @@ def _launch_fwd_core(
         stride_y_d=stride_y_d,
         num_warps=num_warps,
     )
+    for nt_off in range(0, NT, max_nt):
+        nt_len = min(max_nt, NT - nt_off)
+        grid = (triton.cdiv(D, BD), nt_len, B)
+        if cu_seqlens is not None:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['CHUNK_OFFSET'] = 0
+        else:
+            kernel_kwargs['chunk_indices'] = chunk_indices
+            kernel_kwargs['CHUNK_OFFSET'] = nt_off
+        causal_conv1d_fwd_kernel[grid](**kernel_kwargs)
     return y
 
 
@@ -892,18 +922,15 @@ def causal_conv1d_bwd_npu(
         stride_dy_n, stride_dy_t, stride_dy_d = dy_conv.stride()
         dw = weight.new_empty(B * NT, *weight.shape, dtype=torch.float) if weight is not None else None
         db = bias.new_empty(B * NT, *bias.shape, dtype=torch.float) if bias is not None else None
-        grid = (triton.cdiv(D, BD), NT, B)
-        causal_conv1d_bwd_kernel[grid](
+        max_nt = _npu_max_axis_chunks(triton.cdiv(D, BD), B)
+        kernel_kwargs = dict(
             x=x,
             weight=weight,
             initial_state=initial_state,
             dht=dht,
             dy=dy_conv,
             dx=dx,
-            dw=dw,
-            db=db,
             cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
             B=B,
             T=T,
             D=D,
@@ -921,7 +948,22 @@ def causal_conv1d_bwd_npu(
             stride_dy_t=stride_dy_t,
             stride_dy_d=stride_dy_d,
             num_warps=num_warps,
+            NT=NT,
         )
+        for nt_off in range(0, NT, max_nt):
+            nt_len = min(max_nt, NT - nt_off)
+            grid = (triton.cdiv(D, BD), nt_len, B)
+            if cu_seqlens is not None:
+                kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+                kernel_kwargs['CHUNK_OFFSET'] = 0
+                kernel_kwargs['dw'] = dw[nt_off:nt_off + nt_len] if weight is not None else None
+                kernel_kwargs['db'] = db[nt_off:nt_off + nt_len] if bias is not None else None
+            else:
+                kernel_kwargs['chunk_indices'] = chunk_indices
+                kernel_kwargs['CHUNK_OFFSET'] = nt_off
+                kernel_kwargs['dw'] = dw
+                kernel_kwargs['db'] = db
+            causal_conv1d_bwd_kernel[grid](**kernel_kwargs)
     if weight is not None:
         dw = dw.sum(0).to(weight)
     if bias is not None:
@@ -955,7 +997,6 @@ def compute_dh0_npu(
 
     BD = 8 if dy.dtype == torch.float16 and activation in ('swish', 'silu') else 16
     dh0 = torch.zeros_like(initial_state)
-    grid = (triton.cdiv(D, BD), N)
 
     stride_dy_n = dy.stride(0)
     stride_dy_t = dy.stride(1)
@@ -966,10 +1007,10 @@ def compute_dh0_npu(
         stride_y_t = y.stride(1)
         stride_y_d = y.stride(2) if y.dim() == 3 else y.stride(-1)
 
-    y_to_pass = y if activation in ('swish', 'silu') else None
-    compute_dh0_kernel[grid](
+    max_n = _npu_max_axis_chunks(triton.cdiv(D, BD))
+    kernel_kwargs = dict(
         dy=dy,
-        y=y_to_pass,
+        y=y if activation in ('swish', 'silu') else None,
         weight=weight,
         dh0=dh0,
         cu_seqlens=cu_seqlens,
@@ -985,6 +1026,10 @@ def compute_dh0_npu(
         BD=BD,
         num_warps=STATIC_WARPS,
     )
+    for n_off in range(0, N, max_n):
+        n_len = min(max_n, N - n_off)
+        kernel_kwargs['CHUNK_OFFSET'] = n_off
+        compute_dh0_kernel[(triton.cdiv(D, BD), n_len)](**kernel_kwargs)
     return dh0
 
 
@@ -1017,9 +1062,9 @@ def causal_conv1d_update_states_npu(
     final_state = torch.empty(N, D, W, dtype=x.dtype, device=x.device)
     BD = min(triton.next_power_of_2(D), 16)
     BW = triton.next_power_of_2(W)
-    grid = (triton.cdiv(D, BD), N)
-
-    causal_conv1d_states_fwd_kernel[grid](
+    grid_dim0 = triton.cdiv(D, BD)
+    max_n = _npu_max_axis_chunks(grid_dim0)
+    kernel_kwargs = dict(
         x=x,
         initial_state=initial_state,
         final_state=final_state,
@@ -1034,6 +1079,10 @@ def causal_conv1d_update_states_npu(
         BD=BD,
         num_warps=STATIC_WARPS,
     )
+    for n_off in range(0, N, max_n):
+        n_len = min(max_n, N - n_off)
+        kernel_kwargs['CHUNK_OFFSET'] = n_off
+        causal_conv1d_states_fwd_kernel[(grid_dim0, n_len)](**kernel_kwargs)
     return final_state
 
 
@@ -1076,8 +1125,9 @@ def causal_conv1d_update_npu(
     elif y.dim() == 3:
         stride_y_n, stride_y_d = y.stride(0), y.stride(2)
 
-    grid = (triton.cdiv(D, BD), N)
-    causal_conv1d_update_kernel[grid](
+    grid_dim0 = triton.cdiv(D, BD)
+    max_n = _npu_max_axis_chunks(grid_dim0)
+    kernel_kwargs = dict(
         x=x,
         cache=cache,
         y=y,
@@ -1092,5 +1142,9 @@ def causal_conv1d_update_npu(
         BD=BD,
         num_warps=STATIC_WARPS,
     )
+    for n_off in range(0, N, max_n):
+        n_len = min(max_n, N - n_off)
+        kernel_kwargs['CHUNK_OFFSET'] = n_off
+        causal_conv1d_update_kernel[(grid_dim0, n_len)](**kernel_kwargs)
     y = _postprocess_update(y, residual, activation)
     return y.view(shape), cache

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -956,26 +956,39 @@ def test_conv_cache_backward(
         assert_close(name, g_ref, g_tri, ratio=1e-3)
 
 
-def test_conv_varlen_initial_state_backward_random():
+@pytest.mark.parametrize(
+    ('T', 'lengths', 'D'),
+    [
+        pytest.param(256, None, 128, id='random_split_T256'),
+        pytest.param(None, [32] * 128 + [8192], 4096, id='packed_128x32_8k'),
+    ],
+)
+def test_conv_varlen_initial_state_backward_random(T, lengths, D):
+    activation = "swish"
+    W = 4
     torch.manual_seed(1234)
     B = 1
-    T = 256
-    D = 128
-    W = 4
-    activation = "swish"
-
-    # Random but deterministic split into two sequences
-    l1 = int(torch.randint(low=W, high=T - W, size=(1,)).item())
-    cu_seqlens = torch.tensor([0, l1, T], device=device, dtype=torch.int32)
+    if lengths is None:
+        # Random but deterministic split into two sequences.
+        l1 = int(torch.randint(low=W, high=T - W, size=(1,)).item())
+        cu_seqlens = torch.tensor([0, l1, T], device=device, dtype=torch.int32)
+    else:
+        T = sum(lengths)
+        cu_seqlens = torch.tensor(
+            [0, *torch.cumsum(torch.tensor(lengths), 0).tolist()],
+            device=device,
+            dtype=torch.int32,
+        )
 
     x = torch.randn(B, T, D, device=device, dtype=torch.float32, requires_grad=True)
     weight = torch.randn(D, W, device=device, dtype=torch.float32, requires_grad=True)
     bias = torch.randn(D, device=device, dtype=torch.float32, requires_grad=True)
 
     # initial_state uses padded layout [N, D, W] with column 0 as padding
-    initial_state = torch.zeros(2, D, W, device=device, dtype=torch.float32, requires_grad=True)
+    num_seqs = cu_seqlens.numel() - 1
+    initial_state = torch.zeros(num_seqs, D, W, device=device, dtype=torch.float32, requires_grad=True)
     with torch.no_grad():
-        initial_state[:, :, 1:].copy_(torch.randn(2, D, W - 1, device=device, dtype=torch.float32))
+        initial_state[:, :, 1:].copy_(torch.randn(num_seqs, D, W - 1, device=device, dtype=torch.float32))
 
     dy = torch.randn_like(x)
 
@@ -1015,6 +1028,61 @@ def test_conv_varlen_initial_state_backward_random():
         bias=bias,
         activation=activation,
         cu_seqlens=cu_seqlens,
+        initial_state=initial_state,
+    )
+    loss_tri = (y_tri * dy).sum()
+    grads_tri = torch.autograd.grad(
+        loss_tri,
+        (x, weight, bias, initial_state),
+        retain_graph=False,
+        create_graph=False,
+    )
+
+    assert_close("dx", grads_ref[0], grads_tri[0], ratio=1e-3)
+    assert_close("dw", grads_ref[1], grads_tri[1], ratio=1e-3)
+    assert_close("db", grads_ref[2], grads_tri[2], ratio=1e-3)
+    assert_close("d_init", grads_ref[3], grads_tri[3], ratio=1e-3)
+
+
+def test_conv_dense_initial_state_backward_large_nt():
+    """Dense bwd with NT grid chunking (CHUNK_OFFSET + global i_tg indexing)."""
+    activation = "swish"
+    W = 4
+    B, T, D = 1, 8192, 4096
+    torch.manual_seed(1234)
+
+    x = torch.randn(B, T, D, device=device, dtype=torch.float32, requires_grad=True)
+    weight = torch.randn(D, W, device=device, dtype=torch.float32, requires_grad=True)
+    bias = torch.randn(D, device=device, dtype=torch.float32, requires_grad=True)
+    initial_state = torch.zeros(B, D, W, device=device, dtype=torch.float32, requires_grad=True)
+    with torch.no_grad():
+        initial_state[:, :, 1:].copy_(torch.randn(B, D, W - 1, device=device, dtype=torch.float32))
+
+    dy = torch.randn_like(x)
+    cache = initial_state[:, :, 1:].contiguous()
+
+    out_ref, _ = causal_conv1d_ref_torch(
+        x.transpose(1, 2),
+        weight,
+        bias,
+        initial_state=cache,
+        output_final_state=True,
+        activation=activation,
+    )
+    y_ref = out_ref.transpose(1, 2)
+    loss_ref = (y_ref * dy).sum()
+    grads_ref = torch.autograd.grad(
+        loss_ref,
+        (x, weight, bias, initial_state),
+        retain_graph=False,
+        create_graph=False,
+    )
+
+    y_tri, _ = causal_conv1d(
+        x=x,
+        weight=weight,
+        bias=bias,
+        activation=activation,
         initial_state=initial_state,
     )
     loss_tri = (y_tri * dy).sum()


### PR DESCRIPTION
## Summary

Fixes #981. On Ascend, `causal_conv1d` backward can hang or fail when the Triton launch grid product exceeds **65535** (e.g. varlen packed training with many short sequences and large `D`).

This PR adds NT/N-axis launch chunking for the triton-ascend `causal_conv1d` backend, fixes dense backward gradient indexing under chunked launches, and adjusts forward tile config for large `D` to avoid UB overflow.

## Changes

- Introduce `_NPU_MAX_TRITON_GRID = 65535` and `_npu_max_axis_chunks()` for safe axis chunking
- Chunk launches in: forward, backward, `compute_dh0`, `causal_conv1d_states_fwd`, and `causal_conv1d_update`
- Dense backward: use `i_tg = i_b * NT + i_t` with full `dw`/`db` buffers (fixes mis-indexing across chunks)
- Forward tile config for `D >= 1024`: `BD=8`, `BT <= 32` (avoids Ascend UB overflow on large-D forward)
- Raise `RuntimeError` when `cdiv(D, BD) * B` already exceeds 65535 (batch axis not chunked)


## Test plan

- [x] `test_conv_varlen_initial_state_backward_random[random_split_T256]` — original random varlen backward
- [x] `test_conv_varlen_initial_state_backward_random[packed_128x32_8k]` — varlen large-D / multi-chunk backward
- [x] `test_conv_dense_initial_state_backward_large_nt` — dense NT chunking + global `i_tg` indexing
