### PR TITLE
[Fix] Add get_max_length to FLA cache for transformers 5.x

### DIFF
--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -143,8 +143,11 @@ class FLALayer(CacheLayerMixin):
     def get_seq_length(self, cache_position=None) -> int:
         return self._seen_tokens
 
-    def get_max_cache_shape(self) -> int:
+    def get_max_length(self) -> int:
         return -1
+
+    def get_max_cache_shape(self) -> int:
+        return self.get_max_length()
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
         return 0, 0
@@ -425,8 +428,11 @@ class FLACache(HFCacheBase):
             return 0
         return self.layers[layer_idx or 0].get_seq_length()
 
-    def get_max_cache_shape(self, layer_idx: int = 0) -> int:
+    def get_max_length(self, layer_idx: int = 0) -> int:
         return -1
+
+    def get_max_cache_shape(self, layer_idx: int = 0) -> int:
+        return self.get_max_length(layer_idx)
 
     def get_mask_sizes(self, cache_position: torch.Tensor, layer_idx: int) -> tuple[int, int]:
         # kv_length = past_seen + current_query_length


### PR DESCRIPTION
transformers 5.x renamed the abstract cache-layer method `get_max_cache_shape` to `get_max_length` (the old name is now a deprecated alias that delegates to `get_max_length`). `FLALayer` only implemented the old name, so under 5.x it is abstract and `Cache.update` fails to instantiate it:

```
TypeError: Can't instantiate abstract class FLALayer without an implementation for abstract method 'get_max_length'
```

Add `get_max_length` (returning `-1`, the "no maximum / linear attention has no sequence-length dimension" sentinel) to `FLALayer` and `FLACache`, and keep `get_max_cache_shape` delegating to it. Both names are defined unconditionally, so no version branch is needed:

- 5.x: abstract `get_max_length` is satisfied.
- <=4.56: abstract `get_max_cache_shape` is still satisfied; the extra method is unused.

Fixes the `test_modeling_rwkv7.py::test_generation` failure surfaced in the H100 run of #1004 (transformers 5.13.0).