### PR TITLE
[Perf] Fuse Ascend chunk_fwd_o inter+intra into unified 1D core-grid kernel

### DIFF
--- a/fla/ops/common/backends/triton_ascend/chunk_o.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_o.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+import triton.runtime.driver as driver
 
-from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp2
 from fla.utils import input_guard
 from fla.utils.ascend_ub_manager import (
@@ -56,6 +57,11 @@ def _get_bv(V: int) -> int:
         min_block=16,
         max_block=min(_MAX_BV, triton.next_power_of_2(V)),
     )
+
+
+def get_npu_properties():
+    device = torch.npu.current_device()
+    return driver.active.utils.get_device_properties(device)
 
 
 def _launch_fwd_o_kernel(kernel, *, nv: int, nt: int, bh_total: int, kernel_kwargs: dict) -> None:
@@ -430,6 +436,142 @@ def chunk_fwd_kernel_o_intra_npu(
         tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "USE_G_GAMMA": lambda args: args["g_gamma"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': 128}),
+        triton.Config({'BK': 64}),
+        triton.Config({'BK': 32}),
+    ],
+    key=['H', 'HV', 'K', 'V', 'BT', 'STATE_V_FIRST'],
+)
+@triton.jit(do_not_specialize=["T", "total_chunks", "task_num", "num_core", "H", "HV", "K", "V", "N"])
+def chunk_fwd_kernel_o_npu(
+    q,
+    k,
+    v,
+    h,
+    g,
+    g_gamma,
+    o,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    H,
+    HV,
+    K,
+    V,
+    N,
+    total_chunks,
+    task_num,
+    num_core,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    core_id = tl.program_id(0)
+    h_t_step = HV * total_chunks
+    for task_id in tl.range(core_id, task_num, num_core):
+        # Flatten (i_v, i_h, global_t) into task_id
+        i_v = task_id // h_t_step
+        remainder = task_id % h_t_step
+        i_h = remainder // total_chunks
+        global_t = remainder % total_chunks
+        T_cur = T
+
+        if IS_VARLEN:
+            # Find i_n via chunk_offsets: largest i_n with chunk_offsets[i_n] <= global_t
+            i_n = 0
+            for n in tl.range(0, N, 1):
+                i_n = tl.where(tl.load(chunk_offsets + n + 1) <= global_t, n + 1, i_n)
+            i_t = global_t - tl.load(chunk_offsets + i_n).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+            T_cur = eos - bos
+            i_tg = global_t
+        else:
+            NT = tl.cdiv(T, BT)
+            i_n = global_t // NT
+            i_t = global_t % NT
+            bos = i_n * T
+            i_tg = global_t
+
+        # offset calculation (use local pointers to avoid in-place += accumulation across iterations)
+        q_ptr = q + (bos * H + i_h // (HV // H)) * K
+        k_ptr = k + (bos * H + i_h // (HV // H)) * K
+        v_ptr = v + (bos * HV + i_h) * V
+        o_ptr = o + (bos * HV + i_h) * V
+        h_base = h + (i_tg * HV + i_h).to(tl.int64) * K * V
+
+        b_o = tl.zeros([BT, BV], dtype=tl.float32)
+        b_A = tl.zeros([BT, BT], dtype=tl.float32)
+
+        for i_k in range(tl.cdiv(K, BK)):
+            p_q = tl.make_block_ptr(q_ptr, (T_cur, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_k = tl.make_block_ptr(k_ptr, (K, T_cur), (1, H * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            if STATE_V_FIRST:
+                p_h = tl.make_block_ptr(h_base, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            else:
+                p_h = tl.make_block_ptr(h_base, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            # [BT, BK]
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            # [BK, BT]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            # [BK, BV]
+            b_h = tl.load(p_h, boundary_check=(0, 1))
+
+            # [BT, BK] @ [BK, BV] -> [BT, BV]
+            if STATE_V_FIRST:
+                b_o += tl.dot(b_q, tl.trans(b_h))
+            else:
+                b_o += tl.dot(b_q, b_h)
+            # [BT, BK] @ [BK, BT] -> [BT, BT]
+            b_A += tl.dot(b_q, b_k)
+
+        if USE_G:
+            # g is transposed to [B, HV, T] in wrapper for contiguous T-load.
+            # Non-varlen: g_ptr = g + i_n * HV * T + i_h * T (i_n is batch index)
+            # Varlen (B=1): g_ptr = g + bos + i_h * T (bos is absolute token offset)
+            if IS_VARLEN:
+                g_ptr = g + bos + i_h * T
+            else:
+                g_ptr = g + i_n * HV * T + i_h * T
+            p_g = tl.make_block_ptr(g_ptr, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,))
+
+            b_o = b_o * exp2(b_g)[:, None]
+            b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
+        if USE_G_GAMMA:
+            b_gamma = tl.load(g_gamma + i_h)
+            b_g = b_gamma * (tl.arange(0, BT) + 1)
+            b_o = b_o * exp2(b_g)[:, None]
+            b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
+
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T_cur
+        m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+        b_A = tl.where(m_A, b_A, 0)
+
+        p_v = tl.make_block_ptr(v_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_o = tl.make_block_ptr(o_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        # to fix mma -> mma layout conversion
+        # already solved by triton v3.2 or higher
+        b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
 @input_guard
 def chunk_fwd_o_npu(
     q: torch.Tensor,
@@ -446,103 +588,52 @@ def chunk_fwd_o_npu(
 ) -> torch.Tensor:
     B, T, H, K, V, HV = *q.shape, v.shape[-1], v.shape[2]
     BT = chunk_size
-    if chunk_indices is None and cu_seqlens is not None:
-        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
     o = torch.empty_like(v)
-    BK = _get_bk(K)
-    BV = _get_bv(V)
-    use_g = g is not None
-    use_g_gamma = g_gamma is not None
-    g_arg = g if use_g else q
-    base_kwargs = {
-        'g': g_arg,
-        'g_gamma': g_gamma,
-        'cu_seqlens': cu_seqlens,
-        'chunk_indices': chunk_indices,
-        'scale': scale,
-        'T': T,
-        'H': H,
-        'HV': HV,
-        'K': K,
-        'V': V,
-        'BT': BT,
-        'BC': _BC,
-        'BK': BK,
-        'BV': BV,
-        'USE_G': use_g,
-        'USE_G_GAMMA': use_g_gamma,
-        'IS_VARLEN': cu_seqlens is not None,
-        'V_OFFSET': 0,
-        'NT_OFFSET': 0,
-        'BH_OFFSET': 0,
-    }
-    nv = triton.cdiv(V, BV)
-    # Identity gate (exp2(0)=1) when g is disabled.
-    if not use_g and not use_g_gamma:
-        g_arg = torch.zeros(B, T, HV, dtype=torch.float32, device=q.device)
-        use_g = True
-    base_kwargs['g'] = g_arg
-    base_kwargs['USE_G'] = use_g
-    if HV == 1:
-        _launch_fwd_o_kernel(
-            chunk_fwd_kernel_o_inter_npu,
-            nv=nv,
-            nt=NT,
-            bh_total=B * HV,
-            kernel_kwargs={
-                **base_kwargs,
-                'q': q,
-                'h': h,
-                'o': o,
-                'STATE_V_FIRST': state_v_first,
-            },
+    if cu_seqlens is None:
+        N, chunk_offsets = B, None
+        NT = triton.cdiv(T, BT)
+        total_chunks = N * NT
+    else:
+        N, chunk_offsets = (
+            len(cu_seqlens) - 1,
+            prepare_chunk_offsets(cu_seqlens, BT),
         )
-        intra_hv1_kwargs = {k: v for k, v in base_kwargs.items() if k != 'BC'}
-        _launch_fwd_o_kernel(
-            chunk_fwd_kernel_o_intra_hv1_npu,
-            nv=nv,
-            nt=NT,
-            bh_total=B * HV,
-            kernel_kwargs={
-                **intra_hv1_kwargs,
-                'q': q,
-                'k': k,
-                'v': v,
-                'o': o,
-                'ACCUMULATE_OUTPUT': True,
-            },
-        )
-        return o
-    _launch_fwd_o_kernel(
-        chunk_fwd_kernel_o_inter_npu,
-        nv=nv,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs={
-            **base_kwargs,
-            'q': q,
-            'h': h,
-            'o': o,
-            'STATE_V_FIRST': state_v_first,
-        },
-    )
-    _launch_fwd_o_kernel(
-        chunk_fwd_kernel_o_intra_npu,
-        nv=nv,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs={
-            **base_kwargs,
-            'q': q,
-            'k': k,
-            'v': v,
-            'o': o,
-            'ACCUMULATE_OUTPUT': True,
-        },
+        # chunk_offsets[-1] stores the cumulative total chunks across all batches
+        total_chunks = chunk_offsets[-1].item()
+
+    BV = 128
+    NV = triton.cdiv(V, BV)
+    num_core = get_npu_properties()["num_aicore"]
+    task_num = NV * HV * total_chunks
+
+    if g is not None:
+        g = g.transpose(1, 2).contiguous()
+    chunk_fwd_kernel_o_npu[(num_core,)](
+        q=q,
+        k=k,
+        v=v,
+        h=h,
+        g=g,
+        g_gamma=g_gamma,
+        o=o,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        scale=scale,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        N=N,
+        total_chunks=total_chunks,
+        task_num=task_num,
+        num_core=num_core,
+        BT=BT,
+        BV=BV,
+        STATE_V_FIRST=state_v_first,
     )
     return o
 


### PR DESCRIPTION
# Summary
- Replace the two-kernel (inter + intra) split-launch design with a unified chunk_fwd_kernel_o_npu that fuses q·k, q·h, gate application, and v accumulation in a single pass. 
- Switch to 1D (num_core,) grid + tl.range task loop for better Ascend core utilization. 
- Drop UB-aware tile sizing in favor of hardcoded BV=128 and @triton.autotune over BK={32,64,128}.
- Remove _launch_fwd_o_kernel, _get_bk, _get_bv helpers and UB manager dependency.

# Benchmark

python benchmarks/ops/run.py --op chunk_gdn

```
===========================================================================================================================
  Machine: Ascend910B3 | NPU: CANN 9.0.0-beta.2 | PyTorch 2.7.1+cpu
===========================================================================================================================
  fwd        B      T    H    D  op                                   main[c70f11c5](ms) 260718/c...[3fb86c97](ms)  speedup
          -----------------------------------------------------------------------------------------------------------------
             1   8192   96  128  chunk_gdn                                       878.552                   322.502    2.72x
          -----------------------------------------------------------------------------------------------------------------
             2  16384   16  128  chunk_gdn                                       584.040                   221.356    2.64x
          -----------------------------------------------------------------------------------------------------------------
             4   2048   16  128  chunk_gdn                                       144.508                    53.813    2.69x
          -----------------------------------------------------------------------------------------------------------------
             4   4096   64  128  chunk_gdn                                      1170.191                   426.412    2.74x
          -----------------------------------------------------------------------------------------------------------------
             8   1024    8   64  chunk_gdn                                        45.822                    24.041    1.91x
          -----------------------------------------------------------------------------------------------------------------
             8   2048   32  256  chunk_gdn                                      1072.363                   270.626    3.96x
===========================================================================================================================
  fwdbwd     B      T    H    D  op                                   main[c70f11c5](ms) 260718/c...[3fb86c97](ms)  speedup
          -----------------------------------------------------------------------------------------------------------------
             1   8192   96  128  chunk_gdn                                      3797.186                  3188.816    1.19x
          -----------------------------------------------------------------------------------------------------------------
             2  16384   16  128  chunk_gdn                                      2571.662                  2177.782    1.18x
          -----------------------------------------------------------------------------------------------------------------
             4   2048   16  128  chunk_gdn                                       632.964                   544.005    1.16x
          -----------------------------------------------------------------------------------------------------------------
             4   4096   64  128  chunk_gdn                                      5079.154                  4270.597    1.19x
          -----------------------------------------------------------------------------------------------------------------
             8   1024    8   64  chunk_gdn                                       162.701                   143.384    1.13x
          -----------------------------------------------------------------------------------------------------------------
             8   2048   32  256  chunk_gdn                                      5865.469                  5034.330    1.17x
===========================================================================================================================
```