### PR TITLE
[Fix] Drop deprecated tl.extra.cuda.libdevice prefix

### DIFF
--- a/fla/modules/fused_bitlinear.py
+++ b/fla/modules/fused_bitlinear.py
@@ -133,7 +133,7 @@ def layer_norm_fwd_kernel_quant(
     # Aply quantization to the output
     scale = 127.0 / tl.maximum(tl.max(tl.abs(y), 0), 1e-5)
     # Quantize and then de-quantize the tensor
-    y = tl.extra.cuda.libdevice.round(y * scale)
+    y = tl.extra.libdevice.round(y * scale)
     y = tl.maximum(tl.minimum(y, 127), -128) / scale
 
     # Write output
@@ -276,7 +276,7 @@ def layer_norm_bwd_kernel(
             # Aply quantization to the output
             scale = 127.0 / tl.maximum(tl.max(tl.abs(y), 0), 1e-5)
             # Quantize and then de-quantize the tensor
-            y = tl.extra.cuda.libdevice.round(y * scale)
+            y = tl.extra.libdevice.round(y * scale)
             y = tl.maximum(tl.minimum(y, 127), -128) / scale
 
             tl.store(Y + cols, y, mask=mask)


### PR DESCRIPTION
mainline triton dropped implicit conversion for \`tl.extra.cuda.<op>\` (the old CUDA-namespaced spelling). recent nightly builds now raise:

\`\`\`
RuntimeError: Implicit conversion of CUDA __nv_roundf device function has been dropped;
please, update your source program to use triton.language.extra.<op>
to replace triton.language.extra.cuda.<op>
\`\`\`

which currently breaks bitnet at import/compile time. two call sites in \`fla/modules/fused_bitlinear.py\`, both switched to \`tl.extra.libdevice.round\` (backend-agnostic).

verified on rocm7.2 + torch 2.14 nightly with a source-built triton at the latest main.