### PR TITLE
[GDN] Add batch-invariant mode: bitwise-reproducible prefill/decode across batch sizes

### DIFF
--- a/ENVs.md
+++ b/ENVs.md
@@ -31,6 +31,7 @@ runtime. Variables are grouped by what they control:
 | -------------------- | ------- | ------------------------ | ---------------------------------------------------------------------------------------------------------- |
 | `FLA_TRIL_PRECISION` | `ieee`  | `ieee` / `tf32` / `tf32x3` | Precision used by `solve_tril`. `tf32x3` is NVIDIA-only and gives the best performance / accuracy trade-off on Ampere+. |
 | `FLA_USE_FAST_OPS`   | `0`     | `0` / `1`                | Enable faster but less accurate Triton math intrinsics in shared op helpers.                               |
+| `FLA_BATCH_INVARIANT` | `0`    | `0` / `1`, `true` / `yes` | Enable the batch-invariant execution mode: participating ops (currently `fused_recurrent_gated_delta_rule`) produce bitwise-identical outputs regardless of batch size and of how a sequence is split across calls (full-sequence vs. prefill + decode). Read once at import time; after importing `fla`, use `fla.utils.set_batch_invariant_mode` or the `fla.utils.batch_invariant_mode` context manager instead. |
 
 ---
 

--- a/ENVs.md
+++ b/ENVs.md
@@ -31,7 +31,7 @@ runtime. Variables are grouped by what they control:
 | -------------------- | ------- | ------------------------ | ---------------------------------------------------------------------------------------------------------- |
 | `FLA_TRIL_PRECISION` | `ieee`  | `ieee` / `tf32` / `tf32x3` | Precision used by `solve_tril`. `tf32x3` is NVIDIA-only and gives the best performance / accuracy trade-off on Ampere+. |
 | `FLA_USE_FAST_OPS`   | `0`     | `0` / `1`                | Enable faster but less accurate Triton math intrinsics in shared op helpers.                               |
-| `FLA_BATCH_INVARIANT` | `0`    | `0` / `1`, `true` / `yes` | Enable the batch-invariant execution mode: participating ops (currently `fused_recurrent_gated_delta_rule`) produce bitwise-identical outputs regardless of batch size and of how a sequence is split across calls (full-sequence vs. prefill + decode). Read once at import time; after importing `fla`, use `fla.utils.set_batch_invariant_mode` or the `fla.utils.batch_invariant_mode` context manager instead. |
+| `FLA_BATCH_INVARIANT` | `0`    | `0` / `1`, `true` / `yes` | Enable the batch-invariant execution mode: participating ops (currently `fused_recurrent_gated_delta_rule` and `chunk_gated_delta_rule`) produce bitwise-identical outputs regardless of batch size and of how a sequence is split across calls (full-sequence vs. prefill + decode; chunk splits at chunk-size boundaries). Autotuned kernels launch a fixed config instead of a timing-based winner. Read once at import time; after importing `fla`, use `fla.utils.set_batch_invariant_mode` or the `fla.utils.batch_invariant_mode` context manager instead. |
 
 ---
 

--- a/fla/ops/gated_delta_rule/chunk.py
+++ b/fla/ops/gated_delta_rule/chunk.py
@@ -21,12 +21,13 @@ from fla.ops.cp.chunk_delta_h import (
     expand_h0,
 )
 from fla.ops.gated_delta_rule.chunk_fwd import chunk_gated_delta_rule_fwd_intra
+from fla.ops.gated_delta_rule.fused_recurrent import flat_cu_seqlens, materialize_initial_state
 from fla.ops.gated_delta_rule.gate import gdn_gate_bwd, gdn_gate_chunk_cumsum
 from fla.ops.gated_delta_rule.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
 from fla.ops.utils import chunk_local_cumsum
 from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.index import prepare_chunk_indices
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, is_batch_invariant_mode_enabled
 
 
 def chunk_gated_delta_rule_fwd(
@@ -562,6 +563,24 @@ def chunk_gated_delta_rule(
 
     if scale is None:
         scale = k.shape[-1] ** -0.5
+
+    final_state_requested = output_final_state
+    unflatten_batch = None
+    if is_batch_invariant_mode_enabled() and cp_context is None:
+        # Pin every call to a single compiled specialization of each chunk kernel,
+        # mirroring the fused recurrent path: fp32 initial state always present,
+        # final state always stored, and varlen addressing always used. Unlike the
+        # recurrent path, chunk kernels size intermediate buffers from the batch
+        # dimension, so fixed-length batches are flattened to true varlen form;
+        # for contiguous inputs these reshapes are views.
+        initial_state = materialize_initial_state(k, v, initial_state, state_v_first, cu_seqlens)
+        output_final_state = True
+        if cu_seqlens is None:
+            B, T = q.shape[0], q.shape[1]
+            cu_seqlens = flat_cu_seqlens(B, T, q.device)
+            q, k, v, g, beta = (x.reshape(1, B * T, *x.shape[2:]) for x in (q, k, v, g, beta))
+            unflatten_batch = (B, T)
+
     o, final_state = ChunkGatedDeltaRuleFunction.apply(
         q,
         k,
@@ -583,6 +602,10 @@ def chunk_gated_delta_rule(
         cp_context,
         chunk_size,
     )
+    if unflatten_batch is not None:
+        o = o.view(*unflatten_batch, *o.shape[2:])
+    if not final_state_requested:
+        final_state = None
     return o, final_state
 
 

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -108,9 +108,14 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
             p_h0 = h0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
         else:
             p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
-        b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
-    for _ in tl.range(0, T):
+    for i_t in tl.range(0, T):
+        # the initial state is added in the first iteration rather than before the
+        # loop: a pre-loop load anchors b_h to the load's register layout for the
+        # whole loop, costing ~40% on long sequences (l2norm/gate fused, H100)
+        if USE_INITIAL_STATE:
+            if i_t == 0:
+                b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
         b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
         b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
         b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -439,7 +439,9 @@ def fused_recurrent_gated_delta_rule(
     if scale is None:
         scale = k.shape[-1] ** -0.5
     if beta is None:
-        beta = torch.ones_like(q[..., 0])
+        # beta is headwise over the HV value heads; sizing it from q would give
+        # [B, T, H] and read out of bounds in the kernel under GVA (HV > H)
+        beta = torch.ones_like(v[..., 0])
     if use_gate_in_kernel:
         if A_log is None:
             raise ValueError("`A_log` must be provided when `use_gate_in_kernel=True`.")

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -5,6 +5,7 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+import functools
 import warnings
 
 import torch
@@ -13,7 +14,7 @@ import triton.language as tl
 
 from fla.ops.utils.op import exp
 from fla.ops.utils.softplus import softplus
-from fla.utils import input_guard
+from fla.utils import input_guard, is_batch_invariant_mode_enabled
 
 
 @triton.heuristics({
@@ -248,6 +249,40 @@ def fused_recurrent_gated_delta_rule_fwd(
     return o, final_state
 
 
+@functools.lru_cache(maxsize=32)
+def _flat_cu_seqlens(batch_size: int, seq_len: int, device: torch.device) -> torch.Tensor:
+    """Cumulative sequence lengths of a fixed-length batch in flattened varlen form.
+
+    Cached so that steady-state decode does not pay an allocation + kernel launch
+    per call, and so the tensor is stable across calls for CUDA-graph capture.
+    """
+    return torch.arange(0, (batch_size + 1) * seq_len, seq_len, device=device, dtype=torch.long)
+
+
+def materialize_initial_state(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    state_v_first: bool,
+    cu_seqlens: torch.LongTensor | None,
+) -> torch.Tensor:
+    """Return an fp32 initial state, materializing zeros when none is given.
+
+    Passing `initial_state=None` compiles a `USE_INITIAL_STATE=False` kernel
+    specialization whose loop body the compiler may schedule differently from
+    the `True` one, breaking bitwise equality between a full-sequence call and
+    a prefill+decode split. Always materializing the state pins every call to
+    a single specialization. The fp32 cast makes the state handoff between
+    calls lossless, matching the fp32 accumulator inside the kernel.
+    """
+    if initial_state is not None:
+        return initial_state.float()
+    N = k.shape[0] if cu_seqlens is None else len(cu_seqlens) - 1
+    HV, K, V = v.shape[2], k.shape[-1], v.shape[-1]
+    shape = (N, HV, V, K) if state_v_first else (N, HV, K, V)
+    return k.new_zeros(shape, dtype=torch.float32)
+
+
 class FusedRecurrentFunction(torch.autograd.Function):
 
     @staticmethod
@@ -386,6 +421,13 @@ def fused_recurrent_gated_delta_rule(
         final_state (torch.Tensor):
             Final state of shape `[N, HV, K, V]` if `output_final_state=True` else `None`.
 
+    Note:
+        Under the batch-invariant mode (see :func:`fla.utils.batch_invariant_mode`),
+        this op guarantees bitwise-identical outputs regardless of batch size and of
+        how the sequence is split across calls: processing a full sequence in one call
+        equals a prefill call plus token-by-token decode calls, provided the fp32
+        `final_state` of each call is passed unmodified as the next `initial_state`.
+
     Examples::
         >>> import torch
         >>> import torch.nn.functional as F
@@ -453,6 +495,20 @@ def fused_recurrent_gated_delta_rule(
     if allow_neg_eigval and not use_beta_sigmoid_in_kernel:
         raise ValueError("`allow_neg_eigval=True` requires `use_beta_sigmoid_in_kernel=True`.")
 
+    final_state_requested = output_final_state
+    if is_batch_invariant_mode_enabled():
+        # Pin every call (prefill or decode, fixed-length or varlen, any batch size)
+        # to a single compiled kernel specialization: always pass an fp32 initial
+        # state (USE_INITIAL_STATE), store the final state (STORE_FINAL_STATE), and
+        # address fixed-length batches through cu_seqlens (IS_VARLEN). The latter
+        # needs no reshape: the kernel addresses tokens by linear offset, and a
+        # contiguous [B, T, ...] batch is laid out identically to a packed varlen
+        # batch of B equal-length sequences.
+        initial_state = materialize_initial_state(k, v, initial_state, state_v_first, cu_seqlens)
+        output_final_state = True
+        if cu_seqlens is None:
+            cu_seqlens = _flat_cu_seqlens(q.shape[0], q.shape[1], q.device)
+
     o, final_state = FusedRecurrentFunction.apply(
         q,
         k,
@@ -472,6 +528,8 @@ def fused_recurrent_gated_delta_rule(
         state_v_first,
         cu_seqlens,
     )
+    if not final_state_requested:
+        final_state = None
     return o, final_state
 
 

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -255,7 +255,7 @@ def fused_recurrent_gated_delta_rule_fwd(
 
 
 @functools.lru_cache(maxsize=32)
-def _flat_cu_seqlens(batch_size: int, seq_len: int, device: torch.device) -> torch.Tensor:
+def flat_cu_seqlens(batch_size: int, seq_len: int, device: torch.device) -> torch.Tensor:
     """Cumulative sequence lengths of a fixed-length batch in flattened varlen form.
 
     Cached so that steady-state decode does not pay an allocation + kernel launch
@@ -512,7 +512,7 @@ def fused_recurrent_gated_delta_rule(
         initial_state = materialize_initial_state(k, v, initial_state, state_v_first, cu_seqlens)
         output_final_state = True
         if cu_seqlens is None:
-            cu_seqlens = _flat_cu_seqlens(q.shape[0], q.shape[1], q.device)
+            cu_seqlens = flat_cu_seqlens(q.shape[0], q.shape[1], q.device)
 
     o, final_state = FusedRecurrentFunction.apply(
         q,

--- a/fla/ops/utils/cache.py
+++ b/fla/ops/utils/cache.py
@@ -20,6 +20,8 @@ import triton
 from packaging import version
 from triton.runtime.autotuner import Autotuner
 
+from fla.utils._batch_invariant import is_batch_invariant_mode_enabled
+
 TRITON_ABOVE_3_5_1 = version.parse(triton.__version__) >= version.parse("3.5.1")
 TRITON_ABOVE_3_4_0 = version.parse(triton.__version__) >= version.parse("3.4.0")
 
@@ -372,6 +374,12 @@ class CachedAutotuner(Autotuner):
         return key.autotune_key not in self.cache
 
     def run(self, *args, **kwargs):
+        if is_batch_invariant_mode_enabled():
+            # Batch-invariant mode: skip both the config cache and timing-based
+            # autotuning and always launch the first (deterministically ordered)
+            # config, so the kernel binary -- and with it the in-kernel reduction
+            # order -- cannot vary with shapes, timing noise, or cache state.
+            return self.fn.run(*args, **kwargs, **self.configs[0].all_kwargs())
         key = AutotuneKey.build(self.arg_names, self.keys, args, kwargs)
         if self.should_check_fla_cache(key):
             self.maybe_load_cached_config(key)

--- a/fla/utils/__init__.py
+++ b/fla/utils/__init__.py
@@ -7,6 +7,11 @@
 
 import sys
 
+from ._batch_invariant import (  # noqa: F401
+    batch_invariant_mode,
+    is_batch_invariant_mode_enabled,
+    set_batch_invariant_mode,
+)
 from ._compat import (  # noqa: F401
     SUPPORTS_AUTOTUNE_CACHE,
     TRITON_ABOVE_3_4_0,

--- a/fla/utils/_batch_invariant.py
+++ b/fla/utils/_batch_invariant.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Batch-invariant execution mode.
+
+When this mode is enabled, participating kernels guarantee that the output for
+a given token is **bitwise identical** regardless of
+
+- how many other sequences are present in the batch, and
+- how the sequence is split across calls, e.g. a single full-sequence call vs.
+  a prefill call followed by token-by-token decode calls with the fp32
+  recurrent state carried unmodified between them.
+
+Participating ops achieve this by pinning every call to a single compiled
+kernel specialization (same ``tl.constexpr`` flags, launch config, and block
+sizes for prefill, decode, fixed-length, and varlen calls alike) and by
+keeping the recurrent state handoff in fp32, which matches the in-kernel
+accumulator and makes the store/reload at call boundaries lossless.
+
+This is a prerequisite for reproducible inference and for exact
+training/inference equivalence checks. It comes at a small performance cost
+(e.g. always materializing the fp32 state buffers), hence it is opt-in.
+
+The mode can be enabled process-wide via the ``FLA_BATCH_INVARIANT``
+environment variable (``1`` / ``true`` / ``yes``, read once at import time),
+or at runtime via :func:`set_batch_invariant_mode` or the
+:func:`batch_invariant_mode` context manager. The runtime toggles are backed
+by a :class:`contextvars.ContextVar` and therefore only affect the current
+thread (or async task), so a multi-threaded server can serve invariant and
+regular requests concurrently::
+
+    >>> from fla.utils import batch_invariant_mode
+    >>> with batch_invariant_mode():
+    ...     o, state = fused_recurrent_gated_delta_rule(q, k, v, g, beta, ...)
+
+Currently participating ops:
+
+- ``fla.ops.gated_delta_rule.fused_recurrent_gated_delta_rule``
+"""
+
+import os
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_batch_invariant_mode: ContextVar[bool] = ContextVar(
+    'fla_batch_invariant_mode',
+    default=os.getenv('FLA_BATCH_INVARIANT', '0').lower() in ('1', 'true', 'yes'),
+)
+
+
+def is_batch_invariant_mode_enabled() -> bool:
+    """Return whether the batch-invariant mode is enabled in the current context."""
+    return _batch_invariant_mode.get()
+
+
+def set_batch_invariant_mode(enabled: bool = True) -> None:
+    """Enable or disable the batch-invariant mode for the current context.
+
+    The setting is scoped to the current thread (or async task). To enable the
+    mode process-wide, set ``FLA_BATCH_INVARIANT=1`` before importing ``fla``.
+    """
+    _batch_invariant_mode.set(enabled)
+
+
+@contextmanager
+def batch_invariant_mode(enabled: bool = True):
+    """Context manager that temporarily enables (or disables) the batch-invariant mode."""
+    token = _batch_invariant_mode.set(enabled)
+    try:
+        yield
+    finally:
+        _batch_invariant_mode.reset(token)

--- a/fla/utils/_batch_invariant.py
+++ b/fla/utils/_batch_invariant.py
@@ -40,6 +40,16 @@ regular requests concurrently::
 Currently participating ops:
 
 - ``fla.ops.gated_delta_rule.fused_recurrent_gated_delta_rule``
+  (splits allowed at any token position)
+- ``fla.ops.gated_delta_rule.chunk_gated_delta_rule``
+  (splits allowed at chunk-size boundaries; the fp32 state handed from a
+  chunked prefill call to recurrent decode calls is lossless, so the
+  chunk-prefill + recurrent-decode serving pipeline is deterministic and
+  batch-invariant end to end)
+
+Under the mode, autotuned kernels launch a fixed, deterministically chosen
+config instead of a timing-based winner, so the compiled binary -- and with it
+the in-kernel reduction order -- cannot vary between runs or shapes.
 """
 
 import os

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -1284,3 +1284,23 @@ def test_prepare_wy_repr_bwd_no_g(B: int, T: int, H: int, HV: int, D: int):
     assert_close('dk', dk_zero_g, dk_no_g, 1e-4)
     assert_close('dv', dv_zero_g, dv_no_g, 1e-4)
     assert_close('db', db_zero_g, db_no_g, 1e-4)
+
+
+def test_fused_recurrent_default_beta_gva():
+    """`beta=None` must default to ones over the HV value heads; sizing it from
+    q ([B, T, H]) makes the kernel read out of bounds under GVA (HV > H)."""
+    torch.manual_seed(42)
+    B, T, H, HV, D = 2, 64, 2, 4, 64
+    q = torch.randn(B, T, H, D, dtype=torch.float32, device=device)
+    k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32, device=device), p=2, dim=-1)
+    v = torch.randn(B, T, HV, D, dtype=torch.float32, device=device)
+    g = F.logsigmoid(torch.randn(B, T, HV, dtype=torch.float32, device=device))
+
+    o_default, ht_default = fused_recurrent_gated_delta_rule(
+        q=q, k=k, v=v, g=g, beta=None, output_final_state=True,
+    )
+    o_ones, ht_ones = fused_recurrent_gated_delta_rule(
+        q=q, k=k, v=v, g=g, beta=torch.ones(B, T, HV, dtype=torch.float32, device=device), output_final_state=True,
+    )
+    assert torch.equal(o_default, o_ones)
+    assert torch.equal(ht_default, ht_ones)

--- a/tests/ops/test_gdn_batch_invariant.py
+++ b/tests/ops/test_gdn_batch_invariant.py
@@ -5,25 +5,31 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-"""Bitwise batch-invariance tests for the fused recurrent GDN kernel.
+"""Bitwise batch-invariance tests for the GDN kernels.
 
-Under `fla.utils.batch_invariant_mode`, `fused_recurrent_gated_delta_rule`
-guarantees two invariants, both checked here with `torch.equal` (bitwise):
+Under `fla.utils.batch_invariant_mode`, `fused_recurrent_gated_delta_rule` and
+`chunk_gated_delta_rule` guarantee two invariants, checked here with
+`torch.equal` (bitwise):
 
 1. Split invariance: processing a full sequence in one call produces exactly
-   the same outputs and final state as a prefill call followed by
-   token-by-token decode calls, with the fp32 recurrent state carried
-   unmodified between calls.
+   the same outputs and final state as several calls over pieces of it, with
+   the fp32 recurrent state carried unmodified between calls. For the
+   recurrent kernel any split point is allowed; for the chunk kernel splits
+   must fall on chunk-size (64-token) boundaries.
 2. Batch invariance: a sequence's outputs do not depend on the other
    sequences present in the batch.
+
+Cross-algorithm agreement (chunk vs recurrent vs naive) is tolerance-based,
+not bitwise: the two kernels order their floating-point reductions
+differently.
 """
 
 import pytest
 import torch
 import torch.nn.functional as F
 
-from fla.ops.gated_delta_rule import fused_recurrent_gated_delta_rule
-from fla.utils import batch_invariant_mode, device, is_batch_invariant_mode_enabled, set_batch_invariant_mode
+from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
+from fla.utils import assert_close, batch_invariant_mode, device, is_batch_invariant_mode_enabled, set_batch_invariant_mode
 
 
 def make_inputs(
@@ -286,3 +292,139 @@ def test_batch_invariant_mode_api():
         assert is_batch_invariant_mode_enabled()
     finally:
         set_batch_invariant_mode(initial)
+
+
+# ---------------------------------------------------------------------------
+# chunk kernel invariance
+#
+# The chunk kernel advances its fp32 running state one 64-token chunk at a
+# time, so bitwise split invariance is guaranteed for splits at chunk-size
+# boundaries (the production pattern: one chunked-prefill call, then decode).
+# Cross-algorithm equality (chunk vs recurrent) is checked at tolerance, not
+# bitwise: the two paths order their floating-point reductions differently.
+# ---------------------------------------------------------------------------
+
+def chunk_run(q, k, v, g, beta, A_log, dt_bias, h0, use_qk_l2norm: bool, gate_fusion: bool):
+    return chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=h0,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm,
+        use_gate_in_kernel=gate_fusion,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        use_beta_sigmoid_in_kernel=gate_fusion,
+    )
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HV', 'D', 'use_qk_l2norm', 'gate_fusion', 'with_initial_state', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HV{}-D{}-l2norm{}-gatefusion{}-h0{}-{}".format(*test))
+        for test in [
+            (2, 256, 2, 4, 64, True, True, False, torch.bfloat16),
+            (2, 256, 2, 4, 64, False, False, True, torch.bfloat16),
+            (2, 320, 2, 2, 128, True, False, False, torch.float32),
+        ]
+    ],
+)
+def test_chunk_split_invariance(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    use_qk_l2norm: bool,
+    gate_fusion: bool,
+    with_initial_state: bool,
+    dtype: torch.dtype,
+):
+    """chunk(full) == chunk(pieces split at 64-token boundaries) with fp32 state handoff."""
+    q, k, v, g, beta, A_log, dt_bias, h0 = make_inputs(B, T, H, HV, D, dtype, gate_fusion, with_initial_state)
+
+    with batch_invariant_mode():
+        o_full, ht_full = chunk_run(q, k, v, g, beta, A_log, dt_bias, h0, use_qk_l2norm, gate_fusion)
+
+        chunks, state = [], h0
+        splits = [(0, 128), (128, 192), (192, T)]
+        for s, e in splits:
+            o_step, state = chunk_run(
+                q[:, s:e], k[:, s:e], v[:, s:e], g[:, s:e], beta[:, s:e],
+                A_log, dt_bias, state, use_qk_l2norm, gate_fusion,
+            )
+            chunks.append(o_step)
+
+    assert torch.equal(o_full, torch.cat(chunks, dim=1))
+    assert torch.equal(ht_full, state)
+
+
+def test_chunk_batch_invariance():
+    B, T, H, HV, D = 4, 256, 2, 4, 64
+    q, k, v, g, beta, A_log, dt_bias, h0 = make_inputs(
+        B, T, H, HV, D, torch.bfloat16, gate_fusion=True, with_initial_state=True,
+    )
+    with batch_invariant_mode():
+        o_batch, ht_batch = chunk_run(q, k, v, g, beta, A_log, dt_bias, h0, True, True)
+        for b in range(B):
+            o_one, ht_one = chunk_run(
+                q[b:b + 1], k[b:b + 1], v[b:b + 1], g[b:b + 1], beta[b:b + 1],
+                A_log, dt_bias, h0[b:b + 1], True, True,
+            )
+            assert torch.equal(o_batch[b:b + 1], o_one), f"chunk outputs of sequence {b} depend on the batch"
+            assert torch.equal(ht_batch[b:b + 1], ht_one), f"chunk final state of sequence {b} depends on the batch"
+
+
+def test_chunk_prefill_recurrent_decode_pipeline():
+    """The production serving pattern, checked bitwise end-to-end: a chunked
+    prefill call followed by batched token-by-token recurrent decode must be
+    deterministic across runs and independent of how requests are batched."""
+    B, T_prefill, T_decode, H, HV, D = 4, 192, 8, 2, 4, 64
+    T = T_prefill + T_decode
+    q, k, v, g, beta, A_log, dt_bias, _ = make_inputs(
+        B, T, H, HV, D, torch.bfloat16, gate_fusion=True, with_initial_state=False,
+    )
+
+    def pipeline(sl=slice(None)):
+        o_pre, state = chunk_run(
+            q[sl, :T_prefill], k[sl, :T_prefill], v[sl, :T_prefill],
+            g[sl, :T_prefill], beta[sl, :T_prefill],
+            A_log, dt_bias, None, True, True,
+        )
+        outs = [o_pre]
+        for t in range(T_prefill, T):
+            o_t, state = run(
+                q[sl, t:t + 1], k[sl, t:t + 1], v[sl, t:t + 1], g[sl, t:t + 1], beta[sl, t:t + 1],
+                A_log, dt_bias, state, True, True,
+            )
+            outs.append(o_t)
+        return torch.cat(outs, dim=1), state
+
+    with batch_invariant_mode():
+        o_batched, ht_batched = pipeline()
+        o_repeat, ht_repeat = pipeline()
+        assert torch.equal(o_batched, o_repeat), "pipeline is not deterministic across runs"
+        assert torch.equal(ht_batched, ht_repeat)
+
+        for b in range(B):
+            o_one, ht_one = pipeline(slice(b, b + 1))
+            assert torch.equal(o_batched[b:b + 1], o_one), f"pipeline output of sequence {b} depends on the batch"
+            assert torch.equal(ht_batched[b:b + 1], ht_one)
+
+
+def test_chunk_vs_recurrent_tolerance():
+    """chunk and recurrent share the exp2 decay convention and fp32 states but
+    order their reductions differently, so cross-algorithm agreement is checked
+    at tolerance (bitwise equality is not expected)."""
+    B, T, H, HV, D = 2, 256, 2, 4, 64
+    q, k, v, g, beta, A_log, dt_bias, h0 = make_inputs(
+        B, T, H, HV, D, torch.bfloat16, gate_fusion=True, with_initial_state=True,
+    )
+    with batch_invariant_mode():
+        o_c, ht_c = chunk_run(q, k, v, g, beta, A_log, dt_bias, h0, True, True)
+        o_r, ht_r = run(q, k, v, g, beta, A_log, dt_bias, h0, True, True)
+    assert_close('o', o_c, o_r, 0.005)
+    assert_close('ht', ht_c, ht_r, 0.005)

--- a/tests/ops/test_gdn_batch_invariant.py
+++ b/tests/ops/test_gdn_batch_invariant.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Bitwise batch-invariance tests for the fused recurrent GDN kernel.
+
+Under `fla.utils.batch_invariant_mode`, `fused_recurrent_gated_delta_rule`
+guarantees two invariants, both checked here with `torch.equal` (bitwise):
+
+1. Split invariance: processing a full sequence in one call produces exactly
+   the same outputs and final state as a prefill call followed by
+   token-by-token decode calls, with the fp32 recurrent state carried
+   unmodified between calls.
+2. Batch invariance: a sequence's outputs do not depend on the other
+   sequences present in the batch.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from fla.ops.gated_delta_rule import fused_recurrent_gated_delta_rule
+from fla.utils import batch_invariant_mode, device, is_batch_invariant_mode_enabled, set_batch_invariant_mode
+
+
+def make_inputs(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    dtype: torch.dtype,
+    gate_fusion: bool,
+    with_initial_state: bool,
+    seed: int = 42,
+):
+    """Build GDN inputs; with `gate_fusion`, `g`/`beta` are raw pre-activations."""
+    torch.manual_seed(seed)
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32, device=device), p=2, dim=-1).to(dtype)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    if gate_fusion:
+        g = torch.randn(B, T, HV, dtype=torch.float32, device=device)
+        beta = torch.randn(B, T, HV, dtype=dtype, device=device)
+        A_log = torch.randn(HV, dtype=torch.float32, device=device)
+        dt_bias = torch.randn(HV, dtype=torch.float32, device=device)
+    else:
+        g = F.logsigmoid(torch.randn(B, T, HV, dtype=torch.float32, device=device))
+        beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
+        A_log, dt_bias = None, None
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device) if with_initial_state else None
+    return q, k, v, g, beta, A_log, dt_bias, h0
+
+
+def run(q, k, v, g, beta, A_log, dt_bias, h0, use_qk_l2norm: bool, gate_fusion: bool, state_v_first: bool = False):
+    return fused_recurrent_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=h0,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm,
+        use_gate_in_kernel=gate_fusion,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        use_beta_sigmoid_in_kernel=gate_fusion,
+        state_v_first=state_v_first,
+    )
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HV', 'D', 'prefill_len', 'use_qk_l2norm', 'gate_fusion', 'with_initial_state', 'dtype'),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-HV{}-D{}-prefill{}-l2norm{}-gatefusion{}-h0{}-{}".format(*test),
+        )
+        for test in [
+            (2, 64, 2, 4, 64, 37, False, False, False, torch.bfloat16),
+            (2, 64, 2, 4, 64, 37, True, True, False, torch.bfloat16),
+            (2, 64, 2, 4, 64, 37, True, False, True, torch.bfloat16),
+            (2, 64, 2, 4, 64, 37, False, True, True, torch.bfloat16),
+            (1, 100, 1, 1, 128, 63, True, True, False, torch.bfloat16),
+            (2, 64, 2, 2, 100, 37, True, False, False, torch.float32),
+            (2, 64, 2, 4, 64, 37, True, True, True, torch.float32),
+        ]
+    ],
+)
+def test_split_invariance_full_vs_prefill_decode(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    prefill_len: int,
+    use_qk_l2norm: bool,
+    gate_fusion: bool,
+    with_initial_state: bool,
+    dtype: torch.dtype,
+):
+    q, k, v, g, beta, A_log, dt_bias, h0 = make_inputs(B, T, H, HV, D, dtype, gate_fusion, with_initial_state)
+
+    with batch_invariant_mode():
+        o_full, ht_full = run(q, k, v, g, beta, A_log, dt_bias, h0, use_qk_l2norm, gate_fusion)
+
+        # prefill, then token-by-token decode with the state carried between calls
+        chunks = []
+        state = h0
+        splits = [(0, prefill_len)] + [(t, t + 1) for t in range(prefill_len, T)]
+        for s, e in splits:
+            o_step, state = run(
+                q[:, s:e], k[:, s:e], v[:, s:e], g[:, s:e], beta[:, s:e],
+                A_log, dt_bias, state, use_qk_l2norm, gate_fusion,
+            )
+            chunks.append(o_step)
+        o_split = torch.cat(chunks, dim=1)
+
+    assert torch.equal(o_full, o_split), \
+        f"outputs diverge: max abs diff {(o_full.float() - o_split.float()).abs().max().item():.3e}"
+    assert torch.equal(ht_full, state), \
+        f"final states diverge: max abs diff {(ht_full - state).abs().max().item():.3e}"
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'HV', 'D', 'use_qk_l2norm', 'gate_fusion', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-HV{}-D{}-l2norm{}-gatefusion{}-{}".format(*test))
+        for test in [
+            (4, 64, 2, 4, 64, True, True, torch.bfloat16),
+            (4, 64, 2, 2, 64, False, False, torch.float32),
+        ]
+    ],
+)
+def test_batch_invariance_batched_vs_single(
+    B: int,
+    T: int,
+    H: int,
+    HV: int,
+    D: int,
+    use_qk_l2norm: bool,
+    gate_fusion: bool,
+    dtype: torch.dtype,
+):
+    q, k, v, g, beta, A_log, dt_bias, h0 = make_inputs(B, T, H, HV, D, dtype, gate_fusion, with_initial_state=True)
+
+    with batch_invariant_mode():
+        o_batch, ht_batch = run(q, k, v, g, beta, A_log, dt_bias, h0, use_qk_l2norm, gate_fusion)
+        for b in range(B):
+            o_one, ht_one = run(
+                q[b:b + 1], k[b:b + 1], v[b:b + 1], g[b:b + 1], beta[b:b + 1],
+                A_log, dt_bias, h0[b:b + 1], use_qk_l2norm, gate_fusion,
+            )
+            assert torch.equal(o_batch[b:b + 1], o_one), f"outputs of sequence {b} depend on the rest of the batch"
+            assert torch.equal(ht_batch[b:b + 1], ht_one), f"final state of sequence {b} depends on the rest of the batch"
+
+
+def test_split_invariance_state_v_first():
+    """Split invariance for the V-first state layout, with K != V so that a
+    transposed or mis-shaped state materialization cannot go unnoticed."""
+    B, T, H, HV, K, V, prefill_len = 2, 64, 2, 4, 64, 32, 37
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+    q = torch.randn(B, T, H, K, dtype=dtype, device=device)
+    k = F.normalize(torch.randn(B, T, H, K, dtype=torch.float32, device=device), p=2, dim=-1).to(dtype)
+    v = torch.randn(B, T, HV, V, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, T, HV, dtype=torch.float32, device=device))
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
+    h0 = torch.randn(B, HV, V, K, dtype=torch.float32, device=device)
+
+    with batch_invariant_mode():
+        o_full, ht_full = run(q, k, v, g, beta, None, None, h0, False, False, state_v_first=True)
+
+        chunks, state = [], h0
+        splits = [(0, prefill_len)] + [(t, t + 1) for t in range(prefill_len, T)]
+        for s, e in splits:
+            o_step, state = run(
+                q[:, s:e], k[:, s:e], v[:, s:e], g[:, s:e], beta[:, s:e],
+                None, None, state, False, False, state_v_first=True,
+            )
+            chunks.append(o_step)
+
+    assert torch.equal(o_full, torch.cat(chunks, dim=1))
+    assert torch.equal(ht_full, state)
+
+
+def test_prefill_single_decode_batched():
+    """Crossing both invariants at once: prefill each sequence in its own call,
+    then decode all sequences batched, against one full-batch full-sequence call."""
+    B, T, H, HV, D, prefill_len = 4, 64, 2, 4, 64, 49
+    q, k, v, g, beta, A_log, dt_bias, _ = make_inputs(
+        B, T, H, HV, D, torch.bfloat16, gate_fusion=True, with_initial_state=False,
+    )
+
+    with batch_invariant_mode():
+        o_full, ht_full = run(q, k, v, g, beta, A_log, dt_bias, None, True, True)
+
+        prefill_outs, prefill_states = [], []
+        for b in range(B):
+            o_b, s_b = run(
+                q[b:b + 1, :prefill_len], k[b:b + 1, :prefill_len], v[b:b + 1, :prefill_len],
+                g[b:b + 1, :prefill_len], beta[b:b + 1, :prefill_len],
+                A_log, dt_bias, None, True, True,
+            )
+            prefill_outs.append(o_b)
+            prefill_states.append(s_b)
+
+        chunks = [torch.cat(prefill_outs, dim=0)]
+        state = torch.cat(prefill_states, dim=0)
+        for t in range(prefill_len, T):
+            o_t, state = run(
+                q[:, t:t + 1], k[:, t:t + 1], v[:, t:t + 1], g[:, t:t + 1], beta[:, t:t + 1],
+                A_log, dt_bias, state, True, True,
+            )
+            chunks.append(o_t)
+
+    assert torch.equal(o_full, torch.cat(chunks, dim=1))
+    assert torch.equal(ht_full, state)
+
+
+def test_varlen_split_invariance():
+    """Split invariance also holds for varlen (`cu_seqlens`) prefill vs. batched decode."""
+    T0, T1, H, HV, D = 37, 51, 2, 4, 64
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+    q = torch.randn(1, T0 + T1, H, D, dtype=dtype, device=device)
+    k = F.normalize(torch.randn(1, T0 + T1, H, D, dtype=torch.float32, device=device), p=2, dim=-1).to(dtype)
+    v = torch.randn(1, T0 + T1, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(1, T0 + T1, HV, dtype=torch.float32, device=device))
+    beta = torch.rand(1, T0 + T1, HV, dtype=dtype, device=device).sigmoid()
+    cu_seqlens = torch.tensor([0, T0, T0 + T1], dtype=torch.long, device=device)
+
+    with batch_invariant_mode():
+        o_full, ht_full = fused_recurrent_gated_delta_rule(
+            q=q, k=k, v=v, g=g, beta=beta,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # per-sequence prefill of all but the last token, then one decode step each
+        o_parts, ht_parts = [], []
+        for s, e in ((0, T0), (T0, T0 + T1)):
+            o_pre, state = fused_recurrent_gated_delta_rule(
+                q=q[:, s:e - 1], k=k[:, s:e - 1], v=v[:, s:e - 1], g=g[:, s:e - 1], beta=beta[:, s:e - 1],
+                output_final_state=True,
+            )
+            o_dec, state = fused_recurrent_gated_delta_rule(
+                q=q[:, e - 1:e], k=k[:, e - 1:e], v=v[:, e - 1:e], g=g[:, e - 1:e], beta=beta[:, e - 1:e],
+                initial_state=state,
+                output_final_state=True,
+            )
+            o_parts += [o_pre, o_dec]
+            ht_parts.append(state)
+
+    assert torch.equal(o_full, torch.cat(o_parts, dim=1))
+    assert torch.equal(ht_full, torch.cat(ht_parts, dim=0))
+
+
+def test_final_state_not_returned_when_not_requested():
+    """The invariant-mode internal final-state buffer must not leak to the caller."""
+    q, k, v, g, beta, *_ = make_inputs(1, 16, 1, 1, 64, torch.bfloat16, gate_fusion=False, with_initial_state=False)
+    with batch_invariant_mode():
+        o, final_state = fused_recurrent_gated_delta_rule(q=q, k=k, v=v, g=g, beta=beta, output_final_state=False)
+    assert final_state is None
+    assert o.shape == v.shape
+
+
+def test_batch_invariant_mode_api():
+    # save/restore so the test is independent of the FLA_BATCH_INVARIANT env var
+    initial = is_batch_invariant_mode_enabled()
+    try:
+        set_batch_invariant_mode(False)
+        assert not is_batch_invariant_mode_enabled()
+        with batch_invariant_mode():
+            assert is_batch_invariant_mode_enabled()
+            with batch_invariant_mode(enabled=False):
+                assert not is_batch_invariant_mode_enabled()
+            assert is_batch_invariant_mode_enabled()
+        assert not is_batch_invariant_mode_enabled()
+
+        set_batch_invariant_mode(True)
+        assert is_batch_invariant_mode_enabled()
+    finally:
+        set_batch_invariant_mode(initial)

--- a/tests/ops/test_gdn_batch_invariant.py
+++ b/tests/ops/test_gdn_batch_invariant.py
@@ -418,7 +418,14 @@ def test_chunk_prefill_recurrent_decode_pipeline():
 def test_chunk_vs_recurrent_tolerance():
     """chunk and recurrent share the exp2 decay convention and fp32 states but
     order their reductions differently, so cross-algorithm agreement is checked
-    at tolerance (bitwise equality is not expected)."""
+    at tolerance (bitwise equality is not expected).
+
+    TODO: the cross-algorithm gap (and the boundary drift it implies when a
+    token is recomputed under a different prefill/decode split) could be
+    removed entirely by serving prefill through fused_recurrent as well --
+    one bitwise numerical path at the cost of prefill speed (chunk is ~7x
+    faster at T=4096 on H100). Worth an end-to-end benchmark.
+    """
     B, T, H, HV, D = 2, 256, 2, 4, 64
     q, k, v, g, beta, A_log, dt_bias, h0 = make_inputs(
         B, T, H, HV, D, torch.bfloat16, gate_fusion=True, with_initial_state=True,


### PR DESCRIPTION
This adds an opt-in **batch-invariant mode** for the GDN kernels.

The motivation: today, running the same sequence alone vs. in a batch, or in one full-sequence call vs. prefill + token-by-token decode, gives bitwise-different results. Nothing random is going on — the wrapper just compiles different kernel specializations depending on how you call it (`h0=None` vs. `h0` given, varlen vs. fixed-length), and the different binaries schedule their float ops differently. With `FLA_BATCH_INVARIANT=1` (or the `fla.utils.batch_invariant_mode()` context manager, ContextVar-backed so threads can opt in independently) every call is pinned to one specialization and results become exactly reproducible — `torch.equal`, not `allclose`.

What the mode actually does:

- always passes an fp32 initial state (zeros if you didn't give one) and always stores the fp32 final state, so `USE_INITIAL_STATE` / `STORE_FINAL_STATE` never fork. This one is load-bearing: without it, the fp32 final states of a full run and a split run genuinely diverge bitwise.
- routes fixed-length batches through `cu_seqlens`, so `IS_VARLEN` never forks either. For the recurrent kernel this is free: a contiguous `[B, T, ...]` batch is byte-identical to a packed varlen batch of equal-length sequences, so no data moves — just a cached cu_seqlens tensor. The chunk wrapper flattens with views.
- skips timing-based autotuning and always launches the first config, so the compiled binary (and its reduction order) can't drift between runs or shapes.

Everything below is asserted with `torch.equal` in the new tests: results don't depend on batch size; full == prefill + decode (any split point for recurrent, chunk-size boundaries for chunk); and the actual serving pipeline — chunked prefill followed by batched recurrent decode — is deterministic and batch-invariant end to end, including the mixed case of per-sequence prefill + batched decode.

What is *not* bitwise: the same tokens pushed through chunk vs. recurrent. Different reduction orders, so this is checked at 0.005 tolerance; measured at the prefill/decode boundary with Qwen3.5-9B shapes it's ~1.2e-4 on the boundary token. With a fixed split policy you never observe this. There's a TODO in the tests about serving prefill through `fused_recurrent` too, which would give a single bitwise numerical path at ~7x prefill cost.

A few things that fell out of this work and are bundled here:

- **Fix**: `beta=None` allocated `[B, T, H]`, but the kernel reads beta with stride `HV` — out-of-bounds reads under GVA (`HV > H`). Now sized from the value heads, with a bitwise regression test. The same latent pattern exists in comba / delta_rule / gated_oja_rule; follow-up.
- **Perf**: pinning forces the h0-given specialization everywhere, which turned out ~39% slower than the h0=None one at long T with fused l2norm/gate. The pre-loop h0 load anchors the accumulator's register layout for the entire loop; moving the load into the first loop iteration cuts the gap to ~11% with identical operation order. (num_warps/num_stages sweeps were flat — it's codegen, not scheduling.)

## Numbers

H100 · triton 3.7.1 · bf16 · H=4, HV=8, D=128 · off/on interleaved in one process, min of 5 rounds.

`fused_recurrent` (l2norm + gate fused in kernel):

| case | off | on | delta |
|---|---|---|---|
| decode B=1/8/64, T=1 (wall) | ~73 µs | ~76 µs | +3–5% |
| decode B=8/64, T=1 (GPU time) | — | — | ±0% |
| single call T=4096, B=8 | 3.91 ms | 4.36 ms | +11.6% |
| fwd T=2048, B=8, no final state | 2.33 ms | 2.19 ms | −6.0% |

`chunk`:

| case | off | on | delta |
|---|---|---|---|
| prefill B=8, T=4096 | 0.57 ms | 0.65 ms | +12.5% |
| prefill B=32, T=1024 | 0.58 ms | 0.65 ms | +12.0% |
| prefill B=1, T=4096 | 0.59 ms | 0.47 ms | −20.3% |
| fwd B=8, T=2048, no ht | 0.60 ms | 0.49 ms | −19.1% |

The chunk deltas are dominated by pinned-config-vs-tuned-winner, not by the pinning itself. So in practice the mode costs a few µs of wrapper work per decode call; prefill runs the chunk kernel where the deltas are config-choice noise.

## Test plan

- `tests/ops/test_gdn_batch_invariant.py` (new): 24 tests — recurrent split invariance across l2norm/gate-fusion/GVA/`state_v_first` (K≠V)/varlen combos, batch invariance, per-sequence-prefill + batched-decode, chunk split invariance at 64-token boundaries, chunk batch invariance, the chunk-prefill + recurrent-decode pipeline, chunk-vs-recurrent tolerance, mode API semantics.
- `tests/ops/test_gdn.py::test_fused_recurrent_default_beta_gva` (new): bitwise regression for the GVA beta fix.
- Full regression on H100: test_gdn / test_gdn_kernels / layers + new file — **135 passed, 9 skipped, 0 failed**. ruff + autopep8 + pre-commit clean.

## Behavior notes

Mode off, nothing changes except one deliberate one: the initial-state load moved inside the loop (identical operation order; the compiled schedule differs, which was never covered by any bitwise guarantee). All existing tolerance tests pass unchanged. `beta=None` under GVA goes from undefined behavior to correct.
