### PR TITLE
[Fix] Support value-split Wall backward with local deltas

### DIFF
--- a/fla/ops/wall_attn/parallel.py
+++ b/fla/ops/wall_attn/parallel.py
@@ -16,7 +16,6 @@ import triton
 import triton.language as tl
 from einops import reduce
 
-from fla.ops.attn.parallel import parallel_attn_bwd_preprocess
 from fla.ops.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.constant import RCP_LN2
@@ -58,6 +57,27 @@ def _prune_wall_fwd_configs(configs, nargs, **kwargs):
     nargs = {**(nargs or {}), **kwargs}  # keyword launches leave nargs empty
     BV = nargs.get('BV') or 128
     return [c for c in configs if c.kwargs['BT'] * BV <= 16384]
+
+
+@triton.jit(do_not_specialize=['N'])
+def parallel_wall_attn_bwd_kernel_preprocess(
+    o,
+    do,
+    delta,
+    N,
+    V: tl.constexpr,
+    BV: tl.constexpr,
+):
+    i_nv = tl.program_id(0).to(tl.int64)
+    i_v, i_n = i_nv // N, i_nv % N
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+
+    b_o = tl.load(o + i_n * V + o_v, mask=m_v, other=0.).to(tl.float32)
+    b_do = tl.load(do + i_n * V + o_v, mask=m_v, other=0.).to(tl.float32)
+    b_delta = tl.sum(b_o * b_do)
+
+    tl.store(delta + i_v * N + i_n, b_delta)
 
 
 @triton.autotune(
@@ -274,6 +294,13 @@ def parallel_wall_attn_bwd_kernel_dq(
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
+    i_v64 = i_v.to(tl.int64)
+    delta += i_v64 * B * T * HQ
+    dq += i_v64 * B * T * HQ * K
+    dg_cumsum += i_v64 * B * T * HQ * K
+    if USE_SCALAR_G:
+        dg_scalar_cumsum += i_v64 * B * T * HQ
+
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -299,7 +326,7 @@ def parallel_wall_attn_bwd_kernel_dq(
     # Off-diagonal q_til (bf16 tensor cores, exp2 <= 1).
     b_q_til = (b_q.to(tl.float32) * exp2(b_pq - b_R)).to(b_q.dtype)
 
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
     b_lse = tl.load(p_lse, boundary_check=(0,))
     b_delta = tl.load(p_delta, boundary_check=(0,))
 
@@ -323,7 +350,7 @@ def parallel_wall_attn_bwd_kernel_dq(
         m_k = o_k < T
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
         b_k_til = (b_k.to(tl.float32) * exp2(b_R_t - b_pk)).to(b_k.dtype)
         b_s = tl.dot(b_q_til, b_k_til) * scale * RCP_LN2
 
@@ -357,7 +384,7 @@ def parallel_wall_attn_bwd_kernel_dq(
         m_k = o_k < T
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
 
         # Local-ref k_til: exp2 arg bounded by BS positions <= 110 (fp32-safe with BK dot).
         b_exp_k = b_R_local_t - b_pk
@@ -449,6 +476,13 @@ def parallel_wall_attn_bwd_kernel_dkv(
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
+    i_v64 = i_v.to(tl.int64)
+    delta += i_v64 * B * T * HQ
+    dk += i_v64 * B * T * HQ * K
+    dg_cumsum += i_v64 * B * T * HQ * K
+    if USE_SCALAR_G:
+        dg_scalar_cumsum += i_v64 * B * T * HQ
+
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -469,7 +503,7 @@ def parallel_wall_attn_bwd_kernel_dkv(
     b_k = tl.load(p_k, boundary_check=(0, 1))
     b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
     b_dv = tl.zeros([BT, BV], dtype=tl.float32)
 
     o_k = i_t * BT + tl.arange(0, BT)
@@ -510,7 +544,7 @@ def parallel_wall_attn_bwd_kernel_dkv(
             # Precise path: fp32 tensor cores.
             b_q_til = b_q.to(tl.float32) * exp2(b_pq - b_Rq_bc_q)
             b_k_til = b_k.to(tl.float32) * b_exp_k_val
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
         b_lse = tl.load(p_lse, boundary_check=(0,))
         b_delta = tl.load(p_delta, boundary_check=(0,))
         b_s = tl.dot(b_k_til, tl.trans(b_q_til)) * scale * RCP_LN2
@@ -556,7 +590,7 @@ def parallel_wall_attn_bwd_kernel_dkv(
         b_exp_k_off = b_Rq_bc_k - b_pk
         b_exp_k_off_val = exp2(b_exp_k_off)  # CSE: reused for k_til and final dk scaling
         b_k_til = (b_k.to(tl.float32) * b_exp_k_off_val).to(b_k.dtype)
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
         b_lse = tl.load(p_lse, boundary_check=(0,))
         b_delta = tl.load(p_delta, boundary_check=(0,))
         b_s = tl.dot(b_k_til, tl.trans(b_q_til)) * scale * RCP_LN2
@@ -678,6 +712,26 @@ def parallel_wall_attn_fwd(
     return o, lse
 
 
+def parallel_wall_attn_bwd_preprocess(
+    o: torch.Tensor,
+    do: torch.Tensor,
+    BV: int,
+) -> torch.Tensor:
+    V = o.shape[-1]
+    NV = triton.cdiv(V, BV)
+    N = o.numel() // V
+    delta = torch.empty(NV, *o.shape[:-1], dtype=torch.float, device=o.device)
+    parallel_wall_attn_bwd_kernel_preprocess[(NV * N,)](
+        o=o,
+        do=do,
+        delta=delta,
+        N=N,
+        V=V,
+        BV=BV,
+    )
+    return delta
+
+
 @dispatch('attn')
 def parallel_wall_attn_bwd(
     q: torch.Tensor,
@@ -701,10 +755,11 @@ def parallel_wall_attn_bwd(
     B, T, H, K, V = *k.shape, v.shape[-1]
     HQ = q.shape[2]
     G = HQ // H
-    # dq/dk are reduced over the full value dim in one program (no cross-program accumulation),
-    # so BV must span all of V (NV == 1). Don't cap it here -- the forward can, the backward can't.
     BK = max(triton.next_power_of_2(K), 16)
-    BV = max(triton.next_power_of_2(V), 16)
+    if check_shared_mem('hopper', q.device.index) or check_shared_mem('ampere', q.device.index):
+        BV = min(128, max(triton.next_power_of_2(V), 16))
+    else:
+        BV = min(64, max(triton.next_power_of_2(V), 16))
 
     NV = triton.cdiv(V, BV)
 
@@ -714,9 +769,9 @@ def parallel_wall_attn_bwd(
     extra = {}
     if is_varlen:
         BT = 128
-        if check_shared_mem('hopper'):
+        if check_shared_mem('hopper', q.device.index):
             BS, num_warps = min(64, max(16, triton.next_power_of_2(T))), 8
-        elif check_shared_mem('ampere'):
+        elif check_shared_mem('ampere', q.device.index):
             BS, num_warps = min(32, max(16, triton.next_power_of_2(T))), 4
         else:
             BS, num_warps = min(32, max(16, triton.next_power_of_2(T))), 2
@@ -729,23 +784,19 @@ def parallel_wall_attn_bwd(
         def grid(meta):
             return (NV, triton.cdiv(T, meta['BT']), B * HQ)
 
-    delta = parallel_attn_bwd_preprocess(o, do)
+    delta = parallel_wall_attn_bwd_preprocess(o, do, BV)
 
-    dq = torch.empty(B, T, HQ, K, dtype=k.dtype if H == HQ else torch.float, device=q.device)
-    dk = torch.empty(B, T, HQ, K, dtype=k.dtype if H == HQ else torch.float, device=q.device)
-    dv = torch.empty(B, T, HQ, V, dtype=v.dtype if H == HQ else torch.float, device=q.device)
+    partial_dtype = k.dtype if NV == 1 and H == HQ else torch.float
+    dq = torch.empty(NV, B, T, HQ, K, dtype=partial_dtype, device=q.device)
     dq_kernel = parallel_wall_attn_bwd_kernel_dq.fn if is_varlen else parallel_wall_attn_bwd_kernel_dq
     dkv_kernel = parallel_wall_attn_bwd_kernel_dkv.fn if is_varlen else parallel_wall_attn_bwd_kernel_dkv
 
-    dg_cumsum = torch.empty(B, T, HQ, K, dtype=torch.float, device=q.device)
-    dg_cumsum_k = torch.empty_like(dg_cumsum)
+    dg_cumsum = torch.empty(NV, B, T, HQ, K, dtype=torch.float, device=q.device)
 
     if g_scalar_cumsum is not None:
-        dg_scalar_cumsum = torch.empty(B, T, HQ, dtype=torch.float, device=q.device)
-        dg_scalar_cumsum_k = torch.empty_like(dg_scalar_cumsum)
+        dg_scalar_cumsum = torch.empty(NV, B, T, HQ, dtype=torch.float, device=q.device)
     else:
         dg_scalar_cumsum = None
-        dg_scalar_cumsum_k = None
 
     dq_kernel[grid](
         q=q,
@@ -774,6 +825,26 @@ def parallel_wall_attn_bwd(
         BV=BV,
         **extra,
     )
+    # reduce query-side partials before allocating key-side partials to bound peak temporary memory
+    if NV > 1:
+        dq = dq.sum(0)
+        dg_cumsum = dg_cumsum.sum(0)
+        if g_scalar_cumsum is not None:
+            dg_scalar_cumsum = dg_scalar_cumsum.sum(0)
+    else:
+        dq = dq[0]
+        dg_cumsum = dg_cumsum[0]
+        if g_scalar_cumsum is not None:
+            dg_scalar_cumsum = dg_scalar_cumsum[0]
+
+    dk = torch.empty(NV, B, T, HQ, K, dtype=partial_dtype, device=q.device)
+    dv = torch.empty(B, T, HQ, V, dtype=v.dtype if H == HQ else torch.float, device=q.device)
+    dg_cumsum_k = torch.empty(NV, B, T, HQ, K, dtype=torch.float, device=q.device)
+    if g_scalar_cumsum is not None:
+        dg_scalar_cumsum_k = torch.empty(NV, B, T, HQ, dtype=torch.float, device=q.device)
+    else:
+        dg_scalar_cumsum_k = None
+
     dkv_kernel[grid](
         q=q,
         k=k,
@@ -803,6 +874,17 @@ def parallel_wall_attn_bwd(
         DIAG_BF16=_DKV_DIAG_BF16,
         **extra,
     )
+    if NV > 1:
+        dk = dk.sum(0)
+        dg_cumsum_k = dg_cumsum_k.sum(0)
+        if g_scalar_cumsum is not None:
+            dg_scalar_cumsum_k = dg_scalar_cumsum_k.sum(0)
+    else:
+        dk = dk[0]
+        dg_cumsum_k = dg_cumsum_k[0]
+        if g_scalar_cumsum is not None:
+            dg_scalar_cumsum_k = dg_scalar_cumsum_k[0]
+
     dk = reduce(dk, 'b t (h g) k -> b t h k', g=G, reduction='sum')
     dv = reduce(dv, 'b t (h g) v -> b t h v', g=G, reduction='sum')
     dg_cumsum.add_(dg_cumsum_k)
@@ -813,7 +895,8 @@ def parallel_wall_attn_bwd(
     dsink_bias = None
     if sink_bias is not None:
         p_sink_bias = torch.exp2(sink_bias[None, None, :] - lse)
-        dsink_bias = -(p_sink_bias * delta).sum((0, 1))
+        delta_total = delta.sum(0) if NV > 1 else delta[0]
+        dsink_bias = -(p_sink_bias * delta_total).sum((0, 1))
 
     return dq, dk, dv, dg_cumsum, dsink_bias, dg_scalar_cumsum
 

--- a/tests/ops/test_wall_attn.py
+++ b/tests/ops/test_wall_attn.py
@@ -198,10 +198,11 @@ def test_backward_value_split_matches_single_tile(monkeypatch):
     sink_bias0 = torch.randn(HQ, device=device, dtype=dtype) * 0.1
     do = torch.randn(B, T, HQ, V, device=device, dtype=dtype)
 
-    def run(single_tile: bool):
+    def run(single_tile_backward: bool):
+        force_single_tile = True
         monkeypatch.setattr(
             "fla.ops.wall_attn.parallel.check_shared_mem",
-            lambda arch, *args, **kwargs: single_tile and arch == 'hopper',
+            lambda arch, *args, **kwargs: force_single_tile and arch == 'hopper',
         )
         inputs = [x.clone().requires_grad_(True) for x in (q0, k0, v0, g0, g_scalar0, sink_bias0)]
         q, k, v, g, g_scalar, sink_bias = inputs
@@ -216,14 +217,16 @@ def test_backward_value_split_matches_single_tile(monkeypatch):
             window_size=window_size,
             cu_seqlens=cu_seqlens,
         )
+        force_single_tile = single_tile_backward
         grads = torch.autograd.grad((o * do).sum(), inputs)
         return o, grads
 
-    # The split run uses BV=64, so V=96 launches NV=2 with a 32-wide tail.
-    # If either slice subtracts the full-V delta, summing its score gradients
+    # keep forward single-tile so this backward regression does not depend on split-LSE ownership.
+    # the split backward uses BV=64, so V=96 launches NV=2 with a 32-wide tail.
+    # if either slice subtracts the full-V delta, summing its score gradients
     # subtracts delta twice and disagrees with the single-tile result below.
-    o_split, grads_split = run(single_tile=False)
-    o_single, grads_single = run(single_tile=True)
+    o_split, grads_split = run(single_tile_backward=False)
+    o_single, grads_single = run(single_tile_backward=True)
 
     assert_close("       o", o_single, o_split, RTOL_FWD)
     for name, single, split in zip(

--- a/tests/ops/test_wall_attn.py
+++ b/tests/ops/test_wall_attn.py
@@ -182,6 +182,58 @@ def test_backward_matches_eager_reference(B: int, T: int, H: int, HQ: int, K: in
     # `dg` is validated separately in `test_g_gradient_matches_finite_differences`.
 
 
+def test_backward_value_split_matches_single_tile(monkeypatch):
+    torch.manual_seed(42)
+    dtype = torch.float32
+    B, T, H, HQ, K, V = 1, 17, 1, 2, 16, 96
+    scale = K**-0.5
+    window_size = 8
+    cu_seqlens = torch.tensor([0, 7, T], dtype=torch.long, device=device)
+
+    q0 = torch.randn(B, T, HQ, K, device=device, dtype=dtype)
+    k0 = torch.randn(B, T, H, K, device=device, dtype=dtype)
+    v0 = torch.randn(B, T, H, V, device=device, dtype=dtype)
+    g0 = log_decay(B, T, HQ, K, dtype=dtype)
+    g_scalar0 = log_decay(B, T, HQ, dtype=dtype)
+    sink_bias0 = torch.randn(HQ, device=device, dtype=dtype) * 0.1
+    do = torch.randn(B, T, HQ, V, device=device, dtype=dtype)
+
+    def run(single_tile: bool):
+        monkeypatch.setattr(
+            "fla.ops.wall_attn.parallel.check_shared_mem",
+            lambda arch, *args, **kwargs: single_tile and arch == 'hopper',
+        )
+        inputs = [x.clone().requires_grad_(True) for x in (q0, k0, v0, g0, g_scalar0, sink_bias0)]
+        q, k, v, g, g_scalar, sink_bias = inputs
+        o = parallel_wall_attn(
+            q,
+            k,
+            v,
+            g,
+            g_scalar=g_scalar,
+            sink_bias=sink_bias,
+            scale=scale,
+            window_size=window_size,
+            cu_seqlens=cu_seqlens,
+        )
+        grads = torch.autograd.grad((o * do).sum(), inputs)
+        return o, grads
+
+    # The split run uses BV=64, so V=96 launches NV=2 with a 32-wide tail.
+    # If either slice subtracts the full-V delta, summing its score gradients
+    # subtracts delta twice and disagrees with the single-tile result below.
+    o_split, grads_split = run(single_tile=False)
+    o_single, grads_single = run(single_tile=True)
+
+    assert_close("       o", o_single, o_split, RTOL_FWD)
+    for name, single, split in zip(
+        ("dq", "dk", "dv", "dg", "dg_scalar", "dsink_bias"),
+        grads_single,
+        grads_split,
+    ):
+        assert_close(name, single, split, RTOL_GRAD)
+
+
 def test_dg_nonzero_after_backward():
     torch.manual_seed(3)
     B, T, H, HQ, K, V = 1, 16, 1, 1, 8, 8


### PR DESCRIPTION
Closes #1039.

## Summary

Support bounded value tiles in Wall backward with a local softmax delta for each value slice.

Wall backward currently forces `BV` to span the full value dimension. This avoids subtracting the full softmax delta once per value program, but makes the accumulator width grow with the complete value dimension.

This change:

- computes each value slice's local delta in FP32;
- emits value-slice partial `dq`, per-query-head `dk`, and vector/scalar gate gradients, then reduces them once over `NV`;
- keeps `dv` writes disjoint and slice-local;
- reconstructs the full delta for the sink gradient;
- zero-pads partial value tails;
- bounds `BV` to 128 on Hopper/Ampere and 64 on the lower shared-memory path;
- reduces query-side partials before allocating key-side partial buffers.

## Why value splitting is correct

Let the value dimension be partitioned into slices $r$. For query $i$, key $j$, output gradient $dO_i$, and attention probability $p_{ij}$, define

$$
dp_{ij}^{(r)}=\left\langle dO_i^{(r)},V_j^{(r)}\right\rangle,
\qquad
\delta_i^{(r)}=\left\langle dO_i^{(r)},O_i^{(r)}\right\rangle.
$$

The score-gradient contribution from slice $r$ is

$$
dS_{ij}^{(r)}=p_{ij}\left(dp_{ij}^{(r)}-\delta_i^{(r)}\right).
$$

Because the slices partition the value dimension,

$$
\sum_r dS_{ij}^{(r)}
=p_{ij}\left(\left\langle dO_i,V_j\right\rangle-\left\langle dO_i,O_i\right\rangle\right)
=dS_{ij}.
$$

Query, key, and gate gradients are linear in $dS$, so summing their slice-local partials once recovers the unsplit gradients. The value gradient is already slice-local:

$$
dV_j^{(r)}=\sum_i p_{ij}dO_i^{(r)},
$$

so each program can write its disjoint value slice directly.

The attention sink has a zero value vector, giving

$$
dS_{i,\mathrm{sink}}=-p_{i,\mathrm{sink}}\sum_r\delta_i^{(r)}.
$$

Its gradient therefore uses the reconstructed full delta. If every slice instead subtracts the full delta, the reduction produces

$$
p_{ij}\left(dp_{ij}-NV\delta_i\right),
$$

which over-subtracts the delta $NV-1$ additional times.

## Regression coverage

The new regression uses a single value tile for both forward executions, then forces `V=96`, `BV=64`, and `NV=2` only for one backward execution. This isolates backward value splitting from forward LSE ownership while covering a 32-element partial tail.

It compares split and single-tile backward execution for `dq`, `dk`, `dv`, vector-gate and scalar-gate gradients, and sink-bias gradient under GQA, variable-length packing, and causal windowing.

## Test plan

- `pre-commit run --files fla/ops/wall_attn/parallel.py tests/ops/test_wall_attn.py`
- `python3 -m py_compile fla/ops/wall_attn/parallel.py tests/ops/test_wall_attn.py`
- `python3 -m pytest --collect-only -q tests/ops/test_wall_attn.py tests/models/test_modeling_wall_transformer.py` — 32 tests collected
- direct FP64 decomposition check — local-delta error $3.1\times10^{-15}$; deliberately incorrect full-delta-per-slice error `10.79`
- Triton interpreter split-versus-single checks across every gradient path
- BF16 interpreter finite-gradient and public gradient-dtype checks

## Compatibility and tradeoffs

No public API changes.

Value splitting introduces `NV`-leading FP32 partial buffers. Query-side partials are reduced before key-side buffers are allocated so both sets are not retained simultaneously. Runtime, compilation, and peak-memory measurements remain outstanding and should be considered before merge.

## Breaking changes

None.
