### PR TITLE
[GDN] Restrict Blackwell gated delta bwd autotune

### DIFF
--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -12,7 +12,13 @@ import triton.language as tl
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
-from fla.utils import autotune_cache_kwargs, check_shared_mem
+from fla.utils import IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
+
+# Blackwell can select unstable Triton configs for prepare_wy_repr_bwd_kernel
+# during autotuning (see #913). Restrict it to the config that has been
+# validated on B200 until the wider config space is re-validated.
+PREPARE_WY_REPR_BWD_NUM_WARPS = [2] if IS_NVIDIA_BLACKWELL else [2, 4]
+PREPARE_WY_REPR_BWD_NUM_STAGES = [4] if IS_NVIDIA_BLACKWELL else [2, 3, 4]
 
 
 @triton.heuristics({
@@ -94,8 +100,8 @@ def recompute_w_u_fwd_kernel(
 @fla_cache_autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4]
-        for num_stages in [2, 3, 4]
+        for num_warps in PREPARE_WY_REPR_BWD_NUM_WARPS
+        for num_stages in PREPARE_WY_REPR_BWD_NUM_STAGES
     ],
     key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
     **autotune_cache_kwargs,


### PR DESCRIPTION
This PR restricts `prepare_wy_repr_bwd_kernel` autotune configs on NVIDIA Blackwell to:

```python
num_warps = 2
num_stages = 4
```

On B200 / sm100, the wider autotune config space can select unstable Triton configs for Qwen3.5 gated delta rule training. In our runs this can hang during long-sequence backward inside `prepare_wy_repr_bwd_kernel`; in distributed training the visible failure is often a later NCCL watchdog timeout because some ranks are stuck in a CUDA/Triton kernel.

Forcing `prepare_wy_repr_bwd_kernel` to `num_warps=2, num_stages=4` avoids the observed backward hang in our B200 Qwen3.5 tests. This PR applies that restriction only on Blackwell. Non-Blackwell GPUs keep the existing config space unchanged.

This follows the same style as existing architecture-specific config guards in the codebase, such as the Blackwell guard for gated delta forward h and the Hopper guard in delta rule WY backward.

Scope:

- Addresses the backward `prepare_wy_repr_bwd_kernel` part of the B200 gated delta rule issue.
- Does not change the forward `chunk_fwd_o` path. We have also observed a forward-side hang around `chunk_fwd_o` in B200 training, but that should be handled separately after isolating an upstream-safe forward config policy.

Testing:

```text
python3 -m py_compile fla/ops/gated_delta_rule/wy_fast.py
git diff --check
```

Training validation:

```text
GPU: NVIDIA B200 / sm100
torch: 2.7.1
CUDA: 12.8
triton: 3.3.1
fla-core: 0.5.0
model: Qwen3.5-0.8B linear attention / gated delta rule
```

With `prepare_wy_repr_bwd_kernel` fixed to `num_warps=2, num_stages=4`, our B200 Qwen3.5 training no longer hangs in the tested runs.

Fixes #999
Related to #913
