### PR TITLE
[Perf] Optimize Ascend NPU activation kernels

### DIFF
--- a/fla/modules/backends/triton_ascend/activations.py
+++ b/fla/modules/backends/triton_ascend/activations.py
@@ -13,19 +13,69 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp, log
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
-# Ascend vector UB is small; keep warps and tile sizes conservative.
-NUM_WARPS_AUTOTUNE = [2, 4]
-BLOCK_SIZES_AUTOTUNE = [512, 1024, 2048]
-STATIC_WARPS = 2
-STATIC_BLOCK_SIZE = 1024
+# Ascend launch limits: grid dim and per-core vector width.
+_PREFERRED_BLOCK_SIZES = (2048, 1024, 512)
+_MAX_GRID_DIM = 65535
+_MAX_CORE_DIM = 65535
+
+
+def _activation_launch_config(T: int) -> tuple[tuple[int], int]:
+    """Pick block size under Ascend launch limits."""
+    for B in _PREFERRED_BLOCK_SIZES:
+        if triton.cdiv(T, B) <= _MAX_GRID_DIM and B * 8 <= _MAX_CORE_DIM:
+            return (triton.cdiv(T, B),), B
+    B = min(triton.cdiv(T, _MAX_GRID_DIM), _MAX_CORE_DIM // 8)
+    return (triton.cdiv(T, B),), max(B, 1)
+
+
+@triton.jit
+def _flat_offset(
+    offs,
+    D: tl.constexpr,
+    stride,
+    IS_LINEAR: tl.constexpr,
+):
+    if IS_LINEAR:
+        return offs
+    row = offs // D
+    col = offs % D
+    return row * stride + col
 
 
 def _get_stride(x: torch.Tensor) -> int:
     if x.ndim < 2:
         return 0
     return x.stride(-2)
+
+
+def _is_linear_stride(stride: int, D: int) -> bool:
+    return stride == D
+
+
+_LINEAR_HEURISTICS_XY = {
+    'X_LINEAR': lambda args: _is_linear_stride(args['stride_x_row'], args['D']),
+    'Y_LINEAR': lambda args: _is_linear_stride(args['stride_y_row'], args['D']),
+}
+
+_LINEAR_HEURISTICS_XYZ = {
+    **_LINEAR_HEURISTICS_XY,
+    'Z_LINEAR': lambda args: _is_linear_stride(args['stride_z_row'], args['D']),
+}
+
+_LINEAR_HEURISTICS_BWD = {
+    'X_LINEAR': lambda args: _is_linear_stride(args['stride_x_row'], args['D']),
+    'DY_LINEAR': lambda args: _is_linear_stride(args['stride_dy_row'], args['D']),
+    'DX_LINEAR': lambda args: _is_linear_stride(args['stride_dx_row'], args['D']),
+}
+
+_LINEAR_HEURISTICS_FWDBWD = {
+    **_LINEAR_HEURISTICS_XYZ,
+    'G_LINEAR': lambda args: _is_linear_stride(args['stride_g_row'], args['D']),
+    'DX_LINEAR': lambda args: _is_linear_stride(args['stride_dx_row'], args['D']),
+    'DY_LINEAR': lambda args: _is_linear_stride(args['stride_dy_row'], args['D']),
+}
 
 
 def _is_inner_contiguous(x: torch.Tensor) -> bool:
@@ -62,15 +112,7 @@ def _alloc_output(x: torch.Tensor, contiguous: bool = False) -> torch.Tensor:
     return torch.empty_like(x)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_XY)
 @triton.jit(do_not_specialize=['T'])
 def sigmoid_fwd_kernel(
     x, y,
@@ -79,28 +121,20 @@ def sigmoid_fwd_kernel(
     stride_x_row,
     stride_y_row,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    y_off = row * stride_y_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
-    y_val = 1.0 / (1.0 + exp(-x_val))
+    y_val = tl.sigmoid(x_val)
     tl.store(y + y_off, y_val.to(y.dtype.element_ty), mask=mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_BWD)
 @triton.jit(do_not_specialize=['T'])
 def sigmoid_bwd_kernel(
     x, dy, dx,
@@ -110,31 +144,24 @@ def sigmoid_bwd_kernel(
     stride_dy_row,
     stride_dx_row,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    DY_LINEAR: tl.constexpr,
+    DX_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    dy_off = row * stride_dy_row + col
-    dx_off = row * stride_dx_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    dy_off = _flat_offset(offs, D, stride_dy_row, DY_LINEAR)
+    dx_off = _flat_offset(offs, D, stride_dx_row, DX_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     g_val = tl.load(dy + dy_off, mask=mask, other=0.).to(tl.float32)
-    s = 1.0 / (1.0 + exp(-x_val))
+    s = tl.sigmoid(x_val)
     dx_val = g_val * s * (1.0 - s)
     tl.store(dx + dx_off, dx_val.to(dx.dtype.element_ty), mask=mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_XY)
 @triton.jit(do_not_specialize=['T'])
 def logsigmoid_fwd_kernel(
     x,
@@ -145,31 +172,23 @@ def logsigmoid_fwd_kernel(
     stride_x_row,
     stride_y_row,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
 ):
     i = tl.program_id(0)
-    o_i = i * B + tl.arange(0, B)
-    m_i = o_i < T
-    row = o_i // D
-    col = o_i % D
-    x_off = row * stride_x_row + col
-    y_off = row * stride_y_row + col
+    offs = i * B + tl.arange(0, B)
+    mask = offs < T
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
 
-    b_x = tl.load(x + x_off, mask=m_i, other=0.).to(tl.float32)
+    b_x = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     b_m = tl.minimum(0., b_x)
     b_z = 1. + exp(-tl.abs(b_x))
     b_y = (b_m - log(b_z)) / temperature
-    tl.store(y + y_off, b_y.to(y.dtype.element_ty), mask=m_i)
+    tl.store(y + y_off, b_y.to(y.dtype.element_ty), mask=mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_BWD)
 @triton.jit(do_not_specialize=['T'])
 def logsigmoid_bwd_kernel(
     x,
@@ -182,32 +201,25 @@ def logsigmoid_bwd_kernel(
     stride_dx_row,
     stride_dy_row,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    DX_LINEAR: tl.constexpr,
+    DY_LINEAR: tl.constexpr,
 ):
     i = tl.program_id(0)
-    o_i = i * B + tl.arange(0, B)
-    m_i = o_i < T
-    row = o_i // D
-    col = o_i % D
-    x_off = row * stride_x_row + col
-    dx_off = row * stride_dx_row + col
-    dy_off = row * stride_dy_row + col
+    offs = i * B + tl.arange(0, B)
+    mask = offs < T
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    dx_off = _flat_offset(offs, D, stride_dx_row, DX_LINEAR)
+    dy_off = _flat_offset(offs, D, stride_dy_row, DY_LINEAR)
 
-    b_x = tl.load(x + x_off, mask=m_i, other=0.).to(tl.float32)
-    b_dy = tl.load(dy + dy_off, mask=m_i, other=0.).to(tl.float32)
-    b_s = 1.0 / (1.0 + exp(-b_x))
+    b_x = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
+    b_dy = tl.load(dy + dy_off, mask=mask, other=0.).to(tl.float32)
+    b_s = tl.sigmoid(b_x)
     b_dx = b_dy * ((1. - b_s) / temperature)
-    tl.store(dx + dx_off, b_dx.to(dx.dtype.element_ty), mask=m_i)
+    tl.store(dx + dx_off, b_dx.to(dx.dtype.element_ty), mask=mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_XY)
 @triton.jit(do_not_specialize=['T'])
 def swish_fwd_kernel(
     x, y,
@@ -216,29 +228,21 @@ def swish_fwd_kernel(
     stride_x_row,
     stride_y_row,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    y_off = row * stride_y_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
-    s = 1.0 / (1.0 + exp(-x_val))
+    s = tl.sigmoid(x_val)
     y_val = x_val * s
     tl.store(y + y_off, y_val.to(y.dtype.element_ty), mask=mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_BWD)
 @triton.jit(do_not_specialize=['T'])
 def swish_bwd_kernel(
     x, dy, dx,
@@ -248,31 +252,24 @@ def swish_bwd_kernel(
     stride_dy_row,
     stride_dx_row,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    DY_LINEAR: tl.constexpr,
+    DX_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    dy_off = row * stride_dy_row + col
-    dx_off = row * stride_dx_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    dy_off = _flat_offset(offs, D, stride_dy_row, DY_LINEAR)
+    dx_off = _flat_offset(offs, D, stride_dx_row, DX_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     g_val = tl.load(dy + dy_off, mask=mask, other=0.).to(tl.float32)
-    s = 1.0 / (1.0 + exp(-x_val))
+    s = tl.sigmoid(x_val)
     dx_val = g_val * s * (1.0 + x_val * (1.0 - s))
     tl.store(dx + dx_off, dx_val.to(dx.dtype.element_ty), mask=mask)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_XYZ)
 @triton.jit(do_not_specialize=['T'])
 def swiglu_fwd_kernel(
     x, y, z,
@@ -282,34 +279,27 @@ def swiglu_fwd_kernel(
     stride_y_row,
     stride_z_row,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
+    Z_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    y_off = row * stride_y_row + col
-    z_off = row * stride_z_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
+    z_off = _flat_offset(offs, D, stride_z_row, Z_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     y_val = tl.load(y + y_off, mask=mask, other=0.).to(tl.float32)
-    s = 1.0 / (1.0 + exp(-x_val))
+    s = tl.sigmoid(x_val)
     z_val = x_val * s * y_val
     tl.store(z + z_off, z_val.to(z.dtype.element_ty), mask=mask)
 
 
 @triton.heuristics({
     'HAS_WEIGHT': lambda args: args['z'] is not None,
+    **_LINEAR_HEURISTICS_FWDBWD,
 })
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in BLOCK_SIZES_AUTOTUNE
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
 @triton.jit(do_not_specialize=['T'])
 def swiglu_fwdbwd_kernel(
     x, y, g, dx, dy, z,
@@ -323,22 +313,26 @@ def swiglu_fwdbwd_kernel(
     stride_z_row,
     B: tl.constexpr,
     HAS_WEIGHT: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
+    G_LINEAR: tl.constexpr,
+    DX_LINEAR: tl.constexpr,
+    DY_LINEAR: tl.constexpr,
+    Z_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    y_off = row * stride_y_row + col
-    g_off = row * stride_g_row + col
-    dx_off = row * stride_dx_row + col
-    dy_off = row * stride_dy_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
+    g_off = _flat_offset(offs, D, stride_g_row, G_LINEAR)
+    dx_off = _flat_offset(offs, D, stride_dx_row, DX_LINEAR)
+    dy_off = _flat_offset(offs, D, stride_dy_row, DY_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     y_val = tl.load(y + y_off, mask=mask, other=0.).to(tl.float32)
     g_val = tl.load(g + g_off, mask=mask, other=0.).to(tl.float32)
 
-    s = 1.0 / (1.0 + exp(-x_val))
+    s = tl.sigmoid(x_val)
     x_s = x_val * s
     dx_val = g_val * s * (1.0 + x_val * (1.0 - s)) * y_val
     dy_val = g_val * x_s
@@ -346,11 +340,12 @@ def swiglu_fwdbwd_kernel(
     tl.store(dx + dx_off, dx_val.to(dx.dtype.element_ty), mask=mask)
     tl.store(dy + dy_off, dy_val.to(dy.dtype.element_ty), mask=mask)
     if HAS_WEIGHT:
-        z_off = row * stride_z_row + col
+        z_off = _flat_offset(offs, D, stride_z_row, Z_LINEAR)
         z_val = x_s * y_val
         tl.store(z + z_off, z_val.to(z.dtype.element_ty), mask=mask)
 
 
+@triton.heuristics(_LINEAR_HEURISTICS_XY)
 @triton.jit(do_not_specialize=['T'])
 def gelu_fwd_kernel(
     x, y,
@@ -358,23 +353,23 @@ def gelu_fwd_kernel(
     D: tl.constexpr,
     stride_x_row,
     stride_y_row,
-    BLOCK_SIZE: tl.constexpr,
+    B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    y_off = row * stride_y_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     t = 0.79788456 * x_val * (1.0 + 0.044715 * x_val * x_val)
-    s = 1.0 / (1.0 + exp(-2.0 * t))
-    tanh_out = 2.0 * s - 1.0
+    tanh_out = tl.tanh(t)
     y_val = x_val * 0.5 * (1.0 + tanh_out)
     tl.store(y + y_off, y_val.to(y.dtype.element_ty), mask=mask)
 
 
+@triton.heuristics(_LINEAR_HEURISTICS_BWD)
 @triton.jit(do_not_specialize=['T'])
 def gelu_bwd_kernel(
     x, dy, dx,
@@ -383,21 +378,21 @@ def gelu_bwd_kernel(
     stride_x_row,
     stride_dy_row,
     stride_dx_row,
-    BLOCK_SIZE: tl.constexpr,
+    B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    DY_LINEAR: tl.constexpr,
+    DX_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    dy_off = row * stride_dy_row + col
-    dx_off = row * stride_dx_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    dy_off = _flat_offset(offs, D, stride_dy_row, DY_LINEAR)
+    dx_off = _flat_offset(offs, D, stride_dx_row, DX_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     g_val = tl.load(dy + dy_off, mask=mask, other=0.).to(tl.float32)
     t = 0.79788456 * x_val * (1.0 + 0.044715 * x_val * x_val)
-    s = 1.0 / (1.0 + exp(-2.0 * t))
-    tanh_out = 2.0 * s - 1.0
+    tanh_out = tl.tanh(t)
     ff = 0.5 * x_val * (
         (1.0 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x_val * x_val)
     ) + 0.5 * (1.0 + tanh_out)
@@ -405,6 +400,7 @@ def gelu_bwd_kernel(
     tl.store(dx + dx_off, dx_val.to(dx.dtype.element_ty), mask=mask)
 
 
+@triton.heuristics(_LINEAR_HEURISTICS_XY)
 @triton.jit(do_not_specialize=['T'])
 def sqrelu_fwd_kernel(
     x, y,
@@ -412,21 +408,22 @@ def sqrelu_fwd_kernel(
     D: tl.constexpr,
     stride_x_row,
     stride_y_row,
-    BLOCK_SIZE: tl.constexpr,
+    B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    y_off = row * stride_y_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     r = tl.maximum(x_val, 0.0)
     y_val = r * r
     tl.store(y + y_off, y_val.to(y.dtype.element_ty), mask=mask)
 
 
+@triton.heuristics(_LINEAR_HEURISTICS_BWD)
 @triton.jit(do_not_specialize=['T'])
 def sqrelu_bwd_kernel(
     x, dy, dx,
@@ -435,16 +432,17 @@ def sqrelu_bwd_kernel(
     stride_x_row,
     stride_dy_row,
     stride_dx_row,
-    BLOCK_SIZE: tl.constexpr,
+    B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    DY_LINEAR: tl.constexpr,
+    DX_LINEAR: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs = pid * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    x_off = row * stride_x_row + col
-    dy_off = row * stride_dy_row + col
-    dx_off = row * stride_dx_row + col
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    dy_off = _flat_offset(offs, D, stride_dy_row, DY_LINEAR)
+    dx_off = _flat_offset(offs, D, stride_dx_row, DX_LINEAR)
     x_val = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
     g_val = tl.load(dy + dy_off, mask=mask, other=0.).to(tl.float32)
     dx_val = 2.0 * g_val * tl.maximum(x_val, 0.0)
@@ -456,13 +454,12 @@ def gelu_fwd_npu(x: torch.Tensor) -> torch.Tensor:
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
     y = _alloc_output(x)
-    grid = (triton.cdiv(T, STATIC_BLOCK_SIZE),)
+    grid, B = _activation_launch_config(T)
     gelu_fwd_kernel[grid](
         x, y, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_y_row=_get_stride(y),
-        BLOCK_SIZE=STATIC_BLOCK_SIZE,
-        num_warps=STATIC_WARPS,
+        BLOCK_SIZE=B,
     )
     return y
 
@@ -473,14 +470,13 @@ def gelu_bwd_npu(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     g = _ensure_inner_contiguous(g)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x)
-    grid = (triton.cdiv(T, STATIC_BLOCK_SIZE),)
+    grid, B = _activation_launch_config(T)
     gelu_bwd_kernel[grid](
         x, g, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_dy_row=_get_stride(g),
         stride_dx_row=_get_stride(dx),
-        BLOCK_SIZE=STATIC_BLOCK_SIZE,
-        num_warps=STATIC_WARPS,
+        BLOCK_SIZE=B,
     )
     return dx
 
@@ -490,13 +486,12 @@ def sqrelu_fwd_npu(x: torch.Tensor) -> torch.Tensor:
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
     y = _alloc_output(x)
-    grid = (triton.cdiv(T, STATIC_BLOCK_SIZE),)
+    grid, B = _activation_launch_config(T)
     sqrelu_fwd_kernel[grid](
         x, y, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_y_row=_get_stride(y),
-        BLOCK_SIZE=STATIC_BLOCK_SIZE,
-        num_warps=STATIC_WARPS,
+        BLOCK_SIZE=B,
     )
     return y
 
@@ -507,14 +502,13 @@ def sqrelu_bwd_npu(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     g = _ensure_inner_contiguous(g)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x)
-    grid = (triton.cdiv(T, STATIC_BLOCK_SIZE),)
+    grid, B = _activation_launch_config(T)
     sqrelu_bwd_kernel[grid](
         x, g, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_dy_row=_get_stride(g),
         stride_dx_row=_get_stride(dx),
-        BLOCK_SIZE=STATIC_BLOCK_SIZE,
-        num_warps=STATIC_WARPS,
+        BLOCK_SIZE=B,
     )
     return dx
 
@@ -524,10 +518,12 @@ def sigmoid_fwd_npu(x: torch.Tensor, output_contiguous: bool = False) -> torch.T
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
     y = _alloc_output(x, output_contiguous)
-    sigmoid_fwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    sigmoid_fwd_kernel[grid](
         x, y, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_y_row=_get_stride(y),
+        B=B,
     )
     return y
 
@@ -538,11 +534,13 @@ def sigmoid_bwd_npu(x: torch.Tensor, dy: torch.Tensor, output_contiguous: bool =
     dy = _ensure_inner_contiguous(dy)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x, output_contiguous)
-    sigmoid_bwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    sigmoid_bwd_kernel[grid](
         x, dy, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_dy_row=_get_stride(dy),
         stride_dx_row=_get_stride(dx),
+        B=B,
     )
     return dx
 
@@ -552,7 +550,8 @@ def logsigmoid_fwd_npu(x: torch.Tensor, temperature: float = 1., output_contiguo
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
     y = _alloc_output(x, output_contiguous)
-    logsigmoid_fwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    logsigmoid_fwd_kernel[grid](
         x=x,
         y=y,
         temperature=temperature,
@@ -560,6 +559,7 @@ def logsigmoid_fwd_npu(x: torch.Tensor, temperature: float = 1., output_contiguo
         D=D,
         stride_x_row=_get_stride(x),
         stride_y_row=_get_stride(y),
+        B=B,
     )
     return y
 
@@ -575,7 +575,8 @@ def logsigmoid_bwd_npu(
     dy = _ensure_inner_contiguous(dy)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x, output_contiguous)
-    logsigmoid_bwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    logsigmoid_bwd_kernel[grid](
         x=x,
         dx=dx,
         dy=dy,
@@ -585,6 +586,7 @@ def logsigmoid_bwd_npu(
         stride_x_row=_get_stride(x),
         stride_dx_row=_get_stride(dx),
         stride_dy_row=_get_stride(dy),
+        B=B,
     )
     return dx
 
@@ -594,10 +596,12 @@ def swish_fwd_npu(x: torch.Tensor, output_contiguous: bool = False) -> torch.Ten
     x = _ensure_inner_contiguous(x)
     T, D = x.numel(), x.shape[-1]
     y = _alloc_output(x, output_contiguous)
-    swish_fwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    swish_fwd_kernel[grid](
         x, y, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_y_row=_get_stride(y),
+        B=B,
     )
     return y
 
@@ -608,11 +612,13 @@ def swish_bwd_npu(x: torch.Tensor, dy: torch.Tensor, output_contiguous: bool = F
     dy = _ensure_inner_contiguous(dy)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x, output_contiguous)
-    swish_bwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    swish_bwd_kernel[grid](
         x, dy, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_dy_row=_get_stride(dy),
         stride_dx_row=_get_stride(dx),
+        B=B,
     )
     return dx
 
@@ -624,11 +630,13 @@ def swiglu_fwd_npu(x: torch.Tensor, y: torch.Tensor, output_contiguous: bool = F
     y = _ensure_inner_contiguous(y)
     T, D = x.numel(), x.shape[-1]
     z = _alloc_output(x, output_contiguous)
-    swiglu_fwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    swiglu_fwd_kernel[grid](
         x, y, z, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_y_row=_get_stride(y),
         stride_z_row=_get_stride(z),
+        B=B,
     )
     return z
 
@@ -652,7 +660,8 @@ def swiglu_fwdbwd_npu(
         z = _alloc_output(x, output_contiguous)
     else:
         z = None
-    swiglu_fwdbwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    swiglu_fwdbwd_kernel[grid](
         x, y, g, dx, dy, z, T=T, D=D,
         stride_x_row=_get_stride(x),
         stride_y_row=_get_stride(y),
@@ -660,6 +669,7 @@ def swiglu_fwdbwd_npu(
         stride_dx_row=_get_stride(dx),
         stride_dy_row=_get_stride(dy),
         stride_z_row=_get_stride(z) if z is not None else 0,
+        B=B,
     )
     if use_weight:
         return dx, dy, z
@@ -696,15 +706,7 @@ def swiglu_linear_npu(x, y, weight, bias):
     return SwiGLULinearFunctionNPU.apply(x, y, weight, bias)
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
+@triton.heuristics(_LINEAR_HEURISTICS_XYZ)
 @triton.jit(do_not_specialize=['T'])
 def powglu_fwd_kernel(
     x, y, z,
@@ -715,14 +717,18 @@ def powglu_fwd_kernel(
     T,
     D: tl.constexpr,
     B: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
+    Z_LINEAR: tl.constexpr,
 ):
-    i_n = tl.program_id(0).to(tl.int64)
+    i_n = tl.program_id(0)
     offs = i_n * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    b_x = tl.load(x + row * stride_x_row + col, mask=mask, other=0.).to(tl.float32)
-    b_y = tl.load(y + row * stride_y_row + col, mask=mask, other=0.).to(tl.float32)
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
+    z_off = _flat_offset(offs, D, stride_z_row, Z_LINEAR)
+    b_x = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
+    b_y = tl.load(y + y_off, mask=mask, other=0.).to(tl.float32)
     b_s = tl.sigmoid(b_x)
     b_pos = b_x > 0
     # feed only positive lanes to log/sqrt; masked lanes give x**p = 1 and are dropped by the where
@@ -732,21 +738,13 @@ def powglu_fwd_kernel(
     b_pow = exp(b_p * log(b_xp))
     b_g = tl.where(b_pos, b_pow * b_s, b_x * b_s)
     b_z = b_g * b_y
-    tl.store(z + row * stride_z_row + col, b_z.to(z.dtype.element_ty), mask=mask)
+    tl.store(z + z_off, b_z.to(z.dtype.element_ty), mask=mask)
 
 
 @triton.heuristics({
     'HAS_WEIGHT': lambda args: args['z'] is not None,
+    **_LINEAR_HEURISTICS_FWDBWD,
 })
-@triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
-    key=['D'],
-    **autotune_cache_kwargs,
-)
 @triton.jit(do_not_specialize=['T'])
 def powglu_fwdbwd_kernel(
     x, y, g, dx, dy, z,
@@ -761,15 +759,24 @@ def powglu_fwdbwd_kernel(
     D: tl.constexpr,
     B: tl.constexpr,
     HAS_WEIGHT: tl.constexpr,
+    X_LINEAR: tl.constexpr,
+    Y_LINEAR: tl.constexpr,
+    G_LINEAR: tl.constexpr,
+    DX_LINEAR: tl.constexpr,
+    DY_LINEAR: tl.constexpr,
+    Z_LINEAR: tl.constexpr,
 ):
-    i_n = tl.program_id(0).to(tl.int64)
+    i_n = tl.program_id(0)
     offs = i_n * B + tl.arange(0, B)
     mask = offs < T
-    row = offs // D
-    col = offs % D
-    b_x = tl.load(x + row * stride_x_row + col, mask=mask, other=0.).to(tl.float32)
-    b_y = tl.load(y + row * stride_y_row + col, mask=mask, other=0.).to(tl.float32)
-    b_g = tl.load(g + row * stride_g_row + col, mask=mask, other=0.).to(tl.float32)
+    x_off = _flat_offset(offs, D, stride_x_row, X_LINEAR)
+    y_off = _flat_offset(offs, D, stride_y_row, Y_LINEAR)
+    g_off = _flat_offset(offs, D, stride_g_row, G_LINEAR)
+    dx_off = _flat_offset(offs, D, stride_dx_row, DX_LINEAR)
+    dy_off = _flat_offset(offs, D, stride_dy_row, DY_LINEAR)
+    b_x = tl.load(x + x_off, mask=mask, other=0.).to(tl.float32)
+    b_y = tl.load(y + y_off, mask=mask, other=0.).to(tl.float32)
+    b_g = tl.load(g + g_off, mask=mask, other=0.).to(tl.float32)
 
     b_s = tl.sigmoid(b_x)
     b_pos = b_x > 0
@@ -792,11 +799,12 @@ def powglu_fwdbwd_kernel(
     b_dx = b_g * b_y * b_dgate
     b_dy = b_g * b_gate
 
-    tl.store(dx + row * stride_dx_row + col, b_dx.to(dx.dtype.element_ty), mask=mask)
-    tl.store(dy + row * stride_dy_row + col, b_dy.to(dy.dtype.element_ty), mask=mask)
+    tl.store(dx + dx_off, b_dx.to(dx.dtype.element_ty), mask=mask)
+    tl.store(dy + dy_off, b_dy.to(dy.dtype.element_ty), mask=mask)
     if HAS_WEIGHT:
         b_z = b_gate * b_y
-        tl.store(z + row * stride_z_row + col, b_z.to(z.dtype.element_ty), mask=mask)
+        z_off = _flat_offset(offs, D, stride_z_row, Z_LINEAR)
+        tl.store(z + z_off, b_z.to(z.dtype.element_ty), mask=mask)
 
 
 @torch.compiler.disable
@@ -806,7 +814,8 @@ def powglu_fwd_npu(x: torch.Tensor, y: torch.Tensor, power: float = 3.0, output_
     y = _ensure_inner_contiguous(y)
     T, D = x.numel(), x.shape[-1]
     z = _alloc_output(x, output_contiguous)
-    powglu_fwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    powglu_fwd_kernel[grid](
         x=x,
         y=y,
         z=z,
@@ -816,6 +825,7 @@ def powglu_fwd_npu(x: torch.Tensor, y: torch.Tensor, power: float = 3.0, output_
         m=power,
         T=T,
         D=D,
+        B=B,
     )
     return z
 
@@ -840,7 +850,8 @@ def powglu_fwdbwd_npu(
         z = _alloc_output(x, output_contiguous)
     else:
         z = None
-    powglu_fwdbwd_kernel[lambda meta: (triton.cdiv(T, meta['B']),)](
+    grid, B = _activation_launch_config(T)
+    powglu_fwdbwd_kernel[grid](
         x=x,
         y=y,
         g=g,
@@ -856,6 +867,7 @@ def powglu_fwdbwd_npu(
         m=power,
         T=T,
         D=D,
+        B=B,
     )
     if use_weight:
         return dx, dy, z


### PR DESCRIPTION
# Summary

Optimize the Triton kernel launch and memory access paths for activation operators on the Ascend (`triton_ascend`) backend to reduce autotune overhead and improve execution efficiency for large tensors.

## Major Changes
### Remove `@triton.autotune`
Autotune (originally used to search over combinations of block size and `num_warps`) is removed from kernels including sigmoid, logsigmoid, swish, swiglu and powglu. Launch configurations are now statically selected at runtime to eliminate extra compilation and profiling costs introduced by autotune on the NPU platform.

### Newly Added `_activation_launch_config`
Dynamically select block size while complying with Ascend launch constraints (the upper limit of grid dimension and per-core vector width is 65535). The priority order of attempted block sizes is 2048 → 1024 → 512, ensuring grid limits are not exceeded under large sequence length T.

### Linear Stride Heuristic (`_flat_offset` + `@triton.heuristics`)
Adopt linear offset addressing when tensors have contiguous inner dimensions (stride equals feature dimension D), which skips division and modulo operations of `offs // D` and `offs % D`. The original row/column addressing logic is preserved for non-contiguous memory layouts. This optimized path is applied uniformly to all forward, backward and fused forward-backward kernels.

### Adopt Native Triton Mathematical Intrinsics
- Replace manual implementation of \(1/(1+e^{-x})\) with `tl.sigmoid`
- Replace handwritten tanh implementation (derived from sigmoid) in GELU with native `tl.tanh`

This optimization cuts down instruction count and facilitates better code generation for the Ascend backend.

### Unified Launch Interface
All NPU wrapper functions (e.g., `sigmoid_fwd_npu`, `swiglu_fwd_npu`, `gelu_fwd_npu`) retrieve grid and block configurations via `_activation_launch_config(T)` uniformly. The autotune-style lambda grid definition and hardcoded constants `STATIC_BLOCK_SIZE=1024`, `STATIC_WARPS=2` are no longer used.

## Scope of Impact
Only the file `fla/modules/backends/triton_ascend/activations.py` is modified, covering forward, backward and fused forward-backward execution paths of sigmoid, logsigmoid, swish, swiglu, powglu, GELU and sqrelu. No public API changes are introduced, and this commit contains no breaking changes.

# Motivation

Autotune incurs high profiling overhead on Ascend NPU, and the fixed block size of 1024 may result in an excessively large grid that hits the hardware limit when processing a large number of tokens. In addition, addressing via division and modulo operations, together with hand-implemented sigmoid and tanh functions, suffers from low efficiency on vector cores. This optimization delivers targeted improvements addressing these three pain points.

# Testing Done

<img width="1166" height="284" alt="image" src="https://github.com/user-attachments/assets/5e1940c6-7909-48c9-aff5-b5d7fa695ded" />
