### PR TITLE
[Fix] fix benchamrk issues and add ub management for npu

### DIFF
--- a/benchmarks/modules/benchmark_conv.py
+++ b/benchmarks/modules/benchmark_conv.py
@@ -11,6 +11,7 @@ from einops import rearrange
 
 from fla.modules.convolution import causal_conv1d
 from fla.ops.utils.index import prepare_sequence_ids
+from fla.utils import IS_NPU
 
 try:
     from causal_conv1d import causal_conv1d_fn
@@ -18,27 +19,20 @@ except ImportError:
     causal_conv1d_fn = None
 
 
-@triton.testing.perf_report(
-    triton.testing.Benchmark(
-        # argument names to use as an x-axis for the plot
-        x_names=['T', 'D'],
-        # different possible values for `x_name`
-        x_vals=[(128 * 2 ** i, d) for d in [256, 512, 1024, 2048, 4096] for i in range(1, 10)],
-        # argument name whose value corresponds to a different line in the plot
-        line_arg='provider',
-        # possible values for `line_arg``
-        line_vals=['causal_conv1d_fwd', 'causal_conv1d_cuda_fwd', 'causal_conv1d_fwdbwd', 'causal_conv1d_cuda_fwdbwd'],
-        # label name for the lines
-        line_names=['causal_conv1d_fwd', 'causal_conv1d_cuda_fwd', 'causal_conv1d_fwdbwd', 'causal_conv1d_cuda_fwdbwd'],
-        # line styles
-        styles=[('green', '-'), ('blue', '--'), ('red', '-.'),
-                ('cyan', ':'), ('yellow', 'dotted'), ('cyan', '--'), ('cyan', '-'), ('black', ':')],
-        ylabel="Execution Time (ms)",  # label name for the y-axis
-        # name for the plot. Used also as a file name for saving the plot.
-        plot_name="Performance",
-        args={},
-    ),
-)
+def _conv_benchmark_providers():
+    providers = ['causal_conv1d_fwd', 'causal_conv1d_fwdbwd']
+    if not IS_NPU and causal_conv1d_fn is not None:
+        providers.extend(['causal_conv1d_cuda_fwd', 'causal_conv1d_cuda_fwdbwd'])
+    return providers
+
+
+_LINE_VALS = _conv_benchmark_providers()
+_STYLES = [
+    ('green', '-'), ('blue', '--'), ('red', '-.'), ('cyan', ':'),
+    ('yellow', 'dotted'), ('cyan', '--'), ('cyan', '-'), ('black', ':'),
+]
+
+
 def benchmark(T, D, provider):
     from fla.utils import device
     dtype = torch.bfloat16
@@ -98,6 +92,28 @@ def benchmark(T, D, provider):
             quantiles=quantiles,
         )
     return results
+
+
+benchmark = triton.testing.perf_report(
+    triton.testing.Benchmark(
+        # argument names to use as an x-axis for the plot
+        x_names=['T', 'D'],
+        # different possible values for `x_name`
+        x_vals=[(128 * 2 ** i, d) for d in [256, 512, 1024, 2048, 4096] for i in range(1, 10)],
+        # argument name whose value corresponds to a different line in the plot
+        line_arg='provider',
+        # possible values for `line_arg``
+        line_vals=_LINE_VALS,
+        # label name for the lines
+        line_names=_LINE_VALS,
+        # line styles
+        styles=_STYLES[:len(_LINE_VALS)],
+        ylabel="Execution Time (ms)",  # label name for the y-axis
+        # name for the plot. Used also as a file name for saving the plot.
+        plot_name="Performance",
+        args={},
+    ),
+)(benchmark)
 
 
 if __name__ == '__main__':

--- a/fla/modules/backends/triton_ascend/activations.py
+++ b/fla/modules/backends/triton_ascend/activations.py
@@ -14,20 +14,27 @@ import triton.language as tl
 
 from fla.ops.utils.op import exp, log
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, compute_activation_block_size
 
 # Ascend launch limits: grid dim and per-core vector width.
-_PREFERRED_BLOCK_SIZES = (2048, 1024, 512)
-_MAX_GRID_DIM = 65535
 _MAX_CORE_DIM = 65535
 
 
-def _activation_launch_config(T: int) -> tuple[tuple[int], int]:
-    """Pick block size under Ascend launch limits."""
-    for B in _PREFERRED_BLOCK_SIZES:
-        if triton.cdiv(T, B) <= _MAX_GRID_DIM and B * 8 <= _MAX_CORE_DIM:
-            return (triton.cdiv(T, B),), B
-    B = min(triton.cdiv(T, _MAX_GRID_DIM), _MAX_CORE_DIM // 8)
-    return (triton.cdiv(T, B),), max(B, 1)
+def _activation_launch_config(
+    T: int,
+    is_backward: bool = False,
+    *,
+    memory_multiplier: float | None = None,
+) -> tuple[tuple[int], int]:
+    """Pick block size under Ascend launch and UB limits."""
+    B = compute_activation_block_size(
+        T,
+        is_backward,
+        max_grid=ASCEND_MAX_GRID_DIM,
+        max_core_dim=_MAX_CORE_DIM,
+        memory_multiplier=memory_multiplier,
+    )
+    return (triton.cdiv(T, B),), B
 
 
 @triton.jit
@@ -470,7 +477,7 @@ def gelu_bwd_npu(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     g = _ensure_inner_contiguous(g)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x)
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, is_backward=True)
     gelu_bwd_kernel[grid](
         x, g, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
@@ -502,7 +509,7 @@ def sqrelu_bwd_npu(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     g = _ensure_inner_contiguous(g)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x)
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, is_backward=True)
     sqrelu_bwd_kernel[grid](
         x, g, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
@@ -534,7 +541,7 @@ def sigmoid_bwd_npu(x: torch.Tensor, dy: torch.Tensor, output_contiguous: bool =
     dy = _ensure_inner_contiguous(dy)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x, output_contiguous)
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, is_backward=True)
     sigmoid_bwd_kernel[grid](
         x, dy, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
@@ -575,7 +582,7 @@ def logsigmoid_bwd_npu(
     dy = _ensure_inner_contiguous(dy)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x, output_contiguous)
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, is_backward=True)
     logsigmoid_bwd_kernel[grid](
         x=x,
         dx=dx,
@@ -612,7 +619,7 @@ def swish_bwd_npu(x: torch.Tensor, dy: torch.Tensor, output_contiguous: bool = F
     dy = _ensure_inner_contiguous(dy)
     T, D = x.numel(), x.shape[-1]
     dx = _alloc_output(x, output_contiguous)
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, is_backward=True)
     swish_bwd_kernel[grid](
         x, dy, dx, T=T, D=D,
         stride_x_row=_get_stride(x),
@@ -660,7 +667,7 @@ def swiglu_fwdbwd_npu(
         z = _alloc_output(x, output_contiguous)
     else:
         z = None
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, is_backward=True)
     swiglu_fwdbwd_kernel[grid](
         x, y, g, dx, dy, z, T=T, D=D,
         stride_x_row=_get_stride(x),
@@ -807,6 +814,11 @@ def powglu_fwdbwd_kernel(
         tl.store(z + z_off, b_z.to(z.dtype.element_ty), mask=mask)
 
 
+# Peak fp32 temporaries: sigmoid, sqrt, log, exp, pow, gate, output.
+_POWGLU_FWD_MEM_MULT = 8.0
+_POWGLU_BWD_MEM_MULT = 10.0
+
+
 @torch.compiler.disable
 def powglu_fwd_npu(x: torch.Tensor, y: torch.Tensor, power: float = 3.0, output_contiguous: bool = False) -> torch.Tensor:
     assert x.shape == y.shape, f"powglu_fwd: shape mismatch x={x.shape} y={y.shape}"
@@ -814,7 +826,7 @@ def powglu_fwd_npu(x: torch.Tensor, y: torch.Tensor, power: float = 3.0, output_
     y = _ensure_inner_contiguous(y)
     T, D = x.numel(), x.shape[-1]
     z = _alloc_output(x, output_contiguous)
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, memory_multiplier=_POWGLU_FWD_MEM_MULT)
     powglu_fwd_kernel[grid](
         x=x,
         y=y,
@@ -850,7 +862,7 @@ def powglu_fwdbwd_npu(
         z = _alloc_output(x, output_contiguous)
     else:
         z = None
-    grid, B = _activation_launch_config(T)
+    grid, B = _activation_launch_config(T, is_backward=True, memory_multiplier=_POWGLU_BWD_MEM_MULT)
     powglu_fwdbwd_kernel[grid](
         x=x,
         y=y,

--- a/fla/modules/backends/triton_ascend/fused_cross_entropy.py
+++ b/fla/modules/backends/triton_ascend/fused_cross_entropy.py
@@ -14,6 +14,15 @@ from triton.language.math import tanh
 
 from fla.ops.utils.op import exp, log
 from fla.utils import input_guard
+from fla.utils.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_vocab_block_size,
+    iter_axis_launch_chunks,
+)
+
+# Cross-entropy fwd/bwd peak fp32 buffers along vocab dimension.
+_CE_FWD_MEM_MULT = 8.0
+_CE_BWD_MEM_MULT = 12.0
 
 
 @triton.heuristics({
@@ -36,12 +45,14 @@ def cross_entropy_fwd_kernel(
     n_cols,
     n_rows,
     logits_row_stride,
+    ROW_OFFSET,
     BLOCK_SIZE: tl.constexpr,
     HAS_SMOOTHING: tl.constexpr,
     HAS_SOFTCAPPING: tl.constexpr,
     SPLIT: tl.constexpr,
 ):
     row_idx = tl.program_id(0)
+    abs_row_idx = row_idx + ROW_OFFSET
     col_block_idx = tl.program_id(1)
     logits_ptr = logits_ptr + row_idx * logits_row_stride.to(tl.int64)
     col_offsets = col_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -54,7 +65,7 @@ def cross_entropy_fwd_kernel(
     if HAS_SMOOTHING:
         sum_logits = tl.sum(tl.where(col_offsets < n_cols, logits, 0.0), 0)
     lse = log(tl.sum(exp(logits - max_logits), 0)) + max_logits
-    tl.store(lse_ptr + col_block_idx * n_rows + row_idx, lse)
+    tl.store(lse_ptr + col_block_idx * n_rows + abs_row_idx, lse)
     if label_idx == ignore_index:
         loss = 0.0
         z_loss = 0.0
@@ -84,9 +95,9 @@ def cross_entropy_fwd_kernel(
             loss += z_loss
         else:
             z_loss = 0.0
-    tl.store(loss_ptr + col_block_idx * n_rows + row_idx, loss)
+    tl.store(loss_ptr + col_block_idx * n_rows + abs_row_idx, loss)
     if not SPLIT:
-        tl.store(z_loss_ptr + col_block_idx * n_rows + row_idx, z_loss)
+        tl.store(z_loss_ptr + col_block_idx * n_rows + abs_row_idx, z_loss)
 
 
 @triton.heuristics({
@@ -110,18 +121,20 @@ def cross_entropy_bwd_kernel(
     logits_row_stride,
     dlogits_row_stride,
     dloss_row_stride,
+    ROW_OFFSET,
     BLOCK_SIZE: tl.constexpr,
     HAS_SMOOTHING: tl.constexpr,
     HAS_SOFTCAPPING: tl.constexpr,
 ):
     row_idx = tl.program_id(0)
+    abs_row_idx = row_idx + ROW_OFFSET
     col_block_idx = tl.program_id(1)
     logits_ptr = logits_ptr + row_idx * logits_row_stride.to(tl.int64)
     dlogits_ptr = dlogits_ptr + row_idx * dlogits_row_stride.to(tl.int64)
     col_offsets = col_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     label_idx = tl.load(labels_ptr + row_idx)
     if label_idx != ignore_index:
-        dloss = tl.load(dloss_ptr + row_idx * dloss_row_stride)
+        dloss = tl.load(dloss_ptr + abs_row_idx * dloss_row_stride)
     else:
         dloss = 0.0
     logits = tl.load(logits_ptr + col_offsets, mask=col_offsets < n_cols, other=-float("inf")).to(
@@ -130,7 +143,7 @@ def cross_entropy_bwd_kernel(
     if HAS_SOFTCAPPING:
         t = tanh(logits / logit_softcapping)
         logits = logit_softcapping * t
-    lse = tl.load(lse_ptr + row_idx)
+    lse = tl.load(lse_ptr + abs_row_idx)
     probs = exp(logits - lse)
     probs += 2.0 * lse_square_scale * lse * probs
     label_idx -= class_start_idx
@@ -144,15 +157,108 @@ def cross_entropy_bwd_kernel(
     tl.store(dlogits_ptr + col_offsets, (dloss * logit_scale) * probs, mask=col_offsets < n_cols)
 
 
-def _npu_block_size(n_cols: int, n_rows: int) -> tuple[int, int]:
-    block_size = 1024 if n_cols <= 32768 else (2048 if n_cols <= 131072 else 4096)
-    max_splits = max(1, 65535 // max(n_rows, 1))
-    block_size = min(
-        max(block_size, triton.next_power_of_2((n_cols + max_splits - 1) // max_splits)),
-        8192,
-    )
+def _npu_block_size(n_cols: int, n_rows: int, is_backward: bool = False) -> tuple[int, int]:
+    memory_multiplier = _CE_BWD_MEM_MULT if is_backward else _CE_FWD_MEM_MULT
+    block_size = compute_vocab_block_size(n_cols, n_rows, memory_multiplier)
     num_warps = 2 if block_size <= 2048 else 4
     return block_size, num_warps
+
+
+def _launch_cross_entropy_fwd(
+    losses,
+    lse,
+    z_losses,
+    logits,
+    target,
+    *,
+    label_smoothing,
+    logit_scale,
+    lse_square_scale,
+    softcap_val,
+    ignore_index,
+    total_classes,
+    class_start_idx,
+    n_cols,
+    n_rows,
+    logits_stride,
+    BLOCK_SIZE,
+    has_softcapping,
+    num_warps,
+    split,
+):
+    n_splits = triton.cdiv(n_cols, BLOCK_SIZE)
+    for row_off, row_len in iter_axis_launch_chunks(n_rows, n_splits, max_grid=ASCEND_MAX_GRID_DIM):
+        cross_entropy_fwd_kernel[(row_len, n_splits)](
+            losses,
+            lse,
+            z_losses,
+            logits[row_off:row_off + row_len],
+            target[row_off:row_off + row_len],
+            label_smoothing,
+            logit_scale,
+            lse_square_scale,
+            softcap_val,
+            ignore_index,
+            total_classes,
+            class_start_idx,
+            n_cols,
+            n_rows,
+            logits_stride,
+            row_off,
+            BLOCK_SIZE=BLOCK_SIZE,
+            HAS_SOFTCAPPING=has_softcapping,
+            num_warps=num_warps,
+            SPLIT=split,
+        )
+
+
+def _launch_cross_entropy_bwd(
+    dlogits,
+    grad_losses,
+    logits,
+    lse,
+    target,
+    *,
+    label_smoothing,
+    logit_scale,
+    lse_square_scale,
+    softcap_val,
+    ignore_index,
+    total_classes,
+    class_start_idx,
+    n_cols,
+    n_rows,
+    logits_stride,
+    dlogits_stride,
+    grad_losses_stride,
+    BLOCK_SIZE,
+    has_softcapping,
+    num_warps,
+):
+    n_splits = triton.cdiv(n_cols, BLOCK_SIZE)
+    for row_off, row_len in iter_axis_launch_chunks(n_rows, n_splits, max_grid=ASCEND_MAX_GRID_DIM):
+        cross_entropy_bwd_kernel[(row_len, n_splits)](
+            dlogits[row_off:row_off + row_len],
+            grad_losses,
+            logits[row_off:row_off + row_len],
+            lse,
+            target[row_off:row_off + row_len],
+            label_smoothing,
+            logit_scale,
+            lse_square_scale,
+            softcap_val,
+            ignore_index,
+            total_classes,
+            class_start_idx,
+            n_cols,
+            logits_stride,
+            dlogits_stride,
+            grad_losses_stride,
+            row_off,
+            BLOCK_SIZE=BLOCK_SIZE,
+            HAS_SOFTCAPPING=has_softcapping,
+            num_warps=num_warps,
+        )
 
 
 def fused_cross_entropy_forward_npu(
@@ -186,26 +292,26 @@ def fused_cross_entropy_forward_npu(
     lse = torch.empty(*loss_shape, dtype=torch.float, device=logits.device)
     z_losses = torch.empty(*loss_shape, dtype=torch.float, device=logits.device)
 
-    cross_entropy_fwd_kernel[(n_rows, n_splits)](
+    _launch_cross_entropy_fwd(
         losses,
         lse,
         z_losses,
         logits,
         target,
-        label_smoothing,
-        logit_scale,
-        lse_square_scale,
-        softcap_val,
-        ignore_index,
-        total_classes,
-        class_start_idx,
-        n_cols,
-        n_rows,
-        logits.stride(0),
+        label_smoothing=label_smoothing,
+        logit_scale=logit_scale,
+        lse_square_scale=lse_square_scale,
+        softcap_val=softcap_val,
+        ignore_index=ignore_index,
+        total_classes=total_classes,
+        class_start_idx=class_start_idx,
+        n_cols=n_cols,
+        n_rows=n_rows,
+        logits_stride=logits.stride(0),
         BLOCK_SIZE=BLOCK_SIZE,
-        HAS_SOFTCAPPING=has_softcapping,
+        has_softcapping=has_softcapping,
         num_warps=num_warps,
-        SPLIT=split,
+        split=split,
     )
 
     if split:
@@ -247,30 +353,30 @@ def fused_cross_entropy_backward_npu(
     class_start_idx: int,
 ) -> torch.Tensor:
     n_rows, n_cols = logits.shape
-    BLOCK_SIZE, num_warps = _npu_block_size(n_cols, n_rows)
+    BLOCK_SIZE, num_warps = _npu_block_size(n_cols, n_rows, is_backward=True)
     has_softcapping = logit_softcapping is not None
     softcap_val = float(logit_softcapping) if has_softcapping else 0.0
 
-    def grid(META): return (n_rows, triton.cdiv(n_cols, META["BLOCK_SIZE"]))  # noqa
-    cross_entropy_bwd_kernel[grid](
+    _launch_cross_entropy_bwd(
         dlogits,
         grad_losses,
         logits,
         lse,
         target,
-        label_smoothing,
-        logit_scale,
-        lse_square_scale,
-        softcap_val,
-        ignore_index,
-        total_classes,
-        class_start_idx,
-        n_cols,
-        logits.stride(0),
-        dlogits.stride(0),
-        grad_losses.stride(0),
+        label_smoothing=label_smoothing,
+        logit_scale=logit_scale,
+        lse_square_scale=lse_square_scale,
+        softcap_val=softcap_val,
+        ignore_index=ignore_index,
+        total_classes=total_classes,
+        class_start_idx=class_start_idx,
+        n_cols=n_cols,
+        n_rows=n_rows,
+        logits_stride=logits.stride(0),
+        dlogits_stride=dlogits.stride(0),
+        grad_losses_stride=grad_losses.stride(0),
         BLOCK_SIZE=BLOCK_SIZE,
-        HAS_SOFTCAPPING=has_softcapping,
+        has_softcapping=has_softcapping,
         num_warps=num_warps,
     )
     return dlogits

--- a/fla/modules/backends/triton_ascend/fused_kl_div.py
+++ b/fla/modules/backends/triton_ascend/fused_kl_div.py
@@ -13,8 +13,10 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp, log
+from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, compute_elementwise_block_size, compute_vocab_block_size
 
-MAX_FUSED_SIZE = 65536 // 2
+_KLD_FWD_MEM_MULT = 12.0
+_ELEMENTWISE_MEM_MULT = 2.5
 STATIC_WARPS = 2
 
 
@@ -92,12 +94,7 @@ def elementwise_mul_kernel(
 
 
 def _npu_vocab_block_size(vocab_size: int, num_rows: int) -> int:
-    block_size = 1024 if vocab_size <= 32768 else (2048 if vocab_size <= 131072 else 4096)
-    max_splits = max(1, 65535 // max(num_rows, 1))
-    return min(
-        max(block_size, triton.next_power_of_2((vocab_size + max_splits - 1) // max_splits)),
-        8192,
-    )
+    return compute_vocab_block_size(vocab_size, num_rows, _KLD_FWD_MEM_MULT)
 
 
 def fused_kl_div_forward_npu(
@@ -113,7 +110,7 @@ def fused_kl_div_forward_npu(
     N, H, V = *x.shape, weight.shape[0]
     BV = _npu_vocab_block_size(V, N)
     NC = min(8, triton.cdiv(V, H))
-    C = triton.next_power_of_2(triton.cdiv(N, NC))
+    C = min(triton.next_power_of_2(triton.cdiv(N, NC)), ASCEND_MAX_GRID_DIM)
     NC = triton.cdiv(N, C)
 
     grad_dtype = torch.float32 if accumulate_grad_in_fp32 else weight.dtype
@@ -167,7 +164,7 @@ def fused_kl_div_backward_npu(
 ):
     if torch.ne(do, torch.tensor(1.0, device=do.device)):
         N, H = dx.shape
-        B = min(MAX_FUSED_SIZE, max(1024, triton.next_power_of_2((N * H + 65534) // 65535)))
+        B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
 
         elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
             x=dx,
@@ -179,7 +176,7 @@ def fused_kl_div_backward_npu(
 
         if dw is not None:
             V, H = dw.shape
-            B_dw = min(MAX_FUSED_SIZE, max(1024, triton.next_power_of_2((V * H + 65534) // 65535)))
+            B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
             elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
                 x=dw,
                 g=do,

--- a/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
+++ b/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
@@ -14,8 +14,17 @@ import triton.language as tl
 from triton.language.math import tanh
 
 from fla.ops.utils.op import exp, log
+from fla.utils.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_elementwise_block_size,
+    compute_vocab_block_size,
+    iter_axis_launch_chunks,
+)
 
-MAX_FUSED_SIZE = 65536 // 2
+# Fused linear CE: logsumexp forward vs gradient kernels along vocab.
+_LCE_FWD_MEM_MULT = 8.0
+_LCE_BWD_MEM_MULT = 12.0
+_ELEMENTWISE_MEM_MULT = 2.5
 STATIC_WARPS = 2
 
 
@@ -157,13 +166,9 @@ def elementwise_mul_kernel(
     tl.store(x + o_x, b_x * b_g, mask=o_x < N)
 
 
-def _npu_vocab_block_size(vocab_size: int, num_rows: int) -> int:
-    block_size = 1024 if vocab_size <= 32768 else (2048 if vocab_size <= 131072 else 4096)
-    max_splits = max(1, 65535 // max(num_rows, 1))
-    return min(
-        max(block_size, triton.next_power_of_2((vocab_size + max_splits - 1) // max_splits)),
-        8192,
-    )
+def _npu_vocab_block_size(vocab_size: int, num_rows: int, is_backward: bool = True) -> int:
+    memory_multiplier = _LCE_BWD_MEM_MULT if is_backward else _LCE_FWD_MEM_MULT
+    return compute_vocab_block_size(vocab_size, num_rows, memory_multiplier)
 
 
 def logsumexp_fwd_npu(
@@ -175,21 +180,22 @@ def logsumexp_fwd_npu(
     shape = x.shape
     x = x.view(-1, shape[-1])
     N, D = x.shape
-    B = _npu_vocab_block_size(D, N)
+    B = _npu_vocab_block_size(D, N, is_backward=False)
     has_softcapping = softcapping is not None
     softcap_val = float(softcapping) if has_softcapping else 0.0
 
     z = x.new_empty(N, dtype=torch.float)
-    logsumexp_fwd_kernel[(N,)](
-        x=x,
-        z=z,
-        scale=scale,
-        softcapping=softcap_val,
-        D=D,
-        B=B,
-        ROWWISE=True,
-        HAS_SOFTCAPPING=has_softcapping,
-    )
+    for row_off, row_len in iter_axis_launch_chunks(N, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        logsumexp_fwd_kernel[(row_len,)](
+            x=x[row_off:row_off + row_len],
+            z=z[row_off:row_off + row_len],
+            scale=scale,
+            softcapping=softcap_val,
+            D=D,
+            B=B,
+            ROWWISE=True,
+            HAS_SOFTCAPPING=has_softcapping,
+        )
     z = z.view(*shape[:-1])
     if dtype is not None and dtype != torch.float:
         z = z.to(dtype)
@@ -217,7 +223,7 @@ def fused_linear_cross_entropy_forward_npu(
     has_softcapping = logit_softcapping is not None
     softcap_val = float(logit_softcapping) if has_softcapping else 0.0
     NC = min(num_chunks, triton.cdiv(V, H))
-    C = triton.next_power_of_2(triton.cdiv(N, NC))
+    C = min(triton.next_power_of_2(triton.cdiv(N, NC)), ASCEND_MAX_GRID_DIM)
     NC = triton.cdiv(N, C)
 
     dx = torch.zeros_like(x, device=device)
@@ -307,7 +313,7 @@ def fused_linear_cross_entropy_backward_npu(
 ):
     if torch.ne(do, torch.tensor(1.0, device=do.device)):
         N, H = dx.shape
-        B = min(MAX_FUSED_SIZE, max(1024, triton.next_power_of_2((N * H + 65534) // 65535)))
+        B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
 
         elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
             x=dx,
@@ -319,7 +325,7 @@ def fused_linear_cross_entropy_backward_npu(
 
         if dw is not None:
             V, H = dw.shape
-            B_dw = min(MAX_FUSED_SIZE, max(1024, triton.next_power_of_2((V * H + 65534) // 65535)))
+            B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
             elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
                 x=dw,
                 g=do,
@@ -330,7 +336,7 @@ def fused_linear_cross_entropy_backward_npu(
 
         if db is not None:
             V = db.shape[0]
-            B_db = min(MAX_FUSED_SIZE, max(1024, triton.next_power_of_2((V + 65534) // 65535)))
+            B_db = compute_elementwise_block_size(V, _ELEMENTWISE_MEM_MULT)
             elementwise_mul_kernel[(triton.cdiv(V, B_db),)](
                 x=db,
                 g=do,

--- a/fla/modules/backends/triton_ascend/grpo.py
+++ b/fla/modules/backends/triton_ascend/grpo.py
@@ -13,17 +13,15 @@ import triton.language as tl
 
 from fla.ops.utils.op import exp, log
 from fla.utils import input_guard
+from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, compute_vocab_block_size, iter_axis_launch_chunks
 
+# GRPO: use conservative multiplier covering both fwd softmax and bwd grad paths.
+_GRPO_MEM_MULT = 8.0
 STATIC_WARPS = 2
 
 
 def _npu_vocab_block_size(vocab_size: int, num_rows: int) -> int:
-    block_size = 1024 if vocab_size <= 32768 else (2048 if vocab_size <= 131072 else 4096)
-    max_splits = max(1, 65535 // max(num_rows, 1))
-    return min(
-        max(block_size, triton.next_power_of_2((vocab_size + max_splits - 1) // max_splits)),
-        8192,
-    )
+    return compute_vocab_block_size(vocab_size, num_rows, _GRPO_MEM_MULT)
 
 
 @triton.jit
@@ -43,8 +41,9 @@ def grpo_fwd_kernel(
     L,
     start_idx,
     BLOCK_SIZE: tl.constexpr,
+    ROW_OFFSET: tl.constexpr,
 ):
-    row_idx = tl.program_id(0)
+    row_idx = tl.program_id(0) + ROW_OFFSET
 
     off_b = row_idx // L
     N = tl.cast(N, tl.int64)
@@ -108,8 +107,9 @@ def grpo_bwd_kernel(
     L,
     start_idx,
     BLOCK_SIZE: tl.constexpr,
+    ROW_OFFSET: tl.constexpr,
 ):
-    row_idx = tl.program_id(0)
+    row_idx = tl.program_id(0) + ROW_OFFSET
     off_b = row_idx // L
 
     N = tl.cast(N, tl.int64)
@@ -177,24 +177,26 @@ class GrpoLossNPU(torch.autograd.Function):
         else:
             loss[:B].masked_fill_(completion_mask.logical_not(), 0.0)
 
-        grpo_fwd_kernel[(M,)](
-            logits_ptr=logits,
-            ref_logp_ptr=ref_logp,
-            input_ids_ptr=input_ids,
-            advantages_ptr=advantages,
-            completion_mask_ptr=completion_mask,
-            loss_ptr=loss,
-            lse_ptr=lse,
-            beta=beta,
-            save_kl=save_kl,
-            B=B,
-            M=M,
-            N=N,
-            L=L,
-            start_idx=input_ids_start_index,
-            BLOCK_SIZE=block_size,
-            num_warps=STATIC_WARPS,
-        )
+        for row_off, row_len in iter_axis_launch_chunks(M, 1, max_grid=ASCEND_MAX_GRID_DIM):
+            grpo_fwd_kernel[(row_len,)](
+                logits_ptr=logits,
+                ref_logp_ptr=ref_logp,
+                input_ids_ptr=input_ids,
+                advantages_ptr=advantages,
+                completion_mask_ptr=completion_mask,
+                loss_ptr=loss,
+                lse_ptr=lse,
+                beta=beta,
+                save_kl=save_kl,
+                B=B,
+                M=M,
+                N=N,
+                L=L,
+                start_idx=input_ids_start_index,
+                BLOCK_SIZE=block_size,
+                ROW_OFFSET=row_off,
+                num_warps=STATIC_WARPS,
+            )
         ctx.beta = beta
         ctx.save_for_backward(lse, logits, input_ids, advantages, completion_mask)
         ctx.ref_logp = ref_logp
@@ -216,23 +218,25 @@ class GrpoLossNPU(torch.autograd.Function):
 
         dlogits = logits if inplace else torch.empty_like(logits)
 
-        grpo_bwd_kernel[(M,)](
-            dloss_ptr=dloss,
-            dlogits_ptr=dlogits,
-            logits_ptr=logits,
-            ref_logp_ptr=ctx.ref_logp,
-            input_ids_ptr=input_ids,
-            advantages_ptr=advantages,
-            completion_mask_ptr=completion_mask,
-            lse_ptr=lse,
-            beta=ctx.beta,
-            B=B,
-            N=N,
-            L=L,
-            BLOCK_SIZE=block_size,
-            start_idx=input_ids_start_index,
-            num_warps=STATIC_WARPS,
-        )
+        for row_off, row_len in iter_axis_launch_chunks(M, 1, max_grid=ASCEND_MAX_GRID_DIM):
+            grpo_bwd_kernel[(row_len,)](
+                dloss_ptr=dloss,
+                dlogits_ptr=dlogits,
+                logits_ptr=logits,
+                ref_logp_ptr=ctx.ref_logp,
+                input_ids_ptr=input_ids,
+                advantages_ptr=advantages,
+                completion_mask_ptr=completion_mask,
+                lse_ptr=lse,
+                beta=ctx.beta,
+                B=B,
+                N=N,
+                L=L,
+                BLOCK_SIZE=block_size,
+                start_idx=input_ids_start_index,
+                ROW_OFFSET=row_off,
+                num_warps=STATIC_WARPS,
+            )
         dlogits[:, -1, :].fill_(0.0)
         return dlogits.view(*ctx.input_shape), None, None, None, None, None, None, None
 

--- a/fla/modules/backends/triton_ascend/layernorm.py
+++ b/fla/modules/backends/triton_ascend/layernorm.py
@@ -11,17 +11,38 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.utils import autotune_cache_kwargs, get_multiprocessor_count
+from fla.utils import get_multiprocessor_count
+from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, compute_ub_block_size, iter_axis_launch_chunks
 
-# Ascend vector UB is small; avoid make_block_ptr tiled kernels and large warp counts.
-NUM_WARPS_AUTOTUNE = [2, 4]
+# Peak live fp32 vectors in row-wise kernel1 (see Liger Ascend layer_norm).
+_FWD_MEM_MULT = 6.0
+_BWD_MEM_MULT = 8.0
+_UB_SAFETY_MARGIN = 0.85
+# Legacy byte cap when UB capacity cannot be detected (65536 // fp32).
+_FALLBACK_MAX_BD = 65536 // 4
 
 
-@triton.autotune(
-    configs=[triton.Config({}, num_warps=num_warps) for num_warps in NUM_WARPS_AUTOTUNE],
-    key=['D', 'IS_RMS_NORM'],
-    **autotune_cache_kwargs,
-)
+def _get_layer_norm_bd(D: int, is_forward: bool) -> int:
+    """Return power-of-2 block size for feature dim D under UB constraints."""
+    memory_multiplier = _FWD_MEM_MULT if is_forward else _BWD_MEM_MULT
+    return compute_ub_block_size(
+        D,
+        memory_multiplier,
+        safety_margin=_UB_SAFETY_MARGIN,
+        fallback=_FALLBACK_MAX_BD,
+        desired=triton.next_power_of_2(D),
+    )
+
+
+def _layer_norm_bwd_launch_config(T: int, G: int, device_index: int) -> tuple[int, int, int]:
+    """Return (NS, BS, GS) capped under Ascend grid limit."""
+    NS = min(triton.cdiv(get_multiprocessor_count(device_index), G), T // G) * G
+    NS = min(NS, ASCEND_MAX_GRID_DIM)
+    BS = triton.cdiv(T, NS) if NS > 0 else T
+    GS = NS // G if G > 0 else NS
+    return NS, BS, GS
+
+
 @triton.jit
 def layer_norm_fwd_kernel1(
     x,
@@ -85,11 +106,6 @@ def layer_norm_fwd_kernel1(
 @triton.heuristics({
     'RECOMPUTE_OUTPUT': lambda args: args['y'] is not None,
 })
-@triton.autotune(
-    configs=[triton.Config({}, num_warps=num_warps) for num_warps in NUM_WARPS_AUTOTUNE],
-    key=['D', 'HAS_DRESIDUAL', 'STORE_DRESIDUAL', 'IS_RMS_NORM'],
-    **autotune_cache_kwargs,
-)
 @triton.jit
 def layer_norm_bwd_kernel1(
     x,
@@ -172,6 +188,43 @@ def layer_norm_bwd_kernel1(
         tl.store(db + i_s * D + o_d, b_db, mask=mask)
 
 
+def _launch_layer_norm_fwd_kernel1(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    residual: torch.Tensor,
+    res_out: torch.Tensor,
+    mean: torch.Tensor,
+    rstd: torch.Tensor,
+    eps: float,
+    G: int,
+    D: int,
+    BD: int,
+    is_rms_norm: bool,
+):
+    chunk_T = x.shape[0]
+    layer_norm_fwd_kernel1[(chunk_T,)](
+        x,
+        y,
+        weight,
+        bias,
+        residual,
+        res_out,
+        mean,
+        rstd,
+        eps,
+        G=G,
+        D=D,
+        BD=BD,
+        IS_RMS_NORM=is_rms_norm,
+        HAS_RESIDUAL=residual is not None,
+        STORE_RESIDUAL_OUT=res_out is not None,
+        HAS_WEIGHT=weight is not None,
+        HAS_BIAS=bias is not None,
+    )
+
+
 def layer_norm_fwd_npu(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -201,31 +254,32 @@ def layer_norm_fwd_npu(
     mean = torch.empty((T,), dtype=torch.float, device=x.device) if not is_rms_norm else None
     rstd = torch.empty((T,), dtype=torch.float, device=x.device)
 
-    MAX_FUSED_SIZE = 65536 // x.element_size()
-    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    BD = _get_layer_norm_bd(D, is_forward=True)
     if D > BD:
-        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+        raise RuntimeError(
+            f"LayerNorm feature dim {D} exceeds UB-safe block size {BD}. "
+            "Column-tiled kernels are not yet implemented for this size."
+        )
 
     # Ascend: use row-wise kernel1 (no make_block_ptr) for all feature dims.
-    layer_norm_fwd_kernel1[(T,)](
-        x,
-        y,
-        weight,
-        bias,
-        residual,
-        res_out,
-        mean,
-        rstd,
-        eps,
-        G=G,
-        D=D,
-        BD=BD,
-        IS_RMS_NORM=is_rms_norm,
-        HAS_RESIDUAL=residual is not None,
-        STORE_RESIDUAL_OUT=res_out is not None,
-        HAS_WEIGHT=weight is not None,
-        HAS_BIAS=bias is not None,
-    )
+    # Split along rows when T exceeds the Ascend grid limit.
+    for row_start, row_len in iter_axis_launch_chunks(T, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        row_end = row_start + row_len
+        _launch_layer_norm_fwd_kernel1(
+            x[row_start:row_end],
+            y[row_start:row_end],
+            weight,
+            bias,
+            None if residual is None else residual[row_start:row_end],
+            None if res_out is None else res_out[row_start:row_end],
+            None if mean is None else mean[row_start:row_end],
+            rstd[row_start:row_end],
+            eps,
+            G,
+            D,
+            BD,
+            is_rms_norm,
+        )
     return y, mean, rstd, res_out if res_out is not None else x
 
 
@@ -256,14 +310,14 @@ def layer_norm_bwd_npu(
     dres_in = torch.empty_like(x) if has_residual and dx.dtype != x.dtype else None
     y = torch.empty(T, D, dtype=dy.dtype, device=dy.device) if recompute_output else None
 
-    MAX_FUSED_SIZE = 65536 // x.element_size()
-    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    BD = _get_layer_norm_bd(D, is_forward=False)
     if D > BD:
-        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+        raise RuntimeError(
+            f"LayerNorm feature dim {D} exceeds UB-safe block size {BD}. "
+            "Column-tiled kernels are not yet implemented for this size."
+        )
 
-    NS = min(triton.cdiv(get_multiprocessor_count(x.device.index), G), T // G) * G
-    BS = triton.cdiv(T, NS)
-    GS = NS // G
+    NS, BS, GS = _layer_norm_bwd_launch_config(T, G, x.device.index)
 
     dw = torch.empty((NS, D), dtype=torch.float, device=weight.device) if weight is not None else None
     db = torch.empty((NS, D), dtype=torch.float, device=bias.device) if bias is not None else None

--- a/fla/modules/backends/triton_ascend/rotary.py
+++ b/fla/modules/backends/triton_ascend/rotary.py
@@ -13,6 +13,16 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.utils import autotune_cache_kwargs, get_multiprocessor_count
+from fla.utils.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_grid_limited_tile_size,
+    compute_row_tile_block_size,
+    max_grid_axis_chunks,
+)
+
+# Peak live fp32 tiles in rotary kernel: cos, sin, x0, x1, o0, o1.
+_ROTARY_MEM_MULT = 6.0
+_ROTARY_SAFETY_MARGIN = 0.90
 
 # Ascend vector UB is small; large num_warps / stages explodes compile-time UB (see bishengir ub overflow).
 NUM_WARPS_AUTOTUNE = [2, 4]
@@ -49,8 +59,10 @@ def rotary_embedding_kernel(
     IS_VARLEN: tl.constexpr,
     INTERLEAVED: tl.constexpr,
     CONJUGATE: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
 ):
     i_t, i_b, i_h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t += NT_OFFSET
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
@@ -149,27 +161,30 @@ def rotary_embedding_fwdbwd_npu(
         y[..., R2:].copy_(x[..., R2:])
 
     BD = triton.next_power_of_2(R2)
-    # GPU: one program loads a [BT, R] tile of cos/sin/x in fp32; Ascend UB (~192KiB) overflows for BT=128, R=128.
-    if R >= 128:
-        bt_cap = 16
-    elif R >= 64:
-        bt_cap = 32
-    else:
-        bt_cap = 64
-    BT = min(bt_cap, triton.next_power_of_2(triton.cdiv(T, get_multiprocessor_count(x.device.index))))
+    desired_bt = triton.next_power_of_2(triton.cdiv(T, get_multiprocessor_count(x.device.index)))
+    bt_cap = compute_row_tile_block_size(
+        desired_bt,
+        R2,
+        _ROTARY_MEM_MULT,
+        safety_margin=_ROTARY_SAFETY_MARGIN,
+        dtype_size=x.element_size(),
+        fallback=16 if R >= 128 else (32 if R >= 64 else 64),
+        min_block=1,
+    )
+    BT = min(bt_cap, desired_bt)
+    BT = compute_grid_limited_tile_size(T, B * H, BT, max_grid=ASCEND_MAX_GRID_DIM)
     if chunk_indices is None and is_varlen:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = len(chunk_indices) if is_varlen else triton.cdiv(T, BT)
 
-    grid = (NT, B, H)
-    rotary_embedding_kernel[grid](
-        x,
-        cos,
-        sin,
-        y,
-        cu_seqlens,
-        chunk_indices,
-        seqlen_offsets,
+    kernel_kwargs = dict(
+        x=x,
+        cos=cos,
+        sin=sin,
+        y=y,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        seq_offsets=seqlen_offsets,
         B=B,
         T=T,
         H=H,
@@ -183,4 +198,14 @@ def rotary_embedding_fwdbwd_npu(
         INTERLEAVED=interleaved,
         CONJUGATE=conjugate,
     )
+    max_nt = max_grid_axis_chunks(NT, B * H, max_grid=ASCEND_MAX_GRID_DIM)
+    for nt_off in range(0, NT, max_nt):
+        nt_len = min(max_nt, NT - nt_off)
+        if is_varlen:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['NT_OFFSET'] = 0
+        else:
+            kernel_kwargs['chunk_indices'] = chunk_indices
+            kernel_kwargs['NT_OFFSET'] = nt_off
+        rotary_embedding_kernel[(nt_len, B, H)](**kernel_kwargs)
     return y

--- a/fla/ops/utils/backends/triton_ascend/cumsum.py
+++ b/fla/ops/utils/backends/triton_ascend/cumsum.py
@@ -13,11 +13,172 @@ import triton.language as tl
 
 from fla.ops.utils.index import prepare_chunk_indices
 from fla.utils import input_guard
+from fla.utils.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_grid_limited_tile_size,
+    compute_row_tile_block_size,
+    compute_ub_block_size,
+    iter_axis_launch_chunks,
+    max_grid_axis_chunks,
+)
 
 _NUM_WARPS = 4
-_BT_GLOBAL = 32
-_BS_GLOBAL = 16
-_BS_LOCAL = 32
+# Peak live fp32 tiles: b_s, b_o (and b_z / partial sums for vector/global).
+_CUMSUM_SCALAR_MEM_MULT = 3.0
+# b_s, b_c, b_z, plus tl.cumsum multi-buffer on [BT, BS] tiles.
+_CUMSUM_VECTOR_MEM_MULT = 8.0
+_CUMSUM_SAFETY_MARGIN = 0.85
+_FALLBACK_BT_GLOBAL = 32
+_FALLBACK_BS_LOCAL = 32
+_FALLBACK_BS_GLOBAL = 16
+_MAX_BT_GLOBAL = 256
+
+
+def _get_global_scalar_bt(T: int) -> int:
+    """UB-safe time chunk size for global scalar cumsum."""
+    desired = min(triton.next_power_of_2(T), _MAX_BT_GLOBAL)
+    return compute_ub_block_size(
+        T,
+        _CUMSUM_SCALAR_MEM_MULT,
+        safety_margin=_CUMSUM_SAFETY_MARGIN,
+        dtype_size=4,
+        fallback=_FALLBACK_BT_GLOBAL,
+        desired=desired,
+    )
+
+
+def _get_vector_bs(BT: int, S: int, *, fallback: int, max_block: int | None = None) -> int:
+    """UB-safe feature tile size for vector cumsum with fixed time chunk BT."""
+    return compute_row_tile_block_size(
+        BT,
+        S,
+        _CUMSUM_VECTOR_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_CUMSUM_SAFETY_MARGIN,
+        dtype_size=4,
+        fallback=fallback,
+        min_block=1,
+        max_block=max_block,
+    )
+
+
+def _get_global_vector_tile_config(T: int, S: int) -> tuple[int, int]:
+    """UB-safe (BT, BS) for global vector cumsum."""
+    bs_cap = min(_FALLBACK_BS_GLOBAL, triton.next_power_of_2(S))
+    BS = _get_vector_bs(
+        _FALLBACK_BT_GLOBAL,
+        S,
+        fallback=_FALLBACK_BS_GLOBAL,
+        max_block=bs_cap,
+    )
+    BT = compute_row_tile_block_size(
+        T,
+        BS,
+        _CUMSUM_VECTOR_MEM_MULT,
+        tiling_row=True,
+        safety_margin=_CUMSUM_SAFETY_MARGIN,
+        dtype_size=4,
+        fallback=_FALLBACK_BT_GLOBAL,
+        min_block=1,
+        max_block=_FALLBACK_BT_GLOBAL,
+    )
+    BS = _get_vector_bs(BT, S, fallback=_FALLBACK_BS_GLOBAL, max_block=bs_cap)
+    return BT, BS
+
+
+def _launch_local_cumsum_scalar(
+    *,
+    g_org,
+    g,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B,
+    H,
+    BT,
+    NT,
+    head_first,
+    reverse,
+):
+    bh_total = B * H
+    kernel_kwargs = dict(
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        T=T,
+        B=B,
+        H=H,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+        num_warps=_NUM_WARPS,
+    )
+    max_nt = max_grid_axis_chunks(NT, bh_total, max_grid=ASCEND_MAX_GRID_DIM)
+    for nt_off in range(0, NT, max_nt):
+        nt_len = min(max_nt, NT - nt_off)
+        if cu_seqlens is not None:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['NT_OFFSET'] = 0
+        else:
+            kernel_kwargs['chunk_indices'] = chunk_indices
+            kernel_kwargs['NT_OFFSET'] = nt_off
+        max_bh = max_grid_axis_chunks(bh_total, nt_len, max_grid=ASCEND_MAX_GRID_DIM)
+        for bh_off in range(0, bh_total, max_bh):
+            bh_len = min(max_bh, bh_total - bh_off)
+            kernel_kwargs['BH_OFFSET'] = bh_off
+            chunk_local_cumsum_scalar_kernel_npu[(nt_len, bh_len)](**kernel_kwargs)
+
+
+def _launch_local_cumsum_vector(
+    *,
+    g_org,
+    g,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B,
+    H,
+    S,
+    BT,
+    BS,
+    NT,
+    head_first,
+    reverse,
+):
+    bh_total = B * H
+    ns = triton.cdiv(S, BS)
+    kernel_kwargs = dict(
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        T=T,
+        B=B,
+        H=H,
+        S=S,
+        BT=BT,
+        BS=BS,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+        num_warps=_NUM_WARPS,
+    )
+    max_nt = max_grid_axis_chunks(NT, ns * bh_total, max_grid=ASCEND_MAX_GRID_DIM)
+    for nt_off in range(0, NT, max_nt):
+        nt_len = min(max_nt, NT - nt_off)
+        if cu_seqlens is not None:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['NT_OFFSET'] = 0
+        else:
+            kernel_kwargs['chunk_indices'] = chunk_indices
+            kernel_kwargs['NT_OFFSET'] = nt_off
+        max_bh = max_grid_axis_chunks(bh_total, ns * nt_len, max_grid=ASCEND_MAX_GRID_DIM)
+        for bh_off in range(0, bh_total, max_bh):
+            bh_len = min(max_bh, bh_total - bh_off)
+            kernel_kwargs['BH_OFFSET'] = bh_off
+            chunk_local_cumsum_vector_kernel_npu[(ns, nt_len, bh_len)](**kernel_kwargs)
 
 
 @triton.heuristics({
@@ -39,8 +200,12 @@ def chunk_local_cumsum_scalar_kernel_npu(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HEAD_FIRST: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t += NT_OFFSET
+    i_bh += BH_OFFSET
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
@@ -86,8 +251,12 @@ def chunk_local_cumsum_vector_kernel_npu(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HEAD_FIRST: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
 ):
     i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t += NT_OFFSET
+    i_bh += BH_OFFSET
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
@@ -130,8 +299,9 @@ def chunk_global_cumsum_scalar_kernel_npu(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HEAD_FIRST: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
 ):
-    i_nh = tl.program_id(0)
+    i_nh = tl.program_id(0) + BH_OFFSET
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
@@ -182,8 +352,9 @@ def chunk_global_cumsum_vector_kernel_npu(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HEAD_FIRST: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
 ):
-    i_s, i_nh = tl.program_id(0), tl.program_id(1)
+    i_s, i_nh = tl.program_id(0), tl.program_id(1) + BH_OFFSET
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
@@ -232,10 +403,9 @@ def chunk_local_cumsum_scalar_npu(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
-    grid = (NT, B * H)
-    chunk_local_cumsum_scalar_kernel_npu[grid](
-        s=g_org,
-        o=g,
+    _launch_local_cumsum_scalar(
+        g_org=g_org,
+        g=g,
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
@@ -243,9 +413,9 @@ def chunk_local_cumsum_scalar_npu(
         B=B,
         H=H,
         BT=BT,
-        HEAD_FIRST=head_first,
-        REVERSE=reverse,
-        num_warps=_NUM_WARPS,
+        NT=NT,
+        head_first=head_first,
+        reverse=reverse,
     )
     return g
 
@@ -270,11 +440,17 @@ def chunk_local_cumsum_vector_npu(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     assert chunk_size == 2**(chunk_size.bit_length()-1), "chunk_size must be a power of 2"
 
+    BS = _get_vector_bs(BT, S, fallback=_FALLBACK_BS_LOCAL)
+    BS = compute_grid_limited_tile_size(
+        S,
+        NT * B * H,
+        BS,
+        max_grid=ASCEND_MAX_GRID_DIM,
+    )
     g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
-    grid = (triton.cdiv(S, _BS_LOCAL), NT, B * H)
-    chunk_local_cumsum_vector_kernel_npu[grid](
-        s=g_org,
-        o=g,
+    _launch_local_cumsum_vector(
+        g_org=g_org,
+        g=g,
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
@@ -283,10 +459,10 @@ def chunk_local_cumsum_vector_npu(
         H=H,
         S=S,
         BT=BT,
-        BS=_BS_LOCAL,
-        HEAD_FIRST=head_first,
-        REVERSE=reverse,
-        num_warps=_NUM_WARPS,
+        BS=BS,
+        NT=NT,
+        head_first=head_first,
+        reverse=reverse,
     )
     return g
 
@@ -306,9 +482,10 @@ def chunk_global_cumsum_scalar_npu(
         B, T, H = s.shape
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
 
+    BT = _get_global_scalar_bt(T)
     z = torch.empty_like(s, dtype=output_dtype or s.dtype)
-    grid = (N * H,)
-    chunk_global_cumsum_scalar_kernel_npu[grid](
+    bh_total = N * H
+    kernel_kwargs = dict(
         s=s,
         o=z,
         scale=scale,
@@ -316,11 +493,14 @@ def chunk_global_cumsum_scalar_npu(
         T=T,
         B=B,
         H=H,
-        BT=_BT_GLOBAL,
+        BT=BT,
         HEAD_FIRST=head_first,
         REVERSE=reverse,
         num_warps=_NUM_WARPS,
     )
+    for bh_off, bh_len in iter_axis_launch_chunks(bh_total, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        kernel_kwargs['BH_OFFSET'] = bh_off
+        chunk_global_cumsum_scalar_kernel_npu[(bh_len,)](**kernel_kwargs)
     return z
 
 
@@ -338,11 +518,18 @@ def chunk_global_cumsum_vector_npu(
     else:
         B, T, H, S = s.shape
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
-    BS = min(_BS_GLOBAL, triton.next_power_of_2(S))
+    BT, BS = _get_global_vector_tile_config(T, S)
+    BS = compute_grid_limited_tile_size(
+        S,
+        N * H,
+        BS,
+        max_grid=ASCEND_MAX_GRID_DIM,
+    )
+    ns = triton.cdiv(S, BS)
 
     z = torch.empty_like(s, dtype=output_dtype or s.dtype)
-    grid = (triton.cdiv(S, BS), N * H)
-    chunk_global_cumsum_vector_kernel_npu[grid](
+    bh_total = N * H
+    kernel_kwargs = dict(
         s=s,
         o=z,
         scale=scale,
@@ -351,12 +538,17 @@ def chunk_global_cumsum_vector_npu(
         B=B,
         H=H,
         S=S,
-        BT=_BT_GLOBAL,
+        BT=BT,
         BS=BS,
         HEAD_FIRST=head_first,
         REVERSE=reverse,
         num_warps=_NUM_WARPS,
     )
+    max_bh = max_grid_axis_chunks(bh_total, ns, max_grid=ASCEND_MAX_GRID_DIM)
+    for bh_off in range(0, bh_total, max_bh):
+        bh_len = min(max_bh, bh_total - bh_off)
+        kernel_kwargs['BH_OFFSET'] = bh_off
+        chunk_global_cumsum_vector_kernel_npu[(ns, bh_len)](**kernel_kwargs)
     return z
 
 

--- a/fla/utils/ascend_ub_manager.py
+++ b/fla/utils/ascend_ub_manager.py
@@ -1,0 +1,576 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+# copied from https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/backends/_ascend/ub_manager.py
+
+"""
+Unified Buffer (UB) Manager for Ascend NPU.
+
+This module provides UB capacity detection and tiling strategy computation
+for running Triton kernels on Ascend NPU. It automatically calculates
+optimal block sizes based on UB capacity constraints to prevent UB overflow.
+"""
+
+import os
+import warnings
+
+import torch
+import triton
+
+# Ascend Triton launch limits (see triton_ascend/activations.py).
+ASCEND_MAX_GRID_DIM = 65535
+# Legacy fused kernel byte cap (65536 // fp16 element size).
+_FALLBACK_MAX_FUSED_BLOCK = 65536 // 2
+# Conservative UB fallback when runtime detection is unavailable (64 KiB).
+_FALLBACK_UB_CAPACITY_BITS = 65536 * 8
+
+
+def is_npu_available() -> bool:
+    """Detect Ascend NPU availability."""
+    if hasattr(torch, 'npu'):
+        try:
+            return torch.npu.is_available()
+        except Exception:
+            pass
+    try:
+        from transformers.utils import is_torch_npu_available
+
+        return is_torch_npu_available()
+    except ImportError:
+        return False
+
+
+def _fallback_ub_capacity(reason: str) -> int:
+    warnings.warn(
+        f"Using fallback UB capacity ({_FALLBACK_UB_CAPACITY_BITS // 8} bytes): {reason}",
+        stacklevel=3,
+    )
+    return _FALLBACK_UB_CAPACITY_BITS
+
+
+def _normalize_tiling_dims(tiling_dim: int | tuple[int, ...]) -> set:
+    """
+    Normalize tiling dimension specification to a set of dimension indices.
+
+    Args:
+        tiling_dim: Either an int (single dimension) or tuple of ints (multiple dimensions).
+
+    Returns:
+        Set of dimension indices that can be tiled.
+    """
+    if isinstance(tiling_dim, int):
+        return {tiling_dim}
+    elif isinstance(tiling_dim, tuple):
+        return set(tiling_dim)
+    else:
+        return set()
+
+
+def _default_strategy(
+    ub_capacity_bits: int,
+    safety_margin: float,
+    dtype_size: int,
+    memory_multiplier: float,
+    shapes: tuple[tuple[int, ...], ...],
+    tiling_dims: tuple[int | tuple[int, ...], ...],
+) -> tuple[int, ...]:
+    """
+    Default tiling strategy: calculate maximum safe block size based on UB capacity.
+
+    This is a unified strategy function that works for all kernels by abstracting
+    the memory calculation as: memory_multiplier * BLOCK_SIZE * unit_param * dtype_size * 8 bits
+
+    Args:
+        ub_capacity_bits: UB capacity in bits
+        safety_margin: Safety margin as a float (e.g., 0.80 for 80%)
+        dtype_size: Size of data type in bytes (e.g., 2 for float16, 4 for float32)
+        memory_multiplier: Memory multiplier for estimating peak memory usage
+        shapes: Tuple of full shapes. Each shape is a tuple of dimension sizes.
+            - For ROPE: ((n_q_head, hd), (n_kv_head, hd))
+            - For GEGLU: ((n_cols,),)
+        tiling_dims: Tuple specifying which dimensions can be tiled for each shape.
+            Each element can be:
+            - int: single dimension index (e.g., 0 for first dimension)
+            - tuple of ints: multiple dimensions that can be tiled together
+            - For ROPE: (0, 0) means first dimension of each shape can be tiled
+            - For GEGLU: (0,) means first dimension of the shape can be tiled
+            Length must match len(shapes).
+
+    Returns:
+        Tuple of maximum safe block sizes, one for each shape.
+        Each element is a power of 2.
+
+    Note:
+        For each shape, fixed dimensions (non-tiling) are multiplied together to get unit_param.
+        The final block size is computed in compute_default_tiling_strategy by taking
+        min(desired_block_size, max_safe_block_size) where desired_block_size = triton.next_power_of_2(original_dim).
+    """
+    if not shapes or not tiling_dims:
+        return ()
+
+    # Calculate max_safe_block_size for each tiling dimension
+    max_safe_sizes = []
+
+    for shape, tiling_dim in zip(shapes, tiling_dims):
+        # Normalize tiling_dim to a set of dimension indices
+        tiling_dim_set = _normalize_tiling_dims(tiling_dim)
+
+        # Validate tiling dimensions are within shape bounds
+        if not tiling_dim_set:
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim}. tiling_dim must be an int or a non-empty tuple of ints."
+            )
+        if any(dim_idx < 0 or dim_idx >= len(shape) for dim_idx in tiling_dim_set):
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim} for shape {shape}. "
+                f"All dimension indices must be in range [0, {len(shape)})."
+            )
+
+        # Calculate unit_param: product of fixed (non-tiling) dimensions
+        unit_param = 1.0
+        for dim_idx, dim_size in enumerate(shape):
+            if dim_idx not in tiling_dim_set:
+                if dim_size <= 0:
+                    # Invalid dimension size, use conservative default
+                    unit_param = 1.0
+                    break
+                unit_param *= float(dim_size)
+
+        # Ensure unit_param is at least 1.0
+        if unit_param <= 0:
+            unit_param = 1.0
+
+        # Calculate maximum safe block size based on UB capacity
+        # Memory: memory_multiplier * BLOCK_SIZE * unit_param * dtype_size * 8 bits
+        SAFE_UB_CAPACITY_BITS = int(ub_capacity_bits * safety_margin)
+
+        # Solve: memory_multiplier * BLOCK_SIZE * unit_param * dtype_size * 8 <= SAFE_UB_CAPACITY_BITS
+        # BLOCK_SIZE <= SAFE_UB_CAPACITY_BITS / (memory_multiplier * unit_param * dtype_size * 8)
+        max_block_size = int(SAFE_UB_CAPACITY_BITS // (memory_multiplier * unit_param * dtype_size * 8))
+        max_block_size = max(1, max_block_size)
+
+        # Find largest power of 2 <= max_block_size
+        # Use triton.next_power_of_2(max_block_size + 1) // 2 to get the largest power of 2 <= max_block_size
+        safe_block_size = triton.next_power_of_2(max_block_size + 1) // 2
+        max_safe_sizes.append(safe_block_size)
+
+    return tuple(max_safe_sizes)
+
+
+class UBManager:
+    """
+    Unified Buffer Manager for Ascend NPU.
+
+    Provides UB capacity detection and management for Ascend NPU devices.
+    The UB capacity is used by tiling strategy functions to calculate optimal block sizes.
+    """
+
+    def __init__(self, ub_capacity_bits: int | None = None):
+        """
+        Initialize UB Manager.
+
+        Args:
+            ub_capacity_bits: UB capacity in bits. If None, will be detected automatically.
+        """
+        self._npu_model = self._detect_npu_model()
+        self._ub_capacity_bits = ub_capacity_bits or self._detect_ub_capacity()
+
+    @property
+    def ub_capacity_bits(self) -> int:
+        """Get UB capacity in bits."""
+        return self._ub_capacity_bits
+
+    @property
+    def ub_capacity_bytes(self) -> int:
+        """Get UB capacity in bytes."""
+        return self._ub_capacity_bits // 8
+
+    @property
+    def npu_model(self) -> str:
+        """Get detected NPU model name."""
+        return self._npu_model
+
+    def _detect_npu_model(self) -> str:
+        """Detect NPU model from device properties."""
+        if not is_npu_available():
+            return "unknown"
+
+        try:
+            dev_props = torch.npu.get_device_properties(0)
+            # Try to get model name from device properties
+            return dev_props.name
+        except Exception:
+            pass
+
+        return "default"
+
+    def _detect_ub_capacity(self) -> int:
+        """
+        Detect UB capacity from environment variable or get_soc_spec.
+
+        Returns:
+            UB capacity in bits. Falls back to a conservative default with a warning
+            when detection fails.
+        """
+        # Check environment variable first (in bits)
+        env_capacity = os.getenv("ASCEND_UB_CAPACITY_BITS")
+        if env_capacity is not None:
+            try:
+                capacity_bits = int(env_capacity)
+                if capacity_bits > 0:
+                    return capacity_bits
+            except ValueError:
+                pass
+
+        # Try to get from get_soc_spec (returns bytes, convert to bits)
+        if is_npu_available():
+            try:
+                from tbe.common.platform import get_soc_spec, set_current_compile_soc_info
+
+                # Set current SOC info for get_soc_spec to work correctly
+                device = torch.npu
+                soc_info = device.get_device_name(device.current_device())
+                set_current_compile_soc_info(soc_info)
+
+                # Query UB size (get_soc_spec returns size in bytes)
+                ub_size_bytes = get_soc_spec("UB_SIZE")
+
+                if ub_size_bytes is None or ub_size_bytes <= 0:
+                    raise ValueError(f"Invalid UB_SIZE from get_soc_spec: {ub_size_bytes}")
+
+                # Convert bytes to bits
+                ub_capacity_bits = ub_size_bytes * 8
+                return ub_capacity_bits
+
+            except ImportError:
+                return _fallback_ub_capacity(
+                    "Cannot import tbe.common.platform.get_soc_spec. "
+                    "Source CANN set_env.sh or set ASCEND_UB_CAPACITY_BITS."
+                )
+            except Exception as e:
+                return _fallback_ub_capacity(
+                    f"Failed to detect UB capacity from get_soc_spec: {e}. "
+                    "Set ASCEND_UB_CAPACITY_BITS to override."
+                )
+
+        return _fallback_ub_capacity(
+            "NPU is not available. Set ASCEND_UB_CAPACITY_BITS to override."
+        )
+
+
+# Global singleton instance
+_ub_manager: UBManager | None = None
+
+
+def get_ub_manager() -> UBManager:
+    """Get global UB manager instance."""
+    global _ub_manager
+    if _ub_manager is None:
+        _ub_manager = UBManager()
+    return _ub_manager
+
+
+def compute_default_tiling_strategy(
+    safety_margin: float = 0.80,
+    dtype_size: int | None = None,
+    memory_multiplier: float | None = None,
+    shapes: tuple[tuple[int, ...], ...] | None = None,
+    tiling_dims: tuple[int | tuple[int, ...], ...] | None = None,
+) -> tuple[tuple[int, ...], ...] | None:
+    """
+    Compute tiling strategy using the default strategy function.
+
+    This function directly calls the default strategy and computes the final
+    tiling result. All kernels use the same unified strategy function, so
+    there's no need for kernel_name-based lookup.
+
+    Args:
+        safety_margin: Safety margin as a float (e.g., 0.80 for 80%). Default is 0.80.
+        dtype_size: Size of data type in bytes (e.g., 2 for float16, 4 for float32).
+            Must be provided. If None or <= 0, defaults to 4 (float32).
+        memory_multiplier: Memory multiplier for estimating peak memory usage.
+            - For GEGLU: typically 10.0 for backward, 4.0 for forward
+            - For ROPE: typically 3.0
+            If None, defaults to 10.0 (conservative estimate).
+        shapes: Tuple of full shapes. Each shape is a tuple of dimension sizes.
+            - For ROPE: ((n_q_head, hd), (n_kv_head, hd))
+            - For GEGLU: ((n_cols,),)
+            Can pass original shapes (will handle padding internally) or padded shapes.
+        tiling_dims: Tuple specifying which dimensions can be tiled for each shape.
+            Each element can be:
+            - int: single dimension index (e.g., 0 for first dimension)
+            - tuple of ints: multiple dimensions that can be tiled together
+            - For ROPE: (0, 0) means first dimension of each shape can be tiled
+            - For GEGLU: (0,) means first dimension of the shape can be tiled
+            Length must match len(shapes). Cannot be empty.
+
+    Returns:
+        Tuple of tiled shapes with same structure as input shapes.
+        Tiling dimensions are replaced with computed block sizes (power of 2),
+        while non-tiling dimensions are padded to next power of 2.
+        - For ROPE: ((block_size_q, pad_hd), (block_size_kv, pad_hd))
+        - For GEGLU: ((block_size,),)
+        Returns None if shapes or tiling_dims is None or empty.
+
+    Examples:
+        >>> # ROPE forward
+        >>> strategy = compute_default_tiling_strategy(
+        ...     safety_margin=0.90,
+        ...     dtype_size=4,
+        ...     memory_multiplier=3.0,
+        ...     shapes=((32, 128), (32, 128)),
+        ...     tiling_dims=(0, 0)
+        ... )
+        >>> # Returns: ((block_size_q, 128), (block_size_kv, 128))
+        >>> # GEGLU forward
+        >>> strategy = compute_default_tiling_strategy(
+        ...     safety_margin=0.80,
+        ...     dtype_size=2,
+        ...     memory_multiplier=7.0,
+        ...     shapes=((4096,),),
+        ...     tiling_dims=(0,)
+        ... )
+        >>> # Returns: ((block_size,),)
+    """
+    ub_manager = get_ub_manager()
+
+    if shapes is None or not shapes or tiling_dims is None or not tiling_dims:
+        return None
+
+    if len(shapes) != len(tiling_dims):
+        return None
+
+    if dtype_size is None or dtype_size <= 0:
+        dtype_size = 4  # Default to float32
+
+    if memory_multiplier is None or memory_multiplier <= 0:
+        memory_multiplier = 10.0  # Default conservative estimate
+
+    # Call strategy to get max_safe_block_size for each shape
+    max_supported = _default_strategy(
+        ub_manager.ub_capacity_bits,
+        safety_margin,
+        dtype_size,
+        memory_multiplier,
+        shapes,
+        tiling_dims,
+    )
+
+    if not max_supported or len(max_supported) != len(shapes):
+        return None
+
+    # Build result: same structure as shapes, with tiling dims replaced by computed block sizes
+    result = []
+    for shape, tiling_dim, max_safe in zip(shapes, tiling_dims, max_supported):
+        result_shape = list(shape)
+
+        # Normalize tiling_dim to a set of dimension indices
+        tiling_dim_set = _normalize_tiling_dims(tiling_dim)
+
+        # Validate tiling dimensions are within shape bounds
+        if not tiling_dim_set:
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim}. tiling_dim must be an int or a non-empty tuple of ints."
+            )
+        if any(dim_idx < 0 or dim_idx >= len(result_shape) for dim_idx in tiling_dim_set):
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim} for shape {shape}. "
+                f"All dimension indices must be in range [0, {len(result_shape)})."
+            )
+
+        # Replace tiling dimensions with computed block sizes
+        # For each tiling dimension, compute: min(desired, max_safe)
+        for dim_idx in tiling_dim_set:
+            original_dim = result_shape[dim_idx]
+            desired = triton.next_power_of_2(original_dim)
+            final_val = min(desired, max_safe)
+            final_val = max(1, final_val)  # Ensure at least 1
+            result_shape[dim_idx] = final_val
+
+        # Pad non-tiling dimensions to next power of 2
+        for dim_idx, dim_size in enumerate(result_shape):
+            if dim_idx not in tiling_dim_set:
+                result_shape[dim_idx] = triton.next_power_of_2(dim_size)
+
+        result.append(tuple(result_shape))
+
+    return tuple(result)
+
+
+def compute_ub_block_size(
+    dim_size: int,
+    memory_multiplier: float,
+    *,
+    safety_margin: float = 0.9,
+    dtype_size: int = 4,
+    fallback: int = 2048,
+    min_block: int = 1,
+    max_block: int | None = None,
+    desired: int | None = None,
+) -> int:
+    """Compute UB-safe block size for a single tilable dimension."""
+    if desired is None:
+        desired = triton.next_power_of_2(dim_size)
+
+    tile_shapes = compute_default_tiling_strategy(
+        safety_margin=safety_margin,
+        dtype_size=dtype_size,
+        memory_multiplier=memory_multiplier,
+        shapes=((dim_size,),),
+        tiling_dims=(0,),
+    )
+    block = min(desired, tile_shapes[0][0]) if tile_shapes else min(desired, fallback)
+    block = max(min_block, block)
+    if max_block is not None:
+        block = min(block, max_block)
+    return block
+
+
+def compute_vocab_block_size(
+    vocab_size: int,
+    num_rows: int,
+    memory_multiplier: float,
+    *,
+    safety_margin: float = 0.9,
+    max_block: int = 8192,
+    fallback: int = 2048,
+) -> int:
+    """UB-safe vocab tile size respecting Ascend grid dim0 limit."""
+    ub_block = compute_ub_block_size(
+        vocab_size,
+        memory_multiplier,
+        safety_margin=safety_margin,
+        fallback=fallback,
+    )
+    max_splits = max(1, ASCEND_MAX_GRID_DIM // max(num_rows, 1))
+    grid_min = triton.next_power_of_2((vocab_size + max_splits - 1) // max_splits)
+    return min(max(ub_block, grid_min), max_block)
+
+
+def compute_elementwise_block_size(
+    n_elements: int,
+    memory_multiplier: float = 2.5,
+    *,
+    safety_margin: float = 0.9,
+    min_block: int = 1024,
+    fallback: int | None = None,
+) -> int:
+    """UB-safe block size for elementwise kernels under grid limit."""
+    if fallback is None:
+        fallback = _FALLBACK_MAX_FUSED_BLOCK
+    ub_block = compute_ub_block_size(
+        n_elements,
+        memory_multiplier,
+        safety_margin=safety_margin,
+        fallback=fallback,
+    )
+    grid_min = max(
+        min_block,
+        triton.next_power_of_2((n_elements + ASCEND_MAX_GRID_DIM - 1) // ASCEND_MAX_GRID_DIM),
+    )
+    return min(ub_block, grid_min)
+
+
+def compute_activation_block_size(
+    total_elements: int,
+    is_backward: bool,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+    max_core_dim: int = 65535,
+    safety_margin: float = 0.9,
+    max_block: int = 2048,
+    memory_multiplier: float | None = None,
+) -> int:
+    """UB-safe block size for flattened activation kernels."""
+    if memory_multiplier is None:
+        memory_multiplier = 6.0 if is_backward else 3.0
+    block = compute_ub_block_size(
+        total_elements,
+        memory_multiplier,
+        safety_margin=safety_margin,
+        fallback=2048,
+        min_block=256,
+        max_block=max_block,
+    )
+    block = min(block, max_core_dim // 8)
+    if triton.cdiv(total_elements, block) > max_grid:
+        block = triton.cdiv(total_elements, max_grid)
+        block = max(triton.next_power_of_2(block), 1)
+    return block
+
+
+def compute_row_tile_block_size(
+    row_dim: int,
+    fixed_dim: int,
+    memory_multiplier: float,
+    *,
+    tiling_row: bool = True,
+    safety_margin: float = 0.85,
+    dtype_size: int = 4,
+    fallback: int = 16,
+    min_block: int = 1,
+    max_block: int | None = None,
+) -> int:
+    """UB-safe tile along one axis of a 2D [row, col] kernel tile."""
+    if tiling_row:
+        shapes = ((row_dim, fixed_dim),)
+        tiling_dims = (0,)
+        desired = triton.next_power_of_2(row_dim)
+    else:
+        shapes = ((row_dim, fixed_dim),)
+        tiling_dims = (1,)
+        desired = triton.next_power_of_2(fixed_dim)
+
+    tile_shapes = compute_default_tiling_strategy(
+        safety_margin=safety_margin,
+        dtype_size=dtype_size,
+        memory_multiplier=memory_multiplier,
+        shapes=shapes,
+        tiling_dims=tiling_dims,
+    )
+    if tile_shapes:
+        block = tile_shapes[0][0] if tiling_row else tile_shapes[0][1]
+        block = min(desired, block)
+    else:
+        block = min(desired, fallback)
+    block = max(min_block, block)
+    if max_block is not None:
+        block = min(block, max_block)
+    return block
+
+
+def max_grid_axis_chunks(
+    axis_size: int,
+    other_grid_product: int,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+) -> int:
+    """Max launch chunks along one grid axis while keeping the product <= max_grid."""
+    return max(1, max_grid // max(other_grid_product, 1))
+
+
+def compute_grid_limited_tile_size(
+    axis_size: int,
+    other_grid_product: int,
+    ub_safe_block: int,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+    min_block: int = 1,
+) -> int:
+    """Pick a UB-safe tile size; host-side chunking handles grid overflow."""
+    return max(min_block, min(ub_safe_block, axis_size))
+
+
+def iter_axis_launch_chunks(
+    axis_size: int,
+    other_grid_product: int,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+):
+    """Yield ``(offset, chunk_len)`` for host-side grid-axis tiling."""
+    max_chunks = max_grid_axis_chunks(axis_size, other_grid_product, max_grid=max_grid)
+    for offset in range(0, axis_size, max_chunks):
+        yield offset, min(max_chunks, axis_size - offset)


### PR DESCRIPTION
# Summary
This PR introduces a unified Unified Buffer (UB) management module for the Triton-Ascend backend on Ascend NPUs. It refactors the block size and grid launch strategies of multiple kernels based on this module to resolve launch failures caused by UB overflow and the Ascend hardware grid dimension limit of 65535. In addition, it fixes runtime errors in `benchmark_conv.py` under the NPU environment, which were triggered by the unavailability of CUDA reference implementations.

## Key Changes
### New File: `fla/utils/ascend_ub_manager.py` (+568 lines)
- Automatically detects the NPU model and its available UB capacity; falls back to a 64 KiB UB limit with a warning if detection fails.
- Provides unified tiling strategy utilities: `UBManager`, `compute_ub_block_size`, `compute_vocab_block_size`, `compute_activation_block_size`, `compute_row_tile_block_size`, etc.
- Exposes grid chunking helpers: defines `ASCEND_MAX_GRID_DIM = 65535`, `max_grid_axis_chunks`, and `iter_axis_launch_chunks` to enable staged kernel launches on the host side.

### Triton-Ascend Kernels Integrated with UB Management (8 files modified)
| Module | Main Modifications |
|--------|--------------------|
| `activations.py` | Replaces hardcoded block sizes with `compute_activation_block_size`; enables backward-pass differentiation via the `is_backward` flag; configures a dedicated memory multiplier for PowGLU. |
| `layernorm.py` | Removes autotune; calculates block dimension BD subject to UB constraints; performs row-axis chunked launches when sequence length T exceeds 65535. |
| `rotary.py` | Adopts UB-aware BT tiling instead of empirical hardcoded rules such as `R>=128 → 16`; chunks along the NT dimension when grid limits are hit, and adds the `NT_OFFSET` argument to kernels. |
| `fused_cross_entropy.py` | Computes vocabulary block size via the UB manager; introduces `ROW_OFFSET` and chunked kernel launches for both forward and backward passes. |
| `fused_linear_cross_entropy.py` | Same UB-based block sizing as above; adds chunked execution for logsumexp in the forward pass; uses `compute_elementwise_block_size` for element-wise multiplication operations. |
| `fused_kl_div.py` | Routes both vocabulary and element-wise block size calculations through the unified UB manager. |
| `grpo.py` | Standardizes vocabulary block size configuration; adds `ROW_OFFSET` and chunked launches for forward and backward kernels. |
| `cumsum.py` | Fully integrates UB-aware `(BT, BS)` block size calculation for scalar/vector local and global cumulative sum operations; supports `NT_OFFSET`/`BH_OFFSET` and multi-dimensional grid chunking. |

### Benchmark Fix (`benchmarks/modules/benchmark_conv.py`)
- Skips unavailable `causal_conv1d_cuda_*` execution providers on NPU devices.
- Dynamically generates the provider list at runtime to prevent decorators from binding incorrect `line_vals` and `styles` during module import.

### Change Scope
10 files modified, with +1220 new lines and -240 deleted lines.

## Motivation
Ascend NPUs have limited UB capacity that varies across different chip models. Previously, all kernels relied on fixed block sizes calculated as `65536 // element_size` or empirical heuristic values. Such hardcoded configurations frequently caused UB overflow or kernel launch failures when the grid dimension exceeded 65535, especially under large vocabulary sizes, high feature dimensions, or long sequence lengths. This PR consolidates these scattered magic numbers into a centralized UB manager and applies more conservative tiling policies by respecting the peak memory multiplier of forward and backward computation paths.