### PR TITLE
[Conv] Harden triton-ascend causal_conv1d silu/add against Ascend launch limits

### DIFF
--- a/fla/modules/backends/triton_ascend/causal_conv1d.py
+++ b/fla/modules/backends/triton_ascend/causal_conv1d.py
@@ -18,6 +18,13 @@ from fla.utils import input_guard
 STATIC_WARPS = 2
 # Ascend Triton rejects grids whose product exceeds 65535 (see fla/modules/token_shift.py).
 _NPU_MAX_TRITON_GRID = 65535
+_ELEM_BLOCK = 2048
+
+
+def _elementwise_launch_iters(numel: int):
+    n_blocks = triton.cdiv(numel, _ELEM_BLOCK)
+    for block_off in range(0, n_blocks, _NPU_MAX_TRITON_GRID):
+        yield min(_NPU_MAX_TRITON_GRID, n_blocks - block_off), block_off * _ELEM_BLOCK
 
 
 def _npu_chunk_size(T: int, BT: int) -> int:
@@ -56,7 +63,10 @@ def _npu_tile_config(
 ) -> tuple[int, int, int]:
     BT = _npu_chunk_size(T, BT)
     BD = 16
-    if D >= 1024:
+    if D >= 8192:
+        BD = 8
+        BT = min(BT, 8)
+    elif D >= 1024:
         # BD=4 overflows Ascend UB on large-D forward; cap BT to limit NT.
         BD = 8
         BT = min(BT, 32)
@@ -193,10 +203,11 @@ def _silu_kernel(
     x_ptr,
     y_ptr,
     n_elements,
+    ELEM_OFFSET: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    offs = pid * BLOCK + tl.arange(0, BLOCK) + ELEM_OFFSET
     mask = offs < n_elements
     x = tl.load(x_ptr + offs, mask=mask, other=0.).to(tl.float32)
     y = x * tl.sigmoid(x)
@@ -209,10 +220,11 @@ def _add_kernel(
     b_ptr,
     out_ptr,
     n_elements,
+    ELEM_OFFSET: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    offs = pid * BLOCK + tl.arange(0, BLOCK) + ELEM_OFFSET
     mask = offs < n_elements
     a = tl.load(a_ptr + offs, mask=mask, other=0.).to(tl.float32)
     b = tl.load(b_ptr + offs, mask=mask, other=0.).to(tl.float32)
@@ -220,20 +232,31 @@ def _add_kernel(
 
 
 def _launch_silu(y: torch.Tensor) -> torch.Tensor:
+    y = y.contiguous()
     out = torch.zeros_like(y)
     n = y.numel()
-    block = 1024
-    grid = (triton.cdiv(n, block),)
-    _silu_kernel[grid](y, out, n, BLOCK=block, num_warps=STATIC_WARPS)
+    for grid, elem_off in _elementwise_launch_iters(n):
+        _silu_kernel[(grid,)](
+            y, out, n,
+            ELEM_OFFSET=elem_off,
+            BLOCK=_ELEM_BLOCK,
+            num_warps=STATIC_WARPS,
+        )
     return out
 
 
 def _launch_add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    a = a.contiguous()
+    b = b.contiguous()
     out = torch.zeros_like(a)
     n = a.numel()
-    block = 1024
-    grid = (triton.cdiv(n, block),)
-    _add_kernel[grid](a, b, out, n, BLOCK=block, num_warps=STATIC_WARPS)
+    for grid, elem_off in _elementwise_launch_iters(n):
+        _add_kernel[(grid,)](
+            a, b, out, n,
+            ELEM_OFFSET=elem_off,
+            BLOCK=_ELEM_BLOCK,
+            num_warps=STATIC_WARPS,
+        )
     return out
 
 
@@ -254,10 +277,11 @@ def _silu_bwd_kernel(
     B,
     T,
     D,
+    ELEM_OFFSET: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    offs = pid * BLOCK + tl.arange(0, BLOCK) + ELEM_OFFSET
     n_elements = B * T * D
     mask = offs < n_elements
     rem = offs % D
@@ -278,20 +302,21 @@ def _silu_bwd_kernel(
 def _launch_silu_bwd(y_pre: torch.Tensor, dy: torch.Tensor) -> torch.Tensor:
     out = torch.zeros_like(dy, memory_format=torch.contiguous_format)
     B, T, D = dy.shape
-    block = 1024
-    grid = (triton.cdiv(B * T * D, block),)
+    n = B * T * D
     sy_n, sy_t, sy_d = y_pre.stride()
     sdy_n, sdy_t, sdy_d = dy.stride()
     so_n, so_t, so_d = out.stride()
-    _silu_bwd_kernel[grid](
-        y_pre, dy, out,
-        sy_n, sy_t, sy_d,
-        sdy_n, sdy_t, sdy_d,
-        so_n, so_t, so_d,
-        B, T, D,
-        BLOCK=block,
-        num_warps=STATIC_WARPS,
-    )
+    for grid, elem_off in _elementwise_launch_iters(n):
+        _silu_bwd_kernel[(grid,)](
+            y_pre, dy, out,
+            sy_n, sy_t, sy_d,
+            sdy_n, sdy_t, sdy_d,
+            so_n, so_t, so_d,
+            B, T, D,
+            ELEM_OFFSET=elem_off,
+            BLOCK=_ELEM_BLOCK,
+            num_warps=STATIC_WARPS,
+        )
     return out
 
 

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -960,10 +960,12 @@ def test_conv_cache_backward(
     ('T', 'lengths', 'D'),
     [
         pytest.param(256, None, 128, id='random_split_T256'),
-        pytest.param(None, [32] * 128 + [8192], 4096, id='packed_128x32_8k'),
+        pytest.param(None, [32] * 128 + [8192], 4096, id='packed_128x32_D4096'),
+        pytest.param(None, [32] * 128 + [8192], 8192, id='packed_128x32_D8192'),
     ],
 )
 def test_conv_varlen_initial_state_backward_random(T, lengths, D):
+    """Varlen swish backward with initial state (random and packed layouts)."""
     activation = "swish"
     W = 4
     torch.manual_seed(1234)
@@ -1044,11 +1046,17 @@ def test_conv_varlen_initial_state_backward_random(T, lengths, D):
     assert_close("d_init", grads_ref[3], grads_tri[3], ratio=1e-3)
 
 
-def test_conv_dense_initial_state_backward_large_nt():
-    """Dense bwd with NT grid chunking (CHUNK_OFFSET + global i_tg indexing)."""
+@pytest.mark.parametrize(
+    ('B', 'T', 'D'),
+    [
+        pytest.param(1, 8192, 4096, id='B1_T8192_D4096'),
+        pytest.param(1, 8192, 8192, id='B1_T8192_D8192'),
+    ],
+)
+def test_conv_dense_initial_state_backward_large_nt(B, T, D):
+    """Dense swish backward with large T/D (conv tiling and activation launch limits)."""
     activation = "swish"
     W = 4
-    B, T, D = 1, 8192, 4096
     torch.manual_seed(1234)
 
     x = torch.randn(B, T, D, device=device, dtype=torch.float32, requires_grad=True)


### PR DESCRIPTION
## Summary

Follow-up to #992: conv NT/N-axis chunking is in place, but `causal_conv1d` still applied swish/silu and residual add via fixed `block=1024` 1-D launches. Under large `B*T*D` (reported in #981 as `_silu_kernel` / `coreDim > 65535`), training can still fail even after the conv kernels are fixed.

This PR is intentionally **defensive**: it hardens the remaining elementwise postprocess path so future large-shape workloads are less likely to hit Ascend launch/compile limits, rather than only patching the one shape that already failed in the wild.

## Defensive changes

- **Chunked elementwise launches**: `_launch_silu`, `_launch_silu_bwd`, and `_launch_add` now iterate with `ELEM_OFFSET` and cap each 1-D grid at 65535 (`_elementwise_launch_iters`), mirroring the chunking discipline already used for conv kernels.
- **Safer inputs**: flatten-based silu/add paths call `.contiguous()` before launch to avoid silent misreads on non-contiguous views.
- **Large-D forward tiling**: tighten fwd tile config for `D >= 8192` (`BT <= 8`) to stay within Ascend UB limits before postprocess runs.

Scope is limited to `fla/modules/backends/triton_ascend/causal_conv1d.py`; no public API changes and no torch fallback.

## Tests

- Extend `test_conv_dense_initial_state_backward_large_nt` with `B1_T8192_D4096` / `B1_T8192_D8192`.
- Extend `test_conv_varlen_initial_state_backward_random` with `packed_128x32_D4096` / `packed_128x32_D8192`.