### PR TITLE
[Test] Skip flash-attn-dependent tests when flash-attn is not installed

### DIFF
--- a/tests/models/test_modeling_bitnet.py
+++ b/tests/models/test_modeling_bitnet.py
@@ -12,6 +12,11 @@ from fla.models import BitNetConfig
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+pytest.importorskip(
+    "flash_attn",
+    reason="BitAttention requires flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 # ===================================================================================
 # Test for Modeling (Forward/Backward Pass)

--- a/tests/models/test_modeling_deltaformer.py
+++ b/tests/models/test_modeling_deltaformer.py
@@ -12,6 +12,11 @@ from fla.models import DeltaFormerConfig
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+pytest.importorskip(
+    "flash_attn",
+    reason="DeltaFormer attention requires flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 # ===================================================================================
 # Test for Modeling (Forward/Backward Pass)

--- a/tests/models/test_modeling_mla.py
+++ b/tests/models/test_modeling_mla.py
@@ -12,6 +12,11 @@ from fla.models import MLAConfig
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+pytest.importorskip(
+    "flash_attn",
+    reason="MultiheadLatentAttention requires flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 # ===================================================================================
 # Test for Modeling (Forward/Backward Pass)

--- a/tests/models/test_modeling_moba.py
+++ b/tests/models/test_modeling_moba.py
@@ -12,6 +12,11 @@ from fla.models import MoBAConfig
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+pytest.importorskip(
+    "flash_attn",
+    reason="MoBA attention requires flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 # ===================================================================================
 # Test for Modeling (Forward/Backward Pass)

--- a/tests/models/test_modeling_nsa.py
+++ b/tests/models/test_modeling_nsa.py
@@ -12,6 +12,11 @@ from fla.models import NSAConfig
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+pytest.importorskip(
+    "flash_attn",
+    reason="NSA sliding-window attention requires flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 # ===================================================================================
 # Test for Modeling (Forward/Backward Pass)

--- a/tests/models/test_modeling_samba.py
+++ b/tests/models/test_modeling_samba.py
@@ -12,6 +12,11 @@ from fla.models import SambaConfig
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+pytest.importorskip(
+    "flash_attn",
+    reason="Samba attention layers require flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 # ===================================================================================
 # Test for Modeling (Forward/Backward Pass)

--- a/tests/models/test_modeling_transformer.py
+++ b/tests/models/test_modeling_transformer.py
@@ -12,6 +12,11 @@ from fla.models import TransformerConfig
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+pytest.importorskip(
+    "flash_attn",
+    reason="Attention requires flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 # ===================================================================================
 # Test for Modeling (Forward/Backward Pass)

--- a/tests/models/test_modeling_yoco.py
+++ b/tests/models/test_modeling_yoco.py
@@ -12,6 +12,12 @@ from fla.models import YOCOConfig, YOCOForCausalLM
 
 from .test_modeling_base import run_test_generation, run_test_model_forward_backward
 
+try:
+    import flash_attn  # noqa: F401
+    HAS_FLASH_ATTN = True
+except ImportError:
+    HAS_FLASH_ATTN = False
+
 
 def _create_yoco_config_kwargs(
     L: int,
@@ -106,6 +112,8 @@ def test_modeling(
     attnres_block_size: int | None,
     dtype: torch.dtype,
 ):
+    if self_decoder_attn_type == 'swa' and not HAS_FLASH_ATTN:
+        pytest.skip(reason="YOCO swa attention requires flash-attn (`pip install flash-attn --no-build-isolation`).")
     torch.manual_seed(42)
     run_test_model_forward_backward(
         L,
@@ -150,6 +158,8 @@ def test_generation(
     dtype: torch.dtype,
     tol: float,
 ):
+    if self_decoder_attn_type == 'swa' and not HAS_FLASH_ATTN:
+        pytest.skip(reason="YOCO swa attention requires flash-attn (`pip install flash-attn --no-build-isolation`).")
     config = _create_yoco_config(
         L,
         H,

--- a/tests/ops/test_deltaformer.py
+++ b/tests/ops/test_deltaformer.py
@@ -12,6 +12,11 @@ from fla.ops.deltaformer import deltaformer_attn
 from fla.ops.deltaformer.naive import naive_deltaformer_attn
 from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device
 
+pytest.importorskip(
+    "flash_attn",
+    reason="deltaformer_attn requires flash-attn to be installed (`pip install flash-attn --no-build-isolation`).",
+)
+
 
 @pytest.mark.parametrize(
     ('B', 'T', 'H', 'D', 'dtype'),

--- a/tests/ops/test_nsa.py
+++ b/tests/ops/test_nsa.py
@@ -452,6 +452,11 @@ def test_parallel_decode(
         window_size: int,
         dtype: torch.dtype,
 ):
+    if window_size > 0:
+        pytest.importorskip(
+            "flash_attn",
+            reason="NSA sliding-window attention requires flash-attn (`pip install flash-attn --no-build-isolation`).",
+        )
     torch.manual_seed(42)
 
     q = (torch.rand((B, T, HQ, D), dtype=dtype, device=device) * 3 - 2).requires_grad_(True)
@@ -841,6 +846,11 @@ def test_parallel_varlen_decode(
         q_lens,
         dtype: torch.dtype,
 ):
+    if window_size > 0:
+        pytest.importorskip(
+            "flash_attn",
+            reason="NSA sliding-window attention requires flash-attn (`pip install flash-attn --no-build-isolation`).",
+        )
     torch.manual_seed(42)
 
     T = cu_seqlens[-1]


### PR DESCRIPTION
## Summary

Environments without flash-attn (e.g. new PyTorch images that don't have matching flash-attn wheels yet) currently fail CI with `ImportError: Please install Flash Attention via `pip install flash-attn --no-build-isolation` first` (e.g. `tests/models/test_modeling_bitnet.py::test_modeling`).

This PR skips those tests instead, mirroring the existing module-level `pytest.importorskip` pattern already used for `mamba_ssm`.

## Changes

Fully flash-attn-dependent suites — module-level `pytest.importorskip("flash_attn", reason=...)`:
- `tests/models/test_modeling_bitnet.py` (BitAttention)
- `tests/models/test_modeling_transformer.py` (full Attention)
- `tests/models/test_modeling_mla.py` (MLA)
- `tests/models/test_modeling_samba.py` (attention layers on by default)
- `tests/models/test_modeling_deltaformer.py` (`deltaformer_attn`)
- `tests/models/test_modeling_moba.py` (`parallel_moba` on the flash path)
- `tests/models/test_modeling_nsa.py` (sliding-window path, `window_size=512` default)
- `tests/ops/test_deltaformer.py`

Partially dependent suites — per-configuration skips:
- `tests/models/test_modeling_yoco.py`: only the `swa` rows need flash-attn; `gated_deltanet` / `gated_retention` rows still run
- `tests/ops/test_nsa.py`: only decode rows with `window_size > 0` need flash-attn; `window_size = 0` rows still run

Hybrid models (`gla`, `kda`, `gsa`, etc.) keep running as before: their full-`Attention` layers are only instantiated when `config.attn` is set, which these tests don't do.

## Test plan

- [x] `ruff check` passes
- [ ] CI on a runner without flash-attn: previously failing suites now skip instead of erroring
- [ ] CI on a runner with flash-attn installed: no behavior change, all suites run