### PR TITLE
[Fix] Store split attention decode outputs at the correct offset

### DIFF
--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -58,7 +58,7 @@ def naive_attn_decoding_kernel(
     T = eos - bos
 
     p_q = tl.make_block_ptr(q + i_bh * K, (K,), (1, ), (0, ), (BK,), (0,))
-    p_o = tl.make_block_ptr(o + i_bh * V, (V,), (1, ), (0, ), (BV,), (0,))
+    p_o = tl.make_block_ptr(o + i_bh * V, (V,), (1, ), (i_v * BV, ), (BV,), (0,))
 
     b_q = tl.load(p_q, boundary_check=(0,))
     b_q = (b_q * scale).to(b_q.dtype)

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -403,6 +403,28 @@ def test_attn_decoding_sink_matches_reference():
     assert_close("o_decode_ref_vs_tri", ref, tri, 0.01)
 
 
+def test_attn_decoding_value_split_matches_reference():
+    torch.manual_seed(456)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    B, T, H, HQ, K, V = 2, 64, 2, 4, 64, 320
+    dtype = torch.float16
+    q = torch.randn((1, B, HQ, K), dtype=dtype, device=device)
+    k = torch.randn((1, T * B, H, K), dtype=dtype, device=device)
+    v = torch.randn((1, T * B, H, V), dtype=dtype, device=device)
+    cu_seqlens = torch.tensor([i * T for i in range(B + 1)], dtype=torch.int32, device=device)
+
+    ref = naive_attn_decoding(
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        cu_seqlens=cu_seqlens,
+    ).to(dtype)
+    tri = attn_decoding_one_step(q=q, k=k, v=v, cu_seqlens=cu_seqlens)
+
+    assert_close("o_decode_value_split_ref_vs_tri", ref, tri, 0.01)
+
+
 def test_attn_decoding_sink_empty_row_matches_reference():
     torch.manual_seed(457)
     os.environ["TRITON_F32_DEFAULT"] = "ieee"


### PR DESCRIPTION
## Summary

Attention decoding launches one program per value tile, but the output block pointer previously omitted the tile offset. When `V > BV`, every program wrote to the first value block while the remaining output stayed unwritten.

Offset each output store by `i_v * BV`, matching the corresponding value load. Add a `V=320` regression case that forces multiple value tiles and compares against the PyTorch reference.

Fixes #1028.

## Failure mode

Before this change, `i_v` selected the value tile to read but not the output tile to write:

```text
program        value read                 old output write          fixed output write
i_v = 0        [0, BV)                    [0, BV)                   [0, BV)
i_v = 1        [BV, 2*BV)                 [0, BV)                   [BV, 2*BV)
i_v = 2        [2*BV, 3*BV)               [0, BV)                   [2*BV, 3*BV)
```

The old mapping overwrote the first tile and left the tail of `o` uninitialized. The corrected mapping gives program `i_v` the interval

`[i_v * BV, min((i_v + 1) * BV, V))`.

For `NV = ceil(V / BV)`, these intervals are pairwise disjoint and their union is `[0, V)`, so every output value is written exactly once.

## Regression coverage

`test_attn_decoding_value_split_matches_reference` uses `K=64` and `V=320`. The value dimension exceeds the kernel's `BV` cap, exercising the split launch and comparing the complete output with `naive_attn_decoding`.

## Test plan

- `python3 -m compileall -q fla/ops/attn/decoding.py tests/ops/test_attn_sink.py`
- `ruff check fla/ops/attn/decoding.py tests/ops/test_attn_sink.py`
- affected-file pre-commit hooks

## Compatibility

No API changes. Shapes that fit within one value tile are unchanged.
