### PR TITLE
[Refactor] Centralize generation errors for unsupported cache strategies

### DIFF
--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.abc import ABCAttention
 from fla.layers.attn import Attention
 from fla.models.abc.configuration_abc import ABCConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as ABCMLP
 from fla.modules.l2warp import l2_warp
@@ -339,7 +339,7 @@ class ABCModel(ABCPreTrainedModel):
         )
 
 
-class ABCForCausalLM(ABCPreTrainedModel, FLAGenerationMixin):
+class ABCForCausalLM(ABCPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -370,21 +370,6 @@ class ABCForCausalLM(ABCPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.comba import Comba
 from fla.models.comba.configuration_comba import CombaConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as CombaMLP
 from fla.modules.l2warp import l2_warp
@@ -350,7 +350,7 @@ class CombaModel(CombaPreTrainedModel):
         )
 
 
-class CombaForCausalLM(CombaPreTrainedModel, FLAGenerationMixin):
+class CombaForCausalLM(CombaPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -381,21 +381,6 @@ class CombaForCausalLM(CombaPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.delta_net import DeltaNet
 from fla.models.delta_net.configuration_delta_net import DeltaNetConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as DeltaNetMLP
 from fla.modules.l2warp import l2_warp
@@ -339,7 +339,7 @@ class DeltaNetModel(DeltaNetPreTrainedModel):
         )
 
 
-class DeltaNetForCausalLM(DeltaNetPreTrainedModel, FLAGenerationMixin):
+class DeltaNetForCausalLM(DeltaNetPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -370,21 +370,6 @@ class DeltaNetForCausalLM(DeltaNetPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/deltaformer/modeling_deltaformer.py
+++ b/fla/models/deltaformer/modeling_deltaformer.py
@@ -19,7 +19,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.deltaformer import DeltaFormerAttention
 from fla.models.deltaformer.configuration_deltaformer import DeltaFormerConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as DeltaFormerMLP
 from fla.modules.l2warp import l2_warp
@@ -290,7 +290,7 @@ class DeltaFormerModel(DeltaFormerPreTrainedModel):
         )
 
 
-class DeltaFormerForCausalLM(DeltaFormerPreTrainedModel, FLAGenerationMixin):
+class DeltaFormerForCausalLM(DeltaFormerPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -328,21 +328,6 @@ class DeltaFormerForCausalLM(DeltaFormerPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gated_deltanet import GatedDeltaNet
 from fla.models.gated_deltanet.configuration_gated_deltanet import GatedDeltaNetConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaNetMLP
 from fla.modules.l2warp import l2_warp
@@ -351,7 +351,7 @@ class GatedDeltaNetModel(GatedDeltaNetPreTrainedModel):
         )
 
 
-class GatedDeltaNetForCausalLM(GatedDeltaNetPreTrainedModel, FLAGenerationMixin):
+class GatedDeltaNetForCausalLM(GatedDeltaNetPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -382,21 +382,6 @@ class GatedDeltaNetForCausalLM(GatedDeltaNetPreTrainedModel, FLAGenerationMixin)
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gated_deltaproduct import GatedDeltaProduct
 from fla.models.gated_deltaproduct.configuration_gated_deltaproduct import GatedDeltaProductConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaProductMLP
 from fla.modules.l2warp import l2_warp
@@ -341,7 +341,7 @@ class GatedDeltaProductModel(GatedDeltaProductPreTrainedModel):
         )
 
 
-class GatedDeltaProductForCausalLM(GatedDeltaProductPreTrainedModel, FLAGenerationMixin):
+class GatedDeltaProductForCausalLM(GatedDeltaProductPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -372,21 +372,6 @@ class GatedDeltaProductForCausalLM(GatedDeltaProductPreTrainedModel, FLAGenerati
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gla import GatedLinearAttention
 from fla.models.gla.configuration_gla import GLAConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GLAMLP
 from fla.modules.l2warp import l2_warp
@@ -341,7 +341,7 @@ class GLAModel(GLAPreTrainedModel):
         )
 
 
-class GLAForCausalLM(GLAPreTrainedModel, FLAGenerationMixin):
+class GLAForCausalLM(GLAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -372,21 +372,6 @@ class GLAForCausalLM(GLAPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gsa import GatedSlotAttention
 from fla.models.gsa.configuration_gsa import GSAConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GSAMLP
 from fla.modules.l2warp import l2_warp
@@ -342,7 +342,7 @@ class GSAModel(GSAPreTrainedModel):
         )
 
 
-class GSAForCausalLM(GSAPreTrainedModel, FLAGenerationMixin):
+class GSAForCausalLM(GSAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -374,21 +374,6 @@ class GSAForCausalLM(GSAPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.hgrn import HGRNAttention
 from fla.models.hgrn.configuration_hgrn import HGRNConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRNMLP
 from fla.modules.l2warp import l2_warp
@@ -343,7 +343,7 @@ class HGRNModel(HGRNPreTrainedModel):
         )
 
 
-class HGRNForCausalLM(HGRNPreTrainedModel, FLAGenerationMixin):
+class HGRNForCausalLM(HGRNPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -374,21 +374,6 @@ class HGRNForCausalLM(HGRNPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.hgrn2 import HGRN2Attention
 from fla.models.hgrn2.configuration_hgrn2 import HGRN2Config
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRN2MLP
 from fla.modules.l2warp import l2_warp
@@ -344,7 +344,7 @@ class HGRN2Model(HGRN2PreTrainedModel):
         )
 
 
-class HGRN2ForCausalLM(HGRN2PreTrainedModel, FLAGenerationMixin):
+class HGRN2ForCausalLM(HGRN2PreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -375,21 +375,6 @@ class HGRN2ForCausalLM(HGRN2PreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/kda/modeling_kda.py
+++ b/fla/models/kda/modeling_kda.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.kda import KimiDeltaAttention
 from fla.models.kda.configuration_kda import KDAConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as KDAMLP
 from fla.modules.l2warp import l2_warp
@@ -369,7 +369,7 @@ class KDAModel(KDAPreTrainedModel):
         )
 
 
-class KDAForCausalLM(KDAPreTrainedModel, FLAGenerationMixin):
+class KDAForCausalLM(KDAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
     _tied_weights_keys = ["lm_head.weight"]
 
     def __init__(self, config):
@@ -399,21 +399,6 @@ class KDAForCausalLM(KDAPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if "past_key_values" in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.lightnet import LightNetAttention
 from fla.models.lightnet.configuration_lightnet import LightNetConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as LightNetMLP
 from fla.modules.l2warp import l2_warp
@@ -334,7 +334,7 @@ class LightNetModel(LightNetPreTrainedModel):
         )
 
 
-class LightNetForCausalLM(LightNetPreTrainedModel, FLAGenerationMixin):
+class LightNetForCausalLM(LightNetPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -365,21 +365,6 @@ class LightNetForCausalLM(LightNetPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.linear_attn import LinearAttention
 from fla.models.linear_attn.configuration_linear_attn import LinearAttentionConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as LinearAttentionMLP
 from fla.modules.l2warp import l2_warp
@@ -341,7 +341,7 @@ class LinearAttentionModel(LinearAttentionPreTrainedModel):
         )
 
 
-class LinearAttentionForCausalLM(LinearAttentionPreTrainedModel, FLAGenerationMixin):
+class LinearAttentionForCausalLM(LinearAttentionPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -372,21 +372,6 @@ class LinearAttentionForCausalLM(LinearAttentionPreTrainedModel, FLAGenerationMi
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.mesa_net import MesaNet
 from fla.models.mesa_net.configuration_mesa_net import MesaNetConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MesaNetMLP
 from fla.modules.l2warp import l2_warp
@@ -337,7 +337,7 @@ class MesaNetModel(MesaNetPreTrainedModel):
         )
 
 
-class MesaNetForCausalLM(MesaNetPreTrainedModel, FLAGenerationMixin):
+class MesaNetForCausalLM(MesaNetPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -368,21 +368,6 @@ class MesaNetForCausalLM(MesaNetPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/mla/modeling_mla.py
+++ b/fla/models/mla/modeling_mla.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.mla import MultiheadLatentAttention
 from fla.models.mla.configuration_mla import MLAConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MLAMLP
 from fla.modules.l2warp import l2_warp
@@ -325,7 +325,7 @@ class MLAModel(MLAPreTrainedModel):
         )
 
 
-class MLAForCausalLM(MLAPreTrainedModel, FLAGenerationMixin):
+class MLAForCausalLM(MLAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -356,21 +356,6 @@ class MLAForCausalLM(MLAPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/moba/modeling_moba.py
+++ b/fla/models/moba/modeling_moba.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.moba import MoBA
 from fla.models.moba.configuration_moba import MoBAConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MoBAMLP
 from fla.modules.l2warp import l2_warp
@@ -309,7 +309,7 @@ class MoBAModel(MoBAPreTrainedModel):
         )
 
 
-class MoBAForCausalLM(MoBAPreTrainedModel, FLAGenerationMixin):
+class MoBAForCausalLM(MoBAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -339,21 +339,6 @@ class MoBAForCausalLM(MoBAPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -21,7 +21,7 @@ from transformers.utils import logging
 from fla.layers import MomAttention
 from fla.layers.attn import Attention
 from fla.models.mom.configuration_mom import MomConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MomMLP
 from fla.ops.attnres import fused_attnres
@@ -444,7 +444,7 @@ class MomCausalLMOutputWithPast(CausalLMOutputWithPast):
     router_logits: tuple[torch.FloatTensor, ...] | None = None
 
 
-class MomForCausalLM(MomPreTrainedModel, FLAGenerationMixin):
+class MomForCausalLM(MomPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -477,21 +477,6 @@ class MomForCausalLM(MomPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     def forward(
         self,

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.nsa import NativeSparseAttention
 from fla.models.nsa.configuration_nsa import NSAConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as NSAMLP
 from fla.modules.l2warp import l2_warp
@@ -343,7 +343,7 @@ class NSAModel(NSAPreTrainedModel):
         )
 
 
-class NSAForCausalLM(NSAPreTrainedModel, FLAGenerationMixin):
+class NSAForCausalLM(NSAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -374,21 +374,6 @@ class NSAForCausalLM(NSAPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/raven/modeling_raven.py
+++ b/fla/models/raven/modeling_raven.py
@@ -24,7 +24,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.raven import Raven
 from fla.models.raven.configuration_raven import RavenConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as RavenMLP
 from fla.modules.l2warp import l2_warp
@@ -351,7 +351,7 @@ class RavenModel(RavenPreTrainedModel):
         )
 
 
-class RavenForCausalLM(RavenPreTrainedModel, FLAGenerationMixin):
+class RavenForCausalLM(RavenPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -383,21 +383,6 @@ class RavenForCausalLM(RavenPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.multiscale_retention import MultiScaleRetention
 from fla.models.retnet.configuration_retnet import RetNetConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as RetNetMLP
 from fla.modules.l2warp import l2_warp
@@ -343,7 +343,7 @@ class RetNetModel(RetNetPreTrainedModel):
         )
 
 
-class RetNetForCausalLM(RetNetPreTrainedModel, FLAGenerationMixin):
+class RetNetForCausalLM(RetNetPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -374,22 +374,6 @@ class RetNetForCausalLM(RetNetPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            # Expected exception: "AttributeError: '(object name)' object has no attribute 'past_key_values'"
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/rodimus/modeling_rodimus.py
+++ b/fla/models/rodimus/modeling_rodimus.py
@@ -22,7 +22,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.rodimus import RodimusAttention, SlidingWindowSharedKeyAttention, align_multiple
 from fla.models.rodimus.configuration_rodimus import RodimusConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as RodimusMLP
 from fla.modules.l2warp import l2_warp
@@ -451,7 +451,7 @@ class RodimusModel(RodimusPreTrainedModel):
         )
 
 
-class RodimusForCausalLM(RodimusPreTrainedModel, FLAGenerationMixin):
+class RodimusForCausalLM(RodimusPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -482,21 +482,6 @@ class RodimusForCausalLM(RodimusPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.rwkv6 import LerpLinear, RWKV6Attention
 from fla.models.rwkv6.configuration_rwkv6 import RWKV6Config
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
 from fla.modules.activations import ACT2FN
 from fla.modules.l2warp import l2_warp
@@ -338,7 +338,7 @@ class RWKV6Model(RWKV6PreTrainedModel):
         )
 
 
-class RWKV6ForCausalLM(RWKV6PreTrainedModel, FLAGenerationMixin):
+class RWKV6ForCausalLM(RWKV6PreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -369,21 +369,6 @@ class RWKV6ForCausalLM(RWKV6PreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.rwkv7 import RWKV7Attention
 from fla.models.rwkv7.configuration_rwkv7 import RWKV7Config
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
 from fla.modules.activations import ACT2FN
 from fla.modules.l2warp import l2_warp
@@ -432,7 +432,7 @@ class RWKV7Model(RWKV7PreTrainedModel):
         )
 
 
-class RWKV7ForCausalLM(RWKV7PreTrainedModel, FLAGenerationMixin):
+class RWKV7ForCausalLM(RWKV7PreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -463,21 +463,6 @@ class RWKV7ForCausalLM(RWKV7PreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
-                )
-            else:
-                raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def forward(

--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -552,6 +552,24 @@ class FLAGenerationMixin(GenerationMixin):
         return model_inputs
 
 
+class FLAUnsupportedCacheGenerationMixin(FLAGenerationMixin):
+    """Generation mixin for models whose caches do not support every decoding strategy."""
+
+    def generate(self, *args, **kwargs):
+        try:
+            return super().generate(*args, **kwargs)
+        except AttributeError as exception:
+            if "past_key_values" in str(exception):
+                raise AttributeError(
+                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
+                    f"which is not supported for {self.__class__.__name__}. "
+                    f"Try another generation strategy instead. "
+                    f"For the available generation strategies, check this doc: "
+                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies",
+                )
+            raise exception
+
+
 if version.parse(_TF_VERSION) > version.parse(_NEED_NEW):
     class Cache(FLACache):
         def __init__(self, seen_tokens: int = 0, **kwargs: Any) -> None:

--- a/fla/models/yoco/modeling_yoco.py
+++ b/fla/models/yoco/modeling_yoco.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gated_deltanet import GatedDeltaNet
 from fla.layers.yoco import YOCOCrossAttention, YOCOGatedRetention, YOCOSharedKVBuilder
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.models.yoco.configuration_yoco import YOCOConfig
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as YOCOMLP
@@ -591,7 +591,7 @@ class YOCOModel(YOCOPreTrainedModel):
         )
 
 
-class YOCOForCausalLM(YOCOPreTrainedModel, FLAGenerationMixin):
+class YOCOForCausalLM(YOCOPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -620,20 +620,6 @@ class YOCOForCausalLM(YOCOPreTrainedModel, FLAGenerationMixin):
 
     def get_decoder(self):
         return self.model
-
-    def generate(self, *args, **kwargs):
-        try:
-            return super().generate(*args, **kwargs)
-        except AttributeError as exception:
-            if 'past_key_values' in str(exception):
-                raise AttributeError(
-                    f"You tried to call `generate` with a decoding strategy that manipulates `past_key_values`, "
-                    f"which is not supported for {self.__class__.__name__}. "
-                    f"Try another generation strategy instead. "
-                    f"For the available generation strategies, check this doc: "
-                    f"https://huggingface.co/docs/transformers/en/generation_strategies#decoding-strategies"
-                )
-            raise exception
 
     @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
     def prepare_inputs_for_generation(

--- a/tests/models/test_generation_utils.py
+++ b/tests/models/test_generation_utils.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+
+from fla.models.utils import FLAGenerationMixin, FLAUnsupportedCacheGenerationMixin
+
+
+class _GenerationBackend(FLAGenerationMixin):
+    def generate(self, *args, **kwargs):
+        return args, kwargs
+
+
+class _PastKeyValuesErrorBackend(FLAGenerationMixin):
+    exception = AttributeError("cache does not expose `past_key_values`")
+
+    def generate(self, *args, **kwargs):
+        raise self.exception
+
+
+class _OtherAttributeErrorBackend(FLAGenerationMixin):
+    exception = AttributeError("unrelated failure")
+
+    def generate(self, *args, **kwargs):
+        raise self.exception
+
+
+class _SuccessfulModel(FLAUnsupportedCacheGenerationMixin, _GenerationBackend):
+    pass
+
+
+class _UnsupportedCacheModel(FLAUnsupportedCacheGenerationMixin, _PastKeyValuesErrorBackend):
+    pass
+
+
+class _OtherAttributeErrorModel(FLAUnsupportedCacheGenerationMixin, _OtherAttributeErrorBackend):
+    pass
+
+
+def test_generate_forwards_supported_generation_calls():
+    args, kwargs = _SuccessfulModel().generate("input", max_new_tokens=1)
+
+    assert args == ("input",)
+    assert kwargs == {"max_new_tokens": 1}
+
+
+def test_generate_translates_unsupported_cache_strategy_errors():
+    with pytest.raises(AttributeError, match="not supported for _UnsupportedCacheModel") as raised:
+        _UnsupportedCacheModel().generate("input")
+
+    assert raised.value.__context__ is _PastKeyValuesErrorBackend.exception
+
+
+def test_generate_preserves_unrelated_attribute_errors():
+    with pytest.raises(AttributeError) as raised:
+        _OtherAttributeErrorModel().generate("input")
+
+    assert raised.value is _OtherAttributeErrorBackend.exception


### PR DESCRIPTION
## Summary

Twenty-four model wrappers carried their own copy of the same `generate()` exception translation for decoding strategies that manipulate unsupported `past_key_values` state. This PR moves that policy into `FLAUnsupportedCacheGenerationMixin` and switches exactly those wrappers to the shared owner, removing 408 duplicated lines.

A separate mixin keeps the capability boundary explicit:

```text
24 models with the existing restriction -> FLAUnsupportedCacheGenerationMixin -> FLAGenerationMixin
10 other generation-enabled models      --------------------------------------> FLAGenerationMixin
```

Successful generation calls, translated error text, exception chaining, and unrelated `AttributeError` behavior are preserved. Cache behavior, generation-strategy support, model forwards, and the ten direct `FLAGenerationMixin` users are unchanged.

## Validation

- `pytest -q tests/models/test_generation_utils.py`
- `pre-commit run --files $(git diff --name-only origin/main)`
- Behavior and method-resolution assertions with Transformers 4.45.0 and 5.13.1
- Source-level control-flow equivalence check against all 24 removed implementations

## Review order

1. Review the shared policy and focused tests in `fla/models/utils.py` and `tests/models/test_generation_utils.py`.
2. Verify one representative model migration; the remaining model changes repeat the same import, base-class, and method-removal edit.

## Breaking changes

None.

Closes #1034.
