### PR TITLE
[Fix] avoid SymInt stride reads in activations under torch.compile

### DIFF
--- a/fla/modules/activations.py
+++ b/fla/modules/activations.py
@@ -33,6 +33,8 @@ def _get_stride(x: torch.Tensor) -> int:
     """
     if x.ndim < 2:
         return 0
+    if torch.compiler.is_compiling():
+        return x.shape[-1]
     return x.stride(-2)
 
 
@@ -69,6 +71,8 @@ def _is_inner_contiguous(x: torch.Tensor) -> bool:
 
 def _ensure_inner_contiguous(x: torch.Tensor) -> torch.Tensor:
     """Make the tensor inner-contiguous if it isn't already."""
+    if torch.compiler.is_compiling():
+        return x.contiguous()
     if _is_inner_contiguous(x):
         return x
     return x.contiguous()


### PR DESCRIPTION
## Summary
Work around a PyTorch 2.12 dynamo `ConstantVariable(SymInt)` assertion when `torch.compile`-ing activations on tensors with size-1 dims.

## Test
`tests/modules/test_activation.py` (dispatch disabled + enabled) on H100 / torch 2.12.1.