### PR TITLE
[Perf] Reuse Wall autotuning across length buckets

### DIFF
--- a/fla/ops/wall_attn/decode.py
+++ b/fla/ops/wall_attn/decode.py
@@ -14,7 +14,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp2, log2
-from fla.utils import check_shared_mem
+from fla.utils import autotune_cache_kwargs, check_shared_mem
 
 WALL_DECODE_AUTOTUNE_CONFIGS = [
     triton.Config({'BT': BT}, num_warps=nw, num_stages=ns)
@@ -26,13 +26,14 @@ WALL_DECODE_AUTOTUNE_CONFIGS = [
 
 @triton.autotune(
     configs=WALL_DECODE_AUTOTUNE_CONFIGS,
-    key=['T_kv', 'K', 'V', 'HQ', 'H', 'C'],
+    key=['KV_CHUNKS_BUCKET', 'K', 'V', 'HQ', 'H', 'C'],
+    **autotune_cache_kwargs,
 )
 @triton.heuristics({
     'USE_SINK_BIAS': lambda args: args['sink_bias'] is not None,
     'USE_SCALAR_G': lambda args: args['g_scalar_cumsum'] is not None,
 })
-@triton.jit
+@triton.jit(do_not_specialize=['T_kv', 'NC', 'KV_CHUNKS_BUCKET'])
 def parallel_wall_attn_decode_kernel(
     q,                # [B, T_q, HQ, K]
     k_tilde,          # [B, T_kv, HQ, K]  pre-rescaled keys (per-Q-head)
@@ -47,6 +48,7 @@ def parallel_wall_attn_decode_kernel(
     T_q,
     T_kv,
     NC,
+    KV_CHUNKS_BUCKET,
     B: tl.constexpr,
     H: tl.constexpr,
     HQ: tl.constexpr,
@@ -189,6 +191,8 @@ def parallel_wall_attn_decode(
     _, T_kv, H, V = v.shape
     NC = r_cache.shape[1]
     G = HQ // H
+    # the bucket selects an autotune config; exact T_kv remains the runtime loop bound
+    KV_CHUNKS_BUCKET = triton.next_power_of_2(max(1, triton.cdiv(T_kv, C)))
 
     if k_tilde.shape != (B, T_kv, HQ, K):
         raise ValueError(f"k_tilde shape {k_tilde.shape} != expected {(B, T_kv, HQ, K)}")
@@ -238,6 +242,7 @@ def parallel_wall_attn_decode(
         T_q=T_q,
         T_kv=T_kv,
         NC=NC,
+        KV_CHUNKS_BUCKET=KV_CHUNKS_BUCKET,
         B=B,
         H=H,
         HQ=HQ,

--- a/fla/ops/wall_attn/parallel.py
+++ b/fla/ops/wall_attn/parallel.py
@@ -22,7 +22,7 @@ from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.cumsum import chunk_global_cumsum
 from fla.ops.utils.op import exp2, log2
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, check_shared_mem, contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, check_shared_mem, contiguous
 
 _DEBUG_ASSERTS = os.environ.get("WALL_ATTN_DEBUG", "0") == "1"
 
@@ -62,8 +62,9 @@ def _prune_wall_fwd_configs(configs, nargs, **kwargs):
 
 @triton.autotune(
     configs=WALL_FWD_AUTOTUNE_CONFIGS,
-    key=['T', 'K', 'V', 'HQ', 'H'],
+    key=['T_BUCKET', 'K', 'V', 'HQ', 'H'],
     prune_configs_by={'early_config_prune': _prune_wall_fwd_configs},
+    **autotune_cache_kwargs,
 )
 @triton.heuristics({
     'USE_SINK_BIAS': lambda args: args['sink_bias'] is not None,
@@ -71,7 +72,7 @@ def _prune_wall_fwd_configs(configs, nargs, **kwargs):
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
     'USE_SCALAR_G': lambda args: args['g_scalar_cumsum'] is not None,
 })
-@triton.jit
+@triton.jit(do_not_specialize=['T', 'T_BUCKET'])
 def parallel_wall_attn_fwd_kernel(
     q,
     k,
@@ -85,6 +86,7 @@ def parallel_wall_attn_fwd_kernel(
     cu_seqlens,
     chunk_indices,
     T,
+    T_BUCKET,
     W: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
@@ -231,14 +233,15 @@ def parallel_wall_attn_fwd_kernel(
 
 @triton.autotune(
     configs=WALL_BWD_AUTOTUNE_CONFIGS,
-    key=['T', 'K', 'V', 'HQ', 'H'],
+    key=['T_BUCKET', 'K', 'V', 'HQ', 'H'],
+    **autotune_cache_kwargs,
 )
 @triton.heuristics({
     'USE_WINDOW': lambda args: args['W'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
     'USE_SCALAR_G': lambda args: args['g_scalar_cumsum'] is not None,
 })
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=['T', 'T_BUCKET'])
 def parallel_wall_attn_bwd_kernel_dq(
     q,
     k,
@@ -255,6 +258,7 @@ def parallel_wall_attn_bwd_kernel_dq(
     cu_seqlens,
     chunk_indices,
     T,
+    T_BUCKET,
     W: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
@@ -404,14 +408,15 @@ def parallel_wall_attn_bwd_kernel_dq(
 
 @triton.autotune(
     configs=WALL_BWD_AUTOTUNE_CONFIGS,
-    key=['T', 'K', 'V', 'HQ', 'H'],
+    key=['T_BUCKET', 'K', 'V', 'HQ', 'H'],
+    **autotune_cache_kwargs,
 )
 @triton.heuristics({
     'USE_WINDOW': lambda args: args['W'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
     'USE_SCALAR_G': lambda args: args['g_scalar_cumsum'] is not None,
 })
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=['T', 'T_BUCKET'])
 def parallel_wall_attn_bwd_kernel_dkv(
     q,
     k,
@@ -429,6 +434,7 @@ def parallel_wall_attn_bwd_kernel_dkv(
     chunk_indices,
     scale,
     T,
+    T_BUCKET,
     W: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
@@ -642,13 +648,15 @@ def parallel_wall_attn_fwd(
             q=q, k=k, v=v, o=o,
             g_cumsum=g_cumsum, g_scalar_cumsum=g_scalar_cumsum, sink_bias=sink_bias,
             lse=lse, scale=scale, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
-            B=B, T=T, W=window_size, H=H, HQ=HQ, G=G, K=K, V=V,
+            B=B, T=T, T_BUCKET=1, W=window_size, H=H, HQ=HQ, G=G, K=K, V=V,
             BT=BT, BS=BS, BK=BK, BV=BV, num_warps=num_warps, num_stages=num_stages,
         )
         return o, lse
 
     o = torch.empty(B, T, HQ, V, dtype=v.dtype, device=q.device)
     lse = torch.empty(B, T, HQ, dtype=torch.float, device=q.device)
+    # the bucket selects an autotune config; exact T remains the runtime loop bound
+    T_BUCKET = triton.next_power_of_2(T)
 
     def grid(meta):
         return (NV, triton.cdiv(T, meta['BT']), B * HQ)
@@ -666,6 +674,7 @@ def parallel_wall_attn_fwd(
         chunk_indices=chunk_indices,
         B=B,
         T=T,
+        T_BUCKET=T_BUCKET,
         W=window_size,
         H=H,
         HQ=HQ,
@@ -711,6 +720,8 @@ def parallel_wall_attn_bwd(
     # Varlen: pin BT=128 and bypass the autotuner (BT sweep would invalidate the
     # precomputed chunk map). `extra` injects the fixed launch config via `.fn`.
     is_varlen = cu_seqlens is not None
+    # varlen bypasses autotuning; dense lengths share configs within power-of-two buckets
+    T_BUCKET = 1 if is_varlen else triton.next_power_of_2(T)
     extra = {}
     if is_varlen:
         BT = 128
@@ -763,6 +774,7 @@ def parallel_wall_attn_bwd(
         chunk_indices=chunk_indices,
         scale=scale,
         T=T,
+        T_BUCKET=T_BUCKET,
         W=window_size,
         B=B,
         H=H,
@@ -791,6 +803,7 @@ def parallel_wall_attn_bwd(
         chunk_indices=chunk_indices,
         scale=scale,
         T=T,
+        T_BUCKET=T_BUCKET,
         W=window_size,
         B=B,
         H=H,


### PR DESCRIPTION
> [!NOTE]
> Follow-up to #1033. This branch is based on that PR; until it lands, the intended follow-up is the final commit in this branch.

Closes #1037.

## Summary

Reduce repeated Wall attention autotuning across changing sequence lengths.

Dense forward and backward previously used exact `T` values as autotune keys, while decode used exact `T_kv`. This change tunes dense execution on power-of-two sequence-length buckets and decode on power-of-two active-cache-chunk buckets.

Exact `T` and `T_kv` still control every grid, loop, and boundary mask. Changing runtime lengths and tuning-only bucket arguments are marked `do_not_specialize`, and all four Wall autotuners use the repository's persistent autotune-cache helper. The fixed-configuration variable-length path is unchanged.

Single-token decode keeps `T_q=1` specialized because existing callers use that fixed value and it was not part of the repeated tuning key.

## Why bucketing preserves correctness

For an exact sequence length $T$, let $F_c(x,T)$ denote execution with a valid autotune configuration $c$. Tile sizes and launch parameters change how work is scheduled, while exact $T$ continues to control every grid, loop, and boundary mask. Every retained configuration therefore implements the same operation:

$$
F_c(x,T)=F(x,T).
$$

Replacing selection by exact length, $c(T)$, with selection by bucket, $c(b(T))$, gives

$$
F_{c(T)}(x,T)=F(x,T)=F_{c(b(T))}(x,T).
$$

For dense execution,

$$
b(T)=2^{\lceil\log_2 T\rceil}.
$$

For decode with cache chunk size $C$,

$$
b_{\mathrm{kv}}(T_{\mathrm{kv}})
=2^{\left\lceil\log_2\left(\max\left(1,\left\lceil T_{\mathrm{kv}}/C\right\rceil\right)\right)\right\rceil}.
$$

If $S$ is the set of lengths in a workload, the number of dense length-derived tuning keys changes from $|S|$ to

$$
\lvert\lbrace b(T):T\in S\rbrace\rvert\le \lvert S\rvert.
$$

The same inequality holds for decode chunk-count buckets. This proves that bucketing cannot increase the number of length-derived tuning keys; the runtime effect remains a measurement question.

Different valid tilings may change floating-point reduction order, so this is a proof of the mathematical operation rather than bitwise identity. The existing numerical tests remain the correctness gate.

## Test plan

- `pre-commit run --files fla/ops/wall_attn/decode.py fla/ops/wall_attn/parallel.py`
- `python3 -m py_compile fla/ops/wall_attn/decode.py fla/ops/wall_attn/parallel.py`
- `python3 -m pytest --collect-only -q tests/ops/test_wall_attn.py tests/models/test_modeling_wall_transformer.py` — 35 tests collected
- decorator inspection for all four bucket keys, persistent caching, and `do_not_specialize` settings
- cache-disabled inspection with `FLA_CACHE_RESULTS=0`

## Breaking changes

None. Public APIs, numerical precision, and variable-length behavior are unchanged.
