### PR TITLE
[KDA] Fuse chunk_kda forward kernels for ~30% D64 speedup on B200

### DIFF
--- a/fla/modules/l2norm.py
+++ b/fla/modules/l2norm.py
@@ -106,6 +106,91 @@ def l2norm_fwd_kernel(
 
 
 @fla_cache_autotune(
+    configs=[triton.Config({"BT": BT}, num_warps=num_warps) for num_warps in [1, 2, 4] for BT in [16, 32, 64]],
+    key=["D", "NB"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def l2norm_fwd_pair_kernel(
+    x0,
+    x1,
+    y0,
+    y1,
+    rstd0,
+    rstd1,
+    eps,
+    T,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    NB: tl.constexpr,
+    BT: tl.constexpr,
+):
+    i_t = tl.program_id(0).to(tl.int64)
+    rows = i_t * BT + tl.arange(0, BT).to(tl.int64)
+    cols = tl.arange(0, BD).to(tl.int64)
+    row_mask = rows < T
+    col_mask = cols < D
+    mask = row_mask[:, None] & col_mask[None, :]
+    offsets = rows[:, None] * D + cols[None, :]
+
+    b_x0 = tl.load(x0 + offsets, mask=mask, other=0.0).to(tl.float32)
+    b_x1 = tl.load(x1 + offsets, mask=mask, other=0.0).to(tl.float32)
+    b_rstd0 = 1 / tl.sqrt(tl.sum(b_x0 * b_x0, 1) + eps)
+    b_rstd1 = 1 / tl.sqrt(tl.sum(b_x1 * b_x1, 1) + eps)
+    b_y0 = b_x0 * b_rstd0[:, None]
+    b_y1 = b_x1 * b_rstd1[:, None]
+
+    tl.store(y0 + offsets, b_y0.to(y0.dtype.element_ty), mask=mask)
+    tl.store(y1 + offsets, b_y1.to(y1.dtype.element_ty), mask=mask)
+    tl.store(rstd0 + rows, b_rstd0, mask=row_mask)
+    tl.store(rstd1 + rows, b_rstd1, mask=row_mask)
+
+
+@fla_cache_autotune(
+    configs=[triton.Config({"BT": BT}, num_warps=num_warps) for num_warps in [1, 2, 4] for BT in [16, 32, 64]],
+    key=["D", "NB"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def l2norm_bwd_pair_kernel(
+    y0,
+    rstd0,
+    dy0,
+    dx0,
+    y1,
+    rstd1,
+    dy1,
+    dx1,
+    eps,
+    T,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    NB: tl.constexpr,
+    BT: tl.constexpr,
+):
+    i_t = tl.program_id(0).to(tl.int64)
+    rows = i_t * BT + tl.arange(0, BT).to(tl.int64)
+    cols = tl.arange(0, BD).to(tl.int64)
+    row_mask = rows < T
+    col_mask = cols < D
+    mask = row_mask[:, None] & col_mask[None, :]
+    offsets = rows[:, None] * D + cols[None, :]
+
+    b_y0 = tl.load(y0 + offsets, mask=mask, other=0.0).to(tl.float32)
+    b_dy0 = tl.load(dy0 + offsets, mask=mask, other=0.0).to(tl.float32)
+    b_rstd0 = tl.load(rstd0 + rows, mask=row_mask, other=0.0).to(tl.float32)
+    b_dx0 = b_dy0 * b_rstd0[:, None] - tl.sum(b_dy0 * b_y0, 1)[:, None] * b_y0 * b_rstd0[:, None]
+
+    b_y1 = tl.load(y1 + offsets, mask=mask, other=0.0).to(tl.float32)
+    b_dy1 = tl.load(dy1 + offsets, mask=mask, other=0.0).to(tl.float32)
+    b_rstd1 = tl.load(rstd1 + rows, mask=row_mask, other=0.0).to(tl.float32)
+    b_dx1 = b_dy1 * b_rstd1[:, None] - tl.sum(b_dy1 * b_y1, 1)[:, None] * b_y1 * b_rstd1[:, None]
+
+    tl.store(dx0 + offsets, b_dx0.to(dx0.dtype.element_ty), mask=mask)
+    tl.store(dx1 + offsets, b_dx1.to(dx1.dtype.element_ty), mask=mask)
+
+
+@fla_cache_autotune(
     configs=[triton.Config({"BT": BT}, num_warps=num_warps) for num_warps in [1, 2, 4, 8, 16] for BT in BT_LIST],
     key=["D", "NB"],
     **autotune_cache_kwargs,
@@ -190,6 +275,66 @@ def l2norm_fwd(
 
 
 @dispatch('modules')
+def l2norm_fwd_pair(
+    x0: torch.Tensor,
+    x1: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: torch.dtype | None = None,
+):
+    x_shape_og = x0.shape
+    if x1.shape != x_shape_og:
+        raise ValueError(f"paired l2norm inputs must have matching shapes, got {x0.shape} and {x1.shape}.")
+    if x1.device != x0.device:
+        raise ValueError(f"paired l2norm inputs must be on the same device, got {x0.device} and {x1.device}.")
+
+    x0 = x0.view(-1, x0.shape[-1])
+    x1 = x1.view(-1, x1.shape[-1])
+    if output_dtype is None:
+        y0 = torch.empty_like(x0)
+        y1 = torch.empty_like(x1)
+    else:
+        y0 = torch.empty_like(x0, dtype=output_dtype)
+        y1 = torch.empty_like(x1, dtype=output_dtype)
+    assert y0.stride(-1) == 1
+    assert y1.stride(-1) == 1
+    T, D = x0.shape[0], x0.shape[-1]
+    MAX_FUSED_SIZE = 65536 // x0.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        y0, rstd0 = l2norm_fwd(x0, eps=eps, output_dtype=output_dtype)
+        y1, rstd1 = l2norm_fwd(x1, eps=eps, output_dtype=output_dtype)
+        return y0.view(x_shape_og), rstd0.view(x_shape_og[:-1]), y1.view(x_shape_og), rstd1.view(x_shape_og[:-1])
+
+    if D > 512:
+        y0, rstd0 = l2norm_fwd(x0, eps=eps, output_dtype=output_dtype)
+        y1, rstd1 = l2norm_fwd(x1, eps=eps, output_dtype=output_dtype)
+        return y0.view(x_shape_og), rstd0.view(x_shape_og[:-1]), y1.view(x_shape_og), rstd1.view(x_shape_og[:-1])
+
+    rstd0 = torch.empty((T,), dtype=torch.float32, device=x0.device)
+    rstd1 = torch.empty((T,), dtype=torch.float32, device=x1.device)
+    # match the single-input kernel's coarse T bucket to avoid unnecessary retunes.
+    NB = triton.cdiv(T, 2048 * 32)
+
+    def grid(meta):
+        return (triton.cdiv(T, meta["BT"]),)
+
+    l2norm_fwd_pair_kernel[grid](
+        x0=x0,
+        x1=x1,
+        y0=y0,
+        y1=y1,
+        rstd0=rstd0,
+        rstd1=rstd1,
+        eps=eps,
+        T=T,
+        D=D,
+        BD=BD,
+        NB=NB,
+    )
+    return y0.view(x_shape_og), rstd0.view(x_shape_og[:-1]), y1.view(x_shape_og), rstd1.view(x_shape_og[:-1])
+
+
+@dispatch('modules')
 def l2norm_bwd(
     y: torch.Tensor,
     rstd: torch.Tensor,
@@ -241,6 +386,70 @@ def l2norm_bwd(
         )
 
     return dx.view(y_shape_og)
+
+
+@dispatch('modules')
+def l2norm_bwd_pair(
+    y0: torch.Tensor,
+    rstd0: torch.Tensor,
+    dy0: torch.Tensor,
+    y1: torch.Tensor,
+    rstd1: torch.Tensor,
+    dy1: torch.Tensor,
+    eps: float = 1e-6,
+):
+    y_shape_og = y0.shape
+    if y1.shape != y_shape_og or dy0.shape != y_shape_og or dy1.shape != y_shape_og:
+        raise ValueError("paired l2norm backward inputs must have matching activation and gradient shapes.")
+    if rstd0.shape != y_shape_og[:-1] or rstd1.shape != y_shape_og[:-1]:
+        raise ValueError("paired l2norm backward rstd tensors must match the activation shape without the last dimension.")
+    if y1.device != y0.device or dy0.device != y0.device or dy1.device != y0.device:
+        raise ValueError("paired l2norm backward inputs must be on the same device.")
+    if rstd0.device != y0.device or rstd1.device != y0.device:
+        raise ValueError("paired l2norm backward rstd tensors must be on the same device as the inputs.")
+
+    y0 = y0.view(-1, dy0.shape[-1])
+    y1 = y1.view(-1, dy1.shape[-1])
+    dy0 = dy0.view(-1, dy0.shape[-1])
+    dy1 = dy1.view(-1, dy1.shape[-1])
+    rstd0 = rstd0.view(-1)
+    rstd1 = rstd1.view(-1)
+    dx0 = torch.empty_like(y0)
+    dx1 = torch.empty_like(y1)
+    T, D = y0.shape[0], y0.shape[-1]
+    MAX_FUSED_SIZE = 65536 // y0.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        dx0 = l2norm_bwd(y0, rstd0, dy0, eps=eps)
+        dx1 = l2norm_bwd(y1, rstd1, dy1, eps=eps)
+        return dx0.view(y_shape_og), dx1.view(y_shape_og)
+
+    if D > 512:
+        dx0 = l2norm_bwd(y0, rstd0, dy0, eps=eps)
+        dx1 = l2norm_bwd(y1, rstd1, dy1, eps=eps)
+        return dx0.view(y_shape_og), dx1.view(y_shape_og)
+
+    NB = triton.cdiv(T, 2048 * 32)
+
+    def grid(meta):
+        return (triton.cdiv(T, meta["BT"]),)
+
+    l2norm_bwd_pair_kernel[grid](
+        y0=y0,
+        rstd0=rstd0,
+        dy0=dy0,
+        dx0=dx0,
+        y1=y1,
+        rstd1=rstd1,
+        dy1=dy1,
+        dx1=dx1,
+        eps=eps,
+        T=T,
+        D=D,
+        BD=BD,
+        NB=NB,
+    )
+    return dx0.view(y_shape_og), dx1.view(y_shape_og)
 
 
 class L2NormFunction(torch.autograd.Function):

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -11,7 +11,7 @@ import warnings
 
 import torch
 
-from fla.modules.l2norm import l2norm_bwd, l2norm_fwd
+from fla.modules.l2norm import l2norm_bwd_pair, l2norm_fwd_pair
 from fla.ops.backends import dispatch
 from fla.ops.common.gate import fused_beta_sigmoid, fused_beta_sigmoid_bwd
 from fla.ops.cp import FLACPContext
@@ -54,8 +54,7 @@ class ChunkKDAFunction(torch.autograd.Function):
         # Apply l2norm
         q_rstd, k_rstd = None, None
         if use_qk_l2norm_in_kernel:
-            q, q_rstd = l2norm_fwd(q)
-            k, k_rstd = l2norm_fwd(k)
+            q, q_rstd, k, k_rstd = l2norm_fwd_pair(q, k)
 
         beta_raw = beta
         if use_beta_sigmoid_in_kernel:
@@ -164,8 +163,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             h=h,
         )
         if ctx.use_qk_l2norm_in_kernel:
-            dq = l2norm_bwd(q, q_rstd, dq)
-            dk = l2norm_bwd(k, k_rstd, dk)
+            dq, dk = l2norm_bwd_pair(q, q_rstd, dq, k, k_rstd, dk)
         if ctx.use_beta_sigmoid_in_kernel:
             db = fused_beta_sigmoid_bwd(beta_raw, db, scale=2.0 if ctx.allow_neg_eigval else 1.0)
 

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -20,7 +20,7 @@ from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
+from fla.utils import IS_NVIDIA_BLACKWELL, IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
@@ -117,7 +117,13 @@ def chunk_kda_bwd_kernel_dAv(
         for BV in BV_LIST
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
+        # Hopper exclusion unchanged from upstream (do not touch the Hopper autotune space here).
         if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
+        # Blackwell (sm_100)-only workaround: BK==32 with num_warps!=2 currently triggers an
+        # illegal memory access in chunk_kda_bwd_kernel_dAv. This prunes those configs to keep
+        # autotuning safe on Blackwell; it is NOT a root-cause fix for the OOB and does not
+        # affect Hopper or other archs.
+        if not (IS_NVIDIA_BLACKWELL and BK == 32 and num_warps != 2)
     ],
     key=['BT', 'HV', 'STATE_V_FIRST'],
     **autotune_cache_kwargs,

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -42,6 +42,8 @@ def chunk_kda_fwd(
 ):
     # Apply gate activation
     g_org = None
+    fuse_g_cumsum = False
+    g_input_for_intra = g
     if use_gate_in_kernel:
         g_org = g
         g = kda_gate_chunk_cumsum(
@@ -54,28 +56,37 @@ def chunk_kda_fwd(
             chunk_indices=chunk_indices,
             lower_bound=lower_bound,
         )
+        g_input_for_intra = g
     else:
-        g = chunk_local_cumsum(
-            g=g,
-            scale=RCP_LN2,
-            chunk_size=chunk_size,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices
-        )
+        fuse_g_cumsum = safe_gate and cu_seqlens is None and chunk_indices is None
+        if fuse_g_cumsum:
+            g = torch.empty_like(g, dtype=torch.float)
+        else:
+            g = chunk_local_cumsum(
+                g=g,
+                scale=RCP_LN2,
+                chunk_size=chunk_size,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices
+            )
+            g_input_for_intra = g
 
     # qg = None if disable_recompute is False
     w, u, qg, kg, Aqk, Akk = chunk_kda_fwd_intra(
         q=q,
         k=k,
         v=v,
-        gk=g,
+        gk=g_input_for_intra,
+        g_cumsum=g if fuse_g_cumsum else None,
         beta=beta,
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         safe_gate=safe_gate,
-        disable_recompute=disable_recompute
+        disable_recompute=disable_recompute,
+        fuse_g_cumsum=fuse_g_cumsum,
+        g_cumsum_scale=RCP_LN2,
     )
 
     if cp_context is not None:

--- a/fla/ops/kda/chunk_intra.py
+++ b/fla/ops/kda/chunk_intra.py
@@ -35,18 +35,22 @@ else:
         for BK in [32, 64]
         for num_warps in [1, 2, 4]
     ],
-    key=["H", "HV", "K", "BT", "BC", "NC"],
+    key=["H", "HV", "K", "V", "BT", "BC", "NC", "STORE_EPILOGUE"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
 def chunk_kda_fwd_kernel_inter_solve_fused(
     q,
     k,
+    v,
     g,
     beta,
     Aqk,
     Akkd,
     Akk,
+    w,
+    u,
+    kg,
     scale,
     cu_seqlens,
     chunk_indices,
@@ -54,12 +58,15 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
+    V: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
+    BV: tl.constexpr,
     NC: tl.constexpr,
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_SAFE_GATE: tl.constexpr,
+    STORE_EPILOGUE: tl.constexpr,
 ):
     """
     Fused kernel: compute inter-subchunk Akk + solve_tril in one pass.
@@ -98,8 +105,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     Aqk += (bos * HV + i_hv) * BT
     Akk += (bos * HV + i_hv) * BT
     Akkd += (bos * HV + i_hv) * BC
+    if STORE_EPILOGUE:
+        v += (bos * HV + i_hv) * V
+        w += (bos * HV + i_hv) * K
+        u += (bos * HV + i_hv) * V
+        kg += (bos * HV + i_hv) * K
 
     o_i = tl.arange(0, BC)
+    m_tc0 = (i_tc0 + o_i) < T
     m_tc1 = (i_tc1 + o_i) < T
     m_tc2 = (i_tc2 + o_i) < T
     m_tc3 = (i_tc3 + o_i) < T
@@ -363,6 +376,129 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+    if STORE_EPILOGUE:
+        b_A00 = b_Ai00.to(Akk.dtype.element_ty)
+        b_A10 = b_Ai10.to(Akk.dtype.element_ty)
+        b_A11 = b_Ai11.to(Akk.dtype.element_ty)
+        if NC >= 3:
+            b_A20 = b_Ai20.to(Akk.dtype.element_ty)
+            b_A21 = b_Ai21.to(Akk.dtype.element_ty)
+            b_A22 = b_Ai22.to(Akk.dtype.element_ty)
+        if NC >= 4:
+            b_A30 = b_Ai30.to(Akk.dtype.element_ty)
+            b_A31 = b_Ai31.to(Akk.dtype.element_ty)
+            b_A32 = b_Ai32.to(Akk.dtype.element_ty)
+            b_A33 = b_Ai33.to(Akk.dtype.element_ty)
+
+        i_last = min(i_t * BT + BT, T) - 1
+        for i_k in range(tl.cdiv(K, BK)):
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+
+            p_k0 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_k1 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_g0 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_g1 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_b0 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc0,), (BC,), (0,))
+            p_b1 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,))
+
+            b_k0 = tl.load(p_k0, boundary_check=(0, 1))
+            b_k1 = tl.load(p_k1, boundary_check=(0, 1))
+            b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+            b_b0 = tl.load(p_b0, boundary_check=(0,))
+            b_b1 = tl.load(p_b1, boundary_check=(0,))
+            b_gn = tl.load(g + i_last * HV*K + o_k, mask=m_k, other=0.).to(tl.float32)
+
+            b_kb0 = (b_k0 * b_b0[:, None] * exp2(b_g0)).to(b_k0.dtype)
+            b_kb1 = (b_k1 * b_b1[:, None] * exp2(b_g1)).to(b_k1.dtype)
+            b_kg0 = b_k0 * tl.where(m_tc0[:, None], exp2(b_gn[None, :] - b_g0), 0)
+            b_kg1 = b_k1 * tl.where(m_tc1[:, None], exp2(b_gn[None, :] - b_g1), 0)
+
+            b_w0 = tl.dot(b_A00, b_kb0)
+            b_w1 = tl.dot(b_A10, b_kb0) + tl.dot(b_A11, b_kb1)
+
+            p_w0 = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_w1 = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_kg0 = tl.make_block_ptr(kg, (T, K), (HV*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_kg1 = tl.make_block_ptr(kg, (T, K), (HV*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_w0, b_w0.to(p_w0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_w1, b_w1.to(p_w1.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg0, b_kg0.to(p_kg0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg1, b_kg1.to(p_kg1.dtype.element_ty), boundary_check=(0, 1))
+
+            if NC >= 3:
+                p_k2 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                p_g2 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                p_b2 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,))
+                b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+                b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+                b_b2 = tl.load(p_b2, boundary_check=(0,))
+                b_kb2 = (b_k2 * b_b2[:, None] * exp2(b_g2)).to(b_k2.dtype)
+                b_kg2 = b_k2 * tl.where(m_tc2[:, None], exp2(b_gn[None, :] - b_g2), 0)
+                b_w2 = tl.dot(b_A20, b_kb0) + tl.dot(b_A21, b_kb1) + tl.dot(b_A22, b_kb2)
+                p_w2 = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                p_kg2 = tl.make_block_ptr(kg, (T, K), (HV*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                tl.store(p_w2, b_w2.to(p_w2.dtype.element_ty), boundary_check=(0, 1))
+                tl.store(p_kg2, b_kg2.to(p_kg2.dtype.element_ty), boundary_check=(0, 1))
+            if NC >= 4:
+                p_k3 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                p_g3 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                p_b3 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,))
+                b_k3 = tl.load(p_k3, boundary_check=(0, 1))
+                b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+                b_b3 = tl.load(p_b3, boundary_check=(0,))
+                b_kb3 = (b_k3 * b_b3[:, None] * exp2(b_g3)).to(b_k3.dtype)
+                b_kg3 = b_k3 * tl.where(m_tc3[:, None], exp2(b_gn[None, :] - b_g3), 0)
+                b_w3 = (
+                    tl.dot(b_A30, b_kb0) + tl.dot(b_A31, b_kb1) +
+                    tl.dot(b_A32, b_kb2) + tl.dot(b_A33, b_kb3)
+                )
+                p_w3 = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                p_kg3 = tl.make_block_ptr(kg, (T, K), (HV*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                tl.store(p_w3, b_w3.to(p_w3.dtype.element_ty), boundary_check=(0, 1))
+                tl.store(p_kg3, b_kg3.to(p_kg3.dtype.element_ty), boundary_check=(0, 1))
+
+        for i_v in range(tl.cdiv(V, BV)):
+            p_v0 = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
+            p_v1 = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
+            p_b0 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc0,), (BC,), (0,))
+            p_b1 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,))
+            b_v0 = tl.load(p_v0, boundary_check=(0, 1))
+            b_v1 = tl.load(p_v1, boundary_check=(0, 1))
+            b_b0 = tl.load(p_b0, boundary_check=(0,))
+            b_b1 = tl.load(p_b1, boundary_check=(0,))
+            b_vb0 = (b_v0 * b_b0[:, None]).to(b_v0.dtype)
+            b_vb1 = (b_v1 * b_b1[:, None]).to(b_v1.dtype)
+            b_u0 = tl.dot(b_A00, b_vb0)
+            b_u1 = tl.dot(b_A10, b_vb0) + tl.dot(b_A11, b_vb1)
+            p_u0 = tl.make_block_ptr(u, (T, V), (HV*V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
+            p_u1 = tl.make_block_ptr(u, (T, V), (HV*V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
+            tl.store(p_u0, b_u0.to(p_u0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_u1, b_u1.to(p_u1.dtype.element_ty), boundary_check=(0, 1))
+
+            if NC >= 3:
+                p_v2 = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
+                p_b2 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,))
+                b_v2 = tl.load(p_v2, boundary_check=(0, 1))
+                b_b2 = tl.load(p_b2, boundary_check=(0,))
+                b_vb2 = (b_v2 * b_b2[:, None]).to(b_v2.dtype)
+                b_u2 = tl.dot(b_A20, b_vb0) + tl.dot(b_A21, b_vb1) + tl.dot(b_A22, b_vb2)
+                p_u2 = tl.make_block_ptr(u, (T, V), (HV*V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
+                tl.store(p_u2, b_u2.to(p_u2.dtype.element_ty), boundary_check=(0, 1))
+            if NC >= 4:
+                p_v3 = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+                p_b3 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,))
+                b_v3 = tl.load(p_v3, boundary_check=(0, 1))
+                b_b3 = tl.load(p_b3, boundary_check=(0,))
+                b_vb3 = (b_v3 * b_b3[:, None]).to(b_v3.dtype)
+                b_u3 = (
+                    tl.dot(b_A30, b_vb0) + tl.dot(b_A31, b_vb1) +
+                    tl.dot(b_A32, b_vb2) + tl.dot(b_A33, b_vb3)
+                )
+                p_u3 = tl.make_block_ptr(u, (T, V), (HV*V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+                tl.store(p_u3, b_u3.to(p_u3.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.heuristics({
@@ -652,7 +788,7 @@ def chunk_kda_bwd_kernel_intra(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["BT", "BC", "HV"],
+    key=["BT", "BC", "HV", "FUSE_G_CUMSUM"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -660,10 +796,12 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     q,
     k,
     g,
+    g_cumsum,
     beta,
     Aqk,
     Akk,
     scale,
+    g_cumsum_scale,
     cu_seqlens,
     chunk_indices,
     T,
@@ -675,6 +813,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_GATHER: tl.constexpr,
+    FUSE_G_CUMSUM: tl.constexpr,
 ):
     i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_hv = i_bh // HV, i_bh % HV
@@ -691,12 +830,15 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     if i_ti >= T:
         return
 
-    o_c = i_ti + tl.arange(0, BC)
+    o_i = tl.arange(0, BC)
+    o_c = i_ti + o_i
     m_c = o_c < T
 
     q = q + (bos * H + i_h) * K
     k = k + (bos * H + i_h) * K
     g = g + (bos * HV + i_hv) * K
+    if FUSE_G_CUMSUM:
+        g_cumsum = g_cumsum + (bos * HV + i_hv) * K
     beta = beta + bos * HV + i_hv
     Aqk = Aqk + (bos * HV + i_hv) * BT
     Akk = Akk + (bos * HV + i_hv) * BC
@@ -709,11 +851,30 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
 
     b_q = tl.load(p_q, boundary_check=(0, 1))
     b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    if FUSE_G_CUMSUM:
+        b_g_raw = b_g
+        b_g_prefix = tl.zeros([BK], dtype=tl.float32)
+        if i_i > 0:
+            p_g0 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
+            b_g_prefix += tl.sum(tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32), axis=0)
+        if i_i > 1:
+            p_g1 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT + BC, 0), (BC, BK), (1, 0))
+            b_g_prefix += tl.sum(tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32), axis=0)
+        if i_i > 2:
+            p_g2 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT + 2 * BC, 0), (BC, BK), (1, 0))
+            b_g_prefix += tl.sum(tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32), axis=0)
+        b_g = (tl.cumsum(b_g_raw, axis=0) + b_g_prefix[None, :]) * g_cumsum_scale
+        p_g_cumsum = tl.make_block_ptr(g_cumsum, (T, K), (HV*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+        tl.store(p_g_cumsum, b_g.to(p_g_cumsum.dtype.element_ty), boundary_check=(0, 1))
     b_beta = tl.load(p_beta, boundary_check=(0,))
 
     if USE_GATHER:
         b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
+    elif FUSE_G_CUMSUM:
+        i_gn = min(BC // 2, T - i_ti - 1)
+        b_gn = tl.sum(tl.where(o_i[:, None] <= i_gn, b_g_raw, 0.), axis=0)
+        b_gn = ((b_gn + b_g_prefix) * g_cumsum_scale)[None, :]
     else:
         # caculate offset
         p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV*K + tl.arange(0, BK)
@@ -732,7 +893,6 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     b_Aqk = tl.dot(b_q * b_gq, b_kgt) * scale
     b_Akk = tl.dot(b_k * b_gq, b_kgt) * b_beta[:, None]
 
-    o_i = tl.arange(0, BC)
     m_Aqk = o_i[:, None] >= o_i[None, :]
     m_Akk = o_i[:, None] > o_i[None, :]
     m_I = o_i[:, None] == o_i[None, :]
@@ -766,6 +926,7 @@ def chunk_kda_fwd_intra(
     k: torch.Tensor,
     v: torch.Tensor,
     gk: torch.Tensor | None = None,
+    g_cumsum: torch.Tensor | None = None,
     beta: torch.Tensor | None = None,
     scale: float | None = None,
     cu_seqlens: torch.LongTensor | None = None,
@@ -773,6 +934,8 @@ def chunk_kda_fwd_intra(
     chunk_indices: torch.LongTensor | None = None,
     safe_gate: bool = False,
     disable_recompute: bool = False,
+    fuse_g_cumsum: bool = False,
+    g_cumsum_scale: float = 1.0,
 ):
     B, T, H, K, HV = *k.shape, gk.shape[2]
     BT = chunk_size
@@ -783,12 +946,20 @@ def chunk_kda_fwd_intra(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
+    if fuse_g_cumsum and (not safe_gate or g_cumsum is None):
+        raise ValueError("fuse_g_cumsum requires the safe-gate intra path and a cumulative g output tensor.")
+    gk_for_consumers = g_cumsum if fuse_g_cumsum else gk
 
     Aqk = torch.empty(B, T, HV, BT, device=k.device, dtype=k.dtype)
     # Akk must be zero-initialized - kernel only writes lower triangular
     Akk = torch.zeros(B, T, HV, BT, device=k.device, dtype=k.dtype)
     # Separate fp32 buffer for diagonal 16x16 blocks (for precision in solve_tril)
     Akkd = torch.empty(B, T, HV, BC, device=k.device, dtype=torch.float32)
+    use_inter_recompute_epilogue = disable_recompute is False and cu_seqlens is None and chunk_indices is None
+    w = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype) if use_inter_recompute_epilogue else None
+    u = torch.empty_like(v) if use_inter_recompute_epilogue else None
+    qg = None
+    kg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype) if use_inter_recompute_epilogue else None
 
     # Step 1: Run token_parallel first to compute diagonal blocks into Akkd (fp32)
     # Step 1: compute diagonal blocks into Akk_diag (fp32)
@@ -799,10 +970,12 @@ def chunk_kda_fwd_intra(
             q=q,
             k=k,
             g=gk,
+            g_cumsum=g_cumsum if fuse_g_cumsum else gk,
             beta=beta,
             Aqk=Aqk,
             Akk=Akkd,
             scale=scale,
+            g_cumsum_scale=g_cumsum_scale,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             T=T,
@@ -813,6 +986,7 @@ def chunk_kda_fwd_intra(
             BC=BC,
             BK=BK,
             USE_GATHER=IS_GATHER_SUPPORTED,
+            FUSE_G_CUMSUM=fuse_g_cumsum,
         )
     else:
         Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
@@ -833,11 +1007,15 @@ def chunk_kda_fwd_intra(
     chunk_kda_fwd_kernel_inter_solve_fused[grid](
         q=q,
         k=k,
-        g=gk,
+        v=v,
+        g=gk_for_consumers,
         beta=beta,
         Aqk=Aqk,
         Akkd=Akkd,
         Akk=Akk,
+        w=w,
+        u=u,
+        kg=kg,
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
@@ -845,21 +1023,25 @@ def chunk_kda_fwd_intra(
         H=H,
         HV=HV,
         K=K,
+        V=v.shape[-1],
         BT=BT,
         BC=BC,
+        BV=64,
         NC=NC,
         USE_SAFE_GATE=safe_gate,
+        STORE_EPILOGUE=use_inter_recompute_epilogue,
     )
-    w, u, qg, kg = recompute_w_u_fwd(
-        k=k,
-        v=v,
-        beta=beta,
-        A=Akk,
-        q=q if disable_recompute else None,
-        gk=gk,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-    )
+    if not use_inter_recompute_epilogue:
+        w, u, qg, kg = recompute_w_u_fwd(
+            k=k,
+            v=v,
+            beta=beta,
+            A=Akk,
+            q=q if disable_recompute else None,
+            gk=gk_for_consumers,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
     return w, u, qg, kg, Aqk, Akk
 
 


### PR DESCRIPTION
## Summary

This PR fuses several kernels in the **`chunk_kda`** (Kimi Delta Attention) forward
pipeline to remove redundant kernel launches and HBM round-trips, giving a
correctness-preserving, memory-neutral speedup on NVIDIA B200 (sm_100).

Each change follows the same mechanism: an intermediate tensor that the baseline
stores to HBM and reloads in a separate launch is instead produced inside the
upstream kernel and consumed directly.

## Changes

1. **Paired q/k L2-norm fusion (forward + backward)** — `fla/modules/l2norm.py`, `fla/ops/kda/chunk.py`
   The baseline issues two separate `l2norm` launches (for `q` and `k`) in each
   direction. `l2norm_fwd_pair` / `l2norm_bwd_pair` fuse each pair into one kernel,
   halving launch count and normalization HBM traffic.

2. **Forward inter-solve recompute-epilogue fusion** — `fla/ops/kda/chunk_intra.py`
   `chunk_kda_fwd_kernel_inter_solve_fused` already holds the solved `Akk` in
   registers; computing `w/u/kg` in an epilogue removes the separate
   `recompute_w_u_fwd_kda_kernel` launch and its `Akk` HBM reload.

3. **Cumsum-into-intra producer fusion** — `fla/ops/kda/chunk_fwd.py`, `fla/ops/kda/chunk_intra.py`
   The chunk-local cumulative gate `g` is computed inside the intra-subchunk
   producer instead of a standalone `chunk_local_cumsum_vector_kernel` launch, and
   stored once for reuse.

4. **Blackwell (sm_100) autotune workaround** — `fla/ops/kda/chunk_bwd.py`
   On Blackwell, autotuning `chunk_kda_bwd_kernel_dAv` hits an illegal memory access when it
   explores `BK==32` with `num_warps != 2`. This prunes those configs **on Blackwell only**,
   so autotuning stays safe. It is a **workaround, not a root-cause fix** for the OOB, and the
   Hopper autotune space is left exactly as upstream (`num_warps == 2` guard untouched). Happy
   to drop this from the PR or replace it with a proper fix once the OOB is root-caused.

## Benchmark

- **Op / shape:** `chunk_kda`, `B8_T1024_H8_D64` (D64), bf16, forward and forward+backward.
- **Hardware:** NVIDIA B200 (sm_100).
- **Method:** paired baseline-vs-candidate measurement on the same GPU
  (`geomean_speedup = baseline_latency / candidate_latency`); atol 1e-2 / rtol 2e-2;
  peak memory tracked as a ratio.

| Optimization | Speedup | Notes |
|---|---|---|
| Paired q/k L2-norm fusion | **+5.6%** | N=10 median (independent re-verify +8.1%) |
| Forward inter-solve recompute-epilogue fusion | **+7.27%** | N=10 median |
| Cumsum-into-intra producer fusion | **+10.4% increment** | cumulative with the above = **+17.66%**, N=10 |
| **All three combined** | **+29.93% geomean** | single paired run, correctness PASS, `max_mem_ratio` 1.00, 0 CUDA errors |

Each individual optimization is **N≥10** certified (correctness PASS, memory-neutral,
median ≥ 1.05, cold-cache repeat). The **+29.93% combined** figure is from a single
paired verification run (fwd + fwd+bwd); a full N≥10 certification of the combined
stack is expected to land around ~+25–30%.

## Notes

- Branched from `ccb0ff94`; the diff touches only the 5 files above (+432/-32).
- Correctness is checked against the current PyTorch reference for `chunk_kda`.
- Happy to rebase onto the latest `main` and split into smaller PRs if preferred.
