### PR TITLE
[Perf] Add opt-in TileLang RWKV6 intra kernel

### DIFF
--- a/fla/ops/rwkv6/backends/__init__.py
+++ b/fla/ops/rwkv6/backends/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""RWKV6 backends."""
+
+from fla.ops.backends import BackendRegistry, dispatch
+from fla.ops.rwkv6.backends.tilelang import RWKV6TileLangBackend
+
+rwkv6_registry = BackendRegistry("rwkv6")
+rwkv6_registry.register(RWKV6TileLangBackend())
+
+
+__all__ = ['dispatch', 'rwkv6_registry']

--- a/fla/ops/rwkv6/backends/tilelang/__init__.py
+++ b/fla/ops/rwkv6/backends/tilelang/__init__.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""TileLang backend for RWKV6 operations."""
+
+from __future__ import annotations
+
+import torch
+
+from fla.ops.backends import BaseBackend
+from fla.utils import find_spec_cached, has_usable_nvcc
+
+_TILELANG_AVAILABLE = find_spec_cached("tilelang") is not None
+
+
+class RWKV6TileLangBackend(BaseBackend):
+
+    backend_type = "tilelang"
+    package_name = "tilelang"
+    env_var = "FLA_TILELANG"
+    default_enable = False
+    priority = 5
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return _TILELANG_AVAILABLE and has_usable_nvcc()
+
+    def chunk_rwkv6_fwd_intra_verifier(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        gi: torch.Tensor,
+        ge: torch.Tensor,
+        u: torch.Tensor,
+        scale: float,
+        cu_seqlens: torch.LongTensor | None = None,
+        chunk_size: int = 64,
+        chunk_indices: torch.LongTensor | None = None,
+    ) -> tuple[bool, str | None]:
+        if cu_seqlens is not None or chunk_indices is not None:
+            return False, "TileLang RWKV6 intra backend supports dense inputs only"
+        if chunk_size != 64:
+            return False, f"TileLang RWKV6 intra backend requires chunk_size=64, got {chunk_size}"
+        if q.dtype != torch.bfloat16:
+            return False, f"TileLang RWKV6 intra backend supports benchmark dtype bfloat16 only, got {q.dtype}"
+        if k.dtype != q.dtype or u.dtype != q.dtype:
+            return False, f"TileLang RWKV6 intra backend requires q/k/u dtype match, got {q.dtype}/{k.dtype}/{u.dtype}"
+        if gi.dtype != torch.float32 or ge.dtype != torch.float32:
+            return False, f"TileLang RWKV6 intra backend requires fp32 gi/ge, got {gi.dtype}/{ge.dtype}"
+        if not q.is_cuda:
+            return False, "TileLang RWKV6 intra backend requires CUDA tensors"
+        if q.shape != k.shape or q.shape != gi.shape or q.shape != ge.shape:
+            return False, "TileLang RWKV6 intra backend requires q, k, gi, and ge to have identical shapes"
+        if q.ndim != 4:
+            return False, f"TileLang RWKV6 intra backend expects q with rank 4, got {q.ndim}"
+        B, T, H, K = q.shape
+        if u.shape != (H, K):
+            return False, f"TileLang RWKV6 intra backend requires u shape {(H, K)}, got {tuple(u.shape)}"
+        if T % chunk_size != 0:
+            return False, f"TileLang RWKV6 intra backend requires T divisible by {chunk_size}, got T={T}"
+        if K != 64:
+            return False, f"TileLang RWKV6 intra backend currently supports the D=64 benchmark bucket only, got K={K}"
+        if B <= 0 or H <= 0:
+            return False, f"TileLang RWKV6 intra backend requires positive B/H, got B={B}, H={H}"
+        return True, None
+
+    def chunk_rwkv6_fwd_intra(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        gi: torch.Tensor,
+        ge: torch.Tensor,
+        u: torch.Tensor,
+        scale: float,
+        cu_seqlens: torch.LongTensor | None = None,
+        chunk_size: int = 64,
+        chunk_indices: torch.LongTensor | None = None,
+    ) -> torch.Tensor:
+        from fla.ops.rwkv6.backends.tilelang.chunk_fwd_intra import (
+            chunk_rwkv6_fwd_intra_tilelang,
+        )
+        return chunk_rwkv6_fwd_intra_tilelang(
+            q=q,
+            k=k,
+            gi=gi,
+            ge=ge,
+            u=u,
+            scale=scale,
+            chunk_size=chunk_size,
+        )

--- a/fla/ops/rwkv6/backends/tilelang/chunk_fwd_intra.py
+++ b/fla/ops/rwkv6/backends/tilelang/chunk_fwd_intra.py
@@ -68,6 +68,7 @@ def _build_rwkv6_fwd_intra_kernel(
             acc = T.alloc_fragment((_BC, _BC), accum_dtype)
             diag_acc = T.alloc_fragment((_BC, _BC), accum_dtype)
             diag_shared = T.alloc_shared((_BC, _BC), accum_dtype)
+            gn_frag = T.alloc_fragment((_K,), accum_dtype)
             T.clear(acc)
             T.clear(diag_acc)
 
@@ -75,18 +76,25 @@ def _build_rwkv6_fwd_intra_kernel(
                 for i, j in T.Parallel(_BC, _BC):
                     A[i_b, q_s + i, i_h, i_j * _BC + j] = 0.0
             else:
+                # Block-local reference for the decay exponents. gi/ge are sequence-global
+                # cumulative log2 decays, so raw exp2(ge) / exp2(-gi) overflow or underflow
+                # fp32 on long sequences. Any finite center cancels in the product and keeps
+                # both factors bounded by the intra-chunk decay range.
+                gn_pos = T.if_then_else(t_s + i_i * _BC > 0, t_s + i_i * _BC - 1, 0)
+                for k_i in T.Parallel(_K):
+                    gn_frag[k_i] = gi[i_b, gn_pos, i_h, k_i]
                 for k_blk in T.Pipelined(T.ceildiv(_K, _BK), num_stages=2):
                     for i, k_i in T.Parallel(_BC, _BK):
                         k_idx = k_blk * _BK + k_i
                         q_frag[i, k_i] = (
                             T.cast(q[i_b, q_s + i, i_h, k_idx], accum_dtype) *
-                            T.exp2(ge[i_b, q_s + i, i_h, k_idx]) * scale
+                            T.exp2(ge[i_b, q_s + i, i_h, k_idx] - gn_frag[k_idx]) * scale
                         )
                     for j, k_i in T.Parallel(_BC, _BK):
                         k_idx = k_blk * _BK + k_i
                         k_shared[j, k_i] = (
                             T.cast(k[i_b, k_s + j, i_h, k_idx], accum_dtype) *
-                            T.exp2(-gi[i_b, k_s + j, i_h, k_idx])
+                            T.exp2(gn_frag[k_idx] - gi[i_b, k_s + j, i_h, k_idx])
                         )
                     T.gemm(q_frag, k_shared, acc, transpose_B=True)
 

--- a/fla/ops/rwkv6/backends/tilelang/chunk_fwd_intra.py
+++ b/fla/ops/rwkv6/backends/tilelang/chunk_fwd_intra.py
@@ -97,7 +97,7 @@ def _build_rwkv6_fwd_intra_kernel(
                             ku_diag_shared[i, k_i] = (
                                 T.cast(k[i_b, q_s + i, i_h, k_idx], accum_dtype) *
                                 T.cast(u[i_h, k_idx], accum_dtype)
-                        )
+                            )
                         T.gemm(q_diag_frag, ku_diag_shared, diag_acc, transpose_B=True)
 
                 if i_i == i_j:

--- a/fla/ops/rwkv6/backends/tilelang/chunk_fwd_intra.py
+++ b/fla/ops/rwkv6/backends/tilelang/chunk_fwd_intra.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""TileLang implementation of RWKV6 intra-chunk forward A construction."""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+
+@tilelang.jit(pass_configs={
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+})
+def _build_rwkv6_fwd_intra_kernel(
+    B,
+    H,
+    K,
+    BT,
+    BC,
+    BK,
+    dtype_str,
+    num_warps=1,
+):
+    dtype_map = {'float16': T.float16, 'bfloat16': T.bfloat16, 'float32': T.float32}
+    dtype = dtype_map[dtype_str]
+    accum_dtype = T.float32
+    NC = tilelang.cdiv(BT, BC)
+    threads = num_warps * 32
+
+    _B, _H, _K, _BT, _BC, _BK, _NC = B, H, K, BT, BC, BK, NC
+    _dtype = dtype
+    _threads = threads
+
+    T_d = T.dynamic("T")
+
+    qk_s = (_B, T_d, _H, _K)
+    A_s = (_B, T_d, _H, _BT)
+    u_s = (_H, _K)
+
+    @T.prim_func
+    def kernel(
+        q: T.Tensor(qk_s, _dtype),
+        k: T.Tensor(qk_s, _dtype),
+        gi: T.Tensor(qk_s, accum_dtype),
+        ge: T.Tensor(qk_s, accum_dtype),
+        u: T.Tensor(u_s, _dtype),
+        A: T.Tensor(A_s, accum_dtype),
+        scale: accum_dtype,
+    ):
+        with T.Kernel(T.ceildiv(T_d, _BT), _NC * _NC, _B * _H, threads=_threads) as (i_t, i_c, i_bh):
+            i_b = i_bh // _H
+            i_h = i_bh % _H
+            i_i = i_c // _NC
+            i_j = i_c % _NC
+            t_s = i_t * _BT
+            q_s = t_s + i_i * _BC
+            k_s = t_s + i_j * _BC
+
+            q_frag = T.alloc_fragment((_BC, _BK), accum_dtype)
+            k_shared = T.alloc_shared((_BC, _BK), accum_dtype)
+            q_diag_frag = T.alloc_fragment((_BC, _BK), accum_dtype)
+            ku_diag_shared = T.alloc_shared((_BC, _BK), accum_dtype)
+            acc = T.alloc_fragment((_BC, _BC), accum_dtype)
+            diag_acc = T.alloc_fragment((_BC, _BC), accum_dtype)
+            diag_shared = T.alloc_shared((_BC, _BC), accum_dtype)
+            T.clear(acc)
+            T.clear(diag_acc)
+
+            if i_i < i_j:
+                for i, j in T.Parallel(_BC, _BC):
+                    A[i_b, q_s + i, i_h, i_j * _BC + j] = 0.0
+            else:
+                for k_blk in T.Pipelined(T.ceildiv(_K, _BK), num_stages=2):
+                    for i, k_i in T.Parallel(_BC, _BK):
+                        k_idx = k_blk * _BK + k_i
+                        q_frag[i, k_i] = (
+                            T.cast(q[i_b, q_s + i, i_h, k_idx], accum_dtype) *
+                            T.exp2(ge[i_b, q_s + i, i_h, k_idx]) * scale
+                        )
+                    for j, k_i in T.Parallel(_BC, _BK):
+                        k_idx = k_blk * _BK + k_i
+                        k_shared[j, k_i] = (
+                            T.cast(k[i_b, k_s + j, i_h, k_idx], accum_dtype) *
+                            T.exp2(-gi[i_b, k_s + j, i_h, k_idx])
+                        )
+                    T.gemm(q_frag, k_shared, acc, transpose_B=True)
+
+                    if i_i == i_j:
+                        for i, k_i in T.Parallel(_BC, _BK):
+                            k_idx = k_blk * _BK + k_i
+                            q_diag_frag[i, k_i] = T.cast(q[i_b, q_s + i, i_h, k_idx], accum_dtype)
+                            ku_diag_shared[i, k_i] = (
+                                T.cast(k[i_b, q_s + i, i_h, k_idx], accum_dtype) *
+                                T.cast(u[i_h, k_idx], accum_dtype)
+                        )
+                        T.gemm(q_diag_frag, ku_diag_shared, diag_acc, transpose_B=True)
+
+                if i_i == i_j:
+                    T.copy(diag_acc, diag_shared)
+
+                for i, j in T.Parallel(_BC, _BC):
+                    lower_value = T.if_then_else(i_i > i_j, acc[i, j], 0.0)
+                    diag_lower = T.if_then_else(i > j, acc[i, j], 0.0)
+                    diag_value = T.if_then_else(i == j, diag_shared[i, i] * scale, diag_lower)
+                    A[i_b, q_s + i, i_h, i_j * _BC + j] = T.if_then_else(i_i == i_j, diag_value, lower_value)
+
+    return kernel
+
+
+def chunk_rwkv6_fwd_intra_tilelang(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gi: torch.Tensor,
+    ge: torch.Tensor,
+    u: torch.Tensor,
+    scale: float,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    B, T_seq, H, K = q.shape
+    BT = chunk_size
+    BC = 16
+    BK = 32
+    dtype_str = {torch.bfloat16: 'bfloat16'}[q.dtype]
+
+    A = torch.empty(B, T_seq, H, BT, dtype=torch.float32, device=q.device)
+
+    kernel = _build_rwkv6_fwd_intra_kernel(
+        B,
+        H,
+        K,
+        BT,
+        BC,
+        BK,
+        dtype_str,
+        num_warps=1,
+    )
+    kernel(q, k, gi, ge, u, A, scale)
+    return A

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -9,6 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.ops.backends import dispatch
 from fla.ops.common.chunk_h import chunk_fwd_h
 from fla.ops.gla.chunk import chunk_gla_bwd_dA, chunk_gla_bwd_dv, chunk_gla_fwd_o_gk
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
@@ -740,6 +741,7 @@ def chunk_rwkv6_bwd_kernel_inter(
     tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
 
 
+@dispatch('rwkv6')
 def chunk_rwkv6_fwd_intra(
     q: torch.Tensor,
     k: torch.Tensor,

--- a/tests/ops/test_backends.py
+++ b/tests/ops/test_backends.py
@@ -11,9 +11,11 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 import fla.ops.common.backends.tilelang as common_tilelang_backend
 import fla.ops.kda.backends.tilelang as kda_tilelang_backend
+import fla.ops.rwkv6.backends.tilelang as rwkv6_tilelang_backend
 from fla.utils import _compat
 
 _REAL_PATH_EXISTS = Path.exists
@@ -96,10 +98,12 @@ def test_no_nvcc_logs_fallback_once(monkeypatch, caplog):
 def _backend_cls(backend_module):
     if backend_module is common_tilelang_backend:
         return backend_module.TileLangBackend
+    if backend_module is rwkv6_tilelang_backend:
+        return backend_module.RWKV6TileLangBackend
     return backend_module.KDATileLangBackend
 
 
-@pytest.mark.parametrize("backend_module", [common_tilelang_backend, kda_tilelang_backend])
+@pytest.mark.parametrize("backend_module", [common_tilelang_backend, kda_tilelang_backend, rwkv6_tilelang_backend])
 def test_tilelang_backend_gated_by_nvcc_probe(monkeypatch, backend_module):
     monkeypatch.setattr(backend_module, "_TILELANG_AVAILABLE", True)
     monkeypatch.setattr(backend_module, "has_usable_nvcc", lambda: False)
@@ -109,8 +113,56 @@ def test_tilelang_backend_gated_by_nvcc_probe(monkeypatch, backend_module):
     assert _backend_cls(backend_module).is_available() is True
 
 
-@pytest.mark.parametrize("backend_module", [common_tilelang_backend, kda_tilelang_backend])
+@pytest.mark.parametrize("backend_module", [common_tilelang_backend, kda_tilelang_backend, rwkv6_tilelang_backend])
 def test_tilelang_backend_unavailable_without_tilelang(monkeypatch, backend_module):
     monkeypatch.setattr(backend_module, "_TILELANG_AVAILABLE", False)
     monkeypatch.setattr(backend_module, "has_usable_nvcc", lambda: True)
     assert _backend_cls(backend_module).is_available() is False
+
+
+def test_rwkv6_tilelang_backend_requires_opt_in(monkeypatch):
+    monkeypatch.delenv("FLA_TILELANG", raising=False)
+    assert rwkv6_tilelang_backend.RWKV6TileLangBackend.is_enabled() is False
+
+    monkeypatch.setenv("FLA_TILELANG", "1")
+    assert rwkv6_tilelang_backend.RWKV6TileLangBackend.is_enabled() is True
+
+
+def test_rwkv6_tilelang_backend_verifier_accepts_supported_shape():
+    q = SimpleNamespace(dtype=torch.bfloat16, is_cuda=True, shape=(1, 64, 2, 64), ndim=4)
+    k = SimpleNamespace(dtype=torch.bfloat16, shape=q.shape)
+    gi = SimpleNamespace(dtype=torch.float32, shape=q.shape)
+    ge = SimpleNamespace(dtype=torch.float32, shape=q.shape)
+    u = SimpleNamespace(dtype=torch.bfloat16, shape=(2, 64))
+
+    accepted, reason = rwkv6_tilelang_backend.RWKV6TileLangBackend().chunk_rwkv6_fwd_intra_verifier(
+        q=q,
+        k=k,
+        gi=gi,
+        ge=ge,
+        u=u,
+        scale=1.0,
+    )
+
+    assert accepted is True
+    assert reason is None
+
+
+def test_rwkv6_tilelang_backend_verifier_rejects_unsupported_dimension():
+    q = SimpleNamespace(dtype=torch.bfloat16, is_cuda=True, shape=(1, 64, 2, 128), ndim=4)
+    k = SimpleNamespace(dtype=torch.bfloat16, shape=q.shape)
+    gi = SimpleNamespace(dtype=torch.float32, shape=q.shape)
+    ge = SimpleNamespace(dtype=torch.float32, shape=q.shape)
+    u = SimpleNamespace(dtype=torch.bfloat16, shape=(2, 128))
+
+    accepted, reason = rwkv6_tilelang_backend.RWKV6TileLangBackend().chunk_rwkv6_fwd_intra_verifier(
+        q=q,
+        k=k,
+        gi=gi,
+        ge=ge,
+        u=u,
+        scale=1.0,
+    )
+
+    assert accepted is False
+    assert reason == "TileLang RWKV6 intra backend currently supports the D=64 benchmark bucket only, got K=128"


### PR DESCRIPTION
## Summary

Add an opt-in TileLang backend for the dense CUDA bf16 `D=64`, `chunk_size=64` RWKV6 forward-intra path. Unsupported dtypes, dimensions, layouts, sequence shapes, and varlen inputs are rejected by the backend verifier and continue through the existing Triton implementation.

The implementation, optimization loop, correctness validation, and performance evidence were completed autonomously by Argus. The target and H100 hardware constraint were selected by the operator.

## Test plan

- `python -m pytest tests/ops/test_backends.py -q`: 14 passed
- `FLA_TILELANG=1 python -m benchmarks.ops.verify --op chunk_rwkv6 --base b328e7c6`: full frozen gate, 13 passed
- The candidate run logged TileLang compilation for the accepted D64 path.

## Benchmark / NCU

- Hardware: NVIDIA H100 NVL
- Software: CUDA 12.6, PyTorch 2.7.1+cu126, Triton 3.3.1
- Workload: `B=8, T=1024, H=8, D=64`, bf16
- Forward: 0.199 ms -> 0.168 ms (`1.18x`)
- Forward + backward: 0.900 ms -> 0.747 ms (`1.21x`)

The backward-specific kernels remain Triton; the end-to-end forward + backward improvement comes from the faster TileLang forward-intra stage. NCU hardware counters were unavailable because the host denied profiling permissions, so the optimization was supported by CUDA timing and PyTorch profiler evidence instead.

Several larger fallback-only benchmark rows encountered OOM because other processes occupied most of the shared GPU memory. This did not affect the full correctness gate or the reported D64 row.

## Breaking changes

None. The backend is disabled by default and requires `FLA_TILELANG=1`.
