### PR TITLE
[Fix] based: only one V-split program stores z in fused_chunk fwd

### DIFF
--- a/fla/ops/based/fused_chunk.py
+++ b/fla/ops/based/fused_chunk.py
@@ -94,7 +94,12 @@ def fused_chunk_based_fwd_kernel(
         b_o += tl.dot(b_s.to(b_q.dtype), b_v, allow_tf32=False)
         # [TB, BV]
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_z, b_z.to(p_z.dtype.element_ty), mask=(i * BT + tl.arange(0, BT)) < T)
+        # only one V-split program writes z: its address does not depend on
+        # i_v, so all i_v programs would store the same values to the same
+        # locations concurrently (an unsynchronized same-value WAW). The bwd
+        # kernel below already guards its i_v-redundant work with i_v == 0.
+        if i_v == 0:
+            tl.store(p_z, b_z.to(p_z.dtype.element_ty), mask=(i * BT + tl.arange(0, BT)) < T)
 
         # update hidden state
         # [BK, BV]


### PR DESCRIPTION
### Problem

`fused_chunk_based_fwd_kernel` launches on a `(NV, NK, B*H)` grid, but the `z` pointer

```python
p_z = z + (i_bh + i_k * B * H) * T + tl.arange(0, BT)
```

does not depend on `i_v`. Whenever `NV = cdiv(V, BV) > 1` (e.g. the default `BV = 32` with `V = 64` gives `NV = 2`), every V-split program executes

```python
tl.store(p_z, b_z.to(p_z.dtype.element_ty), mask=(i * BT + tl.arange(0, BT)) < T)
```

against the **same addresses concurrently**. `b_z` is computed only from `b_q`, `b_k` and the k running stats (`k_0o/k_1o/k_2o`), so all `i_v` programs store bitwise-identical values and the results happen to come out right — but it is still an unsynchronized inter-program write-write conflict, and it costs `NV - 1` redundant global-memory stores of `z` per chunk iteration.

### Fix

Guard the `z` store with `if i_v == 0:` — the same convention `fused_chunk_based_bwd_kernel` in this file already applies to all of its `i_v`-redundant work (see its `i_v == 0` blocks).

### Testing

`pytest tests/ops/test_based.py`: 5 passed (RTX 4090, triton 3.6.0, torch 2.10.0). Output is unchanged by construction: the surviving store writes exactly the values every program previously wrote.
