### PR TITLE
[Ops] Rewrite NPU chunk_scaled_dot_kkt_fwd

### DIFF
--- a/fla/ops/common/backends/triton_ascend/__init__.py
+++ b/fla/ops/common/backends/triton_ascend/__init__.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+import torch
+
 from fla.ops.backends import BaseBackend
 
 
@@ -23,8 +25,25 @@ class TritonAscendCommonBackend(BaseBackend):
         from fla.utils import IS_NPU
         return IS_NPU
 
-    def chunk_scaled_dot_kkt_fwd_verifier(self, *args, **kwargs):
-        return True, None
+    def chunk_scaled_dot_kkt_fwd_verifier(
+        self,
+        k,
+        g=None,
+        beta=None,
+        cu_seqlens=None,
+        chunk_size=64,
+        output_dtype=torch.float32,
+        chunk_indices=None,
+    ) -> tuple[bool, str | None]:
+        from fla.utils import IS_NPU
+        if not IS_NPU:
+            return False, "not running on NPU"
+        if k.device.type != "npu":
+            return False, "input device is not NPU"
+        tensors = (k, beta) if g is None else (k, g, beta)
+        if all(t.dtype in (torch.float32, torch.float16, torch.bfloat16) for t in tensors):
+            return True, None
+        return False, "unsupported dtype for NPU chunk_scaled_dot_kkt_fwd"
 
     def chunk_scaled_dot_kkt_fwd(self, *args, **kwargs):
         from fla.ops.common.backends.triton_ascend.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_npu

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -73,9 +73,9 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    bt_stride = B.to(tl.int64) * T.to(tl.int64)
+    T = T.to(tl.int64)
+    bt_stride = B.to(tl.int64) * T
     core_id = tl.program_id(0)
-    T64 = T.to(tl.int64)
 
     for task_id in tl.range(core_id, task_num, num_core):
         i_t_i = task_id // bh_step
@@ -84,39 +84,39 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
         if IS_VARLEN:
             i_n, i_t = (
                 tl.load(chunk_indices + i_t_i * 2).to(tl.int32),
-                tl.load(chunk_indices + i_t_i * 2 + 1).to(tl.int32),
+                tl.load(chunk_indices + i_t_i * 2 + 1).to(tl.int64),
             )
-            bos = tl.load(cu_seqlens + i_n)
-            eos = tl.load(cu_seqlens + i_n + 1)
-            T = eos.to(tl.int32) - bos.to(tl.int32)
+            bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+            eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T = eos - bos
         else:
-            bos = i_b.to(tl.int64) * T64
-            eos = bos + T64
-            i_t = i_t_i
-        o_t = tl.arange(0, BT)
-        o_t_fp32 = o_t.to(tl.float32)
+            bos = i_b.to(tl.int64) * T
+            eos = bos + T
+            i_t = i_t_i.to(tl.int64)
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
 
-        p_beta = tl.make_block_ptr(beta + i_h * bt_stride + bos, (T,), (1,), (i_t * BT,), (BT,), (0,))
-        b_beta = tl.load(p_beta, boundary_check=(0,))
+        p_beta = beta + i_h * bt_stride + bos + o_t
+        b_beta = tl.load(p_beta, mask=m_t, other=0.0)
 
         b_A = tl.zeros([BT, BT], dtype=tl.float32)
         for i_k in range(tl.cdiv(K, BK)):
-            p_k = tl.make_block_ptr(
-                k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            o_k = i_k * BK + tl.arange(0, BK)
+            p_k = k + (bos * H + i_h // (HV // H)) * K + o_t[:, None] * (H * K) + o_k[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & (o_k < K)[None, :], other=0.0)
             b_A += tl.dot(b_k, tl.trans(b_k))
 
         if USE_G:
-            p_g = tl.make_block_ptr(g + i_h * bt_stride + bos, (T,), (1,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,))
+            p_g = g + i_h * bt_stride + bos + o_t
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
             b_g_diff = b_g[:, None] - b_g[None, :]
             b_A *= exp2(b_g_diff)
 
         b_A *= b_beta[:, None]
-        b_A = tl.where(o_t_fp32[:, None] > o_t_fp32[None, :], b_A, 0)
-        p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (T, BT), (BT * HV, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-        tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+        m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
+        b_A = tl.where(m_A, b_A, 0)
+        p_A = A + (bos * HV + i_h) * BT + o_t[:, None] * (BT * HV) + tl.arange(0, BT)[None, :]
+        tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_t[:, None])
 
 
 @input_guard

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -16,7 +16,29 @@ import triton.runtime.driver as driver
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
-from fla.utils import autotune_cache_kwargs, input_guard
+from fla.utils import input_guard
+from fla.utils.ascend_ub_manager import compute_row_tile_block_size
+
+# Peak live fp32 tiles: b_A[BT,BT], b_k[BT,BK], plus tl.dot intermediate buffer
+_CHUNK_SCALED_DOT_KKT_MEM_MULT = 5.0
+_SAFETY_MARGIN = 0.85
+_FALLBACK_BK = 16
+_MAX_BK_FWD = 128
+
+
+def _get_fwd_bk(BT: int, K: int) -> int:
+    """UB-safe BK tile size for chunk_scaled_dot_kkt_fwd on NPU."""
+    return compute_row_tile_block_size(
+        BT,
+        K,
+        _CHUNK_SCALED_DOT_KKT_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        dtype_size=4,
+        fallback=_FALLBACK_BK,
+        min_block=16,
+        max_block=min(_MAX_BK_FWD, triton.next_power_of_2(K)),
+    )
 
 
 def get_npu_properties():
@@ -29,16 +51,6 @@ def get_npu_properties():
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "USE_G": lambda args: args["g"] is not None,
     }
-)
-@triton.autotune(
-    configs=[
-        triton.Config({'BK': BK}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64, 128]
-        for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
-    ],
-    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN'],
-    **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T", "B", "bh_step", "task_num", "num_core"])
 def chunk_scaled_dot_kkt_fwd_kernel_npu(
@@ -61,8 +73,9 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    bt_stride = B * T
+    bt_stride = B.to(tl.int64) * T.to(tl.int64)
     core_id = tl.program_id(0)
+    T64 = T.to(tl.int64)
 
     for task_id in tl.range(core_id, task_num, num_core):
         i_t_i = task_id // bh_step
@@ -73,10 +86,12 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
                 tl.load(chunk_indices + i_t_i * 2).to(tl.int32),
                 tl.load(chunk_indices + i_t_i * 2 + 1).to(tl.int32),
             )
-            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+            eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
             T = eos - bos
         else:
-            bos, eos = i_b * T, i_b * T + T
+            bos = i_b.to(tl.int64) * T64
+            eos = bos + T64
             i_t = i_t_i
         o_t = tl.arange(0, BT)
         o_t_fp32 = o_t.to(tl.float32)
@@ -144,12 +159,13 @@ def chunk_scaled_dot_kkt_fwd_npu(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     A = torch.zeros(B, T, HV, BT, device=k.device, dtype=output_dtype)
+    BK = _get_fwd_bk(BT, K)
 
     num_core = get_npu_properties()["num_aicore"]
     bh_step = B * HV
     task_num = NT * bh_step
     g_arg = torch.permute(g, (2, 0, 1)).contiguous() if g is not None else g
-    beta_arg = torch.permute(beta, (2, 0, 1)).contiguous() if beta is not None else beta
+    beta_arg = torch.permute(beta, (2, 0, 1)).contiguous()
     chunk_scaled_dot_kkt_fwd_kernel_npu[(num_core,)](
         k=k,
         g=g_arg,
@@ -166,5 +182,6 @@ def chunk_scaled_dot_kkt_fwd_npu(
         HV=HV,
         K=K,
         BT=BT,
+        BK=BK,
     )
     return A

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -91,7 +91,6 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
             T = eos - bos
         else:
             bos = i_b.to(tl.int64) * T
-            eos = bos + T
             i_t = i_t_i.to(tl.int64)
         o_t = i_t * BT + tl.arange(0, BT)
         m_t = o_t < T

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -166,6 +166,5 @@ def chunk_scaled_dot_kkt_fwd_npu(
         HV=HV,
         K=K,
         BT=BT,
-        multibuffer=True,
     )
     return A

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -12,57 +12,35 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+import triton.runtime.driver as driver
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
-from fla.utils import input_guard
-from fla.utils.ascend_ub_manager import (
-    ASCEND_MAX_GRID_DIM,
-    compute_row_tile_block_size,
-    max_grid_axis_chunks,
+from fla.utils import autotune_cache_kwargs, input_guard
+
+
+def get_npu_properties():
+    device = torch.npu.current_device()
+    return driver.active.utils.get_device_properties(device)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_G": lambda args: args["g"] is not None,
+    }
 )
-
-_NUM_WARPS = 4
-_BC = 16
-# One [BC,BC] fp32 tile + two [BC,BK] operand tiles.
-_KKT_MEM_MULT = 4.0
-_SAFETY_MARGIN = 0.80
-_FALLBACK_BK = 8
-_MAX_BK = 64
-
-
-def _get_bk(K: int) -> int:
-    return compute_row_tile_block_size(
-        _BC,
-        K,
-        _KKT_MEM_MULT,
-        tiling_row=False,
-        safety_margin=_SAFETY_MARGIN,
-        fallback=_FALLBACK_BK,
-        min_block=8,
-        max_block=min(_MAX_BK, triton.next_power_of_2(K)),
-    )
-
-
-def _launch_kkt_kernel(kernel, *, NT: int, bh_total: int, kernel_kwargs: dict) -> None:
-    max_nt = max_grid_axis_chunks(NT, bh_total, max_grid=ASCEND_MAX_GRID_DIM)
-    chunk_indices = kernel_kwargs.get('chunk_indices')
-    cu_seqlens = kernel_kwargs.get('cu_seqlens')
-    for nt_off in range(0, NT, max_nt):
-        nt_len = min(max_nt, NT - nt_off)
-        if cu_seqlens is not None and chunk_indices is not None:
-            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
-            kernel_kwargs['NT_OFFSET'] = 0
-        else:
-            kernel_kwargs['NT_OFFSET'] = nt_off
-        max_bh = max_grid_axis_chunks(bh_total, nt_len, max_grid=ASCEND_MAX_GRID_DIM)
-        for bh_off in range(0, bh_total, max_bh):
-            bh_len = min(max_bh, bh_total - bh_off)
-            kernel_kwargs['BH_OFFSET'] = bh_off
-            kernel[(nt_len, bh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
-
-
-@triton.jit(do_not_specialize=['T'])
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "B", "bh_step", "task_num", "num_core"])
 def chunk_scaled_dot_kkt_fwd_kernel_npu(
     k,
     g,
@@ -71,73 +49,59 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
     cu_seqlens,
     chunk_indices,
     T,
+    B,
+    bh_step,
+    task_num,
+    num_core,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
-    BC: tl.constexpr,
     BK: tl.constexpr,
-    USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
+    USE_G: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_h = i_bh // HV, i_bh % HV
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-    else:
-        bos, eos = i_b * T, i_b * T + T
+    bt_stride = B * T
+    core_id = tl.program_id(0)
 
-    if i_t * BT >= T:
-        return
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t_i = task_id // bh_step
+        i_bh = task_id % bh_step
+        i_b, i_h = i_bh // HV, i_bh % HV
+        if IS_VARLEN:
+            i_n, i_t = (
+                tl.load(chunk_indices + i_t_i * 2).to(tl.int32),
+                tl.load(chunk_indices + i_t_i * 2 + 1).to(tl.int32),
+            )
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T = eos - bos
+        else:
+            bos, eos = i_b * T, i_b * T + T
+            i_t = i_t_i
+        o_t = tl.arange(0, BT)
+        o_t_fp32 = o_t.to(tl.float32)
 
-    k_base = k + (bos * H + i_h // (HV // H)) * K
-    A_base = A + (bos * HV + i_h) * BT
-    beta_base = beta + bos * HV + i_h
-    g_base = g + bos * HV + i_h
+        p_beta = tl.make_block_ptr(beta + i_h * bt_stride + bos, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        b_beta = tl.load(p_beta, boundary_check=(0,))
 
-    o_i = tl.arange(0, BC)
-    n_sub = BT // BC
+        b_A = tl.zeros([BT, BT], dtype=tl.float32)
+        for i_k in range(tl.cdiv(K, BK)):
+            p_k = tl.make_block_ptr(
+                k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_A += tl.dot(b_k, tl.trans(b_k))
 
-    for s in range(n_sub):
-        i_tc_s = i_t * BT + s * BC
-        m_s = (i_tc_s + o_i) < T
-        p_bs = tl.make_block_ptr(beta_base, (T,), (HV,), (i_tc_s,), (BC,), (0,))
-        b_bs = tl.load(p_bs, boundary_check=(0,))
         if USE_G:
-            p_gs = tl.make_block_ptr(g_base, (T,), (HV,), (i_tc_s,), (BC,), (0,))
-            b_gs = tl.load(p_gs, boundary_check=(0,))
+            p_g = tl.make_block_ptr(g + i_h * bt_stride + bos, (T,), (1,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,))
+            b_g_diff = b_g[:, None] - b_g[None, :]
+            b_A *= exp2(b_g_diff)
 
-        for c in range(s + 1):
-            i_tc_c = i_t * BT + c * BC
-            m_c = (i_tc_c + o_i) < T
-            b_A = tl.zeros([BC, BC], dtype=tl.float32)
-            for i_k in range(tl.cdiv(K, BK)):
-                p_ks = tl.make_block_ptr(k_base, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-                p_kc = tl.make_block_ptr(k_base, (T, K), (H * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
-                b_ks = tl.load(p_ks, boundary_check=(0, 1))
-                b_kc = tl.load(p_kc, boundary_check=(0, 1))
-                b_A += tl.dot(b_ks, tl.trans(b_kc), allow_tf32=False)
-
-            if USE_G:
-                p_gc = tl.make_block_ptr(g_base, (T,), (HV,), (i_tc_c,), (BC,), (0,))
-                b_gc = tl.load(p_gc, boundary_check=(0,))
-                b_gdiff = b_gs[:, None] - b_gc[None, :]
-                b_A *= exp2(b_gdiff)
-            b_A *= b_bs[:, None]
-
-            if s == c:
-                m_blk = (o_i[:, None] > o_i[None, :]) & (m_s[:, None] & m_s)
-            else:
-                m_blk = m_s[:, None] & m_c
-            b_A = tl.where(m_blk, b_A, 0)
-
-            p_A = tl.make_block_ptr(A_base, (T, BT), (HV * BT, 1), (i_tc_s, c * BC), (BC, BC), (1, 0))
-            tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+        b_A *= b_beta[:, None]
+        b_A = tl.where(o_t_fp32[:, None] > o_t_fp32[None, :], b_A, 0)
+        p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (T, BT), (BT * HV, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
 
 
 @input_guard
@@ -150,37 +114,58 @@ def chunk_scaled_dot_kkt_fwd_npu(
     output_dtype: torch.dtype = torch.float32,
     chunk_indices: torch.LongTensor | None = None,
 ) -> torch.Tensor:
+    r"""
+    Compute beta * K * K^T.
+
+    Args:
+        k (torch.Tensor):
+            The key tensor of shape `[B, T, H, K]` where `H` is the number of query/key heads.
+        g (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, HV]`. Default: `None`.
+        beta (torch.Tensor):
+            The beta tensor of shape `[B, T, HV]` where `HV` is the number of value/output heads.
+        cu_seqlens (torch.LongTensor):
+            The cumulative sequence lengths of the input tensor.
+            Default: None
+        chunk_size (int):
+            The chunk size. Default: 64.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float32`
+        chunk_indices (torch.LongTensor):
+            The chunk indices of the input tensor. Default: None.
+
+    Returns:
+        beta * K * K^T of shape `[B, T, HV, BT]` where `BT` is the chunk size.
+        For GVA, H < HV and HV % H == 0. For standard attention, H == HV.
+    """
     B, T, H, K, HV = *k.shape, beta.shape[2]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     A = torch.zeros(B, T, HV, BT, device=k.device, dtype=output_dtype)
-    BK = _get_bk(K)
-    use_g = g is not None
-    g_arg = g if use_g else beta
-    _launch_kkt_kernel(
-        chunk_scaled_dot_kkt_fwd_kernel_npu,
-        NT=NT,
-        bh_total=B * HV,
-        kernel_kwargs={
-            'k': k,
-            'g': g_arg,
-            'beta': beta,
-            'A': A,
-            'cu_seqlens': cu_seqlens,
-            'chunk_indices': chunk_indices,
-            'T': T,
-            'H': H,
-            'HV': HV,
-            'K': K,
-            'BT': BT,
-            'BC': _BC,
-            'BK': BK,
-            'USE_G': use_g,
-            'IS_VARLEN': cu_seqlens is not None,
-            'NT_OFFSET': 0,
-            'BH_OFFSET': 0,
-        },
+
+    num_core = get_npu_properties()["num_aicore"]
+    bh_step = B * HV
+    task_num = NT * bh_step
+    g_arg = torch.permute(g, (2, 0, 1)).contiguous() if g is not None else g
+    beta_arg = torch.permute(beta, (2, 0, 1)).contiguous() if beta is not None else beta
+    chunk_scaled_dot_kkt_fwd_kernel_npu[(num_core,)](
+        k=k,
+        g=g_arg,
+        beta=beta_arg,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        bh_step=bh_step,
+        task_num=task_num,
+        num_core=num_core,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        multibuffer=True,
     )
     return A

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -86,9 +86,9 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
                 tl.load(chunk_indices + i_t_i * 2).to(tl.int32),
                 tl.load(chunk_indices + i_t_i * 2 + 1).to(tl.int32),
             )
-            bos = tl.load(cu_seqlens + i_n).to(tl.int64)
-            eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-            T = eos - bos
+            bos = tl.load(cu_seqlens + i_n)
+            eos = tl.load(cu_seqlens + i_n + 1)
+            T = eos.to(tl.int32) - bos.to(tl.int32)
         else:
             bos = i_b.to(tl.int64) * T64
             eos = bos + T64

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -12,57 +12,35 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+import triton.runtime.driver as driver
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
-from fla.utils import input_guard
-from fla.utils.ascend_ub_manager import (
-    ASCEND_MAX_GRID_DIM,
-    compute_row_tile_block_size,
-    max_grid_axis_chunks,
+from fla.utils import autotune_cache_kwargs, input_guard
+
+
+def get_npu_properties():
+    device = torch.npu.current_device()
+    return driver.active.utils.get_device_properties(device)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_G": lambda args: args["g"] is not None,
+    }
 )
-
-_NUM_WARPS = 4
-_BC = 16
-# One [BC,BC] fp32 tile + two [BC,BK] operand tiles.
-_KKT_MEM_MULT = 4.0
-_SAFETY_MARGIN = 0.80
-_FALLBACK_BK = 8
-_MAX_BK = 64
-
-
-def _get_bk(K: int) -> int:
-    return compute_row_tile_block_size(
-        _BC,
-        K,
-        _KKT_MEM_MULT,
-        tiling_row=False,
-        safety_margin=_SAFETY_MARGIN,
-        fallback=_FALLBACK_BK,
-        min_block=8,
-        max_block=min(_MAX_BK, triton.next_power_of_2(K)),
-    )
-
-
-def _launch_kkt_kernel(kernel, *, NT: int, bh_total: int, kernel_kwargs: dict) -> None:
-    max_nt = max_grid_axis_chunks(NT, bh_total, max_grid=ASCEND_MAX_GRID_DIM)
-    chunk_indices = kernel_kwargs.get('chunk_indices')
-    cu_seqlens = kernel_kwargs.get('cu_seqlens')
-    for nt_off in range(0, NT, max_nt):
-        nt_len = min(max_nt, NT - nt_off)
-        if cu_seqlens is not None and chunk_indices is not None:
-            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
-            kernel_kwargs['NT_OFFSET'] = 0
-        else:
-            kernel_kwargs['NT_OFFSET'] = nt_off
-        max_bh = max_grid_axis_chunks(bh_total, nt_len, max_grid=ASCEND_MAX_GRID_DIM)
-        for bh_off in range(0, bh_total, max_bh):
-            bh_len = min(max_bh, bh_total - bh_off)
-            kernel_kwargs['BH_OFFSET'] = bh_off
-            kernel[(nt_len, bh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
-
-
-@triton.jit(do_not_specialize=['T'])
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "B", "bh_step", "task_num", "num_core"])
 def chunk_scaled_dot_kkt_fwd_kernel_npu(
     k,
     g,
@@ -71,73 +49,59 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
     cu_seqlens,
     chunk_indices,
     T,
+    B,
+    bh_step,
+    task_num,
+    num_core,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
-    BC: tl.constexpr,
     BK: tl.constexpr,
-    USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
+    USE_G: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_h = i_bh // HV, i_bh % HV
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
-    else:
-        bos, eos = i_b * T, i_b * T + T
+    bt_stride = B * T
+    core_id = tl.program_id(0)
 
-    if i_t * BT >= T:
-        return
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t_i = task_id // bh_step
+        i_bh = task_id % bh_step
+        i_b, i_h = i_bh // HV, i_bh % HV
+        if IS_VARLEN:
+            i_n, i_t = (
+                tl.load(chunk_indices + i_t_i * 2).to(tl.int32),
+                tl.load(chunk_indices + i_t_i * 2 + 1).to(tl.int32),
+            )
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T = eos - bos
+        else:
+            bos, eos = i_b * T, i_b * T + T
+            i_t = i_t_i
+        o_t = tl.arange(0, BT)
+        o_t_fp32 = o_t.to(tl.float32)
 
-    k_base = k + (bos * H + i_h // (HV // H)) * K
-    A_base = A + (bos * HV + i_h) * BT
-    beta_base = beta + bos * HV + i_h
-    g_base = g + bos * HV + i_h
+        p_beta = tl.make_block_ptr(beta + i_h * bt_stride + bos, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        b_beta = tl.load(p_beta, boundary_check=(0,))
 
-    o_i = tl.arange(0, BC)
-    n_sub = BT // BC
+        b_A = tl.zeros([BT, BT], dtype=tl.float32)
+        for i_k in range(tl.cdiv(K, BK)):
+            p_k = tl.make_block_ptr(
+                k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_A += tl.dot(b_k, tl.trans(b_k))
 
-    for s in range(n_sub):
-        i_tc_s = i_t * BT + s * BC
-        m_s = (i_tc_s + o_i) < T
-        p_bs = tl.make_block_ptr(beta_base, (T,), (HV,), (i_tc_s,), (BC,), (0,))
-        b_bs = tl.load(p_bs, boundary_check=(0,))
         if USE_G:
-            p_gs = tl.make_block_ptr(g_base, (T,), (HV,), (i_tc_s,), (BC,), (0,))
-            b_gs = tl.load(p_gs, boundary_check=(0,))
+            p_g = tl.make_block_ptr(g + i_h * bt_stride + bos, (T,), (1,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,))
+            b_g_diff = b_g[:, None] - b_g[None, :]
+            b_A *= exp2(b_g_diff)
 
-        for c in range(s + 1):
-            i_tc_c = i_t * BT + c * BC
-            m_c = (i_tc_c + o_i) < T
-            b_A = tl.zeros([BC, BC], dtype=tl.float32)
-            for i_k in range(tl.cdiv(K, BK)):
-                p_ks = tl.make_block_ptr(k_base, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-                p_kc = tl.make_block_ptr(k_base, (T, K), (H * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
-                b_ks = tl.load(p_ks, boundary_check=(0, 1))
-                b_kc = tl.load(p_kc, boundary_check=(0, 1))
-                b_A += tl.dot(b_ks, tl.trans(b_kc), allow_tf32=False)
-
-            if USE_G:
-                p_gc = tl.make_block_ptr(g_base, (T,), (HV,), (i_tc_c,), (BC,), (0,))
-                b_gc = tl.load(p_gc, boundary_check=(0,))
-                b_gdiff = b_gs[:, None] - b_gc[None, :]
-                b_A *= exp2(b_gdiff)
-            b_A *= b_bs[:, None]
-
-            if s == c:
-                m_blk = (o_i[:, None] > o_i[None, :]) & (m_s[:, None] & m_s)
-            else:
-                m_blk = m_s[:, None] & m_c
-            b_A = tl.where(m_blk, b_A, 0)
-
-            p_A = tl.make_block_ptr(A_base, (T, BT), (HV * BT, 1), (i_tc_s, c * BC), (BC, BC), (1, 0))
-            tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+        b_A *= b_beta[:, None]
+        b_A = tl.where(o_t_fp32[:, None] > o_t_fp32[None, :], b_A, 0)
+        p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (T, BT), (BT * HV, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
 
 
 @input_guard
@@ -150,37 +114,58 @@ def chunk_scaled_dot_kkt_fwd_npu(
     output_dtype: torch.dtype = torch.float32,
     chunk_indices: torch.LongTensor | None = None,
 ) -> torch.Tensor:
+    r"""
+    Compute beta * K * K^T.
+
+    Args:
+        k (torch.Tensor):
+            The key tensor of shape `[B, T, H, K]` where `H` is the number of query/key heads.
+        g (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, HV]`. Default: `None`.
+        beta (torch.Tensor):
+            The beta tensor of shape `[B, T, HV]` where `HV` is the number of value/output heads.
+        cu_seqlens (torch.LongTensor):
+            The cumulative sequence lengths of the input tensor.
+            Default: None
+        chunk_size (int):
+            The chunk size. Default: 64.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float32`
+        chunk_indices (torch.LongTensor):
+            The chunk indices of the input tensor. Default: None.
+
+    Returns:
+        beta * K * K^T of shape `[B, T, HV, BT]` where `BT` is the chunk size.
+        For GVA, H < HV and HV % H == 0. For standard attention, H == HV.
+    """
     B, T, H, K, HV = *k.shape, beta.shape[2]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     A = torch.zeros(B, T, HV, BT, device=k.device, dtype=output_dtype)
-    BK = _get_bk(K)
-    use_g = g is not None
-    g_arg = g if use_g else beta
-    _launch_kkt_kernel(
-        chunk_scaled_dot_kkt_fwd_kernel_npu,
-        NT=NT,
-        bh_total=B * HV,
-        kernel_kwargs={
-            'k': k,
-            'g': g_arg,
-            'beta': beta,
-            'A': A,
-            'cu_seqlens': cu_seqlens,
-            'chunk_indices': chunk_indices,
-            'T': T,
-            'H': H,
-            'HV': HV,
-            'K': K,
-            'BT': BT,
-            'BC': _BC,
-            'BK': BK,
-            'USE_G': use_g,
-            'IS_VARLEN': cu_seqlens is not None,
-            'NT_OFFSET': 0,
-            'BH_OFFSET': 0,
-        },
+
+    num_core = get_npu_properties()["num_aicore"]
+    bh_step = B * HV
+    task_num = NT * bh_step
+    g_arg = torch.permute(g, (2, 0, 1)).contiguous() if g is not None else g
+    beta_arg = torch.permute(beta, (2, 0, 1)).contiguous() if beta is not None else beta
+    chunk_scaled_dot_kkt_fwd_kernel_npu[(num_core,)](
+        k=k,
+        g=g_arg,
+        beta=beta_arg,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        bh_step=bh_step,
+        task_num=task_num,
+        num_core=num_core,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        multibuffer=True,
     )
     return A


### PR DESCRIPTION
## Summary

Rewrite the Ascend NPU (`triton_ascend` backend) implementation of `chunk_scaled_dot_kkt_fwd` to use a 1-D AICore task-loop grid in place of the upstream 2-D `(NT, B*HV)` grid + host-side `NT_OFFSET`/`BH_OFFSET` sub-launches, and to replace the previous `tl.make_block_ptr` + `boundary_check` loads/stores with explicit `ptr + offset + mask` indexing that mirrors the GPU mainline kernel. As part of the rewrite:

- `T` is cast to `tl.int64` once at the top of the kernel, so `i_b * T` / `bos * H * K` style pointer arithmetic can no longer overflow `int32` for long sequences (this subsumes the varlen `bos/eos` overflow fix from #1118 — we use int64 for both branches and for `T` itself, since `make_block_ptr` is no longer used and the int32-shape constraint no longer applies).
- `BK` is chosen by `_get_fwd_bk` (UB-safe row-tile sizing via `compute_row_tile_block_size`) instead of `triton.autotune`, with a fallback of 16 and a cap of 128.
- The `chunk_scaled_dot_kkt_fwd_verifier` on the `TritonAscendCommonBackend` now actually checks `IS_NPU`, `k.device.type == "npu"`, and the supported dtype set (`fp32`/`fp16`/`bf16`) instead of returning `True, None` unconditionally.

The GPU path in `fla/ops/common/chunk_scaled_dot_kkt.py` is untouched; only the `triton_ascend` backend and its `__init__.py` verifier are modified.

## Test plan

The changed kernel is invoked through `fla.ops.common.chunk_scaled_dot_kkt_fwd` (via `@dispatch('common')`) by the following ops on NPU:

- `fla.ops.gated_delta_rule` (via `fla/ops/gated_delta_rule/backends/triton_ascend/chunk_fwd.py`)
- `fla.ops.delta_rule` (via `fla/ops/delta_rule/wy_fast.py`)
- `fla.ops.gated_delta_product` (via `fla/ops/gated_delta_product/chunk.py`)
- `fla.ops.path_attn` (via `fla/ops/path_attn/parallel.py`)

Existing main-repo test files that exercise this code path on NPU (to be run on Ascend hardware before merge):

- `tests/ops/test_gdn_kernels.py` — direct `chunk_scaled_dot_kkt_fwd` coverage via `test_chunk_kkt_solve`; indirect coverage through `test_gdn_gate_fwd`, `test_gdn_gate_chunk_cumsum`, `test_chunk_fwd_o`, `test_chunk_gated_delta_rule_fwd_h[_varlen_many_documents]`, `test_prepare_wy_repr_bwd[_varlen]`, `test_gdn_full_bwd`, `test_chunk_gated_delta_rule_bwd_dhu[_varlen_many_documents]` (dense + varlen).
- `tests/ops/test_gdn.py` — `test_chunk[_with_chunk_size|_varlen|_varlen_prefill|_gate_in_kernel[_gqa|_varlen]|_state_v_first|_beta_sigmoid_in_kernel]` exercise the full GDN layer that calls the rewritten kernel.
- `tests/ops/test_delta.py` — `test_chunk`, `test_chunk_with_chunk_size`, `test_chunk_varlen`.
- `tests/ops/test_gdp.py` — `test_chunk`, `test_chunk_varlen`.
- `tests/ops/test_solve_tril.py` — directly calls `chunk_scaled_dot_kkt_fwd` with `cu_seqlens` (varlen path).

Run with:

```
pytest tests/ops/test_gdn_kernels.py tests/ops/test_gdn.py tests/ops/test_delta.py tests/ops/test_gdp.py tests/ops/test_solve_tril.py
```

Hardware: Ascend NPU. Both dense and `cu_seqlens` (varlen, many-doc) cases are covered by the above.

## Benchmark / NCU (kernel changes only)

python benchmarks/ops/run.py --op chunk_gdn

```
===========================================================================================================================
  Machine: Ascend910B3 | NPU: CANN 9.0.0-beta.2 | PyTorch 2.7.1+cpu
===========================================================================================================================
  fwd        B      T    H    D  op                                   main[0f0f0c97](ms) 260714/c...[fb04a82f](ms)  speedup
          -----------------------------------------------------------------------------------------------------------------
             1   8192   96  128  chunk_gdn                                       323.358                    93.655    3.45x
          -----------------------------------------------------------------------------------------------------------------
             2  16384   16  128  chunk_gdn                                       221.405                    73.195    3.02x
          -----------------------------------------------------------------------------------------------------------------
             4   2048   16  128  chunk_gdn                                        53.584                    16.509    3.25x
          -----------------------------------------------------------------------------------------------------------------
             4   4096   64  128  chunk_gdn                                       425.553                   122.923    3.46x
          -----------------------------------------------------------------------------------------------------------------
             8   1024    8   64  chunk_gdn                                        24.072                     5.704    4.22x
          -----------------------------------------------------------------------------------------------------------------
             8   2048   32  256  chunk_gdn                                       269.464                   115.775    2.33x
===========================================================================================================================
  fwdbwd     B      T    H    D  op                                   main[0f0f0c97](ms) 260714/c...[fb04a82f](ms)  speedup
          -----------------------------------------------------------------------------------------------------------------
             1   8192   96  128  chunk_gdn                                       528.580                   298.662    1.77x
          -----------------------------------------------------------------------------------------------------------------
             2  16384   16  128  chunk_gdn                                       369.012                   220.120    1.68x
          -----------------------------------------------------------------------------------------------------------------
             4   2048   16  128  chunk_gdn                                        88.748                    51.918    1.71x
          -----------------------------------------------------------------------------------------------------------------
             4   4096   64  128  chunk_gdn                                       696.982                   392.892    1.77x
          -----------------------------------------------------------------------------------------------------------------
             8   1024    8   64  chunk_gdn                                        33.390                    15.125    2.21x
          -----------------------------------------------------------------------------------------------------------------
             8   2048   32  256  chunk_gdn                                       585.052                   430.715    1.36x
===========================================================================================================================
```

## Breaking changes

None. The change is internal to the `triton_ascend` backend; the public `chunk_scaled_dot_kkt_fwd(k, g, beta, cu_seqlens, chunk_size, output_dtype, chunk_indices)` signature is unchanged. The verifier is now stricter (rejects non-NPU devices and unsupported dtypes instead of always returning `True, None`), which aligns actual dispatch behavior with what the kernel implementation supports.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:
