### PR TITLE
[Fix] Correct causal convolution benchmark dispatch and Ascend CI Python setup

### DIFF
--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -70,11 +70,6 @@ jobs:
           cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -m)"-linux/ascend_toolkit_install.info
           npu-smi info
 
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python }}
-
       - name: Install dependencies
         run: |
           python -m pip install -U pip setuptools wheel

--- a/benchmarks/modules/benchmark_conv.py
+++ b/benchmarks/modules/benchmark_conv.py
@@ -53,7 +53,26 @@ def benchmark(T, D, provider):
         torch.arange(16, T)[torch.randperm(T - 16)[:N-1]],
         torch.tensor([T], dtype=torch.long),
     ], 0).to(device).sort()[0]
-    if provider.startswith('causal_conv1d_fwd'):
+    if provider.startswith('causal_conv1d_fwdbwd'):
+        results = triton.testing.do_bench(
+            lambda: causal_conv1d(x, weight, bias, activation='swish', cu_seqlens=cu_seqlens)[0].backward(x),
+            quantiles=quantiles,
+        )
+    elif provider.startswith('causal_conv1d_cuda_fwdbwd'):
+        results = triton.testing.do_bench(
+            lambda: rearrange(
+                causal_conv1d_fn(
+                    x=rearrange(x, 'b t d -> b d t'),
+                    weight=weight,
+                    bias=bias,
+                    activation='swish',
+                    seq_idx=prepare_sequence_ids(cu_seqlens).to(torch.int32).unsqueeze(0),
+                ),
+                'b d t -> b t d',
+            ).backward(x),
+            quantiles=quantiles,
+        )
+    elif provider.startswith('causal_conv1d_fwd'):
         results = triton.testing.do_bench(
             lambda: causal_conv1d(x, weight, bias, activation='swish', cu_seqlens=cu_seqlens),
             quantiles=quantiles,
@@ -70,25 +89,6 @@ def benchmark(T, D, provider):
                 ),
                 'b d t -> b t d',
             ),
-            quantiles=quantiles,
-        )
-    elif provider.startswith('causal_conv1d_fwdbwd'):
-        results = triton.testing.do_bench(
-            lambda: causal_conv1d(x, weight, bias, activation='swish', cu_seqlens=cu_seqlens).backward(x),
-            quantiles=quantiles,
-        )
-    elif provider.startswith('causal_conv1d_cuda_fwdbwd'):
-        results = triton.testing.do_bench(
-            lambda: rearrange(
-                causal_conv1d_fn(
-                    x=rearrange(x, 'b t d -> b d t'),
-                    weight=weight,
-                    bias=bias,
-                    activation='swish',
-                    seq_idx=prepare_sequence_ids(cu_seqlens).to(torch.int32).unsqueeze(0),
-                ),
-                'b d t -> b t d',
-            ).backward(x),
             quantiles=quantiles,
         )
     return results


### PR DESCRIPTION
# Summary

- Fix causal convolution benchmark provider matching so forward-backward cases execute backward correctly.
- Use the Ascend CI container’s bundled Python 3.11 instead of running actions/setup-python.

# Changes

- Reorder provider checks to prevent *_fwdbwd from being incorrectly matched as *_fwd.
- Handle the FLA convolution tuple output before calling backward.
- Remove the redundant Python setup step from Ascend A2 CI.