### PR TITLE
[Misc] Add faceted benchmark visualization and multi-device benchmark support

### DIFF
--- a/benchmarks/modules/benchmark_activations.py
+++ b/benchmarks/modules/benchmark_activations.py
@@ -110,4 +110,9 @@ def benchmark(B, T, D, provider):
 
 
 if __name__ == '__main__':
-    benchmark.run(print_data=True, save_path='./activation_benchmark')
+    try:
+        from runner import run_module_benchmark
+    except ModuleNotFoundError:
+        from benchmarks.modules.runner import run_module_benchmark
+
+    run_module_benchmark(benchmark, script_file=__file__, save_dir='./activation_benchmark')

--- a/benchmarks/modules/benchmark_conv.py
+++ b/benchmarks/modules/benchmark_conv.py
@@ -117,4 +117,9 @@ benchmark = triton.testing.perf_report(
 
 
 if __name__ == '__main__':
-    benchmark.run(print_data=True)
+    try:
+        from runner import run_module_benchmark
+    except ModuleNotFoundError:
+        from benchmarks.modules.runner import run_module_benchmark
+
+    run_module_benchmark(benchmark, script_file=__file__)

--- a/benchmarks/modules/benchmark_cross_entropy.py
+++ b/benchmarks/modules/benchmark_cross_entropy.py
@@ -69,4 +69,9 @@ def benchmark(T, provider):
 
 
 if __name__ == '__main__':
-    benchmark.run(print_data=True)
+    try:
+        from runner import run_module_benchmark
+    except ModuleNotFoundError:
+        from benchmarks.modules.runner import run_module_benchmark
+
+    run_module_benchmark(benchmark, script_file=__file__)

--- a/benchmarks/modules/benchmark_l2norm.py
+++ b/benchmarks/modules/benchmark_l2norm.py
@@ -65,4 +65,9 @@ def benchmark(B, H, D, T, provider):
 
 
 if __name__ == '__main__':
-    benchmark.run(print_data=True)
+    try:
+        from runner import run_module_benchmark
+    except ModuleNotFoundError:
+        from benchmarks.modules.runner import run_module_benchmark
+
+    run_module_benchmark(benchmark, script_file=__file__)

--- a/benchmarks/modules/benchmark_layernorm.py
+++ b/benchmarks/modules/benchmark_layernorm.py
@@ -73,4 +73,9 @@ def benchmark(T, provider):
 
 
 if __name__ == '__main__':
-    benchmark.run(print_data=True)
+    try:
+        from runner import run_module_benchmark
+    except ModuleNotFoundError:
+        from benchmarks.modules.runner import run_module_benchmark
+
+    run_module_benchmark(benchmark, script_file=__file__)

--- a/benchmarks/modules/benchmark_tokenshift.py
+++ b/benchmarks/modules/benchmark_tokenshift.py
@@ -63,4 +63,9 @@ def benchmark(T, provider):
 
 
 if __name__ == '__main__':
-    benchmark.run(print_data=True)
+    try:
+        from runner import run_module_benchmark
+    except ModuleNotFoundError:
+        from benchmarks.modules.runner import run_module_benchmark
+
+    run_module_benchmark(benchmark, script_file=__file__)

--- a/benchmarks/modules/runner.py
+++ b/benchmarks/modules/runner.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Shared runner for Triton ``perf_report`` module benchmarks."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def ensure_repo_root_on_path() -> Path:
+    """Make ``benchmarks.*`` importable when scripts are run directly."""
+    root = Path(__file__).resolve().parents[2]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+    return root
+
+
+def default_save_dir(script_file: str) -> str:
+    """Derive ``./<module>_benchmark`` from ``benchmark_<module>.py``."""
+    stem = Path(script_file).stem
+    name = stem.removeprefix('benchmark_')
+    return f'./{name}_benchmark'
+
+
+def get_plot_name(mark: Any) -> str:
+    benches = mark.benchmarks
+    if not isinstance(benches, list):
+        benches = [benches]
+    return benches[0].plot_name
+
+
+def run_module_benchmark(
+    mark: Any,
+    *,
+    save_dir: str | None = None,
+    plot_name: str | None = None,
+    script_file: str | None = None,
+    print_data: bool = True,
+    visualize: bool = True,
+    **run_kwargs: Any,
+) -> str:
+    """Run a module benchmark and optionally generate faceted plots.
+
+    Args:
+        mark: Object returned by ``@triton.testing.perf_report``.
+        save_dir: Output directory for CSV/PNG/HTML. Defaults to
+            ``./<module>_benchmark`` inferred from *script_file*.
+        plot_name: CSV/plot stem from the Benchmark config. Auto-detected when
+            omitted.
+        script_file: Pass ``__file__`` to enable the default *save_dir*.
+        print_data: Print the benchmark table to stdout.
+        visualize: Generate faceted plots via ``benchmarks.visualize``.
+        **run_kwargs: Extra kwargs forwarded to ``mark.run``.
+
+    Returns:
+        The output directory path.
+    """
+    ensure_repo_root_on_path()
+
+    if plot_name is None:
+        plot_name = get_plot_name(mark)
+    if save_dir is None:
+        if script_file is None:
+            raise ValueError("save_dir or script_file must be provided")
+        save_dir = default_save_dir(script_file)
+
+    mark.run(print_data=print_data, save_path=save_dir, **run_kwargs)
+
+    if visualize:
+        csv_path = Path(save_dir) / f'{plot_name}.csv'
+        if csv_path.exists():
+            try:
+                from benchmarks.visualize import visualize_perf_report_csv
+                for path in visualize_perf_report_csv(csv_path, save_dir=save_dir):
+                    print(f"Saved plot: {path}")
+            except ImportError as exc:
+                print(
+                    f"Warning: skipping visualization (install matplotlib and pandas: {exc})",
+                    file=sys.stderr,
+                )
+        else:
+            print(f"Warning: expected CSV not found at {csv_path}, skipping visualization")
+
+    return save_dir

--- a/benchmarks/ops/run.py
+++ b/benchmarks/ops/run.py
@@ -141,6 +141,8 @@ import tempfile
 
 import torch
 
+from fla.utils import device_name
+
 # Import registry — works both as a package (python -m benchmarks.ops.run)
 # and standalone (python /tmp/fla_bench_xxx/run.py) for cross-commit use.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -153,6 +155,27 @@ from registry import (  # noqa: E402
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _device_synchronize(device: str | None = None) -> None:
+    """Synchronize the active accelerator before/after timed runs."""
+    dev = device or device_name
+    dev_mod = getattr(torch, dev, None)
+    if dev_mod is not None and hasattr(dev_mod, 'synchronize'):
+        dev_mod.synchronize()
+
+
+def _format_machine_line(info: dict) -> str:
+    gpu = info.get('gpu_name', 'N/A')
+    pytorch = info.get('pytorch_version', 'N/A')
+    platform = info.get('device_platform', 'N/A')
+    if platform == 'cuda':
+        backend = f"CUDA {info.get('cuda_version', 'N/A')}"
+    elif platform == 'npu':
+        backend = f"NPU: CANN {info.get('cann_version', 'N/A')}"
+    else:
+        backend = platform.upper() if platform != 'N/A' else 'N/A'
+    return f"Machine: {gpu} | {backend} | PyTorch {pytorch}"
 
 
 def _import_op(config: OpConfig):
@@ -185,11 +208,14 @@ def _get_git_label() -> str:
 
 
 def _get_machine_info() -> dict:
+    from fla.utils import device_platform
+
     info = {
         'hostname': socket.gethostname(),
         'platform': platform.platform(),
         'pytorch_version': torch.__version__,
         'cuda_version': torch.version.cuda or 'N/A',
+        'device_platform': device_platform,
         'git_label': _get_git_label(),
     }
     try:
@@ -198,7 +224,13 @@ def _get_machine_info() -> dict:
     except Exception:
         info['triton_version'] = 'N/A'
 
-    if torch.cuda.is_available():
+    if device_platform == 'npu' and hasattr(torch, 'npu') and torch.npu.is_available():
+        props = torch.npu.get_device_properties(0)
+        info['gpu_name'] = torch.npu.get_device_name(0)
+        info['gpu_count'] = torch.npu.device_count()
+        info['gpu_memory_gb'] = round(props.total_memory / (1024**3), 1)
+        info['cann_version'] = getattr(torch.version, 'cann', None) or 'N/A'
+    elif torch.cuda.is_available():
         info['gpu_name'] = torch.cuda.get_device_name(0)
         info['gpu_count'] = torch.cuda.device_count()
         info['gpu_memory_gb'] = round(
@@ -223,13 +255,13 @@ def _do_bench_kw():
     return {'warmup': max(1, warmup_ms), 'rep': max(1, rep_ms)}
 
 
-def _warmup_autotune(fn, n: int | None = None):
+def _warmup_autotune(fn, n: int | None = None, device: str | None = None):
     """Run *fn* multiple times so triton autotuning is fully cached."""
     if n is None:
         n = _warmup_iters()
     for _ in range(n):
         fn()
-    torch.cuda.synchronize()
+    _device_synchronize(device)
 
 
 def benchmark_op(
@@ -294,7 +326,6 @@ def benchmark_op(
         logger.warning(f"No compatible shapes for {op_name}, skipping.")
         return []
 
-    device = 'cuda'
     dtype = torch.bfloat16
 
     # Phase 1: warmup ALL shapes before timing ANY
@@ -304,7 +335,7 @@ def benchmark_op(
         B, T, H, D = shape_dict['B'], shape_dict['T'], shape_dict['H'], shape_dict['D']
         extra_shape_kw = {k: v for k, v in shape_dict.items() if k not in ('B', 'T', 'H', 'D')}
         try:
-            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device, **extra_shape_kw)
+            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device_name, **extra_shape_kw)
             out = op_fn(**inputs, **call_kwargs)
             out_tensor = out[0] if config.output_is_tuple else out
             do = torch.randn_like(out_tensor)
@@ -314,7 +345,7 @@ def benchmark_op(
                 t = result[0] if config.output_is_tuple else result
                 t.backward(do)
 
-            _warmup_autotune(_fwdbwd_fn)
+            _warmup_autotune(_fwdbwd_fn, device=device_name)
         except Exception as e:
             logger.warning(f"Warmup failed for {op_name} @ {shape_name}: {e}")
             failed_shapes.add(shape_name)
@@ -329,7 +360,7 @@ def benchmark_op(
         B, T, H, D = shape_dict['B'], shape_dict['T'], shape_dict['H'], shape_dict['D']
         extra_shape_kw = {k: v for k, v in shape_dict.items() if k not in ('B', 'T', 'H', 'D')}
         try:
-            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device, **extra_shape_kw)
+            inputs = generate_inputs(config, B, T, H, D, dtype=dtype, device=device_name, **extra_shape_kw)
         except Exception as e:
             logger.warning(f"Input generation failed for {op_name} @ {shape_name}: {e}")
             continue
@@ -458,10 +489,7 @@ def print_results_table(results: list[dict], machine_info: dict | None = None,
 
     print(f"\n{sep}")
     if machine_info:
-        gpu = machine_info.get('gpu_name', 'N/A')
-        cuda = machine_info.get('cuda_version', 'N/A')
-        pytorch = machine_info.get('pytorch_version', 'N/A')
-        print(f"  Machine: {gpu} | CUDA {cuda} | PyTorch {pytorch}")
+        print(f"  {_format_machine_line(machine_info)}")
 
     def _l_cell(r, blank=False):
         if not has_l:
@@ -658,9 +686,7 @@ def main():
     shape_configs = json.loads(args.custom_shapes) if args.custom_shapes else SHAPE_CONFIGS
 
     machine_info = _get_machine_info()
-    print(f"Machine: {machine_info.get('gpu_name', 'N/A')} | "
-          f"CUDA {machine_info.get('cuda_version', 'N/A')} | "
-          f"PyTorch {machine_info.get('pytorch_version', 'N/A')}")
+    print(_format_machine_line(machine_info))
     print(f"Shapes: {len(shape_configs)} configs")
     print(f"Ops: {op_names}")
 

--- a/benchmarks/ops/verify.py
+++ b/benchmarks/ops/verify.py
@@ -58,13 +58,17 @@ import sys
 
 import torch
 
+from fla.utils import device_name
+
 # Import sibling modules. Works both as a package (python -m benchmarks.ops.verify)
 # and standalone, matching run.py's import strategy.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from registry import SHAPE_CONFIGS, get_op, list_ops  # noqa: E402
 from run import (  # noqa: E402
     _bench_at_ref,
+    _device_synchronize,
     _find_project_root,
+    _format_machine_line,
     _get_machine_info,
     benchmark_op,
     print_results_table,
@@ -128,7 +132,7 @@ def profile_op(op_name: str, modes: list[str]) -> None:
     shape = next(iter(shapes.values()))
     B, T, H, D = shape['B'], shape['T'], shape['H'], shape['D']
     extra = {k: v for k, v in shape.items() if k not in ('B', 'T', 'H', 'D')}
-    inputs = generate_inputs(config, B, T, H, D, dtype=torch.bfloat16, device='cuda', **extra)
+    inputs = generate_inputs(config, B, T, H, D, dtype=torch.bfloat16, device=device_name, **extra)
 
     do_bwd = 'fwdbwd' in modes and not config.skip_backward
     out = op_fn(**inputs, **config.extra_kwargs)
@@ -143,19 +147,24 @@ def profile_op(op_name: str, modes: list[str]) -> None:
 
     for _ in range(3):  # warm autotune before profiling
         step()
-    torch.cuda.synchronize()
+    _device_synchronize(device_name)
 
     out_dir = os.path.join(_find_project_root(), 'profile', f'{op_name}-opt')
     os.makedirs(out_dir, exist_ok=True)
-    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True) as prof:
+    activities = [ProfilerActivity.CPU]
+    sort_by = 'self_cpu_time_total'
+    if device_name == 'cuda':
+        activities.append(ProfilerActivity.CUDA)
+        sort_by = 'self_cuda_time_total'
+    with profile(activities=activities, record_shapes=True) as prof:
         step()
-        torch.cuda.synchronize()
+        _device_synchronize(device_name)
 
     trace = os.path.join(out_dir, f'{op_name}_trace.json')
     prof.export_chrome_trace(trace)
-    print(f"\n  Top CUDA ops for {op_name} @ {B}x{T}x{H}x{D} "
+    print(f"\n  Top ops for {op_name} @ {B}x{T}x{H}x{D} "
           f"({'fwd+bwd' if do_bwd else 'fwd'}):")
-    print(prof.key_averages().table(sort_by='self_cuda_time_total', row_limit=10))
+    print(prof.key_averages().table(sort_by=sort_by, row_limit=10))
     print(f"  Chrome trace: {trace}")
 
 
@@ -236,9 +245,7 @@ def main():
 
     # 2. Performance measurement (reuses run.py). Baseline compare via git worktree.
     machine_info = _get_machine_info()
-    print(f"\n  Machine: {machine_info.get('gpu_name', 'N/A')} | "
-          f"CUDA {machine_info.get('cuda_version', 'N/A')} | "
-          f"PyTorch {machine_info.get('pytorch_version', 'N/A')} | "
+    print(f"\n  {_format_machine_line(machine_info)} | "
           f"Triton {machine_info.get('triton_version', 'N/A')} | "
           f"{machine_info.get('git_label', 'unknown')}")
 

--- a/benchmarks/visualize.py
+++ b/benchmarks/visualize.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""
+Visualization helpers for FLA benchmark outputs.
+
+Supports:
+  - Triton ``perf_report`` CSV files (module benchmarks)
+  - ``benchmark_results.json`` from ``scripts/run_benchmark_compare.py``
+
+Usage::
+
+    # From a module benchmark script (recommended)
+    python benchmarks/modules/benchmark_activations.py
+
+    # After running a module benchmark that writes CSV via save_path
+    python -m benchmarks.visualize perf-report activation_benchmark/activation_performance.csv
+
+    # From a CI / local comparison JSON
+    python -m benchmarks.visualize comparison benchmark_results.json --output plots/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+
+_SHAPE_COLS = frozenset({'B', 'T', 'H', 'D', 'L'})
+
+
+def _require_matplotlib():
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError(
+            "matplotlib is required for benchmark visualization. "
+            "Install with: pip install '.[benchmark]'"
+        ) from exc
+    return plt
+
+
+def _require_pandas():
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise ImportError(
+            "pandas is required for benchmark visualization. "
+            "Install with: pip install pandas"
+        ) from exc
+    return pd
+
+
+def _split_shape_and_metric_columns(columns: list[str]) -> tuple[list[str], list[str]]:
+    shape_cols = [c for c in columns if c in _SHAPE_COLS]
+    metric_cols = [c for c in columns if c not in shape_cols]
+    return shape_cols, metric_cols
+
+
+def _pick_x_axis(shape_cols: list[str], df) -> str:
+    if not shape_cols:
+        raise ValueError("No shape columns found in CSV")
+
+    preferred = ['T', 'D', 'H', 'B', 'L']
+    candidates = sorted(
+        shape_cols,
+        key=lambda c: (
+            -(df[c].nunique() if c in df.columns else 0),
+            preferred.index(c) if c in preferred else len(preferred),
+        ),
+    )
+    x_axis = candidates[0]
+    if df[x_axis].nunique() <= 1:
+        raise ValueError(
+            f"Cannot pick a varying x-axis from shape columns {shape_cols}"
+        )
+    return x_axis
+
+
+def _facet_columns(shape_cols: list[str], x_axis: str, df) -> list[str]:
+    facets = []
+    for col in shape_cols:
+        if col == x_axis:
+            continue
+        if df[col].nunique() > 1:
+            facets.append(col)
+    return facets
+
+
+def _iter_facet_groups(df, facet_cols: list[str]):
+    """Yield (mask, title) for each facet group present in the data."""
+    if not facet_cols:
+        yield df.index, ''
+        return
+
+    grouped = df.groupby(facet_cols, sort=True)
+    for keys, sub in grouped:
+        if not isinstance(keys, tuple):
+            keys = (keys,)
+        title = ', '.join(f'{col}={int(val) if val == int(val) else val}'
+                          for col, val in zip(facet_cols, keys, strict=True))
+        yield sub.index, title
+
+
+def _split_metric_groups(metric_cols: list[str]) -> tuple[list[str], list[str]]:
+    """Split providers into forward and backward groups when both exist."""
+    bwd_cols = [m for m in metric_cols if m.endswith('_fwdbwd') or m.endswith('_bwd')]
+    fwd_cols = [m for m in metric_cols if m not in bwd_cols]
+    if fwd_cols and bwd_cols:
+        return fwd_cols, bwd_cols
+    return metric_cols, []
+
+
+def _grid_shape(n_facets: int, n_mode_rows: int) -> tuple[int, int, int]:
+    """Pick a wide-friendly subplot grid.
+
+    Returns (nrows, ncols, rows_per_mode). For single-mode layouts rows_per_mode
+    equals nrows; for forward/backward stacks each mode occupies rows_per_mode rows.
+    """
+    if n_facets <= 1:
+        ncols = 1
+    elif n_mode_rows > 1:
+        ncols = min(n_facets, 5)
+    elif n_facets <= 3:
+        ncols = n_facets
+    else:
+        ncols = min(3, n_facets)
+
+    rows_per_mode = math.ceil(n_facets / ncols) if n_facets else 1
+    nrows = n_mode_rows * rows_per_mode
+    return nrows, ncols, rows_per_mode
+
+
+def _provider_style(name: str) -> tuple[str, str]:
+    if name.endswith('_fwdbwd'):
+        return name.removesuffix('_fwdbwd'), '--'
+    if name.endswith('_fwd'):
+        return name.removesuffix('_fwd'), '-'
+    if name.endswith('_bwd'):
+        return name.removesuffix('_bwd'), '--'
+    return name, '-'
+
+
+def visualize_perf_report_csv(
+    csv_path: str | os.PathLike,
+    save_dir: str | os.PathLike | None = None,
+    *,
+    x_axis: str | None = None,
+    title: str | None = None,
+) -> list[str]:
+    """Plot a Triton perf_report CSV with sensible axes for multi-dim sweeps.
+
+    When the CSV has multiple shape columns (e.g. B, T, D) but only one varies
+    meaningfully on the x-axis, this creates one subplot per facet combination
+    (e.g. one panel per D) instead of plotting the constant B column.
+
+    Returns a list of saved image paths.
+    """
+    pd = _require_pandas()
+    plt = _require_matplotlib()
+
+    csv_path = Path(csv_path)
+    if save_dir is None:
+        save_dir = csv_path.parent
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_csv(csv_path)
+    shape_cols, metric_cols = _split_shape_and_metric_columns(df.columns.tolist())
+    if not metric_cols:
+        raise ValueError(f"No metric columns found in {csv_path}")
+
+    if x_axis is None:
+        x_axis = _pick_x_axis(shape_cols, df)
+    elif x_axis not in shape_cols:
+        raise ValueError(f"x_axis '{x_axis}' is not among shape columns {shape_cols}")
+
+    facet_cols = _facet_columns(shape_cols, x_axis, df)
+    fixed_cols = [c for c in shape_cols if c not in facet_cols and c != x_axis]
+
+    facet_groups = list(_iter_facet_groups(df, facet_cols))
+    n_facets = len(facet_groups)
+
+    fwd_cols, bwd_cols = _split_metric_groups(metric_cols)
+    mode_groups = [('Forward', fwd_cols)]
+    if bwd_cols:
+        mode_groups.append(('Backward', bwd_cols))
+
+    n_mode_rows = len(mode_groups)
+    nrows, ncols, rows_per_mode = _grid_shape(n_facets, n_mode_rows)
+    fig_w = max(3.0 * ncols, 8)
+    fig_h = max(3.8 * nrows, 4)
+    fig, axes = plt.subplots(nrows, ncols, figsize=(fig_w, fig_h), squeeze=False)
+
+    palette = plt.get_cmap('tab10')
+    color_map: dict[str, tuple] = {}
+    legend_handles: dict[str, object] = {}
+
+    for mode_row, (mode_label, cols) in enumerate(mode_groups):
+        for facet_idx, (facet_index, facet_title) in enumerate(facet_groups):
+            row = mode_row * rows_per_mode + facet_idx // ncols
+            col = facet_idx % ncols
+            ax = axes[row, col]
+
+            sub = df.loc[facet_index].sort_values(x_axis)
+            if sub.empty:
+                ax.set_visible(False)
+                continue
+
+            for metric in cols:
+                base, linestyle = _provider_style(metric)
+                if base not in color_map:
+                    color_map[base] = palette(len(color_map) % 10)
+                line, = ax.plot(
+                    sub[x_axis],
+                    sub[metric],
+                    label=base,
+                    color=color_map[base],
+                    linestyle=linestyle,
+                    marker='o',
+                    markersize=3,
+                )
+                legend_handles[base] = line
+
+            # Column header on the top row of each mode block only.
+            if facet_idx // ncols == 0:
+                title_parts = []
+                if facet_title:
+                    title_parts.append(facet_title)
+                for col_name in fixed_cols:
+                    vals = sorted(df[col_name].unique())
+                    if len(vals) == 1:
+                        val = vals[0]
+                        val_str = int(val) if val == int(val) else val
+                        title_parts.append(f'{col_name}={val_str}')
+                if title_parts:
+                    ax.set_title(', '.join(title_parts), fontsize=9, pad=8)
+
+            if facet_idx % ncols == 0:
+                if n_mode_rows > 1:
+                    ax.set_ylabel(f'{mode_label}\nTime (ms)', fontsize=9)
+                else:
+                    ax.set_ylabel('Time (ms)', fontsize=9)
+
+            ax.set_xlabel(x_axis, fontsize=9)
+
+            ax.grid(True, alpha=0.3)
+
+        # Hide unused facet slots in this mode block.
+        for empty_idx in range(n_facets, rows_per_mode * ncols):
+            row = mode_row * rows_per_mode + empty_idx // ncols
+            col = empty_idx % ncols
+            axes[row, col].set_visible(False)
+
+    plot_title = title or csv_path.stem.replace('_', ' ').title()
+    fig.suptitle(plot_title, y=0.98, fontsize=12)
+    fig.subplots_adjust(left=0.07, right=0.98, top=0.90, bottom=0.14, wspace=0.22, hspace=0.35)
+
+    if legend_handles:
+        fig.legend(
+            legend_handles.values(),
+            legend_handles.keys(),
+            loc='lower center',
+            ncol=min(len(legend_handles), 6),
+            fontsize=8,
+            bbox_to_anchor=(0.5, -0.02),
+            frameon=False,
+        )
+
+    out_path = save_dir / f"{csv_path.stem}_faceted.png"
+    fig.savefig(out_path, dpi=150, bbox_inches='tight', pad_inches=0.3)
+    plt.close(fig)
+
+    html_path = save_dir / 'results.html'
+    _write_html_gallery(html_path, [out_path], title=plot_title)
+
+    return [str(out_path)]
+
+
+def _make_comparison_label(r: dict) -> str:
+    parts = [r['op'], r['mode'], f"B{r['B']}", f"T{r['T']}", f"H{r['H']}", f"D{r['D']}"]
+    if 'L' in r:
+        parts.append(f"L{r['L']}")
+    return ' / '.join(parts)
+
+
+def visualize_comparison(
+    json_path: str | os.PathLike,
+    save_dir: str | os.PathLike | None = None,
+    *,
+    threshold: float | None = None,
+    top_n: int = 20,
+) -> list[str]:
+    """Plot base vs head latency and percent-change from a comparison JSON."""
+    plt = _require_matplotlib()
+
+    json_path = Path(json_path)
+    if save_dir is None:
+        save_dir = json_path.parent / 'plots'
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(json_path, encoding='utf-8') as f:
+        data = json.load(f)
+
+    base_results = data.get('base_results', [])
+    head_results = data.get('head_results', [])
+    threshold = threshold if threshold is not None else 5.0
+
+    def _key(r):
+        extras = tuple(sorted((k, v) for k, v in r.items()
+                              if k not in {'op', 'mode', 'B', 'T', 'H', 'D',
+                                           'median_ms', 'p20_ms', 'p80_ms'}))
+        return (r['op'], r['mode'], r['B'], r['T'], r['H'], r['D'], extras)
+
+    base_map = {_key(r): r for r in base_results}
+    head_map = {_key(r): r for r in head_results}
+    all_keys = sorted(set(base_map) | set(head_map))
+
+    rows = []
+    for key in all_keys:
+        b = base_map.get(key)
+        h = head_map.get(key)
+        if b and h:
+            base_ms = b['median_ms']
+            head_ms = h['median_ms']
+            change_pct = (head_ms - base_ms) / base_ms * 100 if base_ms else 0.0
+            rows.append({
+                'label': _make_comparison_label(b),
+                'base_ms': base_ms,
+                'head_ms': head_ms,
+                'change_pct': change_pct,
+            })
+
+    if not rows:
+        return []
+
+    rows.sort(key=lambda r: abs(r['change_pct']), reverse=True)
+    rows = rows[:top_n]
+
+    saved: list[str] = []
+
+    # Percent-change bar chart
+    fig, ax = plt.subplots(figsize=(10, max(4, 0.35 * len(rows))))
+    labels = [r['label'] for r in rows][::-1]
+    changes = [r['change_pct'] for r in rows][::-1]
+    colors = []
+    for c in changes:
+        if c > threshold:
+            colors.append('#d62728')
+        elif c < -threshold:
+            colors.append('#2ca02c')
+        else:
+            colors.append('#7f7f7f')
+    ax.barh(labels, changes, color=colors)
+    ax.axvline(0, color='black', linewidth=0.8)
+    ax.axvline(threshold, color='#d62728', linestyle='--', linewidth=0.8, alpha=0.6)
+    ax.axvline(-threshold, color='#2ca02c', linestyle='--', linewidth=0.8, alpha=0.6)
+    ax.set_xlabel('Change (%)')
+    base_sha = data.get('base_sha', 'base')
+    head_sha = data.get('head_sha', 'head')
+    ax.set_title(f'Benchmark Change: {base_sha} → {head_sha}')
+    fig.tight_layout()
+    change_path = save_dir / 'comparison_change_pct.png'
+    fig.savefig(change_path, dpi=150, bbox_inches='tight')
+    plt.close(fig)
+    saved.append(str(change_path))
+
+    # Grouped latency bar chart
+    fig, ax = plt.subplots(figsize=(10, max(4, 0.35 * len(rows))))
+    y_pos = list(range(len(rows)))
+    height = 0.35
+    base_vals = [r['base_ms'] for r in rows][::-1]
+    head_vals = [r['head_ms'] for r in rows][::-1]
+    ax.barh([y - height / 2 for y in y_pos], base_vals, height=height,
+            label=f"base ({base_sha})", color='#1f77b4')
+    ax.barh([y + height / 2 for y in y_pos], head_vals, height=height,
+            label=f"head ({head_sha})", color='#ff7f0e')
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(labels)
+    ax.set_xlabel('Median latency (ms)')
+    ax.set_title('Base vs Head Latency')
+    ax.legend()
+    fig.tight_layout()
+    latency_path = save_dir / 'comparison_latency.png'
+    fig.savefig(latency_path, dpi=150, bbox_inches='tight')
+    plt.close(fig)
+    saved.append(str(latency_path))
+
+    _write_html_gallery(
+        save_dir / 'results.html',
+        [Path(p) for p in saved],
+        title=f'Benchmark Comparison {base_sha} → {head_sha}',
+    )
+    return saved
+
+
+def _write_html_gallery(html_path: Path, image_paths: list[Path], *, title: str):
+    lines = [
+        '<html><head>',
+        f'<title>{title}</title>',
+        '<style>body{font-family:sans-serif;margin:24px;} img{max-width:100%;margin:16px 0;}</style>',
+        '</head><body>',
+        f'<h1>{title}</h1>',
+    ]
+    for img in image_paths:
+        rel = os.path.relpath(img, html_path.parent)
+        lines.append(f'<img src="{rel}" alt="{img.stem}"/>')
+    lines.append('</body></html>')
+    html_path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Visualize FLA benchmark results')
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    perf = sub.add_parser('perf-report', help='Visualize a Triton perf_report CSV')
+    perf.add_argument('csv', help='Path to the CSV file')
+    perf.add_argument('--output', '-o', default=None, help='Output directory for plots')
+    perf.add_argument('--x-axis', default=None, help='Shape column for the x-axis (default: auto)')
+
+    cmp = sub.add_parser('comparison', help='Visualize a benchmark_results.json comparison')
+    cmp.add_argument('json', help='Path to benchmark_results.json')
+    cmp.add_argument('--output', '-o', default=None, help='Output directory for plots')
+    cmp.add_argument('--threshold', type=float, default=None, help='Regression threshold (%%)')
+    cmp.add_argument('--top-n', type=int, default=20, help='Max rows to plot')
+
+    args = parser.parse_args()
+
+    if args.command == 'perf-report':
+        paths = visualize_perf_report_csv(
+            args.csv,
+            save_dir=args.output,
+            x_axis=args.x_axis,
+        )
+    else:
+        paths = visualize_comparison(
+            args.json,
+            save_dir=args.output,
+            threshold=args.threshold,
+            top_n=args.top_n,
+        )
+
+    for p in paths:
+        print(f"Saved: {p}")
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ npu  = ["torch==2.7.1", "torch_npu==2.7.1.post4", "torchvision==0.22.1", "triton
 cpu  = ["torch>=2.7.0", "triton>=3.3"]
 tilelang = ["tilelang>=0.1.9"]
 conv1d = ["causal-conv1d>=1.4.0"]
-benchmark = ["matplotlib", "datasets>=3.3.0"]
+benchmark = ["matplotlib", "pandas", "datasets>=3.3.0"]
 test = ["pytest", "pytest-xdist"]
 
 [project.urls]

--- a/scripts/run_benchmark_compare.py
+++ b/scripts/run_benchmark_compare.py
@@ -318,7 +318,16 @@ def main():
     parser.add_argument("--output", help="Save comparison results to JSON file")
     parser.add_argument("--no-fail-on-regression", action="store_true",
                         help="Do not exit with non-zero code on performance regression")
+    parser.add_argument("--plot", default=None,
+                        help="Save comparison visualization plots to this directory")
     args = parser.parse_args()
+
+    if args.plot and not args.output:
+        print(
+            "Warning: --plot requires --output to save comparison JSON first; "
+            "no plots will be generated.",
+            file=sys.stderr,
+        )
 
     # Resolve commit SHAs
     head_sha = get_commit_sha(args.head)
@@ -442,6 +451,17 @@ def main():
             with open(args.output, 'w') as f:
                 json.dump(comparison, f, indent=2)
             print(f"\nFull results saved to {args.output}")
+
+            if args.plot:
+                sys.path.insert(0, str(PROJECT_ROOT))
+                from benchmarks.visualize import visualize_comparison
+                plot_paths = visualize_comparison(
+                    args.output,
+                    save_dir=args.plot,
+                    threshold=args.threshold,
+                )
+                for p in plot_paths:
+                    print(f"  Plot saved: {p}")
 
         if args.no_fail_on_regression:
             print("\n  --no-fail-on-regression set, exiting with code 0 despite regressions.")


### PR DESCRIPTION
## Summary

Adds **faceted visualization** to the FLA benchmark workflow and aligns module/ops benchmark output and device handling, making results easier to read and compare across commits and hardware backends (including Ascend NPU).

### 1. New faceted visualization module (`benchmarks/visualize.py`)

- Supports two input types:
  - **Triton `perf_report` CSV** (module benchmark output)
  - **`benchmark_results.json`** (cross-commit comparison from `scripts/run_benchmark_compare.py`)
- For multi-dimensional shape sweeps (B/T/H/D/L), automatically picks the x-axis and splits remaining dimensions into **facet subplots**
- Separates Forward / Backward providers and generates `*_faceted.png` plus an HTML gallery (`results.html`)
- Comparison mode produces a **percent-change bar chart** and a **base vs head latency chart**
- CLI entry point: `python -m benchmarks.visualize perf-report|comparison`

### 2. New shared module benchmark runner (`benchmarks/modules/runner.py`)

- Introduces `run_module_benchmark()`: runs Triton `perf_report` and optionally auto-generates faceted plots
- Auto-infers `save_dir` (e.g. `benchmark_layernorm.py` → `./layernorm_benchmark`)
- Auto-detects `plot_name` and calls `visualize_perf_report_csv` after the benchmark finishes

### 3. Updated 6 module benchmark scripts

These scripts now use `run_module_benchmark()` instead of calling `benchmark.run()` directly, and auto-generate visualizations after each run:

- `benchmark_activations.py`
- `benchmark_conv.py`
- `benchmark_cross_entropy.py`
- `benchmark_l2norm.py`
- `benchmark_layernorm.py`
- `benchmark_tokenshift.py`

### 4. Multi-device support for ops benchmarks (`benchmarks/ops/run.py`)

- Replaces hardcoded `'cuda'` with `fla.utils.device_name`
- Adds `_device_synchronize()` for consistent device sync during warmup and timing
- Extends `_get_machine_info()` for NPU: records `device_platform`, NPU device name, and memory
- Adds `_format_machine_line()` for consistent machine info output (CUDA / NPU / PyTorch version)

### 5. Ops verify updates (`benchmarks/ops/verify.py`)

- Profiler selects `ProfilerActivity` based on device type (CUDA uses `self_cuda_time_total`, otherwise CPU)
- Input generation and synchronization aligned with `run.py` for non-CUDA devices

### 6. Cross-commit comparison script enhancement (`scripts/run_benchmark_compare.py`)

- Adds `--plot` flag to auto-generate visualization plots after comparison completes

### 7. Dependency update (`pyproject.toml`)

- Adds `pandas` to the `benchmark` optional extra (required for CSV parsing in visualization)

---

## Usage Examples

```bash
# Module benchmark (auto-generates plots)
python benchmarks/modules/benchmark_activations.py
```
<img width="959" height="815" alt="image" src="https://github.com/user-attachments/assets/f7d3fddb-b2c2-439b-845d-916775eee1b4" />

```shell
# Manually visualize an existing CSV
python -m benchmarks.visualize perf-report benchmarks/modules/activation_benchmark/activation_performance.csv

# Cross-commit comparison + visualization
python scripts/run_benchmark_compare.py --base HEAD --output results.json --plot plots/
```