### PR TITLE
[Fix] Probe TileLang availability via find_spec to avoid per-dispatch import cost

### DIFF
--- a/fla/ops/common/backends/tilelang/__init__.py
+++ b/fla/ops/common/backends/tilelang/__init__.py
@@ -14,11 +14,15 @@ hardware-specific regressions (see #640). Can also be forced via FLA_TILELANG=1.
 from __future__ import annotations
 
 import os
+from importlib.util import find_spec
 
 import torch
 
 from fla.ops.backends import BaseBackend
 from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0
+
+# find_spec, not `import tilelang`: probe availability without triggering it
+_TILELANG_AVAILABLE = find_spec("tilelang") is not None
 
 
 class TileLangBackend(BaseBackend):
@@ -29,11 +33,7 @@ class TileLangBackend(BaseBackend):
 
     @classmethod
     def is_available(cls) -> bool:
-        try:
-            import tilelang  # noqa: F401
-            return True
-        except ImportError:
-            return False
+        return _TILELANG_AVAILABLE
 
     @classmethod
     def is_enabled(cls) -> bool:

--- a/fla/ops/kda/backends/tilelang/__init__.py
+++ b/fla/ops/kda/backends/tilelang/__init__.py
@@ -9,9 +9,14 @@
 
 from __future__ import annotations
 
+from importlib.util import find_spec
+
 import torch
 
 from fla.ops.backends import BaseBackend
+
+# find_spec, not `import tilelang`: probe availability without triggering it
+_TILELANG_AVAILABLE = find_spec("tilelang") is not None
 
 
 class KDATileLangBackend(BaseBackend):
@@ -22,11 +27,7 @@ class KDATileLangBackend(BaseBackend):
 
     @classmethod
     def is_available(cls) -> bool:
-        try:
-            import tilelang  # noqa: F401
-            return True
-        except ImportError:
-            return False
+        return _TILELANG_AVAILABLE
 
     def chunk_kda_bwd_wy_dqkg_fused_verifier(
         self,


### PR DESCRIPTION
## Summary

The TileLang backends' `is_available()` (both `fla/ops/common/backends/tilelang` and `fla/ops/kda/backends/tilelang`) probed for the package by running `import tilelang` inside a `try/except` on **every call**. A failed import is not cached in `sys.modules`, so when `tilelang` is not installed each call re-ran the full import machinery — ~400+µs measured per call on a cold miss.

This matters because the dispatch hot path calls `is_available()` directly on every dispatched op (it intentionally bypasses the `@cache`'d `can_use()` to stay out of `torch.compile` tracing). So the cost recurred on every forward/backward of `chunk_bwd_dqkwg` (simple_gla / comba / gated_delta_rule / delta_rule) and the KDA backward — pure overhead for users without `tilelang`, scaling with layers × steps.

<img width="1624" height="490" alt="image" src="https://github.com/user-attachments/assets/d60ed2f4-bbed-4aeb-b368-fae8b3938ac3" />


## Changes
This PR resolves availability **once at module load** via `importlib.util.find_spec`, which locates the package without executing it, and `is_available()` now returns the cached bool. Benefits:

- Per-call cost drops from ~400+µs to a bool read.
- `tilelang`/TVM initialization stays deferred to the kernel call sites that actually import it — `find_spec` never triggers it.

This also aligns the two overrides with the base `BaseBackend.is_available()`, which already uses `find_spec(package_name)`.


## Test plan

- `python -m py_compile` on both changed files — pass.
- AST check confirming `is_available()` is a plain `return _TILELANG_AVAILABLE` with no decorators, and that the module-level flag is assigned via `find_spec`.
- Microbenchmark reproducing the import-vs-find_spec gap (~400+µs `import` miss vs ~0.05µs bool read), and confirming a failed `import` leaves no `sys.modules` entry (hence no caching).
