### PR TITLE
[Ops] Add triton-ascend backend for l2norm and fused_norm_gate kernels

### DIFF
--- a/fla/modules/backends/triton_ascend/__init__.py
+++ b/fla/modules/backends/triton_ascend/__init__.py
@@ -225,6 +225,25 @@ class TritonAscendBackend(BaseBackend):
         from fla.modules.backends.triton_ascend.fused_kl_div import fused_kl_div_backward_npu
         return fused_kl_div_backward_npu(do, dx, dw)
 
+    def l2norm_fwd(
+        self,
+        x,
+        eps=1e-6,
+        output_dtype=None,
+    ):
+        from fla.modules.backends.triton_ascend.l2norm import l2norm_fwd_npu
+        return l2norm_fwd_npu(x, eps, output_dtype)
+
+    def l2norm_bwd(
+        self,
+        y,
+        rstd,
+        dy,
+        eps=1e-6,
+    ):
+        from fla.modules.backends.triton_ascend.l2norm import l2norm_bwd_npu
+        return l2norm_bwd_npu(y, rstd, dy, eps)
+
     def layer_norm_fwd(
         self,
         x,

--- a/fla/modules/backends/triton_ascend/__init__.py
+++ b/fla/modules/backends/triton_ascend/__init__.py
@@ -244,6 +244,68 @@ class TritonAscendBackend(BaseBackend):
         from fla.modules.backends.triton_ascend.l2norm import l2norm_bwd_npu
         return l2norm_bwd_npu(y, rstd, dy, eps)
 
+    def layer_norm_gated_fwd(
+        self,
+        x,
+        g,
+        weight,
+        bias,
+        activation="swish",
+        eps=1e-5,
+        residual=None,
+        out_dtype=None,
+        residual_dtype=None,
+        is_rms_norm=False,
+    ):
+        from fla.modules.backends.triton_ascend.fused_norm_gate import layer_norm_gated_fwd_npu
+        return layer_norm_gated_fwd_npu(
+            x,
+            g,
+            weight,
+            bias,
+            activation,
+            eps,
+            residual,
+            out_dtype,
+            residual_dtype,
+            is_rms_norm,
+        )
+
+    def layer_norm_gated_bwd(
+        self,
+        dy,
+        x,
+        g,
+        weight,
+        bias,
+        activation="swish",
+        eps=1e-5,
+        mean=None,
+        rstd=None,
+        dresidual=None,
+        has_residual=False,
+        is_rms_norm=False,
+        x_dtype=None,
+        recompute_output=False,
+    ):
+        from fla.modules.backends.triton_ascend.fused_norm_gate import layer_norm_gated_bwd_npu
+        return layer_norm_gated_bwd_npu(
+            dy,
+            x,
+            g,
+            weight,
+            bias,
+            activation,
+            eps,
+            mean,
+            rstd,
+            dresidual,
+            has_residual,
+            is_rms_norm,
+            x_dtype,
+            recompute_output,
+        )
+
     def layer_norm_fwd(
         self,
         x,

--- a/fla/modules/backends/triton_ascend/fused_norm_gate.py
+++ b/fla/modules/backends/triton_ascend/fused_norm_gate.py
@@ -1,0 +1,363 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Fused LayerNorm/RMSNorm + gate kernels adapted for triton-ascend on Huawei NPU."""
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.utils import get_multiprocessor_count
+
+# Ascend Triton rejects grids whose product exceeds 65535.
+_NPU_MAX_TRITON_GRID = 65535
+_STATIC_NUM_WARPS = 2
+
+# ACTIVATION constexpr: 0 = swish/silu, 1 = sigmoid
+_ACTIVATION_SWISH = 0
+_ACTIVATION_SIGMOID = 1
+
+
+def _activation_id(activation: str) -> int:
+    if activation in ("swish", "silu"):
+        return _ACTIVATION_SWISH
+    if activation == "sigmoid":
+        return _ACTIVATION_SIGMOID
+    raise ValueError(f"Unsupported activation: {activation}")
+
+
+def _iter_grid_chunks(grid_size: int):
+    for grid_off in range(0, grid_size, _NPU_MAX_TRITON_GRID):
+        yield grid_off, min(_NPU_MAX_TRITON_GRID, grid_size - grid_off)
+
+
+@triton.jit
+def layer_norm_gated_fwd_kernel1(
+    x,
+    g,
+    y,
+    w,
+    b,
+    residual,
+    residual_out,
+    mean,
+    rstd,
+    eps,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    ROW_OFFSET: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    i_t = tl.program_id(0) + ROW_OFFSET
+    x += i_t * D
+    y += i_t * D
+    g += i_t * D
+    if HAS_RESIDUAL:
+        residual += i_t * D
+    if STORE_RESIDUAL_OUT:
+        residual_out += i_t * D
+
+    o_d = tl.arange(0, BD)
+    m_d = o_d < D
+    b_x = tl.load(x + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if HAS_RESIDUAL:
+        b_x += tl.load(residual + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if STORE_RESIDUAL_OUT:
+        tl.store(residual_out + o_d, b_x, mask=m_d)
+    if not IS_RMS_NORM:
+        b_mean = tl.sum(b_x, axis=0) / D
+        tl.store(mean + i_t, b_mean)
+        b_xbar = tl.where(m_d, b_x - b_mean, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    else:
+        b_xbar = tl.where(m_d, b_x, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+    tl.store(rstd + i_t, b_rstd)
+
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=m_d).to(tl.float32)
+    b_x_hat = (b_x - b_mean) * b_rstd if not IS_RMS_NORM else b_x * b_rstd
+    b_y = b_x_hat * b_w if HAS_WEIGHT else b_x_hat
+    if HAS_BIAS:
+        b_y = b_y + b_b
+
+    b_g = tl.load(g + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if ACTIVATION == 0:
+        b_y = b_y * b_g * tl.sigmoid(b_g)
+    else:
+        b_y = b_y * tl.sigmoid(b_g)
+
+    tl.store(y + o_d, b_y, mask=m_d)
+
+
+@triton.jit
+def layer_norm_gated_bwd_kernel1(
+    x,
+    g,
+    w,
+    b,
+    y,
+    dy,
+    dx,
+    dg,
+    dw,
+    db,
+    dresidual,
+    dresidual_in,
+    mean,
+    rstd,
+    T,
+    BS,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    PROGRAM_OFFSET: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_DRESIDUAL: tl.constexpr,
+    HAS_DRESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    RECOMPUTE_OUTPUT: tl.constexpr,
+):
+    i_s = tl.program_id(0) + PROGRAM_OFFSET
+    o_d = tl.arange(0, BD)
+    mask = o_d < D
+    x += i_s * BS * D
+    g += i_s * BS * D
+    if HAS_DRESIDUAL:
+        dresidual += i_s * BS * D
+    if STORE_DRESIDUAL:
+        dresidual_in += i_s * BS * D
+    dy += i_s * BS * D
+    dx += i_s * BS * D
+    dg += i_s * BS * D
+    if RECOMPUTE_OUTPUT:
+        y += i_s * BS * D
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=mask).to(tl.float32)
+        b_dw = tl.zeros((BD,), dtype=tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=mask, other=0.0).to(tl.float32)
+        b_db = tl.zeros((BD,), dtype=tl.float32)
+
+    for i_t in range(i_s * BS, min(i_s * BS + BS, T)):
+        b_x = tl.load(x + o_d, mask=mask, other=0).to(tl.float32)
+        b_g = tl.load(g + o_d, mask=mask, other=0).to(tl.float32)
+        b_dy = tl.load(dy + o_d, mask=mask, other=0).to(tl.float32)
+
+        if not IS_RMS_NORM:
+            b_mean = tl.load(mean + i_t)
+        b_rstd = tl.load(rstd + i_t)
+        b_xhat = (b_x - b_mean) * b_rstd if not IS_RMS_NORM else b_x * b_rstd
+        b_xhat = tl.where(mask, b_xhat, 0.0)
+
+        b_y = b_xhat * b_w if HAS_WEIGHT else b_xhat
+        if HAS_BIAS:
+            b_y = b_y + b_b
+        if RECOMPUTE_OUTPUT:
+            tl.store(y + o_d, b_y, mask=mask)
+
+        b_sigmoid_g = tl.sigmoid(b_g)
+        if ACTIVATION == 0:
+            b_dg = b_dy * b_y * (b_sigmoid_g + b_g * b_sigmoid_g * (1 - b_sigmoid_g))
+            b_dy = b_dy * b_g * b_sigmoid_g
+        else:
+            b_dg = b_dy * b_y * b_sigmoid_g * (1 - b_sigmoid_g)
+            b_dy = b_dy * b_sigmoid_g
+        b_wdy = b_dy
+        if HAS_WEIGHT:
+            b_wdy = b_dy * b_w
+            b_dw += b_dy * b_xhat
+        if HAS_BIAS:
+            b_db += b_dy
+        if not IS_RMS_NORM:
+            b_c1 = tl.sum(b_xhat * b_wdy, axis=0) / D
+            b_c2 = tl.sum(b_wdy, axis=0) / D
+            b_dx = (b_wdy - (b_xhat * b_c1 + b_c2)) * b_rstd
+        else:
+            b_c1 = tl.sum(b_xhat * b_wdy, axis=0) / D
+            b_dx = (b_wdy - b_xhat * b_c1) * b_rstd
+        if HAS_DRESIDUAL:
+            b_dres = tl.load(dresidual + o_d, mask=mask, other=0).to(tl.float32)
+            b_dx += b_dres
+        if STORE_DRESIDUAL:
+            tl.store(dresidual_in + o_d, b_dx, mask=mask)
+        tl.store(dx + o_d, b_dx, mask=mask)
+        tl.store(dg + o_d, b_dg, mask=mask)
+
+        x += D
+        g += D
+        if HAS_DRESIDUAL:
+            dresidual += D
+        if STORE_DRESIDUAL:
+            dresidual_in += D
+        if RECOMPUTE_OUTPUT:
+            y += D
+        dy += D
+        dx += D
+        dg += D
+    if HAS_WEIGHT:
+        tl.store(dw + i_s * D + o_d, b_dw, mask=mask)
+    if HAS_BIAS:
+        tl.store(db + i_s * D + o_d, b_db, mask=mask)
+
+
+def layer_norm_gated_fwd_npu(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    activation: str = "swish",
+    eps: float = 1e-5,
+    residual: torch.Tensor = None,
+    out_dtype: torch.dtype = None,
+    residual_dtype: torch.dtype = None,
+    is_rms_norm: bool = False,
+):
+    if residual is not None:
+        residual_dtype = residual.dtype
+    T, D = x.shape
+    if residual is not None:
+        assert residual.shape == (T, D)
+    if weight is not None:
+        assert weight.shape == (D,)
+    if bias is not None:
+        assert bias.shape == (D,)
+
+    y = torch.empty_like(x, dtype=x.dtype if out_dtype is None else out_dtype)
+    if residual is not None or (residual_dtype is not None and residual_dtype != x.dtype):
+        residual_out = torch.empty(T, D, device=x.device, dtype=residual_dtype)
+    else:
+        residual_out = None
+    mean = torch.empty((T,), dtype=torch.float, device=x.device) if not is_rms_norm else None
+    rstd = torch.empty((T,), dtype=torch.float, device=x.device)
+
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+
+    act_id = _activation_id(activation)
+    kernel_kwargs = dict(
+        x=x,
+        g=g,
+        y=y,
+        w=weight,
+        b=bias,
+        residual=residual,
+        residual_out=residual_out,
+        mean=mean,
+        rstd=rstd,
+        eps=eps,
+        D=D,
+        BD=BD,
+        ACTIVATION=act_id,
+        IS_RMS_NORM=is_rms_norm,
+        STORE_RESIDUAL_OUT=residual_out is not None,
+        HAS_RESIDUAL=residual is not None,
+        HAS_WEIGHT=weight is not None,
+        HAS_BIAS=bias is not None,
+        num_warps=_STATIC_NUM_WARPS,
+    )
+    for row_off, chunk in _iter_grid_chunks(T):
+        layer_norm_gated_fwd_kernel1[(chunk,)](
+            **kernel_kwargs,
+            ROW_OFFSET=row_off,
+        )
+    return y, mean, rstd, residual_out if residual_out is not None else x
+
+
+def layer_norm_gated_bwd_npu(
+    dy: torch.Tensor,
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    activation: str = "swish",
+    eps: float = 1e-5,
+    mean: torch.Tensor = None,
+    rstd: torch.Tensor = None,
+    dresidual: torch.Tensor = None,
+    has_residual: bool = False,
+    is_rms_norm: bool = False,
+    x_dtype: torch.dtype = None,
+    recompute_output: bool = False,
+):
+    T, D = x.shape
+    assert dy.shape == (T, D)
+    if dresidual is not None:
+        assert dresidual.shape == (T, D)
+    if weight is not None:
+        assert weight.shape == (D,)
+    if bias is not None:
+        assert bias.shape == (D,)
+
+    dx = torch.empty_like(x) if x_dtype is None else torch.empty(T, D, dtype=x_dtype, device=x.device)
+    dg = torch.empty_like(g) if x_dtype is None else torch.empty(T, D, dtype=x_dtype, device=x.device)
+    dresidual_in = torch.empty_like(x) if has_residual and dx.dtype != x.dtype else None
+    y = torch.empty(T, D, dtype=dy.dtype, device=dy.device) if recompute_output else None
+
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+
+    NS = min(get_multiprocessor_count(x.device.index), T)
+    BS = math.ceil(T / NS)
+
+    dw = torch.empty((NS, D), dtype=torch.float, device=weight.device) if weight is not None else None
+    db = torch.empty((NS, D), dtype=torch.float, device=bias.device) if bias is not None else None
+
+    act_id = _activation_id(activation)
+    kernel_kwargs = dict(
+        x=x,
+        g=g,
+        w=weight,
+        b=bias,
+        y=y,
+        dy=dy,
+        dx=dx,
+        dg=dg,
+        dw=dw,
+        db=db,
+        dresidual=dresidual,
+        dresidual_in=dresidual_in,
+        mean=mean,
+        rstd=rstd,
+        T=T,
+        BS=BS,
+        D=D,
+        BD=BD,
+        ACTIVATION=act_id,
+        IS_RMS_NORM=is_rms_norm,
+        STORE_DRESIDUAL=dresidual_in is not None,
+        HAS_DRESIDUAL=dresidual is not None,
+        HAS_WEIGHT=weight is not None,
+        HAS_BIAS=bias is not None,
+        RECOMPUTE_OUTPUT=y is not None,
+        num_warps=_STATIC_NUM_WARPS,
+    )
+    for prog_off, chunk in _iter_grid_chunks(NS):
+        layer_norm_gated_bwd_kernel1[(chunk,)](
+            **kernel_kwargs,
+            PROGRAM_OFFSET=prog_off,
+        )
+    dw = dw.sum(0).to(weight.dtype) if weight is not None else None
+    db = db.sum(0).to(bias.dtype) if bias is not None else None
+    if has_residual and dx.dtype == x.dtype:
+        dresidual_in = dx
+    return (dx, dg, dw, db, dresidual_in) if not recompute_output else (dx, dg, dw, db, dresidual_in, y)

--- a/fla/modules/backends/triton_ascend/fused_norm_gate.py
+++ b/fla/modules/backends/triton_ascend/fused_norm_gate.py
@@ -14,10 +14,14 @@ import triton
 import triton.language as tl
 
 from fla.utils import get_multiprocessor_count
+from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, compute_ub_block_size, iter_axis_launch_chunks
 
-# Ascend Triton rejects grids whose product exceeds 65535.
-_NPU_MAX_TRITON_GRID = 65535
-_STATIC_NUM_WARPS = 2
+# Peak live fp32 vectors in row-wise gated kernel1 (norm + gate tensors).
+_FWD_MEM_MULT = 7.0
+_BWD_MEM_MULT = 10.0
+_UB_SAFETY_MARGIN = 0.85
+# Legacy byte cap when UB capacity cannot be detected (65536 // fp32).
+_FALLBACK_MAX_BD = 65536 // 4
 
 # ACTIVATION constexpr: 0 = swish/silu, 1 = sigmoid
 _ACTIVATION_SWISH = 0
@@ -32,9 +36,24 @@ def _activation_id(activation: str) -> int:
     raise ValueError(f"Unsupported activation: {activation}")
 
 
-def _iter_grid_chunks(grid_size: int):
-    for grid_off in range(0, grid_size, _NPU_MAX_TRITON_GRID):
-        yield grid_off, min(_NPU_MAX_TRITON_GRID, grid_size - grid_off)
+def _get_layer_norm_gated_bd(D: int, is_forward: bool) -> int:
+    """Return power-of-2 block size for feature dim D under UB constraints."""
+    memory_multiplier = _FWD_MEM_MULT if is_forward else _BWD_MEM_MULT
+    return compute_ub_block_size(
+        D,
+        memory_multiplier,
+        safety_margin=_UB_SAFETY_MARGIN,
+        fallback=_FALLBACK_MAX_BD,
+        desired=triton.next_power_of_2(D),
+    )
+
+
+def _layer_norm_gated_bwd_launch_config(T: int, device_index: int) -> tuple[int, int]:
+    """Return (NS, BS) capped under Ascend grid limit."""
+    NS = min(get_multiprocessor_count(device_index), T)
+    NS = min(NS, ASCEND_MAX_GRID_DIM)
+    BS = math.ceil(T / NS) if NS > 0 else T
+    return NS, BS
 
 
 @triton.jit
@@ -51,7 +70,6 @@ def layer_norm_gated_fwd_kernel1(
     eps,
     D: tl.constexpr,
     BD: tl.constexpr,
-    ROW_OFFSET: tl.constexpr,
     ACTIVATION: tl.constexpr,
     IS_RMS_NORM: tl.constexpr,
     STORE_RESIDUAL_OUT: tl.constexpr,
@@ -59,7 +77,7 @@ def layer_norm_gated_fwd_kernel1(
     HAS_WEIGHT: tl.constexpr,
     HAS_BIAS: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + ROW_OFFSET
+    i_t = tl.program_id(0)
     x += i_t * D
     y += i_t * D
     g += i_t * D
@@ -124,7 +142,6 @@ def layer_norm_gated_bwd_kernel1(
     BS,
     D: tl.constexpr,
     BD: tl.constexpr,
-    PROGRAM_OFFSET: tl.constexpr,
     ACTIVATION: tl.constexpr,
     IS_RMS_NORM: tl.constexpr,
     STORE_DRESIDUAL: tl.constexpr,
@@ -133,7 +150,7 @@ def layer_norm_gated_bwd_kernel1(
     HAS_BIAS: tl.constexpr,
     RECOMPUTE_OUTPUT: tl.constexpr,
 ):
-    i_s = tl.program_id(0) + PROGRAM_OFFSET
+    i_s = tl.program_id(0)
     o_d = tl.arange(0, BD)
     mask = o_d < D
     x += i_s * BS * D
@@ -216,6 +233,45 @@ def layer_norm_gated_bwd_kernel1(
         tl.store(db + i_s * D + o_d, b_db, mask=mask)
 
 
+def _launch_layer_norm_gated_fwd_kernel1(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    residual: torch.Tensor,
+    residual_out: torch.Tensor,
+    mean: torch.Tensor,
+    rstd: torch.Tensor,
+    eps: float,
+    D: int,
+    BD: int,
+    act_id: int,
+    is_rms_norm: bool,
+):
+    chunk_T = x.shape[0]
+    layer_norm_gated_fwd_kernel1[(chunk_T,)](
+        x=x,
+        g=g,
+        y=y,
+        w=weight,
+        b=bias,
+        residual=residual,
+        residual_out=residual_out,
+        mean=mean,
+        rstd=rstd,
+        eps=eps,
+        D=D,
+        BD=BD,
+        ACTIVATION=act_id,
+        IS_RMS_NORM=is_rms_norm,
+        STORE_RESIDUAL_OUT=residual_out is not None,
+        HAS_RESIDUAL=residual is not None,
+        HAS_WEIGHT=weight is not None,
+        HAS_BIAS=bias is not None,
+    )
+
+
 def layer_norm_gated_fwd_npu(
     x: torch.Tensor,
     g: torch.Tensor,
@@ -246,37 +302,31 @@ def layer_norm_gated_fwd_npu(
     mean = torch.empty((T,), dtype=torch.float, device=x.device) if not is_rms_norm else None
     rstd = torch.empty((T,), dtype=torch.float, device=x.device)
 
-    MAX_FUSED_SIZE = 65536 // x.element_size()
-    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    BD = _get_layer_norm_gated_bd(D, is_forward=True)
     if D > BD:
-        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+        raise RuntimeError(
+            f"LayerNormGated feature dim {D} exceeds UB-safe block size {BD}. "
+            "Column-tiled kernels are not yet implemented for this size."
+        )
 
     act_id = _activation_id(activation)
-    kernel_kwargs = dict(
-        x=x,
-        g=g,
-        y=y,
-        w=weight,
-        b=bias,
-        residual=residual,
-        residual_out=residual_out,
-        mean=mean,
-        rstd=rstd,
-        eps=eps,
-        D=D,
-        BD=BD,
-        ACTIVATION=act_id,
-        IS_RMS_NORM=is_rms_norm,
-        STORE_RESIDUAL_OUT=residual_out is not None,
-        HAS_RESIDUAL=residual is not None,
-        HAS_WEIGHT=weight is not None,
-        HAS_BIAS=bias is not None,
-        num_warps=_STATIC_NUM_WARPS,
-    )
-    for row_off, chunk in _iter_grid_chunks(T):
-        layer_norm_gated_fwd_kernel1[(chunk,)](
-            **kernel_kwargs,
-            ROW_OFFSET=row_off,
+    for row_start, row_len in iter_axis_launch_chunks(T, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        row_end = row_start + row_len
+        _launch_layer_norm_gated_fwd_kernel1(
+            x[row_start:row_end],
+            g[row_start:row_end],
+            y[row_start:row_end],
+            weight,
+            bias,
+            None if residual is None else residual[row_start:row_end],
+            None if residual_out is None else residual_out[row_start:row_end],
+            None if mean is None else mean[row_start:row_end],
+            rstd[row_start:row_end],
+            eps,
+            D,
+            BD,
+            act_id,
+            is_rms_norm,
         )
     return y, mean, rstd, residual_out if residual_out is not None else x
 
@@ -311,19 +361,20 @@ def layer_norm_gated_bwd_npu(
     dresidual_in = torch.empty_like(x) if has_residual and dx.dtype != x.dtype else None
     y = torch.empty(T, D, dtype=dy.dtype, device=dy.device) if recompute_output else None
 
-    MAX_FUSED_SIZE = 65536 // x.element_size()
-    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    BD = _get_layer_norm_gated_bd(D, is_forward=False)
     if D > BD:
-        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+        raise RuntimeError(
+            f"LayerNormGated feature dim {D} exceeds UB-safe block size {BD}. "
+            "Column-tiled kernels are not yet implemented for this size."
+        )
 
-    NS = min(get_multiprocessor_count(x.device.index), T)
-    BS = math.ceil(T / NS)
+    NS, BS = _layer_norm_gated_bwd_launch_config(T, x.device.index)
 
     dw = torch.empty((NS, D), dtype=torch.float, device=weight.device) if weight is not None else None
     db = torch.empty((NS, D), dtype=torch.float, device=bias.device) if bias is not None else None
 
     act_id = _activation_id(activation)
-    kernel_kwargs = dict(
+    layer_norm_gated_bwd_kernel1[(NS,)](
         x=x,
         g=g,
         w=weight,
@@ -349,13 +400,7 @@ def layer_norm_gated_bwd_npu(
         HAS_WEIGHT=weight is not None,
         HAS_BIAS=bias is not None,
         RECOMPUTE_OUTPUT=y is not None,
-        num_warps=_STATIC_NUM_WARPS,
     )
-    for prog_off, chunk in _iter_grid_chunks(NS):
-        layer_norm_gated_bwd_kernel1[(chunk,)](
-            **kernel_kwargs,
-            PROGRAM_OFFSET=prog_off,
-        )
     dw = dw.sum(0).to(weight.dtype) if weight is not None else None
     db = db.sum(0).to(bias.dtype) if bias is not None else None
     if has_residual and dx.dtype == x.dtype:

--- a/fla/modules/backends/triton_ascend/l2norm.py
+++ b/fla/modules/backends/triton_ascend/l2norm.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""L2 normalization kernels adapted for triton-ascend on Ascend NPU."""
+
+import torch
+import triton
+import triton.language as tl
+
+# Ascend Triton rejects grids whose product exceeds 65535.
+_NPU_MAX_TRITON_GRID = 65535
+_STATIC_NUM_WARPS = 2
+
+
+def _iter_row_chunks(num_rows: int):
+    for row_off in range(0, num_rows, _NPU_MAX_TRITON_GRID):
+        yield row_off, min(_NPU_MAX_TRITON_GRID, num_rows - row_off)
+
+
+@triton.jit
+def l2norm_fwd_kernel1(
+    x,
+    y,
+    rstd,
+    eps,
+    D,
+    BD: tl.constexpr,
+    ROW_OFFSET: tl.constexpr,
+):
+    i_t = tl.program_id(0) + ROW_OFFSET
+    x += i_t * D
+    y += i_t * D
+    cols = tl.arange(0, BD)
+    mask = cols < D
+
+    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
+    b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x) + eps)
+    b_y = b_x * b_rstd
+    tl.store(y + cols, b_y, mask=mask)
+    tl.store(rstd + i_t, b_rstd)
+
+
+@triton.jit
+def l2norm_bwd_kernel1(
+    y,
+    rstd,
+    dy,
+    dx,
+    eps,
+    D,
+    BD: tl.constexpr,
+    ROW_OFFSET: tl.constexpr,
+):
+    i_t = tl.program_id(0) + ROW_OFFSET
+    y += i_t * D
+    dx += i_t * D
+    dy += i_t * D
+
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    b_y = tl.load(y + cols, mask=mask, other=0.0).to(tl.float32)
+    b_rstd = tl.load(rstd + i_t).to(tl.float32)
+    b_dy = tl.load(dy + cols, mask=mask, other=0.0).to(tl.float32)
+    b_dx = b_dy * b_rstd - tl.sum(b_dy * b_y) * b_y * b_rstd
+    tl.store(dx + cols, b_dx, mask=mask)
+
+
+def l2norm_fwd_npu(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: torch.dtype | None = None,
+):
+    x_shape_og = x.shape
+    x = x.view(-1, x.shape[-1])
+    if output_dtype is None:
+        y = torch.empty_like(x)
+    else:
+        y = torch.empty_like(x, dtype=output_dtype)
+    assert y.stride(-1) == 1
+    T, D = x.shape[0], x.shape[-1]
+
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+
+    rstd = torch.empty((T,), dtype=torch.float32, device=x.device)
+    for row_off, chunk in _iter_row_chunks(T):
+        l2norm_fwd_kernel1[(chunk,)](
+            x=x,
+            y=y,
+            rstd=rstd,
+            eps=eps,
+            D=D,
+            BD=BD,
+            ROW_OFFSET=row_off,
+            num_warps=_STATIC_NUM_WARPS,
+        )
+    return y.view(x_shape_og), rstd.view(x_shape_og[:-1])
+
+
+def l2norm_bwd_npu(
+    y: torch.Tensor,
+    rstd: torch.Tensor,
+    dy: torch.Tensor,
+    eps: float = 1e-6,
+):
+    y_shape_og = y.shape
+    y = y.view(-1, dy.shape[-1])
+    dy = dy.view(-1, dy.shape[-1])
+    assert dy.shape == y.shape
+    dx = torch.empty_like(y)
+    T, D = y.shape[0], y.shape[-1]
+
+    MAX_FUSED_SIZE = 65536 // y.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+
+    for row_off, chunk in _iter_row_chunks(T):
+        l2norm_bwd_kernel1[(chunk,)](
+            y=y,
+            rstd=rstd,
+            dy=dy,
+            dx=dx,
+            eps=eps,
+            D=D,
+            BD=BD,
+            ROW_OFFSET=row_off,
+            num_warps=_STATIC_NUM_WARPS,
+        )
+    return dx.view(y_shape_og)

--- a/fla/modules/backends/triton_ascend/l2norm.py
+++ b/fla/modules/backends/triton_ascend/l2norm.py
@@ -11,14 +11,26 @@ import torch
 import triton
 import triton.language as tl
 
-# Ascend Triton rejects grids whose product exceeds 65535.
-_NPU_MAX_TRITON_GRID = 65535
-_STATIC_NUM_WARPS = 2
+from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, compute_ub_block_size, iter_axis_launch_chunks
+
+# Peak live fp32 vectors in row-wise kernel1 (same order as layer_norm).
+_FWD_MEM_MULT = 6.0
+_BWD_MEM_MULT = 8.0
+_UB_SAFETY_MARGIN = 0.85
+# Legacy byte cap when UB capacity cannot be detected (65536 // fp32).
+_FALLBACK_MAX_BD = 65536 // 4
 
 
-def _iter_row_chunks(num_rows: int):
-    for row_off in range(0, num_rows, _NPU_MAX_TRITON_GRID):
-        yield row_off, min(_NPU_MAX_TRITON_GRID, num_rows - row_off)
+def _get_l2norm_bd(D: int, is_forward: bool) -> int:
+    """Return power-of-2 block size for feature dim D under UB constraints."""
+    memory_multiplier = _FWD_MEM_MULT if is_forward else _BWD_MEM_MULT
+    return compute_ub_block_size(
+        D,
+        memory_multiplier,
+        safety_margin=_UB_SAFETY_MARGIN,
+        fallback=_FALLBACK_MAX_BD,
+        desired=triton.next_power_of_2(D),
+    )
 
 
 @triton.jit
@@ -29,9 +41,8 @@ def l2norm_fwd_kernel1(
     eps,
     D,
     BD: tl.constexpr,
-    ROW_OFFSET: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + ROW_OFFSET
+    i_t = tl.program_id(0)
     x += i_t * D
     y += i_t * D
     cols = tl.arange(0, BD)
@@ -53,9 +64,8 @@ def l2norm_bwd_kernel1(
     eps,
     D,
     BD: tl.constexpr,
-    ROW_OFFSET: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + ROW_OFFSET
+    i_t = tl.program_id(0)
     y += i_t * D
     dx += i_t * D
     dy += i_t * D
@@ -67,6 +77,46 @@ def l2norm_bwd_kernel1(
     b_dy = tl.load(dy + cols, mask=mask, other=0.0).to(tl.float32)
     b_dx = b_dy * b_rstd - tl.sum(b_dy * b_y) * b_y * b_rstd
     tl.store(dx + cols, b_dx, mask=mask)
+
+
+def _launch_l2norm_fwd_kernel1(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    rstd: torch.Tensor,
+    eps: float,
+    D: int,
+    BD: int,
+):
+    chunk_T = x.shape[0]
+    l2norm_fwd_kernel1[(chunk_T,)](
+        x=x,
+        y=y,
+        rstd=rstd,
+        eps=eps,
+        D=D,
+        BD=BD,
+    )
+
+
+def _launch_l2norm_bwd_kernel1(
+    y: torch.Tensor,
+    rstd: torch.Tensor,
+    dy: torch.Tensor,
+    dx: torch.Tensor,
+    eps: float,
+    D: int,
+    BD: int,
+):
+    chunk_T = y.shape[0]
+    l2norm_bwd_kernel1[(chunk_T,)](
+        y=y,
+        rstd=rstd,
+        dy=dy,
+        dx=dx,
+        eps=eps,
+        D=D,
+        BD=BD,
+    )
 
 
 def l2norm_fwd_npu(
@@ -83,22 +133,23 @@ def l2norm_fwd_npu(
     assert y.stride(-1) == 1
     T, D = x.shape[0], x.shape[-1]
 
-    MAX_FUSED_SIZE = 65536 // x.element_size()
-    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    BD = _get_l2norm_bd(D, is_forward=True)
     if D > BD:
-        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+        raise RuntimeError(
+            f"L2Norm feature dim {D} exceeds UB-safe block size {BD}. "
+            "Column-tiled kernels are not yet implemented for this size."
+        )
 
     rstd = torch.empty((T,), dtype=torch.float32, device=x.device)
-    for row_off, chunk in _iter_row_chunks(T):
-        l2norm_fwd_kernel1[(chunk,)](
-            x=x,
-            y=y,
-            rstd=rstd,
-            eps=eps,
-            D=D,
-            BD=BD,
-            ROW_OFFSET=row_off,
-            num_warps=_STATIC_NUM_WARPS,
+    for row_start, row_len in iter_axis_launch_chunks(T, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        row_end = row_start + row_len
+        _launch_l2norm_fwd_kernel1(
+            x[row_start:row_end],
+            y[row_start:row_end],
+            rstd[row_start:row_end],
+            eps,
+            D,
+            BD,
         )
     return y.view(x_shape_og), rstd.view(x_shape_og[:-1])
 
@@ -116,21 +167,22 @@ def l2norm_bwd_npu(
     dx = torch.empty_like(y)
     T, D = y.shape[0], y.shape[-1]
 
-    MAX_FUSED_SIZE = 65536 // y.element_size()
-    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    BD = _get_l2norm_bd(D, is_forward=False)
     if D > BD:
-        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+        raise RuntimeError(
+            f"L2Norm feature dim {D} exceeds UB-safe block size {BD}. "
+            "Column-tiled kernels are not yet implemented for this size."
+        )
 
-    for row_off, chunk in _iter_row_chunks(T):
-        l2norm_bwd_kernel1[(chunk,)](
-            y=y,
-            rstd=rstd,
-            dy=dy,
-            dx=dx,
-            eps=eps,
-            D=D,
-            BD=BD,
-            ROW_OFFSET=row_off,
-            num_warps=_STATIC_NUM_WARPS,
+    for row_start, row_len in iter_axis_launch_chunks(T, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        row_end = row_start + row_len
+        _launch_l2norm_bwd_kernel1(
+            y[row_start:row_end],
+            rstd[row_start:row_end],
+            dy[row_start:row_end],
+            dx[row_start:row_end],
+            eps,
+            D,
+            BD,
         )
     return dx.view(y_shape_og)

--- a/fla/modules/fused_norm_gate.py
+++ b/fla/modules/fused_norm_gate.py
@@ -15,6 +15,7 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
+from fla.modules.backends import dispatch
 from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard
 
 
@@ -440,6 +441,7 @@ def layer_norm_gated_bwd_kernel1(
         tl.store(db + i_s * D + o_d, b_db, mask=mask)
 
 
+@dispatch('modules')
 def layer_norm_gated_fwd(
     x: torch.Tensor,
     g: torch.Tensor,
@@ -524,6 +526,7 @@ def layer_norm_gated_fwd(
     return y, mean, rstd, residual_out if residual_out is not None else x
 
 
+@dispatch('modules')
 def layer_norm_gated_bwd(
     dy: torch.Tensor,
     x: torch.Tensor,

--- a/fla/modules/l2norm.py
+++ b/fla/modules/l2norm.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 
+from fla.modules.backends import dispatch
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.utils import IS_AMD, autotune_cache_kwargs, input_guard
 
@@ -135,6 +136,7 @@ def l2norm_bwd_kernel(
     tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
 
 
+@dispatch('modules')
 def l2norm_fwd(
     x: torch.Tensor,
     eps: float = 1e-6,
@@ -187,6 +189,7 @@ def l2norm_fwd(
     return y.view(x_shape_og), rstd.view(x_shape_og[:-1])
 
 
+@dispatch('modules')
 def l2norm_bwd(
     y: torch.Tensor,
     rstd: torch.Tensor,


### PR DESCRIPTION
## Summary

Add triton-ascend backends for `l2norm` and `fused_norm_gate` (LayerNorm/RMSNorm + gate) on Ascend NPU. Wire them into the existing public APIs via `@dispatch('modules')`, so callers are routed automatically on Ascend without code changes.

- **l2norm**: Add fwd/bwd Triton kernels and register `l2norm_fwd` / `l2norm_bwd` on `TritonAscendBackend`
- **fused_norm_gate**: Add LayerNorm/RMSNorm + gate kernels (swish/sigmoid), with support for residual, weight/bias, and recompute paths
- **UB management**: Integrate `ascend_ub_manager` (#1001)—use `compute_ub_block_size` for dynamic tiling and `iter_axis_launch_chunks` for grid limits; remove `ROW_OFFSET` / `PROGRAM_OFFSET` in favor of host-side tensor slicing

## Test plan

- [x] `pytest tests/modules/test_l2norm.py -v` (NPU)
- [x] `pytest tests/modules/test_layernorm_gated.py -v` (NPU)