### PR TITLE
[CP] Enable context parallelism for GDP

### DIFF
--- a/fla/ops/cp/README.md
+++ b/fla/ops/cp/README.md
@@ -1,6 +1,6 @@
 # Context Parallel of Linear Atttention
 
-Context Parallel of Linear Atttention (alias KCP in Moonshot) is context parallelism designed for delta-rule recurrent models such as GDN (Gated Delta Rule) and KDA (Kimi Delta Attention). It enables efficient distributed training by partitioning the sequence dimension across ranks, with each rank processing a local token chunk and CP automatically synchronizing cross-rank states.
+Context Parallel of Linear Atttention (alias KCP in Moonshot) is context parallelism designed for delta-rule recurrent models such as GDN (Gated Delta Rule), GDP (Gated DeltaProduct), and KDA (Kimi Delta Attention). It enables efficient distributed training by partitioning the sequence dimension across ranks, with each rank processing a local token chunk and CP automatically synchronizing cross-rank states.
 
 ## Quick Start
 
@@ -386,6 +386,7 @@ In CP mode, only the first sequence in the local batch can be a continuation fro
 ## Test References
 
 - [`tests/context_parallel/test_cp_conv.py`](../../../tests/context_parallel/test_cp_conv.py)
+- [`tests/context_parallel/test_cp_gdp.py`](../../../tests/context_parallel/test_cp_gdp.py)
 - [`tests/context_parallel/test_cp_kda.py`](../../../tests/context_parallel/test_cp_kda.py)
 
 ## Discussion
@@ -398,7 +399,7 @@ The only model-specific components are:
 
 As long as these two operations are well-defined, the same CP infrastructure (`build_cp_context`, all-gather, and merge) applies without changing the high-level data flow.
 
-At the time of writing, CP has been implemented and verified for **GDN**, **KDA**, and **DPLR** (a.k.a. RWKV-7). If you would like to see support for another linear-attention variant, please feel free to open an issue.
+At the time of writing, CP has been implemented and verified for **GDN**, **GDP**, **KDA**, and **DPLR** (a.k.a. RWKV-7). GDP support currently requires `g`. If you would like to see support for another linear-attention variant, please feel free to open an issue.
 
 ## Acknowledgments
 

--- a/fla/ops/cp/README.md
+++ b/fla/ops/cp/README.md
@@ -1,6 +1,6 @@
 # Context Parallel of Linear Attention
 
-Context Parallel of Linear Attention (alias KCP in Moonshot) is context parallelism designed for delta-rule recurrent models such as GDN (Gated Delta Rule) and KDA (Kimi Delta Attention). It enables efficient distributed training by partitioning the sequence dimension across ranks, with each rank processing a local token chunk and CP automatically synchronizing cross-rank states.
+Context Parallel of Linear Attention (alias KCP in Moonshot) is context parallelism designed for delta-rule recurrent models such as GDN (Gated Delta Rule), GDP (Gated DeltaProduct), and KDA (Kimi Delta Attention). It enables efficient distributed training by partitioning the sequence dimension across ranks, with each rank processing a local token chunk and CP automatically synchronizing cross-rank states.
 
 ## Quick Start
 
@@ -386,6 +386,7 @@ In CP mode, only the first sequence in the local batch can be a continuation fro
 ## Test References
 
 - [`tests/context_parallel/test_cp_conv.py`](../../../tests/context_parallel/test_cp_conv.py)
+- [`tests/context_parallel/test_cp_gdp.py`](../../../tests/context_parallel/test_cp_gdp.py)
 - [`tests/context_parallel/test_cp_kda.py`](../../../tests/context_parallel/test_cp_kda.py)
 
 ## Discussion
@@ -398,7 +399,7 @@ The only model-specific components are:
 
 As long as these two operations are well-defined, the same CP infrastructure (`build_cp_context`, all-gather, and merge) applies without changing the high-level data flow.
 
-At the time of writing, CP has been implemented and verified for **GDN**, **KDA**, and **DPLR** (a.k.a. RWKV-7). If you would like to see support for another linear-attention variant, please feel free to open an issue.
+At the time of writing, CP has been implemented and verified for **GDN**, **GDP**, **KDA**, and **DPLR** (a.k.a. RWKV-7). GDP support currently requires `g`. If you would like to see support for another linear-attention variant, please feel free to open an issue.
 
 ## Acknowledgments
 

--- a/fla/ops/gated_delta_product/chunk.py
+++ b/fla/ops/gated_delta_product/chunk.py
@@ -10,6 +10,8 @@ from einops import rearrange
 
 from fla.modules.l2norm import l2norm_bwd, l2norm_fwd
 from fla.ops.common.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from fla.ops.cp import FLACPContext
+from fla.ops.cp.chunk_delta_h import chunk_gated_delta_rule_fwd_h_pre_process, compress_h0
 from fla.ops.delta_rule.chunk import chunk_delta_rule_bwd
 from fla.ops.delta_rule.wy_fast import recompute_w_u_fwd as dn_recompute_w_u_fwd
 from fla.ops.gated_delta_product.chunk_deltaproduct_h import chunk_gated_delta_product_fwd_h
@@ -35,6 +37,7 @@ def chunk_gated_delta_product_fwd(
     num_householder: int = 1,
     chunk_indices: torch.LongTensor | None = None,
     chunk_indices_dp: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
 ):
     cu_seqlens_dp = cu_seqlens * num_householder if cu_seqlens is not None else None
     if g is not None:
@@ -94,6 +97,17 @@ def chunk_gated_delta_product_fwd(
             cu_seqlens=cu_seqlens_dp,
             chunk_indices=chunk_indices_dp,
         )
+    if cp_context is not None:
+        initial_state = chunk_gated_delta_rule_fwd_h_pre_process(
+            k=k,
+            w=w,
+            u=u,
+            g=g_interleaved,
+            cu_seqlens=cu_seqlens_dp,
+            initial_state=initial_state,
+            context=cp_context,
+        )
+
     h, v_new, final_state = chunk_gated_delta_product_fwd_h(
         k=k,
         w=w,
@@ -105,6 +119,9 @@ def chunk_gated_delta_product_fwd(
         num_householder=num_householder,
         chunk_indices=chunk_indices,
     )
+    if cp_context is not None:
+        initial_state = compress_h0(initial_state, context=cp_context)
+
     o = chunk_gated_delta_product_fwd_o(
         q=q,
         k=k,
@@ -116,7 +133,7 @@ def chunk_gated_delta_product_fwd(
         num_householder=num_householder,
         chunk_indices=chunk_indices,
     )
-    return g, g_interleaved, o, A, final_state
+    return g, g_interleaved, o, A, final_state, initial_state
 
 
 class ChunkGatedDeltaProductFunction(torch.autograd.Function):
@@ -138,6 +155,7 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
         use_qk_l2norm_in_kernel: bool = False,
         cu_seqlens: torch.LongTensor | None = None,
         cu_seqlens_cpu: torch.LongTensor | None = None,
+        cp_context: FLACPContext | None = None,
     ):
         if use_qk_l2norm_in_kernel:
             q, q_rstd = l2norm_fwd(q)
@@ -156,7 +174,7 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
                 cu_seqlens * num_householder, 64, cu_seqlens_cpu=cu_seqlens_cpu_dp
             )
 
-        g, g_interleaved, o, A, final_state = chunk_gated_delta_product_fwd(
+        g, g_interleaved, o, A, final_state, initial_state = chunk_gated_delta_product_fwd(
             q=q,
             k=k,
             v=v,
@@ -169,6 +187,7 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
             num_householder=num_householder,
             chunk_indices=chunk_indices,
             chunk_indices_dp=chunk_indices_dp,
+            cp_context=cp_context,
         )
         ctx.save_for_backward(
             q,
@@ -186,6 +205,7 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
         ctx.num_householder = num_householder
+        ctx.cp_context = cp_context
         return o.to(q.dtype), final_state
 
     @staticmethod
@@ -230,6 +250,7 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
                 do=do,
                 dht=dht,
                 cu_seqlens=cu_seqlens * ctx.num_householder if cu_seqlens is not None else None,
+                cp_context=ctx.cp_context,
                 chunk_indices=chunk_indices_dp,
             )
             dg = rearrange(dg, 'b (l n) h  -> b l n h ', n=ctx.num_householder)[:, :, 0].contiguous().to(g)
@@ -252,7 +273,7 @@ class ChunkGatedDeltaProductFunction(torch.autograd.Function):
         if ctx.use_qk_l2norm_in_kernel:
             dq = l2norm_bwd(q_org, q_rstd, dq)
             dk = l2norm_bwd(k, k_rstd, dk)
-        return dq.to(q), dk.to(k), dv.to(v), dg, db.to(beta), None, None, dh0, None, None, None, None
+        return dq.to(q), dk.to(k), dv.to(v), dg, db.to(beta), None, None, dh0, None, None, None, None, None
 
 
 @torch.compiler.disable
@@ -269,6 +290,7 @@ def chunk_gated_delta_product(
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
+    cp_context: FLACPContext | None = None,
 ):
     r"""
     Args:
@@ -299,6 +321,11 @@ def chunk_gated_delta_product(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
+        cp_context (FLACPContext, Optional):
+            Context parallel context for distributed training across multiple devices.
+            When provided, `g` is required, `initial_state` and `output_final_state`
+            are not supported, and `cu_seqlens` will be overridden by the context.
+            Default: `None`.
 
     Returns:
         o (torch.Tensor):
@@ -343,6 +370,15 @@ def chunk_gated_delta_product(
     if g is not None:
         assert g.shape == (B, T, H)
 
+    if cp_context is not None:
+        assert g is not None, "Non-gated GDP is not supported for CP"
+        assert initial_state is None, "Initial state is not supported for CP"
+        assert output_final_state is False, "Output final state is not supported for CP"
+        assert cp_context.cu_seqlens is not None, "cu_seqlens is required for CP"
+        cu_seqlens = cp_context.cu_seqlens
+        if cp_context.cu_seqlens_cpu is not None:
+            cu_seqlens_cpu = cp_context.cu_seqlens_cpu
+
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(
@@ -369,5 +405,6 @@ def chunk_gated_delta_product(
         use_qk_l2norm_in_kernel,
         cu_seqlens,
         cu_seqlens_cpu,
+        cp_context,
     )
     return o, final_state

--- a/tests/context_parallel/test_cp_gdp.py
+++ b/tests/context_parallel/test_cp_gdp.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import logging
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+from fla.ops.cp import build_cp_context
+from fla.ops.gated_delta_product import chunk_gated_delta_product
+from fla.ops.gated_delta_product.naive import naive_recurrent_gated_delta_product
+from fla.utils import assert_close, device, device_torch_lib
+
+# Configure logging to see assert_close messages
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def init_distributed(rank, world_size):
+    """Initialize distributed environment for a single process."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "29504"  # Different port from other CP tests
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["LOCAL_RANK"] = str(rank)
+
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    device_torch_lib.set_device(rank)
+
+
+def cleanup_distributed():
+    """Clean up distributed environment."""
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def all_gather_cat(x: torch.Tensor, world_size: int) -> torch.Tensor:
+    gathered = [torch.empty_like(x) for _ in range(world_size)]
+    dist.all_gather(gathered, x)
+    return torch.cat(gathered, dim=1)
+
+
+def run_cp_gdp_test_worker(
+    rank: int,
+    world_size: int,
+    test_name: str,
+    num_householder: int,
+) -> None:
+    """
+    Worker function for CP GDP test.
+    Runs in a spawned process with the given rank.
+    """
+    try:
+        init_distributed(rank, world_size)
+        current_device = torch.device(f"{device}:{rank}")
+        dtype = torch.bfloat16
+        B, T, H, K, V = 1, 256, 2, 64, 80
+        lengths = [80, 110, 66]
+        scale = K ** -0.5
+
+        assert T % world_size == 0, f"T={T} must be divisible by world_size={world_size}"
+        assert sum(lengths) == T, f"Sum of lengths {sum(lengths)} must equal T={T}"
+
+        if rank == 0:
+            print(f"\n{'='*60}")
+            print(f"Test: {test_name}")
+            print(f"Config: T={T}, H={H}, K={K}, V={V}, P={num_householder}, world_size={world_size}")
+            print(f"Sequence lengths: {lengths}")
+            print(f"{'='*60}")
+
+        # Step 1: Prepare Global Data (all generated on rank 0, broadcast to all)
+        q_global = torch.empty(B, T, H, K, dtype=dtype, device=current_device)
+        k_global = torch.empty(B, T * num_householder, H, K, dtype=dtype, device=current_device)
+        v_global = torch.empty(B, T * num_householder, H, V, dtype=dtype, device=current_device)
+        beta_global = torch.empty(B, T * num_householder, H, dtype=dtype, device=current_device)
+        g_global = torch.empty(B, T, H, dtype=torch.float32, device=current_device)
+        do_global = torch.empty(B, T, H, V, dtype=dtype, device=current_device)
+
+        if rank == 0:
+            torch.manual_seed(42)
+            q_global.copy_(
+                F.normalize(
+                    torch.randn(B, T, H, K, dtype=torch.float32, device=current_device), p=2, dim=-1
+                ).to(dtype)
+            )
+            k_global.copy_(
+                F.normalize(
+                    torch.randn(B, T * num_householder, H, K, dtype=torch.float32, device=current_device),
+                    p=2,
+                    dim=-1,
+                ).to(dtype)
+            )
+            v_global.copy_(torch.randn_like(v_global))
+            beta_global.copy_(torch.randn_like(beta_global).sigmoid())
+            g_global.copy_(F.logsigmoid(torch.randn_like(g_global)))
+            do_global.copy_(torch.randn_like(do_global))
+
+        for tensor in (q_global, k_global, v_global, beta_global, g_global, do_global):
+            dist.broadcast(tensor, src=0)
+
+        # Prepare cu_seqlens
+        sequence_offsets = [0, *torch.tensor(lengths).cumsum(0).tolist()]
+        cu_seqlens_global = torch.tensor(sequence_offsets, dtype=torch.long, device=current_device)
+
+        # Step 2: Reference Run (recurrent, varlen, no CP)
+        ref = None
+        if rank == 0:
+            q_ref = q_global.detach().clone().requires_grad_(True)
+            k_ref = k_global.detach().clone().requires_grad_(True)
+            v_ref = v_global.detach().clone().requires_grad_(True)
+            beta_ref = beta_global.detach().clone().requires_grad_(True)
+            g_ref = g_global.detach().clone().requires_grad_(True)
+            outputs = []
+            for bos, eos in zip(sequence_offsets[:-1], sequence_offsets[1:]):
+                bos_dp, eos_dp = bos * num_householder, eos * num_householder
+                o_ref_i, _ = naive_recurrent_gated_delta_product(
+                    q=q_ref[:, bos:eos],
+                    k=k_ref[:, bos_dp:eos_dp],
+                    v=v_ref[:, bos_dp:eos_dp],
+                    g=g_ref[:, bos:eos],
+                    beta=beta_ref[:, bos_dp:eos_dp],
+                    scale=scale,
+                    cu_seqlens=None,
+                    num_householder=num_householder,
+                )
+                outputs.append(o_ref_i)
+            # The recurrent reference accepts scale but does not apply it.
+            o_ref = torch.cat(outputs, dim=1) * scale
+            o_ref.backward(do_global)
+            ref = {
+                "o": o_ref.detach(),
+                "dq": q_ref.grad.detach(),
+                "dk": k_ref.grad.detach(),
+                "dv": v_ref.grad.detach(),
+                "dbeta": beta_ref.grad.detach(),
+                "dg": g_ref.grad.detach(),
+            }
+
+        # Step 3: Context Parallel Run
+        dist.barrier()
+        cp_context = build_cp_context(cu_seqlens_global, group=dist.group.WORLD)
+        local_T = T // world_size
+        start = rank * local_T
+        end = start + local_T
+        start_dp, end_dp = start * num_householder, end * num_householder
+
+        # Get local slices
+        q_local = q_global[:, start:end].detach().clone().requires_grad_(True)
+        k_local = k_global[:, start_dp:end_dp].detach().clone().requires_grad_(True)
+        v_local = v_global[:, start_dp:end_dp].detach().clone().requires_grad_(True)
+        beta_local = beta_global[:, start_dp:end_dp].detach().clone().requires_grad_(True)
+        g_local = g_global[:, start:end].detach().clone().requires_grad_(True)
+        do_local = do_global[:, start:end].clone()
+
+        print(
+            f"[Rank {rank}] chunk: [{start}, {end}), "
+            f"cu_seqlens: {cp_context.cu_seqlens.tolist()}, "
+            f"pre_num_ranks: {cp_context.pre_num_ranks}"
+        )
+        dist.barrier()
+
+        # CP Forward
+        o_local, final_state = chunk_gated_delta_product(
+            q=q_local,
+            k=k_local,
+            v=v_local,
+            g=g_local,
+            beta=beta_local,
+            num_householder=num_householder,
+            scale=scale,
+            cp_context=cp_context,
+        )
+        assert final_state is None
+
+        # CP Backward
+        o_local.backward(do_local)
+
+        # Step 4: Result Aggregation and Verification
+        actual = {
+            "o": all_gather_cat(o_local, world_size),
+            "dq": all_gather_cat(q_local.grad, world_size),
+            "dk": all_gather_cat(k_local.grad, world_size),
+            "dv": all_gather_cat(v_local.grad, world_size),
+            "dbeta": all_gather_cat(beta_local.grad, world_size),
+            "dg": all_gather_cat(g_local.grad, world_size),
+        }
+
+        test_passed = True
+        if rank == 0:
+            print(f"\n[{test_name}] Verifying results...")
+            ratios = {"o": 5e-3, "dq": 8e-3, "dk": 8e-3, "dv": 8e-3, "dbeta": 2e-2, "dg": 2e-2}
+            try:
+                for name, expected in ref.items():
+                    assert_close(name, expected, actual[name], ratio=ratios[name], warning=False)
+                print(f"[{test_name}] Test Passed!\n")
+            except AssertionError as error:
+                print(f"[{test_name}] Test Failed: {error}\n")
+                test_passed = False
+        result = torch.tensor(test_passed, dtype=torch.int32, device=current_device)
+        dist.broadcast(result, src=0)
+        if not result.item():
+            raise AssertionError("GDP context parallel result did not match the single-device reference")
+    finally:
+        cleanup_distributed()
+
+
+@pytest.mark.parametrize("num_householder", [2, 3], ids=["n2", "n3"])
+def test_cp_gdp_sequence_cut(num_householder: int) -> None:
+    """CP2: sequences cut across rank boundary."""
+    world_size = 2
+    if device_torch_lib.device_count() < world_size:
+        pytest.skip("At least 2 GPUs are required")
+    test_name = f"CP2_SequenceCut_N{num_householder}"
+    mp.start_processes(
+        run_cp_gdp_test_worker,
+        args=(world_size, test_name, num_householder),
+        nprocs=world_size,
+        join=True,
+        start_method="spawn",
+    )


### PR DESCRIPTION
## Summary
Enable context parallelism for Gated DeltaProduct by forwarding the CP context through the existing gated delta-rule forward and backward paths.

The implementation reuses the existing CP state preprocessing, expands sequence boundaries for GDP's Householder updates, and preserves the incoming rank state required by backward. Non-gated GDP remains unsupported with CP.

## Test plan
  - `CUDA_VISIBLE_DEVICES=0,1 pytest tests/context_parallel/test_cp_gdp.py -v -s`

<img width="670" height="759" alt="image" src="https://github.com/user-attachments/assets/31e49539-af2f-4419-acae-6ac0336405c0" />

## Breaking changes
None. `cp_context` is optional, so existing GDP callers are unaffected.

  - [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
  - [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
  - [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
  - [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
  - [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.