### PR TITLE
[Fix] fall back to Triton when TileLang has no usable nvcc compiler

### DIFF
--- a/fla/ops/common/backends/tilelang/__init__.py
+++ b/fla/ops/common/backends/tilelang/__init__.py
@@ -13,25 +13,53 @@ hardware-specific regressions (see #640). Can also be forced via FLA_TILELANG=1.
 
 from __future__ import annotations
 
+import logging
 import os
+import shutil
+from functools import cache
+from pathlib import Path
 
 import torch
+from torch.utils import cpp_extension
 
 from fla.ops.backends import BaseBackend
 from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, find_spec_cached
 
+logger = logging.getLogger(__name__)
+
 _TILELANG_AVAILABLE = find_spec_cached("tilelang") is not None
 
 
-class TileLangBackend(BaseBackend):
+@cache
+def _has_usable_nvcc() -> bool:
+    if shutil.which("nvcc") is not None:
+        return True
 
+    cuda_home = cpp_extension.CUDA_HOME
+    if cuda_home is not None and (Path(cuda_home) / "bin" / "nvcc").exists():
+        return True
+
+    try:
+        if find_spec_cached("nvidia.cuda_nvcc") is not None:
+            return True
+    except ModuleNotFoundError:
+        pass
+
+    logger.info(
+        "[FLA Backend] TileLang is installed but no usable nvcc compiler was found; falling back to Triton. "
+        "Install a CUDA toolkit or nvidia-cuda-nvcc, or set FLA_TILELANG=0 to disable TileLang explicitly."
+    )
+    return False
+
+
+class TileLangBackend(BaseBackend):
     backend_type = "tilelang"
     package_name = "tilelang"
     env_var = "FLA_TILELANG"
 
     @classmethod
     def is_available(cls) -> bool:
-        return _TILELANG_AVAILABLE
+        return _TILELANG_AVAILABLE and _has_usable_nvcc()
 
     @classmethod
     def is_enabled(cls) -> bool:

--- a/fla/ops/common/backends/tilelang/__init__.py
+++ b/fla/ops/common/backends/tilelang/__init__.py
@@ -13,43 +13,14 @@ hardware-specific regressions (see #640). Can also be forced via FLA_TILELANG=1.
 
 from __future__ import annotations
 
-import logging
 import os
-import shutil
-from functools import cache
-from pathlib import Path
 
 import torch
-from torch.utils import cpp_extension
 
 from fla.ops.backends import BaseBackend
-from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, find_spec_cached
-
-logger = logging.getLogger(__name__)
+from fla.utils import IS_NVIDIA_HOPPER, TRITON_ABOVE_3_4_0, find_spec_cached, has_usable_nvcc
 
 _TILELANG_AVAILABLE = find_spec_cached("tilelang") is not None
-
-
-@cache
-def _has_usable_nvcc() -> bool:
-    if shutil.which("nvcc") is not None:
-        return True
-
-    cuda_home = cpp_extension.CUDA_HOME
-    if cuda_home is not None and (Path(cuda_home) / "bin" / "nvcc").exists():
-        return True
-
-    try:
-        if find_spec_cached("nvidia.cuda_nvcc") is not None:
-            return True
-    except ModuleNotFoundError:
-        pass
-
-    logger.info(
-        "[FLA Backend] TileLang is installed but no usable nvcc compiler was found; falling back to Triton. "
-        "Install a CUDA toolkit or nvidia-cuda-nvcc, or set FLA_TILELANG=0 to disable TileLang explicitly."
-    )
-    return False
 
 
 class TileLangBackend(BaseBackend):
@@ -59,7 +30,7 @@ class TileLangBackend(BaseBackend):
 
     @classmethod
     def is_available(cls) -> bool:
-        return _TILELANG_AVAILABLE and _has_usable_nvcc()
+        return _TILELANG_AVAILABLE and has_usable_nvcc()
 
     @classmethod
     def is_enabled(cls) -> bool:

--- a/fla/ops/kda/backends/tilelang/__init__.py
+++ b/fla/ops/kda/backends/tilelang/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import torch
 
 from fla.ops.backends import BaseBackend
-from fla.utils import find_spec_cached
+from fla.utils import find_spec_cached, has_usable_nvcc
 
 _TILELANG_AVAILABLE = find_spec_cached("tilelang") is not None
 
@@ -25,7 +25,7 @@ class KDATileLangBackend(BaseBackend):
 
     @classmethod
     def is_available(cls) -> bool:
-        return _TILELANG_AVAILABLE
+        return _TILELANG_AVAILABLE and has_usable_nvcc()
 
     def chunk_kda_bwd_wy_dqkg_fused_verifier(
         self,

--- a/fla/utils/__init__.py
+++ b/fla/utils/__init__.py
@@ -14,6 +14,7 @@ from ._compat import (  # noqa: F401
     TRITON_ABOVE_3_7_1,
     autotune_cache_kwargs,
     find_spec_cached,
+    has_usable_nvcc,
 )
 from ._config import (  # noqa: F401
     FLA_CACHE_RESULTS,

--- a/fla/utils/_compat.py
+++ b/fla/utils/_compat.py
@@ -6,13 +6,20 @@
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
 import functools
+import importlib.metadata
 import inspect
+import logging
+import os
+import shutil
 from importlib.util import find_spec
+from pathlib import Path
 
 import triton
 from packaging import version as package_version
 
 from ._config import FLA_CACHE_RESULTS
+
+logger = logging.getLogger(__name__)
 
 TRITON_ABOVE_3_4_0 = package_version.parse(triton.__version__) >= package_version.parse("3.4.0")
 TRITON_ABOVE_3_5_1 = package_version.parse(triton.__version__) >= package_version.parse("3.5.1")
@@ -25,3 +32,34 @@ autotune_cache_kwargs = {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUN
 @functools.cache
 def find_spec_cached(name):
     return find_spec(name)
+
+
+@functools.cache
+def has_usable_nvcc() -> bool:
+    """Whether a usable nvcc compiler is available for TileLang's JIT.
+
+    Mirrors the guesses in ``tilelang.env._find_cuda_home`` (env
+    CUDA_HOME/CUDA_PATH, nvcc on PATH, the ``nvidia-cuda-nvcc`` wheel,
+    /usr/local/cuda), but verifies the nvcc binary actually exists —
+    only ``nvidia-cuda-nvcc`` >= 13.0 ships it, the ``-cu12`` variant
+    installs just ptxas.
+    """
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    if cuda_home is not None and (Path(cuda_home) / "bin" / "nvcc").exists():
+        return True
+    if shutil.which("nvcc") is not None:
+        return True
+    try:
+        files = importlib.metadata.files("nvidia-cuda-nvcc") or []
+    except importlib.metadata.PackageNotFoundError:
+        files = []
+    if any(f.name in ("nvcc", "nvcc.exe") for f in files):
+        return True
+    if (Path("/usr/local/cuda") / "bin" / "nvcc").exists():
+        return True
+
+    logger.info(
+        "[FLA Backend] TileLang is installed but no usable nvcc compiler was found; falling back to Triton. "
+        "Install a CUDA toolkit or nvidia-cuda-nvcc, or set FLA_TILELANG=0 to disable TileLang explicitly."
+    )
+    return False

--- a/tests/ops/test_backends.py
+++ b/tests/ops/test_backends.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import logging
+
+import pytest
+
+import fla.ops.common.backends.tilelang as tilelang_backend
+
+
+@pytest.fixture(autouse=True)
+def clear_nvcc_probe_cache():
+    tilelang_backend._has_usable_nvcc.cache_clear()
+    yield
+    tilelang_backend._has_usable_nvcc.cache_clear()
+
+
+def _configure_tilelang_without_nvcc(monkeypatch):
+    monkeypatch.setattr(tilelang_backend, "_TILELANG_AVAILABLE", True)
+    monkeypatch.setattr(tilelang_backend.shutil, "which", lambda name: None)
+    monkeypatch.setattr(tilelang_backend.cpp_extension, "CUDA_HOME", None)
+    monkeypatch.setattr(tilelang_backend, "find_spec_cached", lambda name: None)
+
+
+def test_tilelang_available_with_path_nvcc(monkeypatch):
+    _configure_tilelang_without_nvcc(monkeypatch)
+    monkeypatch.setattr(tilelang_backend.shutil, "which", lambda name: "/usr/local/cuda/bin/nvcc")
+
+    assert tilelang_backend.TileLangBackend.is_available() is True
+
+
+def test_tilelang_available_with_cuda_home_nvcc(monkeypatch, tmp_path):
+    _configure_tilelang_without_nvcc(monkeypatch)
+    nvcc = tmp_path / "cuda" / "bin" / "nvcc"
+    nvcc.parent.mkdir(parents=True)
+    nvcc.touch()
+    monkeypatch.setattr(tilelang_backend.cpp_extension, "CUDA_HOME", str(nvcc.parents[1]))
+
+    assert tilelang_backend.TileLangBackend.is_available() is True
+
+
+def test_tilelang_available_with_pip_nvcc(monkeypatch):
+    _configure_tilelang_without_nvcc(monkeypatch)
+    monkeypatch.setattr(
+        tilelang_backend,
+        "find_spec_cached",
+        lambda name: object() if name == "nvidia.cuda_nvcc" else None,
+    )
+
+    assert tilelang_backend.TileLangBackend.is_available() is True
+
+
+def test_tilelang_unavailable_without_nvcc(monkeypatch, caplog):
+    _configure_tilelang_without_nvcc(monkeypatch)
+
+    def find_missing_spec(name):
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(tilelang_backend, "find_spec_cached", find_missing_spec)
+
+    with caplog.at_level(logging.INFO, logger=tilelang_backend.__name__):
+        assert tilelang_backend.TileLangBackend.is_available() is False
+        assert tilelang_backend.TileLangBackend.is_available() is False
+
+    fallback_messages = [record.message for record in caplog.records if "falling back to Triton" in record.message]
+    assert len(fallback_messages) == 1
+    assert "FLA_TILELANG=0" in fallback_messages[0]

--- a/tests/ops/test_backends.py
+++ b/tests/ops/test_backends.py
@@ -5,67 +5,112 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+import importlib.metadata
 import logging
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-import fla.ops.common.backends.tilelang as tilelang_backend
+import fla.ops.common.backends.tilelang as common_tilelang_backend
+import fla.ops.kda.backends.tilelang as kda_tilelang_backend
+from fla.utils import _compat
+
+_REAL_PATH_EXISTS = Path.exists
 
 
 @pytest.fixture(autouse=True)
 def clear_nvcc_probe_cache():
-    tilelang_backend._has_usable_nvcc.cache_clear()
+    _compat.has_usable_nvcc.cache_clear()
     yield
-    tilelang_backend._has_usable_nvcc.cache_clear()
+    _compat.has_usable_nvcc.cache_clear()
 
 
-def _configure_tilelang_without_nvcc(monkeypatch):
-    monkeypatch.setattr(tilelang_backend, "_TILELANG_AVAILABLE", True)
-    monkeypatch.setattr(tilelang_backend.shutil, "which", lambda name: None)
-    monkeypatch.setattr(tilelang_backend.cpp_extension, "CUDA_HOME", None)
-    monkeypatch.setattr(tilelang_backend, "find_spec_cached", lambda name: None)
+def _configure_no_nvcc(monkeypatch):
+    """Hide every nvcc source probed by has_usable_nvcc (CI runners have a real toolkit)."""
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    monkeypatch.setattr(_compat.shutil, "which", lambda name: None)
+
+    def no_such_dist(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "files", no_such_dist)
+
+    def fake_exists(self):
+        if str(self).startswith("/usr/local/cuda"):
+            return False
+        return _REAL_PATH_EXISTS(self)
+
+    monkeypatch.setattr(_compat.Path, "exists", fake_exists)
 
 
-def test_tilelang_available_with_path_nvcc(monkeypatch):
-    _configure_tilelang_without_nvcc(monkeypatch)
-    monkeypatch.setattr(tilelang_backend.shutil, "which", lambda name: "/usr/local/cuda/bin/nvcc")
-
-    assert tilelang_backend.TileLangBackend.is_available() is True
-
-
-def test_tilelang_available_with_cuda_home_nvcc(monkeypatch, tmp_path):
-    _configure_tilelang_without_nvcc(monkeypatch)
+def test_nvcc_from_cuda_home_env(monkeypatch, tmp_path):
+    _configure_no_nvcc(monkeypatch)
     nvcc = tmp_path / "cuda" / "bin" / "nvcc"
     nvcc.parent.mkdir(parents=True)
     nvcc.touch()
-    monkeypatch.setattr(tilelang_backend.cpp_extension, "CUDA_HOME", str(nvcc.parents[1]))
+    monkeypatch.setenv("CUDA_HOME", str(tmp_path / "cuda"))
 
-    assert tilelang_backend.TileLangBackend.is_available() is True
+    assert _compat.has_usable_nvcc() is True
 
 
-def test_tilelang_available_with_pip_nvcc(monkeypatch):
-    _configure_tilelang_without_nvcc(monkeypatch)
+def test_nvcc_from_path(monkeypatch):
+    _configure_no_nvcc(monkeypatch)
+    monkeypatch.setattr(_compat.shutil, "which", lambda name: "/usr/local/cuda/bin/nvcc")
+
+    assert _compat.has_usable_nvcc() is True
+
+
+def test_nvcc_from_pip_wheel(monkeypatch):
+    _configure_no_nvcc(monkeypatch)
     monkeypatch.setattr(
-        tilelang_backend,
-        "find_spec_cached",
-        lambda name: object() if name == "nvidia.cuda_nvcc" else None,
+        importlib.metadata,
+        "files",
+        lambda dist: [SimpleNamespace(name="ptxas"), SimpleNamespace(name="nvcc")],
     )
 
-    assert tilelang_backend.TileLangBackend.is_available() is True
+    assert _compat.has_usable_nvcc() is True
 
 
-def test_tilelang_unavailable_without_nvcc(monkeypatch, caplog):
-    _configure_tilelang_without_nvcc(monkeypatch)
+def test_nvcc_pip_wheel_without_nvcc_binary(monkeypatch):
+    # nvidia-cuda-nvcc-cu12 ships only ptxas; it must not count as a usable compiler
+    _configure_no_nvcc(monkeypatch)
+    monkeypatch.setattr(importlib.metadata, "files", lambda dist: [SimpleNamespace(name="ptxas")])
 
-    def find_missing_spec(name):
-        raise ModuleNotFoundError(name)
+    assert _compat.has_usable_nvcc() is False
 
-    monkeypatch.setattr(tilelang_backend, "find_spec_cached", find_missing_spec)
 
-    with caplog.at_level(logging.INFO, logger=tilelang_backend.__name__):
-        assert tilelang_backend.TileLangBackend.is_available() is False
-        assert tilelang_backend.TileLangBackend.is_available() is False
+def test_no_nvcc_logs_fallback_once(monkeypatch, caplog):
+    _configure_no_nvcc(monkeypatch)
+
+    with caplog.at_level(logging.INFO, logger=_compat.__name__):
+        assert _compat.has_usable_nvcc() is False
+        assert _compat.has_usable_nvcc() is False
 
     fallback_messages = [record.message for record in caplog.records if "falling back to Triton" in record.message]
     assert len(fallback_messages) == 1
     assert "FLA_TILELANG=0" in fallback_messages[0]
+
+
+def _backend_cls(backend_module):
+    if backend_module is common_tilelang_backend:
+        return backend_module.TileLangBackend
+    return backend_module.KDATileLangBackend
+
+
+@pytest.mark.parametrize("backend_module", [common_tilelang_backend, kda_tilelang_backend])
+def test_tilelang_backend_gated_by_nvcc_probe(monkeypatch, backend_module):
+    monkeypatch.setattr(backend_module, "_TILELANG_AVAILABLE", True)
+    monkeypatch.setattr(backend_module, "has_usable_nvcc", lambda: False)
+    assert _backend_cls(backend_module).is_available() is False
+
+    monkeypatch.setattr(backend_module, "has_usable_nvcc", lambda: True)
+    assert _backend_cls(backend_module).is_available() is True
+
+
+@pytest.mark.parametrize("backend_module", [common_tilelang_backend, kda_tilelang_backend])
+def test_tilelang_backend_unavailable_without_tilelang(monkeypatch, backend_module):
+    monkeypatch.setattr(backend_module, "_TILELANG_AVAILABLE", False)
+    monkeypatch.setattr(backend_module, "has_usable_nvcc", lambda: True)
+    assert _backend_cls(backend_module).is_available() is False


### PR DESCRIPTION
## Summary
`TileLangBackend.is_available()` returned true whenever the `tilelang` package was importable, even on machines with no CUDA compiler. TileLang then failed at kernel-build time instead of falling back to Triton. This gates availability on a usable `nvcc`: `shutil.which("nvcc")`, then `CUDA_HOME/bin/nvcc`, then the `nvidia-cuda-nvcc` wheel. When none is found it logs a one-line hint and reports unavailable, so the existing Triton path is used.

## Why this matters
Installing `tilelang` without a matching CUDA toolkit is common (it pulls in as a transitive dep), and today that silently routes work to a backend that cannot compile. The check is cheap and `@cache`d, so it runs once per process.

## Testing
Added `tests/ops/test_backends.py` covering: nvcc on PATH, nvcc under `CUDA_HOME`, the `nvidia-cuda-nvcc` wheel present, and none available (falls back, logs the hint). `FLA_TILELANG=0` still disables TileLang explicitly.

Closes #949

AI was used for assistance.
