### PR TITLE
[Attn] Support for heterogeneous hybrid-attention configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ All of the pretrained models currently available can be found in [`fla-hub`](htt
 
 `fla` provides a flexible method to incorporate standard attention layers into existing linear attention models.
 This is easily achieved by specifying the `attn` argument in the model configuration.
+The original dictionary form applies one shared attention specification to every listed layer.
 
 For example, to create a 2-layer Samba model with one Mamba layer followed by one local attention layer, using a sliding window size of 2048:
 
@@ -420,6 +421,35 @@ SambaForCausalLM(
 ```
 
 </details>
+
+To use different attention settings at different depths, pass a list of specifications. For example, this six-layer Samba model uses local attention at layers 1 and 3, full attention at layer 5, and the native Mamba mixer at layers 0, 2, and 4:
+
+```py
+>>> config = SambaConfig(
+...   num_hidden_layers=6,
+...   attn=[
+...     {
+...       'layers': [1, 3],
+...       'num_heads': 18,
+...       'num_kv_heads': 18,
+...       'qkv_bias': False,
+...       'rope_theta': 10000.,
+...       'window_size': 2048,
+...     },
+...     {
+...       'layers': [5],
+...       'num_heads': 18,
+...       'num_kv_heads': 18,
+...       'qkv_bias': False,
+...       'rope_theta': 10000.,
+...       'window_size': None,
+...     },
+...   ],
+... )
+>>> model = AutoModelForCausalLM.from_config(config)
+```
+
+Each specification is normalized independently. Layers omitted from the plan retain the model's native linear-attention, recurrent, or state-space mixer.
 
 During inference, you **DO NOT** need to revise anything for generation!
 The model will produce output as-is, without any need for additional configurations or modifications.

--- a/fla/layers/gdn2.py
+++ b/fla/layers/gdn2.py
@@ -131,11 +131,18 @@ class GatedDeltaNet2(nn.Module):
         # maps each value head to its qk head via `i_h = i_hv // (HV // H)`. num_v_heads <
         # num_heads would divide by zero there.
         if self.num_v_heads < self.num_heads:
-            raise ValueError(f"num_v_heads={self.num_v_heads} must be >= num_heads={self.num_heads}.")
+            raise ValueError(
+                f"num_v_heads={self.num_v_heads} must be >= num_heads={self.num_heads}."
+            )
         if self.num_v_heads % self.num_heads != 0:
-            raise ValueError(f"num_v_heads={self.num_v_heads} must be divisible by num_heads={self.num_heads}.")
+            raise ValueError(
+                f"num_v_heads={self.num_v_heads} must be divisible by num_heads={self.num_heads}."
+            )
         if not math.isclose(head_dim * expand_v, self.head_v_dim, rel_tol=1e-5):
-            raise ValueError(f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}.")
+            raise ValueError(
+                f"expand_v={expand_v} does not produce an integer value when multiplied by "
+                f"head_dim={head_dim}."
+            )
         assert mode in ("chunk", "fused_recurrent"), f"Unsupported mode `{mode}`."
 
         # q/k/v projections.
@@ -200,7 +207,9 @@ class GatedDeltaNet2(nn.Module):
         **kwargs: Unpack[dict],
     ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
         if attention_mask is not None:
-            assert len(attention_mask.shape) == 2, "Expected attention_mask as a [batch_size, seq_len] 0/1 padding mask."
+            assert len(attention_mask.shape) == 2, (
+                "Expected attention_mask as a [batch_size, seq_len] 0/1 padding mask."
+            )
 
         batch_size, q_len, _ = hidden_states.shape
         # Short inference sequences use the lower-latency recurrent kernel.
@@ -262,7 +271,10 @@ class GatedDeltaNet2(nn.Module):
 
         # Grouped value attention: broadcast QK-side tensors across value-head groups.
         if self.num_v_heads > self.num_heads:
-            q, k, g, b = (repeat(x, "... h d -> ... (h g) d", g=self.num_v_heads // self.num_heads) for x in (q, k, g, b))
+            q, k, g, b = (
+                repeat(x, "... h d -> ... (h g) d", g=self.num_v_heads // self.num_heads)
+                for x in (q, k, g, b)
+            )
 
         if self.allow_neg_eigval:
             b = b * 2.0

--- a/fla/layers/gdn2.py
+++ b/fla/layers/gdn2.py
@@ -131,18 +131,11 @@ class GatedDeltaNet2(nn.Module):
         # maps each value head to its qk head via `i_h = i_hv // (HV // H)`. num_v_heads <
         # num_heads would divide by zero there.
         if self.num_v_heads < self.num_heads:
-            raise ValueError(
-                f"num_v_heads={self.num_v_heads} must be >= num_heads={self.num_heads}."
-            )
+            raise ValueError(f"num_v_heads={self.num_v_heads} must be >= num_heads={self.num_heads}.")
         if self.num_v_heads % self.num_heads != 0:
-            raise ValueError(
-                f"num_v_heads={self.num_v_heads} must be divisible by num_heads={self.num_heads}."
-            )
+            raise ValueError(f"num_v_heads={self.num_v_heads} must be divisible by num_heads={self.num_heads}.")
         if not math.isclose(head_dim * expand_v, self.head_v_dim, rel_tol=1e-5):
-            raise ValueError(
-                f"expand_v={expand_v} does not produce an integer value when multiplied by "
-                f"head_dim={head_dim}."
-            )
+            raise ValueError(f"expand_v={expand_v} does not produce an integer value when multiplied by head_dim={head_dim}.")
         assert mode in ("chunk", "fused_recurrent"), f"Unsupported mode `{mode}`."
 
         # q/k/v projections.
@@ -207,9 +200,7 @@ class GatedDeltaNet2(nn.Module):
         **kwargs: Unpack[dict],
     ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
         if attention_mask is not None:
-            assert len(attention_mask.shape) == 2, (
-                "Expected attention_mask as a [batch_size, seq_len] 0/1 padding mask."
-            )
+            assert len(attention_mask.shape) == 2, "Expected attention_mask as a [batch_size, seq_len] 0/1 padding mask."
 
         batch_size, q_len, _ = hidden_states.shape
         # Short inference sequences use the lower-latency recurrent kernel.
@@ -271,10 +262,7 @@ class GatedDeltaNet2(nn.Module):
 
         # Grouped value attention: broadcast QK-side tensors across value-head groups.
         if self.num_v_heads > self.num_heads:
-            q, k, g, b = (
-                repeat(x, "... h d -> ... (h g) d", g=self.num_v_heads // self.num_heads)
-                for x in (q, k, g, b)
-            )
+            q, k, g, b = (repeat(x, "... h d -> ... (h g) d", g=self.num_v_heads // self.num_heads) for x in (q, k, g, b))
 
         if self.allow_neg_eigval:
             b = b * 2.0

--- a/fla/layers/mamba.py
+++ b/fla/layers/mamba.py
@@ -19,7 +19,7 @@ from fla.layers.utils import get_layer_cache, update_layer_cache
 from fla.modules.activations import ACT2FN
 
 with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
+    warnings.simplefilter('ignore')
     try:
         from mamba_ssm.ops.selective_scan_interface import mamba_inner_fn, selective_scan_fn
         from mamba_ssm.ops.triton.selective_state_update import selective_state_update
@@ -30,13 +30,11 @@ with warnings.catch_warnings():
         from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
     except ImportError:
         causal_conv1d_update, causal_conv1d_fn = None, None
-    is_fast_path_available = all(
-        (
-            selective_state_update,
-            selective_scan_fn,
-            mamba_inner_fn,
-        )
-    )
+    is_fast_path_available = all((
+        selective_state_update,
+        selective_scan_fn,
+        mamba_inner_fn,
+    ))
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
 
@@ -112,9 +110,10 @@ class Mamba(nn.Module):
             raise NotImplementedError
 
         # Initialize dt bias so that F.softplus(dt_bias) is between dt_min and dt_max
-        dt = torch.exp(torch.rand(self.intermediate_size) * (math.log(dt_max) - math.log(dt_min)) + math.log(dt_min)).clamp(
-            min=dt_init_floor
-        )
+        dt = torch.exp(
+            torch.rand(self.intermediate_size) * (math.log(dt_max) - math.log(dt_min))
+            + math.log(dt_min)
+        ).clamp(min=dt_init_floor)
         # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
         inv_dt = dt + torch.log(-torch.expm1(-dt))
         with torch.no_grad():
@@ -142,20 +141,18 @@ class Mamba(nn.Module):
                 " https://github.com/Dao-AILab/causal-conv1d",
             )
         import os
-
-        backend = os.environ.get("FLA_CONV_BACKEND", backend)
-        assert backend in ["cuda", "triton"], f"Unsupported backend: {backend}"
-        if backend == "cuda" and causal_conv1d_fn is None:
+        backend = os.environ.get('FLA_CONV_BACKEND', backend)
+        assert backend in ['cuda', 'triton'], f"Unsupported backend: {backend}"
+        if backend == 'cuda' and causal_conv1d_fn is None:
             logger.warning_once(
                 "The CUDA backend is not available because `causal_conv1d` is None. "
                 "Falling back to the Triton backend. "
                 "To install follow https://github.com/Dao-AILab/causal-conv1d",
             )
-            backend = "triton"
-        if backend == "triton":
+            backend = 'triton'
+        if backend == 'triton':
             from fla.modules.convolution import causal_conv1d as causal_conv1d_triton
             from fla.modules.convolution import causal_conv1d_update as causal_conv1d_update_triton
-
             self.causal_conv1d_fn = causal_conv1d_triton
             self.causal_conv1d_update = causal_conv1d_update_triton
         else:
@@ -172,7 +169,7 @@ class Mamba(nn.Module):
     def _build_conv_state(self, hidden_states: torch.Tensor) -> torch.Tensor:
         seq_len = hidden_states.shape[-1]
         if seq_len >= self.conv_kernel_size:
-            return hidden_states[..., -self.conv_kernel_size :].contiguous()
+            return hidden_states[..., -self.conv_kernel_size:].contiguous()
         return nn.functional.pad(hidden_states, (self.conv_kernel_size - seq_len, 0)).contiguous()
 
     def cuda_kernels_forward(
@@ -217,10 +214,10 @@ class Mamba(nn.Module):
         conv_inputs = hidden_states
         conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
         if last_state is not None:
-            conv_state = last_state["conv_state"]
-            ssm_state = last_state["recurrent_state"]
+            conv_state = last_state['conv_state']
+            ssm_state = last_state['recurrent_state']
 
-            if self.backend == "triton":
+            if self.backend == 'triton':
                 hidden_states, conv_state = self.causal_conv1d_update(
                     x=self._to_causal_conv_layout(conv_inputs),
                     cache=conv_state,
@@ -241,7 +238,7 @@ class Mamba(nn.Module):
         else:
             conv_state = None
             ssm_state = None
-            if self.backend == "triton":
+            if self.backend == 'triton':
                 hidden_states, conv_state = self.causal_conv1d_fn(
                     x=self._to_causal_conv_layout(conv_inputs),
                     weight=conv_weights,
@@ -254,10 +251,7 @@ class Mamba(nn.Module):
                 if use_cache:
                     conv_state = self._build_conv_state(conv_inputs)
                 hidden_states = self.causal_conv1d_fn(
-                    conv_inputs,
-                    conv_weights,
-                    self.conv1d.bias,
-                    activation=self.activation,
+                    conv_inputs, conv_weights, self.conv1d.bias, activation=self.activation,
                 )
 
         if attention_mask is not None and last_state is None:
@@ -269,9 +263,7 @@ class Mamba(nn.Module):
         # 3.a. input varying initialization of time_step, B and C
         ssm_parameters = self.x_proj(hidden_states.transpose(1, 2))
         time_step, B, C = torch.split(
-            ssm_parameters,
-            [self.dt_rank, self.ssm_state_size, self.ssm_state_size],
-            dim=-1,
+            ssm_parameters, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1,
         )
         discrete_time_step = self.dt_proj.weight @ time_step.transpose(1, 2)
 
@@ -333,8 +325,8 @@ class Mamba(nn.Module):
 
         # 2. Convolution sequence transformation
         if last_state is not None:
-            conv_state = last_state["conv_state"]
-            ssm_state = last_state["recurrent_state"].clone().to(hidden_states.device)
+            conv_state = last_state['conv_state']
+            ssm_state = last_state['recurrent_state'].clone().to(hidden_states.device)
 
             # decode path: single token
             conv_state = conv_state.roll(shifts=-1, dims=-1)
@@ -347,8 +339,7 @@ class Mamba(nn.Module):
         elif use_cache:
             ssm_state = torch.zeros(
                 (batch_size, self.intermediate_size, self.ssm_state_size),
-                device=hidden_states.device,
-                dtype=dtype,
+                device=hidden_states.device, dtype=dtype,
             )
             conv_state = self._build_conv_state(hidden_states)
             # [batch, intermediate_size, seq_len]
@@ -356,8 +347,7 @@ class Mamba(nn.Module):
         else:
             ssm_state = torch.zeros(
                 (batch_size, self.intermediate_size, self.ssm_state_size),
-                device=hidden_states.device,
-                dtype=dtype,
+                device=hidden_states.device, dtype=dtype,
             )
             conv_state = None
             # [batch, intermediate_size, seq_len]
@@ -372,9 +362,7 @@ class Mamba(nn.Module):
         # 3.a. Selection:  [batch, seq_len, self.dt_rank + self.ssm_state_size * 2]
         ssm_parameters = self.x_proj(hidden_states.transpose(1, 2))
         time_step, B, C = torch.split(
-            ssm_parameters,
-            [self.dt_rank, self.ssm_state_size, self.ssm_state_size],
-            dim=-1,
+            ssm_parameters, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1,
         )
         # [batch, seq_len, intermediate_size]
         discrete_time_step = self.dt_proj(time_step)
@@ -401,13 +389,12 @@ class Mamba(nn.Module):
         # [batch, seq_len, intermediade_size]
         scan_output = torch.stack(scan_outputs, dim=-1)
         scan_output = scan_output + (hidden_states * self.D[None, :, None])
-        scan_output = scan_output * self.act(gate)
+        scan_output = (scan_output * self.act(gate))
 
         # 4. Final linear projection
         # [batch, seq_len, hidden_size]
         contextualized_states = self.out_proj(scan_output.transpose(1, 2))
         return contextualized_states, conv_state, ssm_state
-
     # fmt: on
 
     def forward(
@@ -426,7 +413,9 @@ class Mamba(nn.Module):
                 hidden_states, last_state, use_cache, attention_mask, **kwargs
             )
         else:
-            output, conv_state, ssm_state = self.slow_forward(hidden_states, last_state, use_cache, attention_mask, **kwargs)
+            output, conv_state, ssm_state = self.slow_forward(
+                hidden_states, last_state, use_cache, attention_mask, **kwargs
+            )
 
         if use_cache and past_key_values is not None:
             update_layer_cache(

--- a/fla/layers/mamba.py
+++ b/fla/layers/mamba.py
@@ -19,7 +19,7 @@ from fla.layers.utils import get_layer_cache, update_layer_cache
 from fla.modules.activations import ACT2FN
 
 with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
+    warnings.simplefilter("ignore")
     try:
         from mamba_ssm.ops.selective_scan_interface import mamba_inner_fn, selective_scan_fn
         from mamba_ssm.ops.triton.selective_state_update import selective_state_update
@@ -30,11 +30,13 @@ with warnings.catch_warnings():
         from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
     except ImportError:
         causal_conv1d_update, causal_conv1d_fn = None, None
-    is_fast_path_available = all((
-        selective_state_update,
-        selective_scan_fn,
-        mamba_inner_fn,
-    ))
+    is_fast_path_available = all(
+        (
+            selective_state_update,
+            selective_scan_fn,
+            mamba_inner_fn,
+        )
+    )
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
 
@@ -110,10 +112,9 @@ class Mamba(nn.Module):
             raise NotImplementedError
 
         # Initialize dt bias so that F.softplus(dt_bias) is between dt_min and dt_max
-        dt = torch.exp(
-            torch.rand(self.intermediate_size) * (math.log(dt_max) - math.log(dt_min))
-            + math.log(dt_min)
-        ).clamp(min=dt_init_floor)
+        dt = torch.exp(torch.rand(self.intermediate_size) * (math.log(dt_max) - math.log(dt_min)) + math.log(dt_min)).clamp(
+            min=dt_init_floor
+        )
         # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
         inv_dt = dt + torch.log(-torch.expm1(-dt))
         with torch.no_grad():
@@ -141,18 +142,20 @@ class Mamba(nn.Module):
                 " https://github.com/Dao-AILab/causal-conv1d",
             )
         import os
-        backend = os.environ.get('FLA_CONV_BACKEND', backend)
-        assert backend in ['cuda', 'triton'], f"Unsupported backend: {backend}"
-        if backend == 'cuda' and causal_conv1d_fn is None:
+
+        backend = os.environ.get("FLA_CONV_BACKEND", backend)
+        assert backend in ["cuda", "triton"], f"Unsupported backend: {backend}"
+        if backend == "cuda" and causal_conv1d_fn is None:
             logger.warning_once(
                 "The CUDA backend is not available because `causal_conv1d` is None. "
                 "Falling back to the Triton backend. "
                 "To install follow https://github.com/Dao-AILab/causal-conv1d",
             )
-            backend = 'triton'
-        if backend == 'triton':
+            backend = "triton"
+        if backend == "triton":
             from fla.modules.convolution import causal_conv1d as causal_conv1d_triton
             from fla.modules.convolution import causal_conv1d_update as causal_conv1d_update_triton
+
             self.causal_conv1d_fn = causal_conv1d_triton
             self.causal_conv1d_update = causal_conv1d_update_triton
         else:
@@ -169,7 +172,7 @@ class Mamba(nn.Module):
     def _build_conv_state(self, hidden_states: torch.Tensor) -> torch.Tensor:
         seq_len = hidden_states.shape[-1]
         if seq_len >= self.conv_kernel_size:
-            return hidden_states[..., -self.conv_kernel_size:].contiguous()
+            return hidden_states[..., -self.conv_kernel_size :].contiguous()
         return nn.functional.pad(hidden_states, (self.conv_kernel_size - seq_len, 0)).contiguous()
 
     def cuda_kernels_forward(
@@ -214,10 +217,10 @@ class Mamba(nn.Module):
         conv_inputs = hidden_states
         conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
         if last_state is not None:
-            conv_state = last_state['conv_state']
-            ssm_state = last_state['recurrent_state']
+            conv_state = last_state["conv_state"]
+            ssm_state = last_state["recurrent_state"]
 
-            if self.backend == 'triton':
+            if self.backend == "triton":
                 hidden_states, conv_state = self.causal_conv1d_update(
                     x=self._to_causal_conv_layout(conv_inputs),
                     cache=conv_state,
@@ -238,7 +241,7 @@ class Mamba(nn.Module):
         else:
             conv_state = None
             ssm_state = None
-            if self.backend == 'triton':
+            if self.backend == "triton":
                 hidden_states, conv_state = self.causal_conv1d_fn(
                     x=self._to_causal_conv_layout(conv_inputs),
                     weight=conv_weights,
@@ -251,7 +254,10 @@ class Mamba(nn.Module):
                 if use_cache:
                     conv_state = self._build_conv_state(conv_inputs)
                 hidden_states = self.causal_conv1d_fn(
-                    conv_inputs, conv_weights, self.conv1d.bias, activation=self.activation,
+                    conv_inputs,
+                    conv_weights,
+                    self.conv1d.bias,
+                    activation=self.activation,
                 )
 
         if attention_mask is not None and last_state is None:
@@ -263,7 +269,9 @@ class Mamba(nn.Module):
         # 3.a. input varying initialization of time_step, B and C
         ssm_parameters = self.x_proj(hidden_states.transpose(1, 2))
         time_step, B, C = torch.split(
-            ssm_parameters, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1,
+            ssm_parameters,
+            [self.dt_rank, self.ssm_state_size, self.ssm_state_size],
+            dim=-1,
         )
         discrete_time_step = self.dt_proj.weight @ time_step.transpose(1, 2)
 
@@ -325,8 +333,8 @@ class Mamba(nn.Module):
 
         # 2. Convolution sequence transformation
         if last_state is not None:
-            conv_state = last_state['conv_state']
-            ssm_state = last_state['recurrent_state'].clone().to(hidden_states.device)
+            conv_state = last_state["conv_state"]
+            ssm_state = last_state["recurrent_state"].clone().to(hidden_states.device)
 
             # decode path: single token
             conv_state = conv_state.roll(shifts=-1, dims=-1)
@@ -339,7 +347,8 @@ class Mamba(nn.Module):
         elif use_cache:
             ssm_state = torch.zeros(
                 (batch_size, self.intermediate_size, self.ssm_state_size),
-                device=hidden_states.device, dtype=dtype,
+                device=hidden_states.device,
+                dtype=dtype,
             )
             conv_state = self._build_conv_state(hidden_states)
             # [batch, intermediate_size, seq_len]
@@ -347,7 +356,8 @@ class Mamba(nn.Module):
         else:
             ssm_state = torch.zeros(
                 (batch_size, self.intermediate_size, self.ssm_state_size),
-                device=hidden_states.device, dtype=dtype,
+                device=hidden_states.device,
+                dtype=dtype,
             )
             conv_state = None
             # [batch, intermediate_size, seq_len]
@@ -362,7 +372,9 @@ class Mamba(nn.Module):
         # 3.a. Selection:  [batch, seq_len, self.dt_rank + self.ssm_state_size * 2]
         ssm_parameters = self.x_proj(hidden_states.transpose(1, 2))
         time_step, B, C = torch.split(
-            ssm_parameters, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1,
+            ssm_parameters,
+            [self.dt_rank, self.ssm_state_size, self.ssm_state_size],
+            dim=-1,
         )
         # [batch, seq_len, intermediate_size]
         discrete_time_step = self.dt_proj(time_step)
@@ -389,12 +401,13 @@ class Mamba(nn.Module):
         # [batch, seq_len, intermediade_size]
         scan_output = torch.stack(scan_outputs, dim=-1)
         scan_output = scan_output + (hidden_states * self.D[None, :, None])
-        scan_output = (scan_output * self.act(gate))
+        scan_output = scan_output * self.act(gate)
 
         # 4. Final linear projection
         # [batch, seq_len, hidden_size]
         contextualized_states = self.out_proj(scan_output.transpose(1, 2))
         return contextualized_states, conv_state, ssm_state
+
     # fmt: on
 
     def forward(
@@ -413,9 +426,7 @@ class Mamba(nn.Module):
                 hidden_states, last_state, use_cache, attention_mask, **kwargs
             )
         else:
-            output, conv_state, ssm_state = self.slow_forward(
-                hidden_states, last_state, use_cache, attention_mask, **kwargs
-            )
+            output, conv_state, ssm_state = self.slow_forward(hidden_states, last_state, use_cache, attention_mask, **kwargs)
 
         if use_cache and past_key_values is not None:
             update_layer_cache(

--- a/fla/models/abc/configuration_abc.py
+++ b/fla/models/abc/configuration_abc.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class ABCConfig(PretrainedConfig):
 
@@ -35,7 +37,7 @@ class ABCConfig(PretrainedConfig):
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
         use_rope: bool = True,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -69,7 +71,7 @@ class ABCConfig(PretrainedConfig):
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
         self.use_rope = use_rope
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -91,18 +93,6 @@ class ABCConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/abc/configuration_abc.py
+++ b/fla/models/abc/configuration_abc.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class ABCConfig(PretrainedConfig):
+class ABCConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'abc'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -71,7 +71,7 @@ class ABCConfig(PretrainedConfig):
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
         self.use_rope = use_rope
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.abc import ABCAttention
 from fla.layers.attn import Attention
 from fla.models.abc.configuration_abc import ABCConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as ABCMLP
@@ -47,14 +48,15 @@ class ABCBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/comba/configuration_comba.py
+++ b/fla/models/comba/configuration_comba.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class CombaConfig(PretrainedConfig):
+class CombaConfig(_HybridAttentionConfigMixin, PretrainedConfig):
     model_type = 'comba'
     keys_to_ignore_at_inference = ['past_key_values']
 
@@ -71,7 +71,7 @@ class CombaConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/comba/configuration_comba.py
+++ b/fla/models/comba/configuration_comba.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class CombaConfig(PretrainedConfig):
     model_type = 'comba'
@@ -34,7 +36,7 @@ class CombaConfig(PretrainedConfig):
         hidden_act: str = "swish",
         num_hidden_layers: int = 21,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -69,7 +71,7 @@ class CombaConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -91,18 +93,6 @@ class CombaConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.comba import Comba
 from fla.models.comba.configuration_comba import CombaConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as CombaMLP
@@ -48,14 +49,15 @@ class CombaBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/delta_net/configuration_delta_net.py
+++ b/fla/models/delta_net/configuration_delta_net.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class DeltaNetConfig(PretrainedConfig):
+class DeltaNetConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'delta_net'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -73,7 +73,7 @@ class DeltaNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.fuse_norm = fuse_norm

--- a/fla/models/delta_net/configuration_delta_net.py
+++ b/fla/models/delta_net/configuration_delta_net.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class DeltaNetConfig(PretrainedConfig):
 
@@ -36,7 +38,7 @@ class DeltaNetConfig(PretrainedConfig):
         hidden_act: str = "swish",
         num_hidden_layers: int = 24,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -71,7 +73,7 @@ class DeltaNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.fuse_norm = fuse_norm
@@ -93,18 +95,6 @@ class DeltaNetConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.delta_net import DeltaNet
 from fla.models.delta_net.configuration_delta_net import DeltaNetConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as DeltaNetMLP
@@ -47,14 +48,15 @@ class DeltaNetBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/deltaformer/configuration_deltaformer.py
+++ b/fla/models/deltaformer/configuration_deltaformer.py
@@ -11,10 +11,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class DeltaFormerConfig(PretrainedConfig):
+class DeltaFormerConfig(_HybridAttentionConfigMixin, PretrainedConfig):
     model_type = 'deltaformer'
     keys_to_ignore_at_inference = ['past_key_values']
 
@@ -68,7 +68,7 @@ class DeltaFormerConfig(PretrainedConfig):
         self.qk_norm = qk_norm
         self.rope_theta = rope_theta
         self.rope_max_position_embeddings = rope_max_position_embeddings
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/deltaformer/configuration_deltaformer.py
+++ b/fla/models/deltaformer/configuration_deltaformer.py
@@ -11,6 +11,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class DeltaFormerConfig(PretrainedConfig):
     model_type = 'deltaformer'
@@ -33,7 +35,7 @@ class DeltaFormerConfig(PretrainedConfig):
         qk_norm: bool = False,
         rope_theta: float = 10000.,
         rope_max_position_embeddings: int | None = None,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -66,7 +68,7 @@ class DeltaFormerConfig(PretrainedConfig):
         self.qk_norm = qk_norm
         self.rope_theta = rope_theta
         self.rope_max_position_embeddings = rope_max_position_embeddings
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -91,18 +93,6 @@ class DeltaFormerConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/gated_deltanet/configuration_gated_deltanet.py
+++ b/fla/models/gated_deltanet/configuration_gated_deltanet.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class GatedDeltaNetConfig(PretrainedConfig):
     model_type = 'gated_deltanet'
@@ -32,7 +34,7 @@ class GatedDeltaNetConfig(PretrainedConfig):
         hidden_act: str = "swish",
         num_hidden_layers: int = 21,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -64,7 +66,7 @@ class GatedDeltaNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -87,18 +89,6 @@ class GatedDeltaNetConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/gated_deltanet/configuration_gated_deltanet.py
+++ b/fla/models/gated_deltanet/configuration_gated_deltanet.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class GatedDeltaNetConfig(PretrainedConfig):
+class GatedDeltaNetConfig(_HybridAttentionConfigMixin, PretrainedConfig):
     model_type = 'gated_deltanet'
     keys_to_ignore_at_inference = ['past_key_values']
 
@@ -66,7 +66,7 @@ class GatedDeltaNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gated_deltanet import GatedDeltaNet
 from fla.models.gated_deltanet.configuration_gated_deltanet import GatedDeltaNetConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaNetMLP
@@ -48,14 +49,15 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/gated_deltaproduct/configuration_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/configuration_gated_deltaproduct.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class GatedDeltaProductConfig(PretrainedConfig):
     model_type = 'gated_deltaproduct'
@@ -30,7 +32,7 @@ class GatedDeltaProductConfig(PretrainedConfig):
         hidden_act: str = "swish",
         num_hidden_layers: int = 21,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int = None,
         bos_token_id: int = 1,
@@ -64,7 +66,7 @@ class GatedDeltaProductConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -91,18 +93,6 @@ class GatedDeltaProductConfig(PretrainedConfig):
         self.num_householder = num_householder
         self.use_forget_gate = use_forget_gate
         self.attnres_block_size = attnres_block_size
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/gated_deltaproduct/configuration_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/configuration_gated_deltaproduct.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class GatedDeltaProductConfig(PretrainedConfig):
+class GatedDeltaProductConfig(_HybridAttentionConfigMixin, PretrainedConfig):
     model_type = 'gated_deltaproduct'
     keys_to_ignore_at_inference = ['past_key_values']
 
@@ -66,7 +66,7 @@ class GatedDeltaProductConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gated_deltaproduct import GatedDeltaProduct
 from fla.models.gated_deltaproduct.configuration_gated_deltaproduct import GatedDeltaProductConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaProductMLP
@@ -48,14 +49,15 @@ class GatedDeltaProductBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/gla/configuration_gla.py
+++ b/fla/models/gla/configuration_gla.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class GLAConfig(PretrainedConfig):
+class GLAConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'gla'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -75,7 +75,7 @@ class GLAConfig(PretrainedConfig):
         self.norm_eps = norm_eps
         self.use_gk = use_gk
         self.use_gv = use_gv
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/gla/configuration_gla.py
+++ b/fla/models/gla/configuration_gla.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class GLAConfig(PretrainedConfig):
 
@@ -37,7 +39,7 @@ class GLAConfig(PretrainedConfig):
         norm_eps: float = 1e-6,
         use_gk: bool = True,
         use_gv: bool = False,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -73,7 +75,7 @@ class GLAConfig(PretrainedConfig):
         self.norm_eps = norm_eps
         self.use_gk = use_gk
         self.use_gv = use_gv
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -95,18 +97,6 @@ class GLAConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gla import GatedLinearAttention
 from fla.models.gla.configuration_gla import GLAConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GLAMLP
@@ -48,14 +49,15 @@ class GLABlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/gsa/configuration_gsa.py
+++ b/fla/models/gsa/configuration_gsa.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class GSAConfig(PretrainedConfig):
 
@@ -38,7 +40,7 @@ class GSAConfig(PretrainedConfig):
         hidden_act: str = "swish",
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -75,7 +77,7 @@ class GSAConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -97,18 +99,6 @@ class GSAConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/gsa/configuration_gsa.py
+++ b/fla/models/gsa/configuration_gsa.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class GSAConfig(PretrainedConfig):
+class GSAConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'gsa'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -77,7 +77,7 @@ class GSAConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gsa import GatedSlotAttention
 from fla.models.gsa.configuration_gsa import GSAConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GSAMLP
@@ -48,14 +49,15 @@ class GSABlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/hgrn/configuration_hgrn.py
+++ b/fla/models/hgrn/configuration_hgrn.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class HGRNConfig(PretrainedConfig):
+class HGRNConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'hgrn'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -59,7 +59,7 @@ class HGRNConfig(PretrainedConfig):
         self.hidden_ratio = hidden_ratio
         self.intermediate_size = intermediate_size
         self.elementwise_affine = elementwise_affine
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.norm_eps = norm_eps
         self.hidden_act = hidden_act
         self.use_cache = use_cache

--- a/fla/models/hgrn/configuration_hgrn.py
+++ b/fla/models/hgrn/configuration_hgrn.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class HGRNConfig(PretrainedConfig):
 
@@ -30,7 +32,7 @@ class HGRNConfig(PretrainedConfig):
         hidden_act: str = "swish",
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -57,7 +59,7 @@ class HGRNConfig(PretrainedConfig):
         self.hidden_ratio = hidden_ratio
         self.intermediate_size = intermediate_size
         self.elementwise_affine = elementwise_affine
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.norm_eps = norm_eps
         self.hidden_act = hidden_act
         self.use_cache = use_cache
@@ -81,18 +83,6 @@ class HGRNConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.hgrn import HGRNAttention
 from fla.models.hgrn.configuration_hgrn import HGRNConfig
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRNMLP
@@ -48,14 +49,15 @@ class HGRNBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/hgrn2/configuration_hgrn2.py
+++ b/fla/models/hgrn2/configuration_hgrn2.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class HGRN2Config(PretrainedConfig):
+class HGRN2Config(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'hgrn2'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -71,7 +71,7 @@ class HGRN2Config(PretrainedConfig):
         self.hidden_act = hidden_act
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/hgrn2/configuration_hgrn2.py
+++ b/fla/models/hgrn2/configuration_hgrn2.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class HGRN2Config(PretrainedConfig):
 
@@ -31,7 +33,7 @@ class HGRN2Config(PretrainedConfig):
         max_position_embeddings: int = 2048,
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -69,7 +71,7 @@ class HGRN2Config(PretrainedConfig):
         self.hidden_act = hidden_act
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -91,18 +93,6 @@ class HGRN2Config(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.hgrn2 import HGRN2Attention
 from fla.models.hgrn2.configuration_hgrn2 import HGRN2Config
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRN2MLP
@@ -48,14 +49,15 @@ class HGRN2Block(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/hybrid.py
+++ b/fla/models/hybrid.py
@@ -101,13 +101,17 @@ def _normalize_spec(
     normalized['window_size'] = window_size
 
     rope_theta = normalized.get('rope_theta', 10000.)
-    if (
-        isinstance(rope_theta, bool)
-        or not isinstance(rope_theta, (int, float))
-        or not math.isfinite(rope_theta)
-        or rope_theta <= 0
-    ):
-        raise ValueError(f"{context} field 'rope_theta' must be positive; got {rope_theta!r}")
+    try:
+        valid_rope_theta = (
+            not isinstance(rope_theta, bool)
+            and isinstance(rope_theta, (int, float))
+            and math.isfinite(rope_theta)
+            and rope_theta > 0
+        )
+    except OverflowError:
+        valid_rope_theta = False
+    if not valid_rope_theta:
+        raise ValueError(f"{context} field 'rope_theta' must be positive and finite; got {rope_theta!r}")
     normalized['rope_theta'] = rope_theta
 
     return normalized
@@ -155,6 +159,21 @@ def normalize_hybrid_attention_config(
     if is_single_spec:
         return normalized_specs[0]
     return normalized_specs
+
+
+class _HybridAttentionConfigMixin:
+    """Apply hybrid-attention validation to constructor and later assignments."""
+
+    @property
+    def attn(self) -> HybridAttentionConfig:
+        return self.__dict__.get('attn')
+
+    @attn.setter
+    def attn(self, value: HybridAttentionConfig) -> None:
+        self.__dict__['attn'] = self._normalize_hybrid_attention_config(value)
+
+    def _normalize_hybrid_attention_config(self, attn: HybridAttentionConfig) -> HybridAttentionConfig:
+        return normalize_hybrid_attention_config(attn, num_hidden_layers=self.num_hidden_layers)
 
 
 def get_hybrid_attention_spec(

--- a/fla/models/hybrid.py
+++ b/fla/models/hybrid.py
@@ -162,7 +162,12 @@ def normalize_hybrid_attention_config(
 
 
 class _HybridAttentionConfigMixin:
-    """Apply hybrid-attention validation to constructor and later assignments."""
+    """Apply hybrid-attention validation to constructor and later assignments.
+
+    Validation depends on ``self.num_hidden_layers`` for layer range checks,
+    so subclasses must assign ``num_hidden_layers`` before ``self.attn`` in
+    their ``__init__``.
+    """
 
     @property
     def attn(self) -> HybridAttentionConfig:

--- a/fla/models/hybrid.py
+++ b/fla/models/hybrid.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import math
+from typing import TypedDict
+
+
+class _RequiredHybridAttentionSpec(TypedDict):
+    layers: list[int]
+    num_heads: int
+
+
+class HybridAttentionSpec(_RequiredHybridAttentionSpec, total=False):
+    """JSON-serializable settings for standard attention at selected model layers."""
+
+    num_kv_heads: int
+    qkv_bias: bool
+    window_size: int | None
+    rope_theta: float
+
+
+HybridAttentionConfig = HybridAttentionSpec | list[HybridAttentionSpec] | None
+
+
+def _spec_context(spec_index: int | None) -> str:
+    if spec_index is None:
+        return "attn specification"
+    return f"attn specification at index {spec_index}"
+
+
+def _positive_int(value: object, *, field: str, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{context} field {field!r} must be a positive integer; got {value!r}")
+    return value
+
+
+def _normalize_spec(
+    spec: dict,
+    *,
+    num_hidden_layers: int,
+    spec_index: int | None,
+    assigned_layers: dict[int, int | None],
+) -> HybridAttentionSpec:
+    context = _spec_context(spec_index)
+    normalized = dict(spec)
+
+    for field in ('layers', 'num_heads'):
+        if field not in normalized:
+            raise ValueError(f"{context} field {field!r} is required; got <missing>")
+
+    layers = normalized['layers']
+    if not isinstance(layers, (list, tuple)):
+        raise ValueError(
+            f"{context} field 'layers' must be a list or tuple of integer layer indices; got {layers!r}",
+        )
+
+    normalized_layers = []
+    seen_layers = set()
+    for layer_idx in layers:
+        if isinstance(layer_idx, bool) or not isinstance(layer_idx, int):
+            raise ValueError(
+                f"{context} field 'layers' must contain only integer layer indices; got {layer_idx!r}",
+            )
+        if layer_idx < 0 or layer_idx >= num_hidden_layers:
+            raise ValueError(
+                f"{context} field 'layers' contains out-of-range layer {layer_idx!r}; "
+                f"expected a value in [0, {num_hidden_layers})",
+            )
+        if layer_idx in seen_layers:
+            raise ValueError(f"{context} field 'layers' contains duplicate layer {layer_idx!r}; got {layers!r}")
+        if layer_idx in assigned_layers:
+            previous_index = assigned_layers[layer_idx]
+            previous_context = _spec_context(previous_index)
+            raise ValueError(
+                f"{context} assigns conflicting layer {layer_idx!r}, which is already assigned by {previous_context}",
+            )
+        seen_layers.add(layer_idx)
+        assigned_layers[layer_idx] = spec_index
+        normalized_layers.append(layer_idx)
+
+    normalized['layers'] = normalized_layers
+    normalized['num_heads'] = _positive_int(normalized['num_heads'], field='num_heads', context=context)
+
+    num_kv_heads = normalized.get('num_kv_heads')
+    if num_kv_heads is None:
+        num_kv_heads = normalized['num_heads']
+    normalized['num_kv_heads'] = _positive_int(num_kv_heads, field='num_kv_heads', context=context)
+
+    qkv_bias = normalized.get('qkv_bias', False)
+    if not isinstance(qkv_bias, bool):
+        raise ValueError(f"{context} field 'qkv_bias' must be a Boolean; got {qkv_bias!r}")
+    normalized['qkv_bias'] = qkv_bias
+
+    window_size = normalized.get('window_size')
+    if window_size is not None:
+        window_size = _positive_int(window_size, field='window_size', context=context)
+    normalized['window_size'] = window_size
+
+    rope_theta = normalized.get('rope_theta', 10000.)
+    if (
+        isinstance(rope_theta, bool)
+        or not isinstance(rope_theta, (int, float))
+        or not math.isfinite(rope_theta)
+        or rope_theta <= 0
+    ):
+        raise ValueError(f"{context} field 'rope_theta' must be positive; got {rope_theta!r}")
+    normalized['rope_theta'] = rope_theta
+
+    return normalized
+
+
+def normalize_hybrid_attention_config(
+    attn: HybridAttentionConfig,
+    *,
+    num_hidden_layers: int,
+) -> HybridAttentionConfig:
+    """Validate and normalize a hybrid-attention configuration.
+
+    The accepted forms are ``None``, one specification dictionary, or a list of
+    specification dictionaries. Defaults are applied independently to copied
+    dictionaries, unknown keys are preserved, and the input's outer dictionary
+    or list representation is retained. A layer may appear in only one
+    specification.
+    """
+    if attn is None:
+        return None
+    if isinstance(num_hidden_layers, bool) or not isinstance(num_hidden_layers, int) or num_hidden_layers < 0:
+        raise ValueError(f"field 'num_hidden_layers' must be a non-negative integer; got {num_hidden_layers!r}")
+    if not isinstance(attn, (dict, list)):
+        raise ValueError(f"attn must be None, a dictionary, or a list of dictionaries; got {attn!r}")
+
+    is_single_spec = isinstance(attn, dict)
+    specs = [attn] if is_single_spec else attn
+    assigned_layers: dict[int, int | None] = {}
+    normalized_specs = []
+
+    for spec_index, spec in enumerate(specs):
+        current_index = None if is_single_spec else spec_index
+        if not isinstance(spec, dict):
+            context = _spec_context(current_index)
+            raise ValueError(f"{context} must be a dictionary; got {spec!r}")
+        normalized_specs.append(
+            _normalize_spec(
+                spec,
+                num_hidden_layers=num_hidden_layers,
+                spec_index=current_index,
+                assigned_layers=assigned_layers,
+            ),
+        )
+
+    if is_single_spec:
+        return normalized_specs[0]
+    return normalized_specs
+
+
+def get_hybrid_attention_spec(
+    attn: HybridAttentionConfig,
+    *,
+    layer_idx: int,
+) -> HybridAttentionSpec | None:
+    """Return the normalized attention specification assigned to ``layer_idx``.
+
+    This lookup is intended for model block construction. Unassigned layers
+    return ``None`` and retain their model's native mixer.
+    """
+    if attn is None:
+        return None
+    specs = [attn] if isinstance(attn, dict) else attn
+    for spec in specs:
+        if layer_idx in spec['layers']:
+            return spec
+    return None

--- a/fla/models/kda/configuration_kda.py
+++ b/fla/models/kda/configuration_kda.py
@@ -7,6 +7,8 @@
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class KDAConfig(PretrainedConfig):
     model_type = 'kda'
@@ -31,7 +33,7 @@ class KDAConfig(PretrainedConfig):
         hidden_act: str = "swish",
         num_hidden_layers: int = 24,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -61,7 +63,7 @@ class KDAConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -77,18 +79,6 @@ class KDAConfig(PretrainedConfig):
 
         if safe_gate and lower_bound is None:
             raise ValueError("`lower_bound` must be specified when `safe_gate=True` (recommended: -5).")
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/kda/configuration_kda.py
+++ b/fla/models/kda/configuration_kda.py
@@ -7,10 +7,10 @@
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class KDAConfig(PretrainedConfig):
+class KDAConfig(_HybridAttentionConfigMixin, PretrainedConfig):
     model_type = 'kda'
     keys_to_ignore_at_inference = ['past_key_values']
 
@@ -63,7 +63,7 @@ class KDAConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/kda/modeling_kda.py
+++ b/fla/models/kda/modeling_kda.py
@@ -20,6 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.kda import KimiDeltaAttention
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.kda.configuration_kda import KDAConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -47,14 +48,15 @@ class KDABlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn["layers"]:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn["num_heads"],
-                num_kv_heads=config.attn["num_kv_heads"],
-                qkv_bias=config.attn["qkv_bias"],
-                window_size=config.attn["window_size"],
-                rope_theta=config.attn["rope_theta"],
+                num_heads=attn_spec["num_heads"],
+                num_kv_heads=attn_spec["num_kv_heads"],
+                qkv_bias=attn_spec["qkv_bias"],
+                window_size=attn_spec["window_size"],
+                rope_theta=attn_spec["rope_theta"],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/lightnet/configuration_lightnet.py
+++ b/fla/models/lightnet/configuration_lightnet.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class LightNetConfig(PretrainedConfig):
+class LightNetConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'lightnet'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -63,7 +63,7 @@ class LightNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/lightnet/configuration_lightnet.py
+++ b/fla/models/lightnet/configuration_lightnet.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class LightNetConfig(PretrainedConfig):
 
@@ -31,7 +33,7 @@ class LightNetConfig(PretrainedConfig):
         gate_low_rank_dim: int = 128,
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -61,7 +63,7 @@ class LightNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -83,18 +85,6 @@ class LightNetConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -20,6 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.lightnet import LightNetAttention
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.lightnet.configuration_lightnet import LightNetConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -48,13 +49,14 @@ class LightNetBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/linear_attn/configuration_linear_attn.py
+++ b/fla/models/linear_attn/configuration_linear_attn.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class LinearAttentionConfig(PretrainedConfig):
 
@@ -35,7 +37,7 @@ class LinearAttentionConfig(PretrainedConfig):
         max_position_embeddings: int = 2048,
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -69,7 +71,7 @@ class LinearAttentionConfig(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -91,18 +93,6 @@ class LinearAttentionConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/linear_attn/configuration_linear_attn.py
+++ b/fla/models/linear_attn/configuration_linear_attn.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class LinearAttentionConfig(PretrainedConfig):
+class LinearAttentionConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'linear_attn'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -71,7 +71,7 @@ class LinearAttentionConfig(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -20,6 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.linear_attn import LinearAttention
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.linear_attn.configuration_linear_attn import LinearAttentionConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -48,14 +49,15 @@ class LinearAttentionBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/mesa_net/configuration_mesa_net.py
+++ b/fla/models/mesa_net/configuration_mesa_net.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class MesaNetConfig(PretrainedConfig):
     model_type = 'mesa_net'
@@ -30,7 +32,7 @@ class MesaNetConfig(PretrainedConfig):
         hidden_act: str = "swish",
         num_hidden_layers: int = 24,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -62,7 +64,7 @@ class MesaNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.lambda_lower_bound = lambda_lower_bound
@@ -87,18 +89,6 @@ class MesaNetConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/mesa_net/configuration_mesa_net.py
+++ b/fla/models/mesa_net/configuration_mesa_net.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class MesaNetConfig(PretrainedConfig):
+class MesaNetConfig(_HybridAttentionConfigMixin, PretrainedConfig):
     model_type = 'mesa_net'
     keys_to_ignore_at_inference = ['past_key_values']
 
@@ -64,7 +64,7 @@ class MesaNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.lambda_lower_bound = lambda_lower_bound

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -20,6 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.mesa_net import MesaNet
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.mesa_net.configuration_mesa_net import MesaNetConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -48,14 +49,15 @@ class MesaNetBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/mom/configuration_mom.py
+++ b/fla/models/mom/configuration_mom.py
@@ -7,10 +7,10 @@
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class MomConfig(PretrainedConfig):
+class MomConfig(_HybridAttentionConfigMixin, PretrainedConfig):
     model_type = 'mom'
     keys_to_ignore_at_inference = ['past_key_values']
 
@@ -67,7 +67,7 @@ class MomConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/mom/configuration_mom.py
+++ b/fla/models/mom/configuration_mom.py
@@ -7,6 +7,8 @@
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class MomConfig(PretrainedConfig):
     model_type = 'mom'
@@ -28,7 +30,7 @@ class MomConfig(PretrainedConfig):
         hidden_act: str = "swish",
         num_hidden_layers: int = 24,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -65,7 +67,7 @@ class MomConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.num_hidden_layers = num_hidden_layers
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -86,16 +88,6 @@ class MomConfig(PretrainedConfig):
 
         if self.mom_backend not in ['gated_deltanet']:
             raise NotImplementedError(f"The MoM backend {mom_backend} is not currently supported.")
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['window_size'] = attn.get('window_size', None)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -20,6 +20,7 @@ from transformers.utils import logging
 
 from fla.layers import MomAttention
 from fla.layers.attn import Attention
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.mom.configuration_mom import MomConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -127,12 +128,13 @@ class MomBlock(GradientCheckpointingLayer):
         self.hidden_size = config.hidden_size
 
         self.attn_norm = RMSNorm(hidden_size=config.hidden_size, eps=config.norm_eps, dtype=torch.float32)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                window_size=config.attn['window_size'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                window_size=attn_spec['window_size'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/raven/configuration_raven.py
+++ b/fla/models/raven/configuration_raven.py
@@ -12,10 +12,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class RavenConfig(PretrainedConfig):
+class RavenConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'raven'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -86,7 +86,7 @@ class RavenConfig(PretrainedConfig):
         self.rope_theta = rope_theta
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/raven/configuration_raven.py
+++ b/fla/models/raven/configuration_raven.py
@@ -12,6 +12,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class RavenConfig(PretrainedConfig):
 
@@ -44,7 +46,7 @@ class RavenConfig(PretrainedConfig):
         rope_theta: float = 10000.,
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -84,7 +86,7 @@ class RavenConfig(PretrainedConfig):
         self.rope_theta = rope_theta
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -106,18 +108,6 @@ class RavenConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/raven/modeling_raven.py
+++ b/fla/models/raven/modeling_raven.py
@@ -23,6 +23,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.raven import Raven
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.raven.configuration_raven import RavenConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -51,14 +52,15 @@ class RavenBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/retnet/configuration_retnet.py
+++ b/fla/models/retnet/configuration_retnet.py
@@ -11,6 +11,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class RetNetConfig(PretrainedConfig):
 
@@ -36,7 +38,7 @@ class RetNetConfig(PretrainedConfig):
         max_position_embeddings: int = 2048,
         elementwise_affine: bool | None = True,
         norm_eps: float = 1e-6,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -70,7 +72,7 @@ class RetNetConfig(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 
@@ -92,18 +94,6 @@ class RetNetConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if attnres_block_size is not None and attnres_block_size != 1:
             if attnres_block_size < 2 or attnres_block_size % 2 != 0:

--- a/fla/models/retnet/configuration_retnet.py
+++ b/fla/models/retnet/configuration_retnet.py
@@ -11,10 +11,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class RetNetConfig(PretrainedConfig):
+class RetNetConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'retnet'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -72,7 +72,7 @@ class RetNetConfig(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.elementwise_affine = elementwise_affine
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
 

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -20,6 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.multiscale_retention import MultiScaleRetention
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.retnet.configuration_retnet import RetNetConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -48,14 +49,15 @@ class RetNetBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.attn_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/rodimus/configuration_rodimus.py
+++ b/fla/models/rodimus/configuration_rodimus.py
@@ -9,13 +9,21 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class RodimusConfig(PretrainedConfig):
+class RodimusConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'rodimus'
     keys_to_ignore_at_inference = ['past_key_values']
+
+    def _normalize_hybrid_attention_config(self, attn: HybridAttentionConfig) -> HybridAttentionConfig:
+        attn = super()._normalize_hybrid_attention_config(attn)
+        specs = [attn] if isinstance(attn, dict) else attn
+        if specs is not None:
+            for attn_spec in specs:
+                attn_spec.setdefault('qk_norm', False)
+        return attn
 
     def __init__(
         self,
@@ -69,12 +77,7 @@ class RodimusConfig(PretrainedConfig):
         self.norm_eps = norm_eps
         self.k_norm_eps = k_norm_eps
 
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
-        if isinstance(self.attn, dict):
-            self.attn.setdefault('qk_norm', False)
-        elif self.attn is not None:
-            for attn_spec in self.attn:
-                attn_spec.setdefault('qk_norm', False)
+        self.attn = attn
         self.ska_attn = ska_attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range

--- a/fla/models/rodimus/configuration_rodimus.py
+++ b/fla/models/rodimus/configuration_rodimus.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class RodimusConfig(PretrainedConfig):
 
@@ -33,7 +35,7 @@ class RodimusConfig(PretrainedConfig):
         max_position_embeddings: int = 2048,
         norm_eps: float = 1e-5,
         k_norm_eps: float | None = None,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         ska_attn: dict | None = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
@@ -67,7 +69,12 @@ class RodimusConfig(PretrainedConfig):
         self.norm_eps = norm_eps
         self.k_norm_eps = k_norm_eps
 
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        if isinstance(self.attn, dict):
+            self.attn.setdefault('qk_norm', False)
+        elif self.attn is not None:
+            for attn_spec in self.attn:
+                attn_spec.setdefault('qk_norm', False)
         self.ska_attn = ska_attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
@@ -89,19 +96,6 @@ class RodimusConfig(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['qk_norm'] = attn.get('qk_norm', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         if ska_attn is not None:
             if not isinstance(ska_attn, dict):

--- a/fla/models/rodimus/modeling_rodimus.py
+++ b/fla/models/rodimus/modeling_rodimus.py
@@ -21,6 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.rodimus import RodimusAttention, SlidingWindowSharedKeyAttention, align_multiple
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.rodimus.configuration_rodimus import RodimusConfig
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -77,16 +78,17 @@ class RodimusBlock(GradientCheckpointingLayer):
             eps=config.norm_eps,
         )
 
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self._is_ori_attn = True
             self.attn_norm = norm_cls()
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/rwkv6/configuration_rwkv6.py
+++ b/fla/models/rwkv6/configuration_rwkv6.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class RWKV6Config(PretrainedConfig):
+class RWKV6Config(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'rwkv6'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -63,7 +63,7 @@ class RWKV6Config(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.norm_bias = norm_bias
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.fuse_norm = fuse_norm

--- a/fla/models/rwkv6/configuration_rwkv6.py
+++ b/fla/models/rwkv6/configuration_rwkv6.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class RWKV6Config(PretrainedConfig):
 
@@ -32,7 +34,7 @@ class RWKV6Config(PretrainedConfig):
         norm_first: bool = True,
         norm_bias: bool = True,
         norm_eps: float = 1e-5,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -61,7 +63,7 @@ class RWKV6Config(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.norm_bias = norm_bias
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.fuse_norm = fuse_norm
@@ -80,18 +82,6 @@ class RWKV6Config(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -20,6 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.rwkv6 import LerpLinear, RWKV6Attention
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.rwkv6.configuration_rwkv6 import RWKV6Config
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
@@ -118,14 +119,15 @@ class RWKV6Block(GradientCheckpointingLayer):
             bias=config.norm_bias,
             eps=config.norm_eps,
         )
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/rwkv7/configuration_rwkv7.py
+++ b/fla/models/rwkv7/configuration_rwkv7.py
@@ -9,10 +9,10 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 
-class RWKV7Config(PretrainedConfig):
+class RWKV7Config(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = 'rwkv7'
     keys_to_ignore_at_inference = ['past_key_values']
@@ -86,7 +86,7 @@ class RWKV7Config(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.norm_bias = norm_bias
         self.norm_eps = norm_eps
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.fuse_norm = fuse_norm

--- a/fla/models/rwkv7/configuration_rwkv7.py
+++ b/fla/models/rwkv7/configuration_rwkv7.py
@@ -9,6 +9,8 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
 
 class RWKV7Config(PretrainedConfig):
 
@@ -33,7 +35,7 @@ class RWKV7Config(PretrainedConfig):
         norm_first: bool = True,
         norm_bias: bool = True,
         norm_eps: float = 1e-5,
-        attn: dict | None = None,
+        attn: HybridAttentionConfig = None,
         use_cache: bool = True,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
@@ -84,7 +86,7 @@ class RWKV7Config(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         self.norm_bias = norm_bias
         self.norm_eps = norm_eps
-        self.attn = attn
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.fuse_norm = fuse_norm
@@ -103,18 +105,6 @@ class RWKV7Config(PretrainedConfig):
                 "at the potential cost of reduced precision. "
                 "If you observe issues like loss divergence, consider disabling this setting.",
             )
-
-        if attn is not None:
-            if not isinstance(attn, dict):
-                raise ValueError("attn must be a dictionary")
-            if 'layers' not in attn:
-                raise ValueError("Layer indices must be provided to initialize hybrid attention layers")
-            if 'num_heads' not in attn:
-                raise ValueError("Number of heads must be provided to initialize hybrid attention layers")
-            attn['num_kv_heads'] = attn.get('num_kv_heads', attn['num_heads'])
-            attn['qkv_bias'] = attn.get('qkv_bias', False)
-            attn['window_size'] = attn.get('window_size', None)
-            attn['rope_theta'] = attn.get('rope_theta', 10000.)
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -20,6 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.rwkv7 import RWKV7Attention
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.rwkv7.configuration_rwkv7 import RWKV7Config
 from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
@@ -138,14 +139,15 @@ class RWKV7Block(GradientCheckpointingLayer):
             bias=config.norm_bias,
             eps=config.norm_eps,
         )
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.attn = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/models/samba/configuration_samba.py
+++ b/fla/models/samba/configuration_samba.py
@@ -10,10 +10,52 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
+from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+
+_DEFAULT_ATTN = {
+    'layers': (1, 3, 5, 7, 9, 11, 13, 15, 17),
+    'num_heads': 18,
+    'num_kv_heads': 18,
+    'qkv_bias': False,
+    'window_size': 2048,
+    'rope_theta': 10000.,
+}
+
+
+def _is_legacy_default_attn(attn: HybridAttentionConfig) -> bool:
+    if not isinstance(attn, dict) or attn.keys() != _DEFAULT_ATTN.keys():
+        return False
+    layers = attn['layers']
+    if not isinstance(layers, (list, tuple)) or tuple(layers) != _DEFAULT_ATTN['layers']:
+        return False
+    return all(attn[key] == value for key, value in _DEFAULT_ATTN.items() if key != 'layers')
+
+
+def _adapt_default_attn(num_hidden_layers: int) -> dict:
+    return {
+        **_DEFAULT_ATTN,
+        'layers': [layer_idx for layer_idx in _DEFAULT_ATTN['layers'] if layer_idx < num_hidden_layers],
+    }
+
 
 class SambaConfig(PretrainedConfig):
 
     model_type = "samba"
+
+    @classmethod
+    def from_dict(cls, config_dict: dict, **kwargs):
+        config_dict = config_dict.copy()
+        is_legacy_serialized_default = (
+            config_dict.get('model_type') == cls.model_type
+            and 'transformers_version' in config_dict
+            and _is_legacy_default_attn(config_dict.get('attn'))
+        )
+        if is_legacy_serialized_default:
+            # Before hybrid-plan validation, shallow Samba JSON retained the
+            # full depth-18 default. Adapt only that serialized legacy shape.
+            num_hidden_layers = config_dict.get('num_hidden_layers', 18)
+            config_dict['attn'] = _adapt_default_attn(num_hidden_layers)
+        return super().from_dict(config_dict, **kwargs)
 
     def __init__(
         self,
@@ -38,14 +80,7 @@ class SambaConfig(PretrainedConfig):
         time_step_init_scheme: str = "random",
         time_step_floor: float = 1e-4,
         max_position_embeddings: int = 2048,
-        attn: dict | None = {
-            'layers': (1, 3, 5, 7, 9, 11, 13, 15, 17),
-            'num_heads': 18,
-            'num_kv_heads': 18,
-            'qkv_bias': False,
-            'window_size': 2048,
-            'rope_theta': 10000.,
-        },
+        attn: HybridAttentionConfig = _DEFAULT_ATTN,
         hidden_ratio: int | None = 4,
         rescale_prenorm_residual: bool = False,
         use_cache: bool = True,
@@ -80,7 +115,9 @@ class SambaConfig(PretrainedConfig):
         self.time_step_init_scheme = time_step_init_scheme
         self.time_step_floor = time_step_floor
         self.max_position_embeddings = max_position_embeddings
-        self.attn = attn
+        if attn is _DEFAULT_ATTN:
+            attn = _adapt_default_attn(num_hidden_layers)
+        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
         self.hidden_ratio = hidden_ratio
         self.rescale_prenorm_residual = rescale_prenorm_residual
         self.residual_in_fp32 = residual_in_fp32

--- a/fla/models/samba/configuration_samba.py
+++ b/fla/models/samba/configuration_samba.py
@@ -10,7 +10,7 @@ import warnings
 
 from transformers.configuration_utils import PretrainedConfig
 
-from fla.models.hybrid import HybridAttentionConfig, normalize_hybrid_attention_config
+from fla.models.hybrid import HybridAttentionConfig, _HybridAttentionConfigMixin
 
 _DEFAULT_ATTN = {
     'layers': (1, 3, 5, 7, 9, 11, 13, 15, 17),
@@ -38,7 +38,7 @@ def _adapt_default_attn(num_hidden_layers: int) -> dict:
     }
 
 
-class SambaConfig(PretrainedConfig):
+class SambaConfig(_HybridAttentionConfigMixin, PretrainedConfig):
 
     model_type = "samba"
 
@@ -51,7 +51,7 @@ class SambaConfig(PretrainedConfig):
             and _is_legacy_default_attn(config_dict.get('attn'))
         )
         if is_legacy_serialized_default:
-            # Before hybrid-plan validation, shallow Samba JSON retained the
+            # before hybrid-plan validation, shallow Samba JSON retained the
             # full depth-18 default. Adapt only that serialized legacy shape.
             num_hidden_layers = config_dict.get('num_hidden_layers', 18)
             config_dict['attn'] = _adapt_default_attn(num_hidden_layers)
@@ -117,7 +117,7 @@ class SambaConfig(PretrainedConfig):
         self.max_position_embeddings = max_position_embeddings
         if attn is _DEFAULT_ATTN:
             attn = _adapt_default_attn(num_hidden_layers)
-        self.attn = normalize_hybrid_attention_config(attn, num_hidden_layers=num_hidden_layers)
+        self.attn = attn
         self.hidden_ratio = hidden_ratio
         self.rescale_prenorm_residual = rescale_prenorm_residual
         self.residual_in_fp32 = residual_in_fp32

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -19,6 +19,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.layers.mamba import Mamba
+from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.samba.configuration_samba import SambaConfig
 from fla.models.utils import Cache, FLAGenerationMixin
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
@@ -47,14 +48,15 @@ class SambaBlock(GradientCheckpointingLayer):
         self.layer_idx = layer_idx
 
         self.mixer_norm = RMSNorm(hidden_size=config.hidden_size, eps=config.norm_eps, dtype=torch.float32)
-        if config.attn is not None and layer_idx in config.attn['layers']:
+        attn_spec = get_hybrid_attention_spec(config.attn, layer_idx=layer_idx)
+        if attn_spec is not None:
             self.mixer = Attention(
                 hidden_size=config.hidden_size,
-                num_heads=config.attn['num_heads'],
-                num_kv_heads=config.attn['num_kv_heads'],
-                qkv_bias=config.attn['qkv_bias'],
-                window_size=config.attn['window_size'],
-                rope_theta=config.attn['rope_theta'],
+                num_heads=attn_spec['num_heads'],
+                num_kv_heads=attn_spec['num_kv_heads'],
+                qkv_bias=attn_spec['qkv_bias'],
+                window_size=attn_spec['window_size'],
+                rope_theta=attn_spec['rope_theta'],
                 max_position_embeddings=config.max_position_embeddings,
                 layer_idx=layer_idx,
             )

--- a/fla/modules/mlp.py
+++ b/fla/modules/mlp.py
@@ -28,12 +28,13 @@ if TYPE_CHECKING:
 
 
 class GatedMLP(nn.Module):
+
     def __init__(
         self,
         hidden_size: int,
         hidden_ratio: int | None = None,
         intermediate_size: int | None = None,
-        hidden_act: str = "swish",
+        hidden_act: str = 'swish',
         fuse_swiglu: bool = True,
         powglu_power: float = 3.0,
     ) -> GatedMLP:
@@ -53,13 +54,13 @@ class GatedMLP(nn.Module):
         self.fuse_swiglu = fuse_swiglu
         self.powglu_power = powglu_power
 
-        if hidden_act not in ("swish", "powlu"):
-            raise ValueError(f"Unsupported hidden_act: {hidden_act}")
+        if hidden_act not in ('swish', 'powlu'):
+            raise ValueError(f'Unsupported hidden_act: {hidden_act}')
 
         self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
-        if self.fuse_swiglu and hidden_act == "swish":
+        if self.fuse_swiglu and hidden_act == 'swish':
             self.swiglu_linear = SwiGLULinear()
 
     def forward(
@@ -68,7 +69,7 @@ class GatedMLP(nn.Module):
         **kwargs: Unpack[Any],
     ) -> torch.Tensor:
         gate, y = self.gate_proj(x), self.up_proj(x)
-        if self.hidden_act == "powlu":
+        if self.hidden_act == 'powlu':
             if self.fuse_swiglu:
                 return powglu_linear(gate, y, self.down_proj.weight, self.down_proj.bias, self.powglu_power)
             return self.down_proj(powglu(gate, y, self.powglu_power))
@@ -78,6 +79,7 @@ class GatedMLP(nn.Module):
 
 
 class SwiGLULinear(nn.Module):
+
     def forward(self, x, y, weight, bias):
         return swiglu_linear(x, y, weight, bias)
 
@@ -98,11 +100,7 @@ class SwiGLULinearParallel(ParallelStyle):
 
     @staticmethod
     def _prepare_input_fn(
-        input_layouts,
-        desired_input_layouts,
-        mod,
-        inputs,
-        device_mesh,
+        input_layouts, desired_input_layouts, mod, inputs, device_mesh,
     ):
         x, y, weight, bias = inputs
         if not isinstance(x, DTensor):

--- a/fla/modules/mlp.py
+++ b/fla/modules/mlp.py
@@ -28,13 +28,12 @@ if TYPE_CHECKING:
 
 
 class GatedMLP(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
         hidden_ratio: int | None = None,
         intermediate_size: int | None = None,
-        hidden_act: str = 'swish',
+        hidden_act: str = "swish",
         fuse_swiglu: bool = True,
         powglu_power: float = 3.0,
     ) -> GatedMLP:
@@ -54,13 +53,13 @@ class GatedMLP(nn.Module):
         self.fuse_swiglu = fuse_swiglu
         self.powglu_power = powglu_power
 
-        if hidden_act not in ('swish', 'powlu'):
-            raise ValueError(f'Unsupported hidden_act: {hidden_act}')
+        if hidden_act not in ("swish", "powlu"):
+            raise ValueError(f"Unsupported hidden_act: {hidden_act}")
 
         self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
-        if self.fuse_swiglu and hidden_act == 'swish':
+        if self.fuse_swiglu and hidden_act == "swish":
             self.swiglu_linear = SwiGLULinear()
 
     def forward(
@@ -69,7 +68,7 @@ class GatedMLP(nn.Module):
         **kwargs: Unpack[Any],
     ) -> torch.Tensor:
         gate, y = self.gate_proj(x), self.up_proj(x)
-        if self.hidden_act == 'powlu':
+        if self.hidden_act == "powlu":
             if self.fuse_swiglu:
                 return powglu_linear(gate, y, self.down_proj.weight, self.down_proj.bias, self.powglu_power)
             return self.down_proj(powglu(gate, y, self.powglu_power))
@@ -79,7 +78,6 @@ class GatedMLP(nn.Module):
 
 
 class SwiGLULinear(nn.Module):
-
     def forward(self, x, y, weight, bias):
         return swiglu_linear(x, y, weight, bias)
 
@@ -100,7 +98,11 @@ class SwiGLULinearParallel(ParallelStyle):
 
     @staticmethod
     def _prepare_input_fn(
-        input_layouts, desired_input_layouts, mod, inputs, device_mesh,
+        input_layouts,
+        desired_input_layouts,
+        mod,
+        inputs,
+        device_mesh,
     ):
         x, y, weight, bias = inputs
         if not isinstance(x, DTensor):

--- a/tests/models/test_hybrid_attention.py
+++ b/tests/models/test_hybrid_attention.py
@@ -1,0 +1,592 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import json
+from copy import deepcopy
+
+import pytest
+import torch
+
+import fla.layers.attn as attn_module
+from fla.layers.attn import Attention
+from fla.layers.gated_deltanet import GatedDeltaNet
+from fla.layers.gla import GatedLinearAttention
+from fla.layers.mamba import Mamba
+from fla.models import (
+    ABCConfig,
+    CombaConfig,
+    DeltaFormerConfig,
+    DeltaNetConfig,
+    GatedDeltaNetConfig,
+    GatedDeltaProductConfig,
+    GLAConfig,
+    GSAConfig,
+    HGRN2Config,
+    HGRNConfig,
+    KDAConfig,
+    LightNetConfig,
+    LinearAttentionConfig,
+    MesaNetConfig,
+    MomConfig,
+    RavenConfig,
+    RetNetConfig,
+    RodimusConfig,
+    RWKV6Config,
+    RWKV7Config,
+    SambaConfig,
+)
+from fla.models.gated_deltanet.modeling_gated_deltanet import GatedDeltaNetBlock
+from fla.models.gla.modeling_gla import GLABlock, GLAForCausalLM
+from fla.models.hybrid import get_hybrid_attention_spec, normalize_hybrid_attention_config
+from fla.models.samba.modeling_samba import SambaBlock
+from fla.utils import assert_close, device, device_platform
+
+CONFIG_CLASSES = (
+    ABCConfig,
+    CombaConfig,
+    DeltaNetConfig,
+    DeltaFormerConfig,
+    GatedDeltaNetConfig,
+    GatedDeltaProductConfig,
+    GLAConfig,
+    GSAConfig,
+    HGRNConfig,
+    HGRN2Config,
+    KDAConfig,
+    LightNetConfig,
+    LinearAttentionConfig,
+    MesaNetConfig,
+    MomConfig,
+    RavenConfig,
+    RetNetConfig,
+    RodimusConfig,
+    RWKV6Config,
+    RWKV7Config,
+    SambaConfig,
+)
+
+SAMBA_CANONICAL_ATTN = {
+    'layers': [1, 3, 5, 7, 9, 11, 13, 15, 17],
+    'num_heads': 18,
+    'num_kv_heads': 18,
+    'qkv_bias': False,
+    'window_size': 2048,
+    'rope_theta': 10000.,
+}
+
+
+def test_normalize_none():
+    assert normalize_hybrid_attention_config(None, num_hidden_layers=4) is None
+    assert normalize_hybrid_attention_config(None, num_hidden_layers='unused') is None
+
+
+def test_normalize_dictionary_defaults_and_unknown_keys():
+    source = {
+        'layers': [3, 1],
+        'num_heads': 8,
+        'extension': {'mode': 'custom'},
+    }
+    original = deepcopy(source)
+
+    normalized = normalize_hybrid_attention_config(source, num_hidden_layers=4)
+
+    assert isinstance(normalized, dict)
+    assert normalized == {
+        'layers': [3, 1],
+        'num_heads': 8,
+        'num_kv_heads': 8,
+        'qkv_bias': False,
+        'window_size': None,
+        'rope_theta': 10000.,
+        'extension': {'mode': 'custom'},
+    }
+    assert source == original
+    assert normalized is not source
+    assert normalized['layers'] is not source['layers']
+    json.dumps(normalized)
+
+
+def test_normalize_list_defaults_each_specification():
+    source = [
+        {'layers': [0, 2], 'num_heads': 8, 'num_kv_heads': 2, 'qkv_bias': True, 'window_size': 128},
+        {'layers': [3], 'num_heads': 4, 'num_kv_heads': None, 'rope_theta': 500000.},
+    ]
+    original = deepcopy(source)
+
+    normalized = normalize_hybrid_attention_config(source, num_hidden_layers=4)
+
+    assert isinstance(normalized, list)
+    assert normalized[0] == {
+        'layers': [0, 2],
+        'num_heads': 8,
+        'num_kv_heads': 2,
+        'qkv_bias': True,
+        'window_size': 128,
+        'rope_theta': 10000.,
+    }
+    assert normalized[1] == {
+        'layers': [3],
+        'num_heads': 4,
+        'num_kv_heads': 4,
+        'qkv_bias': False,
+        'window_size': None,
+        'rope_theta': 500000.,
+    }
+    assert source == original
+    assert normalized is not source
+
+
+@pytest.mark.parametrize(
+    ('attn', 'expected'),
+    [
+        pytest.param([], [], id='empty-plan'),
+        pytest.param({'layers': [], 'num_heads': 2}, {
+            'layers': [],
+            'num_heads': 2,
+            'num_kv_heads': 2,
+            'qkv_bias': False,
+            'window_size': None,
+            'rope_theta': 10000.,
+        }, id='empty-layers'),
+    ],
+)
+def test_normalize_empty_forms(attn, expected):
+    assert normalize_hybrid_attention_config(attn, num_hidden_layers=4) == expected
+
+
+@pytest.mark.parametrize(
+    ('attn', 'match'),
+    [
+        pytest.param(1, r"attn.*dictionary.*1", id='invalid-outer'),
+        pytest.param([{'layers': [0], 'num_heads': 2}, 'invalid'], r"index 1.*dictionary.*'invalid'", id='list-item'),
+        pytest.param({'num_heads': 2}, r"layers.*missing", id='missing-layers'),
+        pytest.param({'layers': [0]}, r"num_heads.*missing", id='missing-num-heads'),
+        pytest.param({'layers': 0, 'num_heads': 2}, r"layers.*list or tuple.*0", id='layers-container'),
+        pytest.param({'layers': [-1], 'num_heads': 2}, r"layers.*-1", id='negative-layer'),
+        pytest.param({'layers': [4], 'num_heads': 2}, r"layers.*4", id='out-of-range-layer'),
+        pytest.param({'layers': [1, 1], 'num_heads': 2}, r"duplicate layer 1", id='duplicate-layer'),
+        pytest.param([
+            {'layers': [1], 'num_heads': 2},
+            {'layers': [1], 'num_heads': 2},
+        ], r"index 1.*conflicting layer 1", id='overlapping-specs'),
+        pytest.param({'layers': [True], 'num_heads': 2}, r"layers.*True", id='boolean-layer'),
+        pytest.param({'layers': [1.], 'num_heads': 2}, r"layers.*1.0", id='non-integer-layer'),
+    ],
+)
+def test_normalize_invalid_structure(attn, match):
+    with pytest.raises(ValueError, match=match):
+        normalize_hybrid_attention_config(attn, num_hidden_layers=4)
+
+
+@pytest.mark.parametrize('value', [0, -1, True, 1.5, None, '8'])
+def test_normalize_invalid_num_heads(value):
+    with pytest.raises(ValueError, match=rf"num_heads.*{value!r}"):
+        normalize_hybrid_attention_config({'layers': [0], 'num_heads': value}, num_hidden_layers=1)
+
+
+@pytest.mark.parametrize('value', [0, -1, True, 1.5, '2'])
+def test_normalize_invalid_num_kv_heads(value):
+    with pytest.raises(ValueError, match=rf"num_kv_heads.*{value!r}"):
+        normalize_hybrid_attention_config(
+            {'layers': [0], 'num_heads': 4, 'num_kv_heads': value},
+            num_hidden_layers=1,
+        )
+
+
+@pytest.mark.parametrize('value', [0, 1, None, 'false'])
+def test_normalize_invalid_qkv_bias(value):
+    with pytest.raises(ValueError, match=rf"qkv_bias.*{value!r}"):
+        normalize_hybrid_attention_config({'layers': [0], 'num_heads': 2, 'qkv_bias': value}, num_hidden_layers=1)
+
+
+@pytest.mark.parametrize('value', [0, -1, True, 1.5])
+def test_normalize_invalid_window_size(value):
+    with pytest.raises(ValueError, match=rf"window_size.*{value!r}"):
+        normalize_hybrid_attention_config({'layers': [0], 'num_heads': 2, 'window_size': value}, num_hidden_layers=1)
+
+
+@pytest.mark.parametrize('value', [0, -1., True, None, '10000', float('nan'), float('inf')])
+def test_normalize_invalid_rope_theta(value):
+    with pytest.raises(ValueError, match=rf"rope_theta.*{value!r}"):
+        normalize_hybrid_attention_config({'layers': [0], 'num_heads': 2, 'rope_theta': value}, num_hidden_layers=1)
+
+
+def test_list_error_identifies_specification_index_and_value():
+    with pytest.raises(ValueError, match=r"index 1.*window_size.*0"):
+        normalize_hybrid_attention_config(
+            [
+                {'layers': [0], 'num_heads': 2},
+                {'layers': [1], 'num_heads': 2, 'window_size': 0},
+            ],
+            num_hidden_layers=2,
+        )
+
+
+def test_lookup_heterogeneous_plan():
+    normalized = normalize_hybrid_attention_config(
+        [
+            {'layers': [4, 1], 'num_heads': 8, 'window_size': 128},
+            {'layers': [5], 'num_heads': 4, 'window_size': None},
+        ],
+        num_hidden_layers=6,
+    )
+
+    assert get_hybrid_attention_spec(normalized, layer_idx=1) is normalized[0]
+    assert get_hybrid_attention_spec(normalized, layer_idx=4) is normalized[0]
+    assert get_hybrid_attention_spec(normalized, layer_idx=5) is normalized[1]
+    assert get_hybrid_attention_spec(normalized, layer_idx=0) is None
+
+
+def test_lookup_dictionary_and_one_item_list_are_equivalent():
+    spec = {'layers': [1, 3], 'num_heads': 4, 'num_kv_heads': 2}
+    dictionary = normalize_hybrid_attention_config(spec, num_hidden_layers=4)
+    plan = normalize_hybrid_attention_config([spec], num_hidden_layers=4)
+
+    for layer_idx in range(4):
+        assert get_hybrid_attention_spec(dictionary, layer_idx=layer_idx) == get_hybrid_attention_spec(
+            plan,
+            layer_idx=layer_idx,
+        )
+
+
+def test_lookup_list_order_does_not_change_disjoint_assignments():
+    first = normalize_hybrid_attention_config(
+        [{'layers': [0], 'num_heads': 2}, {'layers': [2], 'num_heads': 4}],
+        num_hidden_layers=3,
+    )
+    second = normalize_hybrid_attention_config(
+        [{'layers': [2], 'num_heads': 4}, {'layers': [0], 'num_heads': 2}],
+        num_hidden_layers=3,
+    )
+
+    for layer_idx in range(3):
+        assert get_hybrid_attention_spec(first, layer_idx=layer_idx) == get_hybrid_attention_spec(
+            second,
+            layer_idx=layer_idx,
+        )
+
+
+@pytest.mark.parametrize('config_class', CONFIG_CLASSES, ids=lambda config_class: config_class.model_type)
+def test_config_accepts_none(config_class):
+    assert config_class(num_hidden_layers=3, attn=None).attn is None
+
+
+@pytest.mark.parametrize('config_class', CONFIG_CLASSES, ids=lambda config_class: config_class.model_type)
+@pytest.mark.parametrize('outer_type', ['dictionary', 'list'])
+def test_config_normalization_and_round_trip(config_class, outer_type, tmp_path):
+    source_spec = {'layers': [1], 'num_heads': 2, 'extension': 'preserved'}
+    source = source_spec if outer_type == 'dictionary' else [source_spec]
+    original = deepcopy(source)
+
+    config = config_class(num_hidden_layers=3, attn=source)
+    serialized = config.to_dict()['attn']
+
+    assert source == original
+    assert isinstance(config.attn, dict if outer_type == 'dictionary' else list)
+    assert isinstance(serialized, dict if outer_type == 'dictionary' else list)
+    spec = config.attn if outer_type == 'dictionary' else config.attn[0]
+    assert spec['num_kv_heads'] == 2
+    assert spec['qkv_bias'] is False
+    assert spec['window_size'] is None
+    assert spec['rope_theta'] == 10000.
+    assert spec['extension'] == 'preserved'
+
+    config.save_pretrained(tmp_path)
+    reloaded = config_class.from_pretrained(tmp_path)
+    assert isinstance(reloaded.attn, dict if outer_type == 'dictionary' else list)
+    assert reloaded.attn == config.attn
+
+
+def test_samba_canonical_default_adapts_to_model_depth():
+    shallow = SambaConfig(num_hidden_layers=2)
+    deep = SambaConfig(num_hidden_layers=20)
+
+    assert shallow.attn['layers'] == [1]
+    assert deep.attn['layers'] == [1, 3, 5, 7, 9, 11, 13, 15, 17]
+    assert 19 not in deep.attn['layers']
+
+
+def test_samba_legacy_default_load_adapts_to_model_depth(tmp_path):
+    legacy_config = SambaConfig().to_dict()
+    legacy_config['num_hidden_layers'] = 2
+    (tmp_path / 'config.json').write_text(json.dumps(legacy_config))
+
+    reloaded = SambaConfig.from_pretrained(tmp_path)
+
+    assert reloaded.attn['layers'] == [1]
+
+
+@pytest.mark.parametrize('outer_type', ['dictionary', 'list'])
+def test_samba_explicit_canonical_out_of_range_plan_is_rejected(outer_type):
+    attn = SAMBA_CANONICAL_ATTN if outer_type == 'dictionary' else [SAMBA_CANONICAL_ATTN]
+
+    with pytest.raises(ValueError, match=r"layers.*3"):
+        SambaConfig(num_hidden_layers=2, attn=attn)
+
+
+@pytest.mark.parametrize('outer_type', ['dictionary', 'list'])
+def test_samba_from_dict_explicit_canonical_out_of_range_plan_is_rejected(outer_type):
+    attn = SAMBA_CANONICAL_ATTN if outer_type == 'dictionary' else [SAMBA_CANONICAL_ATTN]
+
+    with pytest.raises(ValueError, match=r"layers.*3"):
+        SambaConfig.from_dict({'num_hidden_layers': 2, 'attn': attn})
+
+
+def test_rodimus_qk_norm_defaults_each_specification():
+    config = RodimusConfig(
+        num_hidden_layers=2,
+        attn=[
+            {'layers': [0], 'num_heads': 2},
+            {'layers': [1], 'num_heads': 2, 'qk_norm': True},
+        ],
+    )
+
+    assert config.attn[0]['qk_norm'] is False
+    assert config.attn[1]['qk_norm'] is True
+
+
+@pytest.fixture
+def allow_attention_construction(monkeypatch):
+    monkeypatch.setattr(attn_module, 'flash_attn_func', object())
+
+
+REPRESENTATIVE_BLOCKS = [
+    pytest.param(
+        GLAConfig,
+        GLABlock,
+        'attn',
+        GatedLinearAttention,
+        {'num_heads': 4, 'expand_v': 1., 'hidden_ratio': 2},
+        id='gla',
+    ),
+    pytest.param(
+        GatedDeltaNetConfig,
+        GatedDeltaNetBlock,
+        'attn',
+        GatedDeltaNet,
+        {'num_heads': 4, 'head_dim': 8, 'expand_v': 1., 'hidden_ratio': 2},
+        id='gated-deltanet',
+    ),
+    pytest.param(
+        SambaConfig,
+        SambaBlock,
+        'mixer',
+        Mamba,
+        {'state_size': 4, 'expand': 2, 'hidden_ratio': 2},
+        id='samba',
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ('config_class', 'block_class', 'mixer_attr', 'native_class', 'config_kwargs'),
+    REPRESENTATIVE_BLOCKS,
+)
+def test_heterogeneous_model_block_construction(
+    allow_attention_construction,
+    config_class,
+    block_class,
+    mixer_attr,
+    native_class,
+    config_kwargs,
+):
+    config = config_class(
+        hidden_size=32,
+        num_hidden_layers=6,
+        attn=[
+            {
+                'layers': [1, 4],
+                'num_heads': 4,
+                'num_kv_heads': 2,
+                'qkv_bias': True,
+                'window_size': 8,
+                'rope_theta': 20000.,
+            },
+            {
+                'layers': [5],
+                'num_heads': 8,
+                'num_kv_heads': 4,
+                'qkv_bias': False,
+                'window_size': None,
+                'rope_theta': 40000.,
+            },
+        ],
+        fuse_norm=False,
+        fuse_swiglu=False,
+        fuse_cross_entropy=False,
+        vocab_size=64,
+        **config_kwargs,
+    )
+    blocks = [block_class(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+
+    for layer_idx in (0, 2, 3):
+        assert isinstance(getattr(blocks[layer_idx], mixer_attr), native_class)
+    for layer_idx in (1, 4, 5):
+        assert isinstance(getattr(blocks[layer_idx], mixer_attr), Attention)
+
+    local_attn = getattr(blocks[1], mixer_attr)
+    assert local_attn.num_heads == 4
+    assert local_attn.num_kv_heads == 2
+    assert local_attn.qkv_bias is True
+    assert local_attn.window_size == 8
+    assert local_attn.rope_theta == 20000.
+
+    full_attn = getattr(blocks[5], mixer_attr)
+    assert full_attn.num_heads == 8
+    assert full_attn.num_kv_heads == 4
+    assert full_attn.qkv_bias is False
+    assert full_attn.window_size is None
+    assert full_attn.rope_theta == 40000.
+
+
+@pytest.mark.parametrize(
+    ('config_class', 'block_class', 'mixer_attr', 'native_class', 'config_kwargs'),
+    REPRESENTATIVE_BLOCKS,
+)
+def test_old_dictionary_model_block_construction(
+    allow_attention_construction,
+    config_class,
+    block_class,
+    mixer_attr,
+    native_class,
+    config_kwargs,
+):
+    config = config_class(
+        hidden_size=32,
+        num_hidden_layers=2,
+        attn={
+            'layers': [1],
+            'num_heads': 4,
+            'num_kv_heads': 2,
+            'qkv_bias': True,
+            'window_size': 8,
+            'rope_theta': 20000.,
+        },
+        fuse_norm=False,
+        fuse_swiglu=False,
+        fuse_cross_entropy=False,
+        vocab_size=64,
+        **config_kwargs,
+    )
+
+    native_block = block_class(config, 0)
+    attention_block = block_class(config, 1)
+    attention = getattr(attention_block, mixer_attr)
+
+    assert isinstance(getattr(native_block, mixer_attr), native_class)
+    assert isinstance(attention, Attention)
+    assert attention.num_heads == 4
+    assert attention.num_kv_heads == 2
+    assert attention.qkv_bias is True
+    assert attention.window_size == 8
+    assert attention.rope_theta == 20000.
+
+
+def _tiny_gla_config(attn):
+    return GLAConfig(
+        hidden_size=32,
+        num_hidden_layers=3,
+        num_heads=4,
+        hidden_ratio=2,
+        attn=attn,
+        max_position_embeddings=32,
+        fuse_norm=False,
+        fuse_swiglu=False,
+        fuse_cross_entropy=False,
+        vocab_size=64,
+    )
+
+
+def test_dictionary_and_one_item_list_architecture_equivalence(allow_attention_construction, tmp_path):
+    spec = {
+        'layers': [1],
+        'num_heads': 4,
+        'num_kv_heads': 2,
+        'qkv_bias': True,
+        'window_size': 16,
+        'rope_theta': 20000.,
+    }
+    dictionary_model = GLAForCausalLM(_tiny_gla_config(spec))
+    list_model = GLAForCausalLM(_tiny_gla_config([spec]))
+
+    dictionary_state = dictionary_model.state_dict()
+    list_state = list_model.state_dict()
+    assert dictionary_state.keys() == list_state.keys()
+    assert {key: value.shape for key, value in dictionary_state.items()} == {
+        key: value.shape for key, value in list_state.items()
+    }
+    assert [type(layer.attn) for layer in dictionary_model.model.layers] == [
+        type(layer.attn) for layer in list_model.model.layers
+    ]
+    dictionary_attention = dictionary_model.model.layers[1].attn
+    list_attention = list_model.model.layers[1].attn
+    for attribute in ('num_heads', 'num_kv_heads', 'qkv_bias', 'window_size', 'rope_theta'):
+        assert getattr(dictionary_attention, attribute) == getattr(list_attention, attribute)
+    list_model.load_state_dict(dictionary_state, strict=True)
+
+    for name, config in (('dictionary', dictionary_model.config), ('list', list_model.config)):
+        output_dir = tmp_path / name
+        config.save_pretrained(output_dir)
+        reloaded_config = GLAConfig.from_pretrained(output_dir)
+        reloaded_model = GLAForCausalLM(reloaded_config)
+        assert reloaded_model.state_dict().keys() == dictionary_state.keys()
+        assert isinstance(reloaded_config.attn, dict if name == 'dictionary' else list)
+
+
+@pytest.mark.skipif(
+    attn_module.flash_attn_func is None
+    or device_platform not in ('cuda', 'hip')
+    or not torch.cuda.is_bf16_supported(),
+    reason="numerical hybrid equivalence requires FlashAttention and BF16 on a CUDA or ROCm device",
+)
+def test_dictionary_and_one_item_list_numerical_equivalence():
+    spec = {
+        'layers': [1],
+        'num_heads': 4,
+        'num_kv_heads': 2,
+        'qkv_bias': True,
+        'window_size': None,
+        'rope_theta': 10000.,
+    }
+    common = {
+        'hidden_size': 32,
+        'num_hidden_layers': 2,
+        'num_heads': 4,
+        'hidden_ratio': 2,
+        'max_position_embeddings': 16,
+        'fuse_norm': False,
+        'fuse_swiglu': False,
+        'fuse_cross_entropy': False,
+        'vocab_size': 64,
+    }
+    torch.manual_seed(42)
+    dictionary_model = GLAForCausalLM(GLAConfig(attn=spec, **common)).to(torch.bfloat16).to(device)
+    list_model = GLAForCausalLM(GLAConfig(attn=[spec], **common)).to(torch.bfloat16).to(device)
+    list_model.load_state_dict(dictionary_model.state_dict(), strict=True)
+    dictionary_model.train()
+    list_model.train()
+
+    input_ids = torch.randint(0, 64, (1, 8), device=device)
+    dictionary_logits = dictionary_model(input_ids, use_cache=False).logits
+    list_logits = list_model(input_ids, use_cache=False).logits
+    assert_close('logits', dictionary_logits, list_logits, 1e-5)
+
+    dictionary_logits.float().square().mean().backward()
+    list_logits.float().square().mean().backward()
+    dictionary_grads = {
+        name: parameter.grad.detach().clone()
+        for name, parameter in dictionary_model.named_parameters()
+        if parameter.grad is not None
+    }
+    list_grads = {
+        name: parameter.grad.detach().clone()
+        for name, parameter in list_model.named_parameters()
+        if parameter.grad is not None
+    }
+    assert dictionary_grads.keys() == list_grads.keys()
+    for name in dictionary_grads:
+        assert_close(f'gradient {name}', dictionary_grads[name], list_grads[name], 1e-5)

--- a/tests/models/test_hybrid_attention.py
+++ b/tests/models/test_hybrid_attention.py
@@ -43,7 +43,7 @@ from fla.models.gated_deltanet.modeling_gated_deltanet import GatedDeltaNetBlock
 from fla.models.gla.modeling_gla import GLABlock, GLAForCausalLM
 from fla.models.hybrid import get_hybrid_attention_spec, normalize_hybrid_attention_config
 from fla.models.samba.modeling_samba import SambaBlock
-from fla.utils import assert_close, device, device_platform
+from fla.utils import assert_close, device, device_platform, device_torch_lib
 
 CONFIG_CLASSES = (
     ABCConfig,
@@ -209,7 +209,10 @@ def test_normalize_invalid_window_size(value):
         normalize_hybrid_attention_config({'layers': [0], 'num_heads': 2, 'window_size': value}, num_hidden_layers=1)
 
 
-@pytest.mark.parametrize('value', [0, -1., True, None, '10000', float('nan'), float('inf')])
+@pytest.mark.parametrize(
+    'value',
+    [0, -1., True, None, '10000', float('nan'), float('inf'), pytest.param(10**1000, id='overflowing-integer')],
+)
 def test_normalize_invalid_rope_theta(value):
     with pytest.raises(ValueError, match=rf"rope_theta.*{value!r}"):
         normalize_hybrid_attention_config({'layers': [0], 'num_heads': 2, 'rope_theta': value}, num_hidden_layers=1)
@@ -301,6 +304,68 @@ def test_config_normalization_and_round_trip(config_class, outer_type, tmp_path)
     assert reloaded.attn == config.attn
 
 
+@pytest.mark.parametrize('config_class', CONFIG_CLASSES, ids=lambda config_class: config_class.model_type)
+@pytest.mark.parametrize('outer_type', ['dictionary', 'list'])
+def test_config_assignment_normalizes(config_class, outer_type):
+    source_spec = {'layers': [1], 'num_heads': 2, 'extension': 'preserved'}
+    source = source_spec if outer_type == 'dictionary' else [source_spec]
+    original = deepcopy(source)
+    config = config_class(num_hidden_layers=3, attn=None)
+
+    config.attn = source
+
+    spec = config.attn if outer_type == 'dictionary' else config.attn[0]
+    assert source == original
+    assert spec['num_kv_heads'] == 2
+    assert spec['qkv_bias'] is False
+    assert spec['window_size'] is None
+    assert spec['rope_theta'] == 10000.
+    assert spec['extension'] == 'preserved'
+
+
+@pytest.mark.parametrize('config_class', CONFIG_CLASSES, ids=lambda config_class: config_class.model_type)
+@pytest.mark.parametrize('outer_type', ['dictionary', 'list'])
+def test_config_from_dict_override_normalizes(config_class, outer_type):
+    source_spec = {'layers': [1], 'num_heads': 2}
+    source = source_spec if outer_type == 'dictionary' else [source_spec]
+
+    config = config_class.from_dict(
+        {'num_hidden_layers': 3, 'attn': None},
+        attn=source,
+    )
+
+    spec = config.attn if outer_type == 'dictionary' else config.attn[0]
+    assert spec['num_kv_heads'] == 2
+    assert spec['qkv_bias'] is False
+    assert spec['window_size'] is None
+    assert spec['rope_theta'] == 10000.
+
+
+def test_config_from_pretrained_override_normalizes(tmp_path):
+    GLAConfig(num_hidden_layers=3, attn=None).save_pretrained(tmp_path)
+
+    config = GLAConfig.from_pretrained(
+        tmp_path,
+        attn=[{'layers': [1], 'num_heads': 2}],
+    )
+
+    assert config.attn == [{
+        'layers': [1],
+        'num_heads': 2,
+        'num_kv_heads': 2,
+        'qkv_bias': False,
+        'window_size': None,
+        'rope_theta': 10000.,
+    }]
+
+
+def test_config_assignment_rejects_invalid_plan():
+    config = GLAConfig(num_hidden_layers=2, attn=None)
+
+    with pytest.raises(ValueError, match=r"layers.*2"):
+        config.attn = {'layers': [2], 'num_heads': 2}
+
+
 def test_samba_canonical_default_adapts_to_model_depth():
     shallow = SambaConfig(num_hidden_layers=2)
     deep = SambaConfig(num_hidden_layers=20)
@@ -337,13 +402,11 @@ def test_samba_from_dict_explicit_canonical_out_of_range_plan_is_rejected(outer_
 
 
 def test_rodimus_qk_norm_defaults_each_specification():
-    config = RodimusConfig(
-        num_hidden_layers=2,
-        attn=[
-            {'layers': [0], 'num_heads': 2},
-            {'layers': [1], 'num_heads': 2, 'qk_norm': True},
-        ],
-    )
+    config = RodimusConfig(num_hidden_layers=2, attn=None)
+    config.attn = [
+        {'layers': [0], 'num_heads': 2},
+        {'layers': [1], 'num_heads': 2, 'qk_norm': True},
+    ]
 
     assert config.attn[0]['qk_norm'] is False
     assert config.attn[1]['qk_norm'] is True
@@ -501,6 +564,14 @@ def _tiny_gla_config(attn):
     )
 
 
+def _has_bf16_flash_attention():
+    return (
+        attn_module.flash_attn_func is not None
+        and device_platform in ('cuda', 'hip')
+        and device_torch_lib.is_bf16_supported()
+    )
+
+
 def test_dictionary_and_one_item_list_architecture_equivalence(allow_attention_construction, tmp_path):
     spec = {
         'layers': [1],
@@ -538,9 +609,7 @@ def test_dictionary_and_one_item_list_architecture_equivalence(allow_attention_c
 
 
 @pytest.mark.skipif(
-    attn_module.flash_attn_func is None
-    or device_platform not in ('cuda', 'hip')
-    or not torch.cuda.is_bf16_supported(),
+    not _has_bf16_flash_attention(),
     reason="numerical hybrid equivalence requires FlashAttention and BF16 on a CUDA or ROCm device",
 )
 def test_dictionary_and_one_item_list_numerical_equivalence():

--- a/tests/models/test_hybrid_attention.py
+++ b/tests/models/test_hybrid_attention.py
@@ -659,3 +659,32 @@ def test_dictionary_and_one_item_list_numerical_equivalence():
     assert dictionary_grads.keys() == list_grads.keys()
     for name in dictionary_grads:
         assert_close(f'gradient {name}', dictionary_grads[name], list_grads[name], 1e-5)
+
+
+@pytest.mark.skipif(
+    not _has_bf16_flash_attention(),
+    reason="heterogeneous plan smoke requires FlashAttention and BF16 on a CUDA or ROCm device",
+)
+def test_heterogeneous_plan_numerical_smoke():
+    """A plan with two different specs must run end to end on GPU.
+
+    Covers the actual heterogeneous case (SWA + native mixer + full attention
+    in one model) that the dictionary/list equivalence tests cannot reach.
+    """
+    attn = [
+        {'layers': [0], 'num_heads': 4, 'num_kv_heads': 2, 'window_size': 4},
+        {'layers': [2], 'num_heads': 4, 'num_kv_heads': 4, 'qkv_bias': True, 'window_size': None},
+    ]
+    torch.manual_seed(42)
+    model = GLAForCausalLM(_tiny_gla_config(attn)).to(torch.bfloat16).to(device)
+    model.train()
+
+    input_ids = torch.randint(0, 64, (2, 16), device=device)
+    logits = model(input_ids, use_cache=False).logits
+    assert logits.shape == (2, 16, 64)
+    assert torch.isfinite(logits).all()
+
+    logits.float().square().mean().backward()
+    for name, parameter in model.named_parameters():
+        if parameter.grad is not None:
+            assert torch.isfinite(parameter.grad).all(), f'non-finite gradient: {name}'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,33 +17,33 @@ def test_assert_close_accepts_close_tensors_and_rejects_mismatch():
     ref = torch.tensor([1.0, 2.0, 3.0])
     tri = ref + 1e-7
 
-    fu.assert_close('close', ref, tri, 1e-3)
+    fu.assert_close("close", ref, tri, 1e-3)
 
-    with pytest.raises(AssertionError, match='mismatch'):
-        fu.assert_close('mismatch', ref, ref + 1.0, 1e-3)
+    with pytest.raises(AssertionError, match="mismatch"):
+        fu.assert_close("mismatch", ref, ref + 1.0, 1e-3)
 
 
 def test_tensor_cache_uses_identity_until_disabled(monkeypatch):
-    calls = {'count': 0}
+    calls = {"count": 0}
 
     @fu.tensor_cache
     def cached_add_one(x):
-        calls['count'] += 1
+        calls["count"] += 1
         return x + 1
 
     x = torch.tensor([1.0])
     y = cached_add_one(x)
 
     assert cached_add_one(x) is y
-    assert calls['count'] == 1
+    assert calls["count"] == 1
 
     z = x.clone()
     assert cached_add_one(z) is not y
-    assert calls['count'] == 2
+    assert calls["count"] == 2
 
-    monkeypatch.setattr(fu, 'FLA_DISABLE_TENSOR_CACHE', True)
+    monkeypatch.setattr(fu, "FLA_DISABLE_TENSOR_CACHE", True)
     assert cached_add_one(x) is not y
-    assert calls['count'] == 3
+    assert calls["count"] == 3
 
 
 def test_input_guard_makes_tensors_contiguous_except_skipped():
@@ -58,7 +58,7 @@ def test_input_guard_makes_tensors_contiguous_except_skipped():
     assert guarded_x.is_contiguous()
     assert guarded_y.is_contiguous()
 
-    @fu.input_guard(no_guard_contiguous=['y'])
+    @fu.input_guard(no_guard_contiguous=["y"])
     def skip_y(x, y=None):
         return x, y
 
@@ -66,7 +66,7 @@ def test_input_guard_makes_tensors_contiguous_except_skipped():
     assert skipped_x.is_contiguous()
     assert not skipped_y.is_contiguous()
 
-    @fu.input_guard(no_guard_contiguous=('y',))
+    @fu.input_guard(no_guard_contiguous=("y",))
     def skip_y_with_tuple(x, y=None):
         return x, y
 
@@ -76,37 +76,37 @@ def test_input_guard_makes_tensors_contiguous_except_skipped():
 
 
 def test_deprecate_kwarg_renames_old_keyword_and_warns():
-    @fu.deprecate_kwarg('old_value', version='9.9.0', new_name='new_value')
+    @fu.deprecate_kwarg("old_value", version="9.9.0", new_name="new_value")
     def fn(new_value=None):
         return new_value
 
     with warnings.catch_warnings(record=True) as records:
-        warnings.simplefilter('always')
+        warnings.simplefilter("always")
         assert fn(old_value=42) == 42
 
     assert len(records) == 1
     assert issubclass(records[0].category, FutureWarning)
-    assert 'old_value' in str(records[0].message)
+    assert "old_value" in str(records[0].message)
 
 
 def test_deprecate_kwarg_can_raise_when_both_names_are_set():
-    @fu.deprecate_kwarg('old_value', version='9.9.0', new_name='new_value', raise_if_both_names=True)
+    @fu.deprecate_kwarg("old_value", version="9.9.0", new_name="new_value", raise_if_both_names=True)
     def fn(new_value=None):
         return new_value
 
-    with pytest.raises(ValueError, match='Both `old_value` and `new_value`'):
+    with pytest.raises(ValueError, match="Both `old_value` and `new_value`"):
         fn(old_value=1, new_value=2)
 
 
 def test_public_utils_are_reexported():
     for name in (
-        'assert_close',
-        'autotune_cache_kwargs',
-        'check_shared_mem',
-        'device',
-        'device_platform',
-        'input_guard',
-        'is_nvidia_hopper',
-        'tensor_cache',
+        "assert_close",
+        "autotune_cache_kwargs",
+        "check_shared_mem",
+        "device",
+        "device_platform",
+        "input_guard",
+        "is_nvidia_hopper",
+        "tensor_cache",
     ):
         assert hasattr(fu, name), name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,33 +17,33 @@ def test_assert_close_accepts_close_tensors_and_rejects_mismatch():
     ref = torch.tensor([1.0, 2.0, 3.0])
     tri = ref + 1e-7
 
-    fu.assert_close("close", ref, tri, 1e-3)
+    fu.assert_close('close', ref, tri, 1e-3)
 
-    with pytest.raises(AssertionError, match="mismatch"):
-        fu.assert_close("mismatch", ref, ref + 1.0, 1e-3)
+    with pytest.raises(AssertionError, match='mismatch'):
+        fu.assert_close('mismatch', ref, ref + 1.0, 1e-3)
 
 
 def test_tensor_cache_uses_identity_until_disabled(monkeypatch):
-    calls = {"count": 0}
+    calls = {'count': 0}
 
     @fu.tensor_cache
     def cached_add_one(x):
-        calls["count"] += 1
+        calls['count'] += 1
         return x + 1
 
     x = torch.tensor([1.0])
     y = cached_add_one(x)
 
     assert cached_add_one(x) is y
-    assert calls["count"] == 1
+    assert calls['count'] == 1
 
     z = x.clone()
     assert cached_add_one(z) is not y
-    assert calls["count"] == 2
+    assert calls['count'] == 2
 
-    monkeypatch.setattr(fu, "FLA_DISABLE_TENSOR_CACHE", True)
+    monkeypatch.setattr(fu, 'FLA_DISABLE_TENSOR_CACHE', True)
     assert cached_add_one(x) is not y
-    assert calls["count"] == 3
+    assert calls['count'] == 3
 
 
 def test_input_guard_makes_tensors_contiguous_except_skipped():
@@ -58,7 +58,7 @@ def test_input_guard_makes_tensors_contiguous_except_skipped():
     assert guarded_x.is_contiguous()
     assert guarded_y.is_contiguous()
 
-    @fu.input_guard(no_guard_contiguous=["y"])
+    @fu.input_guard(no_guard_contiguous=['y'])
     def skip_y(x, y=None):
         return x, y
 
@@ -66,7 +66,7 @@ def test_input_guard_makes_tensors_contiguous_except_skipped():
     assert skipped_x.is_contiguous()
     assert not skipped_y.is_contiguous()
 
-    @fu.input_guard(no_guard_contiguous=("y",))
+    @fu.input_guard(no_guard_contiguous=('y',))
     def skip_y_with_tuple(x, y=None):
         return x, y
 
@@ -76,37 +76,37 @@ def test_input_guard_makes_tensors_contiguous_except_skipped():
 
 
 def test_deprecate_kwarg_renames_old_keyword_and_warns():
-    @fu.deprecate_kwarg("old_value", version="9.9.0", new_name="new_value")
+    @fu.deprecate_kwarg('old_value', version='9.9.0', new_name='new_value')
     def fn(new_value=None):
         return new_value
 
     with warnings.catch_warnings(record=True) as records:
-        warnings.simplefilter("always")
+        warnings.simplefilter('always')
         assert fn(old_value=42) == 42
 
     assert len(records) == 1
     assert issubclass(records[0].category, FutureWarning)
-    assert "old_value" in str(records[0].message)
+    assert 'old_value' in str(records[0].message)
 
 
 def test_deprecate_kwarg_can_raise_when_both_names_are_set():
-    @fu.deprecate_kwarg("old_value", version="9.9.0", new_name="new_value", raise_if_both_names=True)
+    @fu.deprecate_kwarg('old_value', version='9.9.0', new_name='new_value', raise_if_both_names=True)
     def fn(new_value=None):
         return new_value
 
-    with pytest.raises(ValueError, match="Both `old_value` and `new_value`"):
+    with pytest.raises(ValueError, match='Both `old_value` and `new_value`'):
         fn(old_value=1, new_value=2)
 
 
 def test_public_utils_are_reexported():
     for name in (
-        "assert_close",
-        "autotune_cache_kwargs",
-        "check_shared_mem",
-        "device",
-        "device_platform",
-        "input_guard",
-        "is_nvidia_hopper",
-        "tensor_cache",
+        'assert_close',
+        'autotune_cache_kwargs',
+        'check_shared_mem',
+        'device',
+        'device_platform',
+        'input_guard',
+        'is_nvidia_hopper',
+        'tensor_cache',
     ):
         assert hasattr(fu, name), name


### PR DESCRIPTION
## Summary

This PR generalizes FLA’s hybrid-attention configuration so different groups of layers can use different standard-attention settings.

The existing single-dictionary form remains supported, while `config.attn` can now also accept a list of attention specifications.

This also centralizes hybrid-attention normalization, validation, defaults, and per-layer lookup that were previously duplicated across model families.

## Problem

FLA currently uses one `attn` dictionary for both layer selection and attention settings:

  ```python
  attn = {
      "layers": [3, 7, 11],
      "num_heads": 16,
      "num_kv_heads": 4,
      "window_size": 2048,
  } 
```

Every selected layer therefore receives the same setting. Several model configuration classes also repeat the same validation and default-handling logic.

This prevents configurations such as sliding-window attention at some depths and full attention at others without model-specific changes.

## Design

You add a shared module at `fla/models/hybrid.py` containing:

- HybridAttentionSpec
- HybridAttentionConfig
- normalize_hybrid_attention_config
- get_hybrid_attention_spec

The accepted forms are:

```python
# Form 1: None
attn = None

# Form 2: dictionary (single config)
attn = {
    "layers": [3, 7],
    "num_heads": 16,
}

# Form 3: list of dictionaries (multi configs)
attn = [
    {
        "layers": [3, 7],
        "num_heads": 16,
        "num_kv_heads": 4,
        "window_size": 2048,
    },
    {
        "layers": [11],
        "num_heads": 16,
        "num_kv_heads": 4,
        "window_size": None,
    },
]
```

Here are the defaults that are applied independently to every specification:
- num_kv_heads = num_heads
- qkv_bias = False
- window_size = None
- rope_theta = 10000.0

Normalization validates:
- required layers and num_heads fields.
- layer index types and bounds.
- duplicate layers inside one specification.
- overlapping layers across specifications.
- positive head counts
- bool qkv_bias
- positive or None window sizes.
- positive finite RoPE theta values.

Unknown keys are preserved for forward compatibility

The original outer representation is retained:
- dictionary input remains a dictionary
- list input remains a list
- None remains None.

Per-layer resolution occurs only during block construction:

```python
attn_spec = get_hybrid_attention_spec(
    config.attn,
    layer_idx=layer_idx,
)
```

The existing Attention class is then constructed from that specification. No lookup is added to model forward methods.

## Model Integration

The shared configuration schema is now used by 21 configuration classes:

- ABC
- Comba
- DeltaNet
- DeltaFormer
- Gated DeltaNet
- Gated DeltaProduct
- GLA
- GSA
- HGRN
- HGRN2
- KDA
- LightNet
- Linear Attention
- MesaNet
- Mom
- Raven
- RetNet
- Rodimus
- RWKV6
- RWKV7
- Samba


All existing hybrid-selection block constructors now use shared per-layer lookup.

DeltaFormer is configuration-only because its modeling implementation doesn't currently select through `config.attn`

## Compatability

- The existing dictionary API remains supported.
- The public field remains `config.attn`
- Dictionary configurations remain  in saved JSON
- List configurations remain in shape of list.
- Existing block attributes such as `self.attn` and `self.mixer` are unchanged.
- Attention constructor arguments sets are unchanged.
- State-dict parameter names are unchanged
- No forward methods were changed
- No cache or generation code was changed.
- No attention kernels or operator mathematics were changed.

Samba includes a narrow compatibility path for historical shallow-model JSON that stored the complete depth-18 default attention plan.

Explicit plans remain strictly range-validated

## Some Alternatives that were considered

### General Token-Mixer Plugin Framework

A general token-mixer registry or class hierarchy was considered. This would allow each layer to select and configure its mixer through a shared plugin interface.

This approach was rejected because it would:

- substantially expand the public API.
- increase configuration complexity.
- introduce additional checkpoint compatibility and migration risk.
- exceed the scope required to support heterogeneous standard-attention settings.

### JSON-Serializable Attention Specifications

A list of plain, JSON-serializable attention specifications was selected.

This approach supports different standard-attention settings across groups of layers while preserving the existing `config.attn` field, serialization behavior, model structure, and checkpoint compatibility.


## Tests

Added tests/models/test_hybrid_attention.py covering:

- None, dictionary, and list normalization.
- independent default handling
- preservation of unknown keys
- invalid fields and useful error messages.
- duplicate and overlapping layer detection
- empty plans and empty layer collections.
- per-layer lookup
- all 21 compatible configuration classes
- dictionary/list serialization round trips
- legacy Samba configuration loading.
- GLA, Gated DeltaNet, and Samba block construction
- local and full attention in one model
- dictionary versus one-item-list architecture equivalence
- state-dict key and tensor-shape equivalence.
- deterministic forward and gradient equivalence on supported GPU hardware.

Local validation:

- Pre-commit hooks passed for the feature files.
- Python compilation passed.
- git diff --check passed.
- Standalone normalization and serialization checks passed for all 21configuration classes.
- Source compatibility checks confirmed unchanged constructor parameter order, forward methods, module assignments, and Attention argument sets.

The pytest suite could not be collected locally because my macOS M1 environment does not support Triton :( 

Therefore, GPU numerical and gradient tests were therefore not run locally.

## Breaking changes

None.

## Limitations


## Limitations
This change supports multiple explicit attention specifications but doesn't add:

- periodic selector syntax
- learned routing
- parallel mixer composition
- new attention implementations
- cache formats
- generation changes
- Titans-or Hamba-specific modules
- a token-mixer registry or plugin framework

GQA divisibility validation remains outside this change while PR#1032 is still active.
