### PR TITLE
[Perf] Cache find_spec lookups in backend dispatch

### DIFF
--- a/fla/ops/backends/__init__.py
+++ b/fla/ops/backends/__init__.py
@@ -15,10 +15,11 @@ import os
 import threading
 from collections.abc import Callable
 from functools import cache, wraps
-from importlib.util import find_spec
 from typing import Any, ClassVar, TypeVar
 
 import torch
+
+from fla.utils import find_spec_cached
 
 logger = logging.getLogger(__name__)
 F = TypeVar('F', bound=Callable)
@@ -60,7 +61,7 @@ class BaseBackend:
     def is_available(cls) -> bool:
         if cls.package_name is None:
             return True
-        return find_spec(cls.package_name) is not None
+        return find_spec_cached(cls.package_name) is not None
 
     @classmethod
     def is_enabled(cls) -> bool:

--- a/fla/ops/common/backends/tilelang/__init__.py
+++ b/fla/ops/common/backends/tilelang/__init__.py
@@ -14,15 +14,13 @@ hardware-specific regressions (see #640). Can also be forced via FLA_TILELANG=1.
 from __future__ import annotations
 
 import os
-from importlib.util import find_spec
 
 import torch
 
 from fla.ops.backends import BaseBackend
-from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0
+from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, find_spec_cached
 
-# find_spec, not `import tilelang`: probe availability without triggering it
-_TILELANG_AVAILABLE = find_spec("tilelang") is not None
+_TILELANG_AVAILABLE = find_spec_cached("tilelang") is not None
 
 
 class TileLangBackend(BaseBackend):

--- a/fla/ops/kda/backends/tilelang/__init__.py
+++ b/fla/ops/kda/backends/tilelang/__init__.py
@@ -9,14 +9,12 @@
 
 from __future__ import annotations
 
-from importlib.util import find_spec
-
 import torch
 
 from fla.ops.backends import BaseBackend
+from fla.utils import find_spec_cached
 
-# find_spec, not `import tilelang`: probe availability without triggering it
-_TILELANG_AVAILABLE = find_spec("tilelang") is not None
+_TILELANG_AVAILABLE = find_spec_cached("tilelang") is not None
 
 
 class KDATileLangBackend(BaseBackend):

--- a/fla/utils/__init__.py
+++ b/fla/utils/__init__.py
@@ -13,6 +13,7 @@ from ._compat import (  # noqa: F401
     TRITON_ABOVE_3_5_1,
     TRITON_ABOVE_3_7_1,
     autotune_cache_kwargs,
+    find_spec_cached,
 )
 from ._config import (  # noqa: F401
     FLA_CACHE_RESULTS,

--- a/fla/utils/_compat.py
+++ b/fla/utils/_compat.py
@@ -5,7 +5,9 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+import functools
 import inspect
+from importlib.util import find_spec
 
 import triton
 from packaging import version as package_version
@@ -18,3 +20,8 @@ TRITON_ABOVE_3_7_1 = package_version.parse(triton.__version__) >= package_versio
 
 SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters
 autotune_cache_kwargs = {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
+
+
+@functools.cache
+def find_spec_cached(name):
+    return find_spec(name)


### PR DESCRIPTION
## Summary

Add `find_spec_cached` (a `functools.cache` wrapper around `importlib.util.find_spec`) in `fla.utils`, and route backend package-availability probing through it.

## Motivation

`BaseBackend.is_available()` is called on every dispatch (the dispatch loop bypasses the cached `can_use()` because its `@cache` wrapper breaks `torch.compile` tracing). It previously called `find_spec()` uncached, so any backend relying on the base — e.g. `flashkda` (`package_name = "flash_kda"`) — re-probed the package on every call.

This is the same class of issue as #993, which fixed the two TileLang backends individually. The base `find_spec` (and therefore `flashkda`) was left uncached.

## Changes

- `fla.utils`: add `find_spec_cached`.
- `BaseBackend.is_available()`: use `find_spec_cached` (covers `flashkda` and any future backend relying on the base).
- Both TileLang backends: use `find_spec_cached("tilelang")` instead of a module-level `find_spec` call.