### PR TITLE
[Ops] Add triton-ascend backend for attn_res kernel

### DIFF
--- a/.github/workflows/ascend-a2-benchmark-ci.yml
+++ b/.github/workflows/ascend-a2-benchmark-ci.yml
@@ -119,7 +119,7 @@ jobs:
           print("matplotlib savefig smoke test: ok")
           PY
 
-      - name: Benchmark chunk_gdn, chunk_kda, and conv1d
+      - name: Benchmark chunk_gdn, chunk_kda, fused_attnres, and conv1d
         shell: bash
         env:
           FLA_BENCH_WARMUP_MS: "25"
@@ -137,19 +137,26 @@ jobs:
             --op chunk_kda --base '' --json benchmark_chunk_kda.json \
             > chunk_kda.log 2>&1 &
           pid_kda=$!
-          ASCEND_RT_VISIBLE_DEVICES=2 python benchmarks/modules/benchmark_conv.py \
+          ASCEND_RT_VISIBLE_DEVICES=2 python -m benchmarks.ops.run \
+            --op fused_attnres --base '' --json benchmark_fused_attnres.json \
+            > fused_attnres.log 2>&1 &
+          pid_attnres=$!
+          ASCEND_RT_VISIBLE_DEVICES=3 python benchmarks/modules/benchmark_conv.py \
             > conv1d.log 2>&1 &
           pid_conv1d=$!
 
           status=0
           wait "$pid_gdn" || status=1
           wait "$pid_kda" || status=1
+          wait "$pid_attnres" || status=1
           wait "$pid_conv1d" || status=1
 
           echo "========== chunk_gdn =========="
           cat chunk_gdn.log
           echo "========== chunk_kda =========="
           cat chunk_kda.log
+          echo "========== fused_attnres =========="
+          cat fused_attnres.log
           echo "========== conv1d =========="
           cat conv1d.log
           exit "$status"
@@ -162,6 +169,7 @@ jobs:
           path: |
             benchmark_chunk_gdn.json
             benchmark_chunk_kda.json
+            benchmark_fused_attnres.json
             conv_benchmark/
           if-no-files-found: ignore
           retention-days: 10

--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -100,7 +100,7 @@ jobs:
           assert IS_NPU, "Expected NPU backend (IS_NPU=True)"
           PY
 
-      - name: Run fla/modules and fla/ops/utils, gdn, kda tests
+      - name: Run fla/modules and fla/ops/utils, gdn, kda, attnres tests
         shell: bash
         env:
           FLA_NPU_XDIST: "1"

--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -111,4 +111,5 @@ jobs:
             tests/ops/utils \
             tests/ops/test_gdn_kernels.py \
             tests/ops/test_gdn.py \
-            tests/ops/test_kda.py
+            tests/ops/test_kda.py \
+            tests/ops/test_attnres.py

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -489,10 +489,19 @@ _attnres_inputs = {
     'rms_weight': TensorSpec(shape_D),
 }
 
+
+def _attnres_post_init(inputs, B, T, H, D, L=None, **kw):
+    # fused_attnres expects a sequence of [B, T, D] tensors, not the stacked [L, B, T, D] buffer.
+    res = inputs['residuals']
+    if isinstance(res, torch.Tensor) and res.ndim == 4:
+        inputs['residuals'] = [res[i] for i in range(res.shape[0])]
+
+
 register_op(OpConfig(
     name='fused_attnres',
     import_path='fla.ops.attnres',
     inputs=_attnres_inputs,
+    post_init=_attnres_post_init,
     output_is_tuple=False,
     default_shapes=_layer_default_shapes,
     category='fused_attnres',
@@ -503,6 +512,7 @@ register_op(OpConfig(
     name='naive_attnres',
     import_path='fla.ops.attnres',
     inputs=_attnres_inputs,
+    post_init=_attnres_post_init,
     output_is_tuple=False,
     default_shapes=_layer_default_shapes,
     category='naive_attnres',

--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -494,7 +494,9 @@ def _attnres_post_init(inputs, B, T, H, D, L=None, **kw):
     # fused_attnres expects a sequence of [B, T, D] tensors, not the stacked [L, B, T, D] buffer.
     res = inputs['residuals']
     if isinstance(res, torch.Tensor) and res.ndim == 4:
-        inputs['residuals'] = [res[i] for i in range(res.shape[0])]
+        inputs['residuals'] = [
+            res[i].detach().clone().requires_grad_(True) for i in range(res.shape[0])
+        ]
 
 
 register_op(OpConfig(

--- a/fla/ops/attnres/backends/__init__.py
+++ b/fla/ops/attnres/backends/__init__.py
@@ -7,11 +7,21 @@
 
 """AttnRes backends."""
 
-from fla.ops.attnres.backends.gluon import AttnResGluonBackend
+from fla.ops.attnres.backends.triton_ascend import TritonAscendAttnResBackend
 from fla.ops.backends import BackendRegistry, dispatch
 
 attnres_registry = BackendRegistry("attnres")
-attnres_registry.register(AttnResGluonBackend())
+
+attnres_registry.register(TritonAscendAttnResBackend())
+
+# gluon.py imports triton.experimental at module load; without this guard, import fails
+# on NPU and attnres backends never register (including triton_ascend above).
+try:
+    from fla.ops.attnres.backends.gluon import AttnResGluonBackend
+
+    attnres_registry.register(AttnResGluonBackend())
+except ImportError:
+    pass
 
 
 __all__ = ['attnres_registry', 'dispatch']

--- a/fla/ops/attnres/backends/triton_ascend/__init__.py
+++ b/fla/ops/attnres/backends/triton_ascend/__init__.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Triton-Ascend Ascend NPU backend for AttnRes."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+from fla.ops.backends import BaseBackend
+
+
+class TritonAscendAttnResBackend(BaseBackend):
+    """Ascend NPU backend for fused AttnRes."""
+
+    backend_type = 'triton_ascend'
+    package_name = None
+    env_var = None
+    priority = 0
+
+    @classmethod
+    def is_available(cls) -> bool:
+        from fla.utils import IS_NPU
+        return IS_NPU
+
+    def fused_attnres_verifier(
+        self,
+        query: torch.Tensor,
+        residuals: Sequence[torch.Tensor],
+        rms_weight: torch.Tensor,
+        output_rms_weight: torch.Tensor | None = None,
+        rms_eps: float = 1e-6,
+        scale: float = 1.0,
+        return_weights: bool = False,
+        checkpoint_level: int = 1,
+        **kwargs,
+    ) -> tuple[bool, str | None]:
+        del query, rms_weight, output_rms_weight, rms_eps, scale, return_weights, kwargs
+        if isinstance(residuals, torch.Tensor):
+            if residuals.ndim != 4 or residuals.shape[0] == 0:
+                return False, 'attnres requires at least one residual source'
+        elif not residuals:
+            return False, 'attnres requires at least one residual source'
+        return True, None
+
+    def fused_attnres(self, *args, **kwargs):
+        from fla.ops.attnres.backends.triton_ascend.fused import fused_attnres_npu
+        return fused_attnres_npu(*args, **kwargs)
+
+
+__all__ = ['TritonAscendAttnResBackend']

--- a/fla/ops/attnres/backends/triton_ascend/fused.py
+++ b/fla/ops/attnres/backends/triton_ascend/fused.py
@@ -1,0 +1,649 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Fused AttnRes kernels for triton-ascend on Ascend NPU.
+
+GPU passes a padded tuple of per-source pointers (``res[i]``). Triton-Ascend
+cannot bind tuple arguments, so sources are stacked in L-chunks as
+``[L_chunk, N, D]`` (capped at 512 MiB per chunk) instead of one ``[L, N, D]``
+buffer. Cross-chunk softmax stats are merged on the host; the weighted sum
+accumulates in a single fp32 ``o_mix`` buffer to match GPU register precision.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.op import exp
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_row_tile_block_size,
+    iter_axis_launch_chunks,
+)
+
+_FWD_MEM_MULT = 3.0
+_BWD_DV_MEM_MULT = 6.0
+_SAFETY_MARGIN = 0.85
+_FALLBACK_BD = 256
+_MAX_L_CHUNK_BYTES = 512 << 20
+
+
+def _l_chunk_size(L: int, N: int, D: int, elem_size: int) -> int:
+    layer_bytes = N * D * elem_size
+    if layer_bytes == 0:
+        return L
+    return max(1, min(L, _MAX_L_CHUNK_BYTES // layer_bytes))
+
+
+def _stack_sources(sources: Sequence[torch.Tensor], l0: int, l1: int) -> torch.Tensor:
+    if l1 - l0 == 1:
+        return sources[l0].unsqueeze(0)
+    return torch.stack(sources[l0:l1], dim=0)
+
+
+def _iter_l_chunks(
+    sources: Sequence[torch.Tensor],
+) -> Iterator[tuple[int, int, torch.Tensor, int, int, int]]:
+    L, N, D = len(sources), *sources[0].shape
+    stride_ln, l_chunk = N * D, _l_chunk_size(L, N, D, sources[0].element_size())
+    for l0 in range(0, L, l_chunk):
+        l1 = min(l0 + l_chunk, L)
+        yield l0, l1 - l0, _stack_sources(sources, l0, l1), stride_ln, N, D
+
+
+def _merge_online_softmax(
+    m: torch.Tensor,
+    acc: torch.Tensor,
+    m_chunk: torch.Tensor,
+    acc_chunk: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m_new = torch.maximum(m, m_chunk)
+    acc_new = acc * torch.exp(m - m_new) + acc_chunk * torch.exp(m_chunk - m_new)
+    return m_new, acc_new
+
+
+def _get_bl(L: int) -> int:
+    return min(8, max(1, triton.next_power_of_2(L)))
+
+
+def _get_bd(row_dim: int, col_dim: int, *, memory_multiplier: float) -> int:
+    return compute_row_tile_block_size(
+        row_dim,
+        col_dim,
+        memory_multiplier,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        dtype_size=4,
+        fallback=_FALLBACK_BD,
+        min_block=64,
+        max_block=2048,
+    )
+
+
+def _launch_n(
+    kernel: Callable,
+    N: int,
+    /,
+    **kwargs,
+) -> None:
+    for n_off, n_len in iter_axis_launch_chunks(N, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        kernel[(n_len,)](N_OFFSET=n_off, **kwargs)
+
+
+@triton.jit(do_not_specialize=['L', 'N', 'D'])
+def attnres_fwd_p1_chunk_kernel(
+    q,
+    res,
+    w,
+    rstd,
+    logit,
+    chunk_m,
+    chunk_acc,
+    L,
+    N,
+    D,
+    stride_ln,
+    eps,
+    scale,
+    BL: tl.constexpr,
+    BD: tl.constexpr,
+    L_OFFSET: tl.constexpr,
+    N_OFFSET: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
+    b_m = tl.full([], float('-inf'), dtype=tl.float32)
+    b_acc = tl.zeros([], dtype=tl.float32)
+    for i_l in range(tl.cdiv(L, BL)):
+        o_l = (i_l * BL + tl.arange(0, BL)).to(tl.int64)
+        m_l = o_l < L
+        b_v_sq = tl.zeros([BL], dtype=tl.float32)
+        b_v_qw = tl.zeros([BL], dtype=tl.float32)
+        for i_d in range(tl.cdiv(D, BD)):
+            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+            m_d = o_d < D
+            b_qw = (
+                tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+                * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+            )
+            b_v = tl.load(
+                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
+                mask=m_l[:, None] & m_d[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            b_v_sq += tl.sum(b_v * b_v, axis=1)
+            b_v_qw += tl.sum(b_v * b_qw[None, :], axis=1)
+        b_rstd = tl.rsqrt(b_v_sq / D + eps)
+        b_logit = b_v_qw * b_rstd
+        b_s = tl.where(m_l, b_logit * scale, float('-inf'))
+        b_m, b_mp = tl.maximum(b_m, tl.max(b_s, axis=0)), b_m
+        b_acc = b_acc * exp(b_mp - b_m) + tl.sum(exp(b_s - b_m), axis=0)
+        g_l = L_OFFSET + o_l
+        tl.store(rstd + g_l * N + i_n, b_rstd.to(rstd.dtype.element_ty), mask=m_l)
+        tl.store(logit + g_l * N + i_n, b_logit.to(logit.dtype.element_ty), mask=m_l)
+    tl.store(chunk_m + i_n, b_m)
+    tl.store(chunk_acc + i_n, b_acc)
+
+
+@triton.jit(do_not_specialize=['L', 'N', 'D'])
+def attnres_fwd_p2_chunk_kernel(
+    res,
+    logit,
+    lse,
+    o_mix,
+    L,
+    N,
+    D,
+    stride_ln,
+    scale,
+    BL: tl.constexpr,
+    BD: tl.constexpr,
+    L_OFFSET: tl.constexpr,
+    N_OFFSET: tl.constexpr,
+    ACCUM: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
+    b_lse = tl.load(lse + i_n).to(tl.float32)
+    for i_d in range(tl.cdiv(D, BD)):
+        o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+        m_d = o_d < D
+        b_o = tl.zeros([BD], dtype=tl.float32)
+        for i_l in range(tl.cdiv(L, BL)):
+            o_l = (i_l * BL + tl.arange(0, BL)).to(tl.int64)
+            m_l = o_l < L
+            g_l = L_OFFSET + o_l
+            b_logit = tl.load(logit + g_l * N + i_n, mask=m_l, other=0.).to(tl.float32)
+            b_p = tl.where(m_l, exp(b_logit * scale - b_lse), 0.0)
+            b_v = tl.load(
+                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
+                mask=m_l[:, None] & m_d[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            b_o += tl.sum(b_p[:, None] * b_v, axis=0)
+        if ACCUM:
+            b_o += tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+        tl.store(o_mix + i_n * D + o_d, b_o, mask=m_d)
+
+
+@triton.jit(do_not_specialize=['N', 'D'])
+def attnres_fwd_onorm_kernel(
+    o,
+    o_mix,
+    ow,
+    N,
+    D,
+    eps,
+    BD: tl.constexpr,
+    N_OFFSET: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
+    b_o_sq = tl.zeros([], dtype=tl.float32)
+    for i_d in range(tl.cdiv(D, BD)):
+        o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+        m_d = o_d < D
+        b_o = tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+        b_o_sq += tl.sum(tl.where(m_d, b_o * b_o, 0.0), axis=0)
+    b_o_rstd = tl.rsqrt(b_o_sq / D + eps)
+    for i_d in range(tl.cdiv(D, BD)):
+        o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+        m_d = o_d < D
+        b_o = tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+        b_ow = tl.load(ow + o_d, mask=m_d, other=0.).to(tl.float32)
+        tl.store(o + i_n * D + o_d, (b_o * b_o_rstd * b_ow).to(o.dtype.element_ty), mask=m_d)
+
+
+@triton.jit(do_not_specialize=['N', 'D'])
+def attnres_bwd_prep_kernel(
+    ow,
+    o_mix,
+    do,
+    do_eff,
+    dow_partial,
+    b_delta,
+    N,
+    D,
+    eps,
+    BD: tl.constexpr,
+    HAS_ONORM: tl.constexpr,
+    N_OFFSET: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
+    if HAS_ONORM:
+        b_o_sq = tl.zeros([], dtype=tl.float32)
+        for i_d in range(tl.cdiv(D, BD)):
+            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+            m_d = o_d < D
+            b_o_pre = tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_o_sq += tl.sum(tl.where(m_d, b_o_pre * b_o_pre, 0.0), axis=0)
+        b_o_rstd = tl.rsqrt(b_o_sq / D + eps)
+        b_c1 = tl.zeros([], dtype=tl.float32)
+        for i_d in range(tl.cdiv(D, BD)):
+            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+            m_d = o_d < D
+            b_do = tl.load(do + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_o_pre = tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_ow = tl.load(ow + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_c1 += tl.sum(tl.where(m_d, b_o_pre * b_o_rstd * b_ow * b_do, 0.0), axis=0)
+        b_c1 /= D
+
+    b_delta_acc = tl.zeros([], dtype=tl.float32)
+    for i_d in range(tl.cdiv(D, BD)):
+        o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+        m_d = o_d < D
+        b_do = tl.load(do + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+        b_o_pre = tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+        if HAS_ONORM:
+            b_ow = tl.load(ow + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_xhat = b_o_pre * b_o_rstd
+            tl.store(dow_partial + i_n * D + o_d, (b_xhat * b_do).to(dow_partial.dtype.element_ty), mask=m_d)
+            b_do = (b_ow * b_do - b_xhat * b_c1) * b_o_rstd
+        tl.store(do_eff + i_n * D + o_d, b_do, mask=m_d)
+        b_delta_acc += tl.sum(tl.where(m_d, b_do * b_o_pre, 0.0), axis=0)
+    tl.store(b_delta + i_n, b_delta_acc)
+
+
+@triton.jit(do_not_specialize=['L', 'N', 'D'])
+def attnres_bwd_dv_chunk_kernel(
+    q,
+    res,
+    w,
+    rstd,
+    logit,
+    lse,
+    do_eff,
+    dres,
+    dqw,
+    b_delta,
+    L,
+    N,
+    D,
+    stride_ln,
+    scale,
+    BL: tl.constexpr,
+    BD: tl.constexpr,
+    L_OFFSET: tl.constexpr,
+    N_OFFSET: tl.constexpr,
+):
+    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
+    b_lse = tl.load(lse + i_n).to(tl.float32)
+    b_delta = tl.load(b_delta + i_n).to(tl.float32)
+    for i_l in range(tl.cdiv(L, BL)):
+        o_l = (i_l * BL + tl.arange(0, BL)).to(tl.int64)
+        m_l = o_l < L
+        g_l = L_OFFSET + o_l
+        b_rstd = tl.load(rstd + g_l * N + i_n, mask=m_l, other=0.).to(tl.float32)
+        b_logit = tl.load(logit + g_l * N + i_n, mask=m_l, other=0.).to(tl.float32)
+        b_p = tl.where(m_l, exp(b_logit * scale - b_lse), 0.0)
+        b_dp = tl.zeros([BL], dtype=tl.float32)
+        for i_d in range(tl.cdiv(D, BD)):
+            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+            m_d = o_d < D
+            b_do = tl.load(do_eff + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_v = tl.load(
+                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
+                mask=m_l[:, None] & m_d[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            b_dp += tl.sum(b_v * b_do[None, :], axis=1)
+        b_ds = b_p * (b_dp - b_delta) * scale
+        for i_d in range(tl.cdiv(D, BD)):
+            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+            m_d = o_d < D
+            m_v = m_l[:, None] & m_d[None, :]
+            b_qw = (
+                tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+                * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+            )
+            b_do = tl.load(do_eff + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_v = tl.load(
+                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
+                mask=m_v,
+                other=0.0,
+            ).to(tl.float32)
+            b_k = b_v * b_rstd[:, None]
+            b_dv = b_p[:, None] * b_do[None, :] + (b_ds * b_rstd)[:, None] * (
+                b_qw[None, :] - b_k * (b_logit / D)[:, None]
+            )
+            tl.store(
+                dres + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
+                b_dv.to(dres.dtype.element_ty),
+                mask=m_v,
+            )
+            b_dqw = tl.load(dqw + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            b_dqw += tl.sum(b_ds[:, None] * b_k, axis=0)
+            tl.store(dqw + i_n * D + o_d, b_dqw, mask=m_d)
+
+
+@triton.jit(do_not_specialize=['N', 'D'])
+def attnres_bwd_kernel_dqdw_npu(
+    q,
+    w,
+    dqw,
+    dow_partial,
+    dq,
+    dw,
+    dow,
+    N,
+    D,
+    BD: tl.constexpr,
+    HAS_ONORM: tl.constexpr,
+):
+    i_d = tl.program_id(0)
+    o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+    m_d = o_d < D
+    b_dqw = tl.zeros([BD], dtype=tl.float32)
+    b_dow = tl.zeros([BD], dtype=tl.float32)
+    for i_n in range(N):
+        b_dqw += tl.load(dqw + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+        if HAS_ONORM:
+            b_dow += tl.load(dow_partial + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+    b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+    b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+    tl.store(dq + o_d, b_dqw * b_w, mask=m_d)
+    tl.store(dw + o_d, b_dqw * b_q, mask=m_d)
+    if HAS_ONORM:
+        tl.store(dow + o_d, b_dow, mask=m_d)
+
+
+def _accumulate_o_mix(
+    sources: Sequence[torch.Tensor],
+    logit: torch.Tensor,
+    lse: torch.Tensor,
+    o_mix: torch.Tensor,
+    scale: float,
+) -> None:
+    first = True
+    for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
+        _launch_n(
+            attnres_fwd_p2_chunk_kernel,
+            N,
+            res=chunk,
+            logit=logit,
+            lse=lse,
+            o_mix=o_mix,
+            L=ll,
+            N=N,
+            D=D,
+            stride_ln=stride_ln,
+            scale=scale,
+            BL=_get_bl(ll),
+            BD=_get_bd(ll, D, memory_multiplier=_FWD_MEM_MULT),
+            L_OFFSET=l0,
+            ACCUM=not first,
+        )
+        first = False
+        del chunk
+
+
+def _resolve_o_mix(
+    sources: Sequence[torch.Tensor],
+    o_pre: torch.Tensor | None,
+    logit: torch.Tensor,
+    lse: torch.Tensor,
+    scale: float,
+    device: torch.device,
+) -> torch.Tensor:
+    if o_pre is not None:
+        return o_pre.to(torch.float32)
+    o_mix = torch.zeros(*sources[0].shape, device=device, dtype=torch.float32)
+    _accumulate_o_mix(sources, logit, lse, o_mix, scale)
+    return o_mix
+
+
+def fused_attnres_fwd_npu(
+    q: torch.Tensor,
+    sources: Sequence[torch.Tensor],
+    w: torch.Tensor,
+    ow: torch.Tensor | None,
+    eps: float,
+    scale: float,
+    checkpoint_level: int,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor, torch.Tensor]:
+    L, N, D = len(sources), *sources[0].shape
+    dtype = sources[0].dtype
+    save_opre = checkpoint_level == 0
+
+    o = torch.empty((N, D), device=sources[0].device, dtype=dtype)
+    o_pre = torch.empty((N, D), device=sources[0].device, dtype=dtype) if save_opre else None
+    lse = torch.empty(N, device=sources[0].device, dtype=torch.float32)
+    rstd = torch.empty((L, N), device=sources[0].device, dtype=torch.float32)
+    logit = torch.empty_like(rstd)
+
+    m = torch.full((N,), float('-inf'), device=sources[0].device, dtype=torch.float32)
+    acc = torch.zeros(N, device=sources[0].device, dtype=torch.float32)
+    for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
+        chunk_m = torch.empty(N, device=chunk.device, dtype=torch.float32)
+        chunk_acc = torch.empty(N, device=chunk.device, dtype=torch.float32)
+        _launch_n(
+            attnres_fwd_p1_chunk_kernel,
+            N,
+            q=q,
+            res=chunk,
+            w=w,
+            rstd=rstd,
+            logit=logit,
+            chunk_m=chunk_m,
+            chunk_acc=chunk_acc,
+            L=ll,
+            N=N,
+            D=D,
+            stride_ln=stride_ln,
+            eps=eps,
+            scale=scale,
+            BL=_get_bl(ll),
+            BD=_get_bd(ll, D, memory_multiplier=_FWD_MEM_MULT),
+            L_OFFSET=l0,
+        )
+        m, acc = _merge_online_softmax(m, acc, chunk_m, chunk_acc)
+        del chunk, chunk_m, chunk_acc
+
+    lse.copy_(m + torch.log(acc))
+    o_mix = torch.zeros(N, D, device=sources[0].device, dtype=torch.float32)
+    _accumulate_o_mix(sources, logit, lse, o_mix, scale)
+
+    if save_opre:
+        o_pre.copy_(o_mix.to(dtype))
+    if ow is not None:
+        _launch_n(
+            attnres_fwd_onorm_kernel,
+            N,
+            o=o,
+            o_mix=o_mix,
+            ow=ow,
+            N=N,
+            D=D,
+            eps=eps,
+            BD=_get_bd(1, D, memory_multiplier=2.0),
+        )
+    else:
+        o.copy_(o_mix.to(dtype))
+    return o, o_pre, rstd, logit, lse
+
+
+def fused_attnres_bwd_npu(
+    do: torch.Tensor,
+    q: torch.Tensor,
+    sources: Sequence[torch.Tensor],
+    flat_dvs: Sequence[torch.Tensor],
+    w: torch.Tensor,
+    ow: torch.Tensor | None,
+    o_pre: torch.Tensor | None,
+    rstd: torch.Tensor,
+    logit: torch.Tensor,
+    lse: torch.Tensor,
+    eps: float,
+    scale: float,
+    checkpoint_level: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    del checkpoint_level
+    has_onorm = ow is not None
+    N, D = do.shape
+
+    do_eff = torch.empty_like(do, dtype=torch.float32)
+    b_delta = torch.empty(N, device=do.device, dtype=torch.float32)
+    dqw = torch.zeros_like(do, dtype=torch.float32)
+    dq, dw = torch.empty_like(q), torch.empty_like(w)
+    dow = torch.empty_like(ow) if has_onorm else None
+    dow_partial = torch.empty_like(do, dtype=torch.float32) if has_onorm else do_eff
+
+    o_mix = _resolve_o_mix(sources, o_pre, logit, lse, scale, do.device)
+    _launch_n(
+        attnres_bwd_prep_kernel,
+        N,
+        ow=ow if ow is not None else w,
+        o_mix=o_mix,
+        do=do,
+        do_eff=do_eff,
+        dow_partial=dow_partial,
+        b_delta=b_delta,
+        N=N,
+        D=D,
+        eps=eps,
+        BD=_get_bd(1, D, memory_multiplier=_BWD_DV_MEM_MULT),
+        HAS_ONORM=has_onorm,
+    )
+
+    for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
+        chunk_dres = torch.empty_like(chunk)
+        _launch_n(
+            attnres_bwd_dv_chunk_kernel,
+            N,
+            q=q,
+            res=chunk,
+            w=w,
+            rstd=rstd,
+            logit=logit,
+            lse=lse,
+            do_eff=do_eff,
+            dres=chunk_dres,
+            dqw=dqw,
+            b_delta=b_delta,
+            L=ll,
+            N=N,
+            D=D,
+            stride_ln=stride_ln,
+            scale=scale,
+            BL=_get_bl(ll),
+            BD=_get_bd(ll, D, memory_multiplier=_BWD_DV_MEM_MULT),
+            L_OFFSET=l0,
+        )
+        for i in range(ll):
+            flat_dvs[l0 + i].copy_(chunk_dres[i])
+        del chunk, chunk_dres
+
+    bd = _get_bd(1, D, memory_multiplier=2.0)
+    attnres_bwd_kernel_dqdw_npu[(triton.cdiv(D, bd),)](
+        q=q,
+        w=w,
+        dqw=dqw,
+        dow_partial=dow_partial,
+        dq=dq,
+        dw=dw,
+        dow=dow if dow is not None else dq,
+        N=N,
+        D=D,
+        BD=bd,
+        HAS_ONORM=has_onorm,
+    )
+    return dq, dw, dow
+
+
+class FusedAttnresNpuFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        query: torch.Tensor,
+        rms_weight: torch.Tensor,
+        output_rms_weight: torch.Tensor | None,
+        rms_eps: float,
+        scale: float,
+        return_weights: bool,
+        checkpoint_level: int,
+        *residuals: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        o, o_pre, rstd, logit, lse = fused_attnres_fwd_npu(
+            query, residuals, rms_weight, output_rms_weight,
+            rms_eps, scale, checkpoint_level,
+        )
+        ctx.save_for_backward(
+            query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse, *residuals,
+        )
+        ctx.eps, ctx.scale, ctx.checkpoint_level = rms_eps, scale, checkpoint_level
+        p = (logit * scale - lse).exp() if return_weights else o.new_empty(0)
+        ctx.mark_non_differentiable(p)
+        return o, p
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(ctx, do: torch.Tensor, dp: torch.Tensor | None = None):
+        del dp
+        query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse, *residuals = ctx.saved_tensors
+        flat_dvs = [torch.empty_like(r) for r in residuals]
+        dq, dw, dow = fused_attnres_bwd_npu(
+            do, query, residuals, flat_dvs, rms_weight, output_rms_weight,
+            o_pre, rstd, logit, lse, ctx.eps, ctx.scale, ctx.checkpoint_level,
+        )
+        return (dq, dw, dow, None, None, None, None, *flat_dvs)
+
+
+def fused_attnres_npu(
+    query: torch.Tensor,
+    residuals: Sequence[torch.Tensor],
+    rms_weight: torch.Tensor,
+    output_rms_weight: torch.Tensor | None = None,
+    rms_eps: float = 1e-6,
+    scale: float = 1.0,
+    return_weights: bool = False,
+    checkpoint_level: int = 1,
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    output_shape = residuals[0].shape
+    D = output_shape[-1]
+    flat = tuple(r.reshape(-1, D).contiguous() for r in residuals)
+    o, p = FusedAttnresNpuFunction.apply(
+        query, rms_weight, output_rms_weight, rms_eps, scale,
+        return_weights, checkpoint_level, *flat,
+    )
+    o = o.view(output_shape)
+    if return_weights:
+        return o, p.view(len(residuals), *output_shape[:-1])
+    return o
+
+
+__all__ = [
+    'FusedAttnresNpuFunction',
+    'fused_attnres_bwd_npu',
+    'fused_attnres_fwd_npu',
+    'fused_attnres_npu',
+]

--- a/fla/ops/attnres/backends/triton_ascend/fused.py
+++ b/fla/ops/attnres/backends/triton_ascend/fused.py
@@ -46,12 +46,7 @@ def _l_chunk_size(L: int, N: int, D: int, elem_size: int) -> int:
 
 def _flat_residual(r: torch.Tensor, D: int) -> torch.Tensor:
     """View ``[..., D]`` as ``[N, D]`` for the autograd path."""
-    flat = r.view(-1, D)
-    if not flat.is_contiguous():
-        flat = flat.contiguous()
-    if r._base is not None:
-        flat = flat.detach().requires_grad_(True)
-    return flat
+    return r.reshape(-1, D).contiguous()
 
 
 def _stack_sources(sources: Sequence[torch.Tensor], l0: int, l1: int) -> torch.Tensor:
@@ -114,7 +109,7 @@ def _launch_n(
         kernel[(n_len,)](N_OFFSET=n_off, **kwargs)
 
 
-@triton.jit(do_not_specialize=['L', 'N', 'D'])
+@triton.jit(do_not_specialize=['L', 'N', 'D', 'L_OFFSET'])
 def attnres_fwd_p1_chunk_kernel(
     q,
     res,
@@ -131,7 +126,7 @@ def attnres_fwd_p1_chunk_kernel(
     scale,
     BL: tl.constexpr,
     BD: tl.constexpr,
-    L_OFFSET: tl.constexpr,
+    L_OFFSET,
     N_OFFSET: tl.constexpr,
 ):
     i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
@@ -168,7 +163,7 @@ def attnres_fwd_p1_chunk_kernel(
     tl.store(chunk_acc + i_n, b_acc)
 
 
-@triton.jit(do_not_specialize=['L', 'N', 'D'])
+@triton.jit(do_not_specialize=['L', 'N', 'D', 'L_OFFSET'])
 def attnres_fwd_p2_chunk_kernel(
     res,
     logit,
@@ -181,7 +176,7 @@ def attnres_fwd_p2_chunk_kernel(
     scale,
     BL: tl.constexpr,
     BD: tl.constexpr,
-    L_OFFSET: tl.constexpr,
+    L_OFFSET,
     N_OFFSET: tl.constexpr,
     ACCUM: tl.constexpr,
 ):
@@ -285,7 +280,7 @@ def attnres_bwd_prep_kernel(
     tl.store(b_delta + i_n, b_delta_acc)
 
 
-@triton.jit(do_not_specialize=['L', 'N', 'D'])
+@triton.jit(do_not_specialize=['L', 'N', 'D', 'L_OFFSET'])
 def attnres_bwd_dv_chunk_kernel(
     q,
     res,
@@ -304,7 +299,7 @@ def attnres_bwd_dv_chunk_kernel(
     scale,
     BL: tl.constexpr,
     BD: tl.constexpr,
-    L_OFFSET: tl.constexpr,
+    L_OFFSET,
     N_OFFSET: tl.constexpr,
 ):
     i_n = tl.program_id(0).to(tl.int64) + N_OFFSET

--- a/fla/ops/attnres/backends/triton_ascend/fused.py
+++ b/fla/ops/attnres/backends/triton_ascend/fused.py
@@ -44,6 +44,18 @@ def _l_chunk_size(L: int, N: int, D: int, elem_size: int) -> int:
     return max(1, min(L, _MAX_L_CHUNK_BYTES // layer_bytes))
 
 
+def _flat_residual(r: torch.Tensor, D: int) -> torch.Tensor:
+    """View ``[..., D]`` as ``[N, D]``; detach views into a stacked buffer."""
+    flat = r.view(-1, D)
+    if not flat.is_contiguous():
+        flat = flat.contiguous()
+    # Benchmark feeds ``[L,B,T,D]`` slices; without detach, backward allocates
+    # one contiguous grad for the whole stack (8 GiB at max shape).
+    if flat._base is not None:
+        flat = flat.detach().requires_grad_(True)
+    return flat
+
+
 def _stack_sources(sources: Sequence[torch.Tensor], l0: int, l1: int) -> torch.Tensor:
     if l1 - l0 == 1:
         return sources[l0].unsqueeze(0)
@@ -87,6 +99,11 @@ def _get_bd(row_dim: int, col_dim: int, *, memory_multiplier: float) -> int:
         min_block=64,
         max_block=2048,
     )
+
+
+def _get_bl_bd(ll: int, D: int, *, mem_mult: float) -> tuple[int, int]:
+    bl = _get_bl(ll)
+    return bl, _get_bd(bl, D, memory_multiplier=mem_mult)
 
 
 def _launch_n(
@@ -373,15 +390,22 @@ def attnres_bwd_kernel_dqdw_npu(
         tl.store(dow + o_d, b_dow, mask=m_d)
 
 
-def _accumulate_o_mix(
+def _get_o_mix(
     sources: Sequence[torch.Tensor],
     logit: torch.Tensor,
     lse: torch.Tensor,
-    o_mix: torch.Tensor,
     scale: float,
-) -> None:
+    device: torch.device,
+    o_pre: torch.Tensor | None = None,
+    o_mix: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if o_pre is not None:
+        return o_pre
+    if o_mix is None:
+        o_mix = torch.zeros(*sources[0].shape, device=device, dtype=torch.float32)
     first = True
     for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
+        bl, bd = _get_bl_bd(ll, D, mem_mult=_FWD_MEM_MULT)
         _launch_n(
             attnres_fwd_p2_chunk_kernel,
             N,
@@ -394,28 +418,28 @@ def _accumulate_o_mix(
             D=D,
             stride_ln=stride_ln,
             scale=scale,
-            BL=_get_bl(ll),
-            BD=_get_bd(ll, D, memory_multiplier=_FWD_MEM_MULT),
+            BL=bl,
+            BD=bd,
             L_OFFSET=l0,
             ACCUM=not first,
         )
         first = False
         del chunk
-
-
-def _resolve_o_mix(
-    sources: Sequence[torch.Tensor],
-    o_pre: torch.Tensor | None,
-    logit: torch.Tensor,
-    lse: torch.Tensor,
-    scale: float,
-    device: torch.device,
-) -> torch.Tensor:
-    if o_pre is not None:
-        return o_pre.to(torch.float32)
-    o_mix = torch.zeros(*sources[0].shape, device=device, dtype=torch.float32)
-    _accumulate_o_mix(sources, logit, lse, o_mix, scale)
     return o_mix
+
+
+def _dres_chunk(
+    flat_dvs: list[torch.Tensor | None],
+    sources: Sequence[torch.Tensor],
+    l0: int,
+    ll: int,
+    chunk: torch.Tensor,
+) -> torch.Tensor:
+    if ll == 1:
+        if flat_dvs[l0] is None:
+            flat_dvs[l0] = torch.empty_like(sources[l0])
+        return flat_dvs[l0].unsqueeze(0)
+    return torch.empty_like(chunk)
 
 
 def fused_attnres_fwd_npu(
@@ -442,6 +466,7 @@ def fused_attnres_fwd_npu(
     for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
         chunk_m = torch.empty(N, device=chunk.device, dtype=torch.float32)
         chunk_acc = torch.empty(N, device=chunk.device, dtype=torch.float32)
+        bl, bd = _get_bl_bd(ll, D, mem_mult=_FWD_MEM_MULT)
         _launch_n(
             attnres_fwd_p1_chunk_kernel,
             N,
@@ -458,19 +483,22 @@ def fused_attnres_fwd_npu(
             stride_ln=stride_ln,
             eps=eps,
             scale=scale,
-            BL=_get_bl(ll),
-            BD=_get_bd(ll, D, memory_multiplier=_FWD_MEM_MULT),
+            BL=bl,
+            BD=bd,
             L_OFFSET=l0,
         )
         m, acc = _merge_online_softmax(m, acc, chunk_m, chunk_acc)
         del chunk, chunk_m, chunk_acc
 
     lse.copy_(m + torch.log(acc))
-    o_mix = torch.zeros(N, D, device=sources[0].device, dtype=torch.float32)
-    _accumulate_o_mix(sources, logit, lse, o_mix, scale)
+    o_mix = _get_o_mix(sources, logit, lse, scale, sources[0].device)
 
     if save_opre:
         o_pre.copy_(o_mix.to(dtype))
+        if ow is None:
+            o.copy_(o_pre)
+    elif ow is None:
+        o.copy_(o_mix.to(dtype))
     if ow is not None:
         _launch_n(
             attnres_fwd_onorm_kernel,
@@ -483,8 +511,6 @@ def fused_attnres_fwd_npu(
             eps=eps,
             BD=_get_bd(1, D, memory_multiplier=2.0),
         )
-    else:
-        o.copy_(o_mix.to(dtype))
     return o, o_pre, rstd, logit, lse
 
 
@@ -492,7 +518,6 @@ def fused_attnres_bwd_npu(
     do: torch.Tensor,
     q: torch.Tensor,
     sources: Sequence[torch.Tensor],
-    flat_dvs: Sequence[torch.Tensor],
     w: torch.Tensor,
     ow: torch.Tensor | None,
     o_pre: torch.Tensor | None,
@@ -502,10 +527,11 @@ def fused_attnres_bwd_npu(
     eps: float,
     scale: float,
     checkpoint_level: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, list[torch.Tensor]]:
     del checkpoint_level
     has_onorm = ow is not None
     N, D = do.shape
+    flat_dvs: list[torch.Tensor | None] = [None] * len(sources)
 
     do_eff = torch.empty_like(do, dtype=torch.float32)
     b_delta = torch.empty(N, device=do.device, dtype=torch.float32)
@@ -514,7 +540,7 @@ def fused_attnres_bwd_npu(
     dow = torch.empty_like(ow) if has_onorm else None
     dow_partial = torch.empty_like(do, dtype=torch.float32) if has_onorm else do_eff
 
-    o_mix = _resolve_o_mix(sources, o_pre, logit, lse, scale, do.device)
+    o_mix = _get_o_mix(sources, logit, lse, scale, do.device, o_pre=o_pre)
     _launch_n(
         attnres_bwd_prep_kernel,
         N,
@@ -532,7 +558,8 @@ def fused_attnres_bwd_npu(
     )
 
     for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
-        chunk_dres = torch.empty_like(chunk)
+        dres = _dres_chunk(flat_dvs, sources, l0, ll, chunk)
+        bl, bd = _get_bl_bd(ll, D, mem_mult=_BWD_DV_MEM_MULT)
         _launch_n(
             attnres_bwd_dv_chunk_kernel,
             N,
@@ -543,7 +570,7 @@ def fused_attnres_bwd_npu(
             logit=logit,
             lse=lse,
             do_eff=do_eff,
-            dres=chunk_dres,
+            dres=dres,
             dqw=dqw,
             b_delta=b_delta,
             L=ll,
@@ -551,13 +578,18 @@ def fused_attnres_bwd_npu(
             D=D,
             stride_ln=stride_ln,
             scale=scale,
-            BL=_get_bl(ll),
-            BD=_get_bd(ll, D, memory_multiplier=_BWD_DV_MEM_MULT),
+            BL=bl,
+            BD=bd,
             L_OFFSET=l0,
         )
-        for i in range(ll):
-            flat_dvs[l0 + i].copy_(chunk_dres[i])
-        del chunk, chunk_dres
+        if ll > 1:
+            for i in range(ll):
+                idx = l0 + i
+                if flat_dvs[idx] is None:
+                    flat_dvs[idx] = torch.empty_like(sources[idx])
+                flat_dvs[idx].copy_(dres[i])
+            del dres
+        del chunk
 
     bd = _get_bd(1, D, memory_multiplier=2.0)
     attnres_bwd_kernel_dqdw_npu[(triton.cdiv(D, bd),)](
@@ -573,7 +605,8 @@ def fused_attnres_bwd_npu(
         BD=bd,
         HAS_ONORM=has_onorm,
     )
-    return dq, dw, dow
+    assert all(t is not None for t in flat_dvs)
+    return dq, dw, dow, flat_dvs  # type: ignore[return-value]
 
 
 class FusedAttnresNpuFunction(torch.autograd.Function):
@@ -610,9 +643,8 @@ class FusedAttnresNpuFunction(torch.autograd.Function):
     def backward(ctx, do: torch.Tensor, dp: torch.Tensor | None = None):
         del dp
         query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse, *residuals = ctx.saved_tensors
-        flat_dvs = [torch.empty_like(r) for r in residuals]
-        dq, dw, dow = fused_attnres_bwd_npu(
-            do, query, residuals, flat_dvs, rms_weight, output_rms_weight,
+        dq, dw, dow, flat_dvs = fused_attnres_bwd_npu(
+            do, query, residuals, rms_weight, output_rms_weight,
             o_pre, rstd, logit, lse, ctx.eps, ctx.scale, ctx.checkpoint_level,
         )
         return (dq, dw, dow, None, None, None, None, *flat_dvs)
@@ -630,7 +662,7 @@ def fused_attnres_npu(
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     output_shape = residuals[0].shape
     D = output_shape[-1]
-    flat = tuple(r.reshape(-1, D).contiguous() for r in residuals)
+    flat = tuple(_flat_residual(r, D) for r in residuals)
     o, p = FusedAttnresNpuFunction.apply(
         query, rms_weight, output_rms_weight, rms_eps, scale,
         return_weights, checkpoint_level, *flat,

--- a/fla/ops/attnres/backends/triton_ascend/fused.py
+++ b/fla/ops/attnres/backends/triton_ascend/fused.py
@@ -45,13 +45,11 @@ def _l_chunk_size(L: int, N: int, D: int, elem_size: int) -> int:
 
 
 def _flat_residual(r: torch.Tensor, D: int) -> torch.Tensor:
-    """View ``[..., D]`` as ``[N, D]``; detach views into a stacked buffer."""
+    """View ``[..., D]`` as ``[N, D]`` for the autograd path."""
     flat = r.view(-1, D)
     if not flat.is_contiguous():
         flat = flat.contiguous()
-    # Benchmark feeds ``[L,B,T,D]`` slices; without detach, backward allocates
-    # one contiguous grad for the whole stack (8 GiB at max shape).
-    if flat._base is not None:
+    if r._base is not None:
         flat = flat.detach().requires_grad_(True)
     return flat
 

--- a/tests/ops/test_attnres.py
+++ b/tests/ops/test_attnres.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from fla.ops.attnres import fused_attnres, naive_attnres
-from fla.utils import assert_close, device
+from fla.utils import IS_NPU, assert_close, device
 
 
 @pytest.mark.parametrize(
@@ -110,3 +110,64 @@ def test_attnres(
     assert_close('dv', torch.stack([r.grad for r in residuals_ref]), torch.stack(tri_dvs), 0.005)
     if fuse_output_norm:
         assert_close('dow', output_rms_weight_ref.grad, tri_dow, 0.005)
+
+
+_TRITON_ASCEND_ATTNRES_OPS = ('fused_attnres',)
+
+
+def _spy_on_triton_ascend_attnres_backend():
+    """Patch every op of the Triton-Ascend AttnRes backend to record dispatched calls."""
+    from fla.ops.backends import BackendRegistry
+
+    BackendRegistry.ensure_initialized('attnres')
+    backend = BackendRegistry._registries['attnres']._backends.get('triton_ascend')
+    assert backend is not None, 'Triton-Ascend AttnRes backend is not registered'
+
+    calls = []
+    for name in _TRITON_ASCEND_ATTNRES_OPS:
+        original = getattr(backend, name)
+
+        def make_spy(name, original):
+            def spy(*args, **kwargs):
+                calls.append(name)
+                return original(*args, **kwargs)
+            return spy
+
+        setattr(backend, name, make_spy(name, original))
+    return backend, calls
+
+
+@pytest.mark.skipif(not IS_NPU, reason='Triton-Ascend AttnRes backend routing is only exercised on NPU')
+def test_triton_ascend_backend_routing():
+    """fused_attnres must actually dispatch to the Triton-Ascend backend on NPU.
+
+    Numerical parity tests alone cannot catch silently-failing verifiers: if
+    every verifier rejected, the call would fall back to the default CUDA Triton
+    path and parity tests would still pass, leaving the NPU kernels dead.
+    """
+    backend, calls = _spy_on_triton_ascend_attnres_backend()
+    try:
+        L, B, T, D = 3, 1, 64, 128
+        dtype = torch.float16
+        residuals = [
+            torch.randn(B, T, D, dtype=dtype, device=device).requires_grad_(True)
+            for _ in range(L)
+        ]
+        query = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
+        rms_weight = torch.randn(D, dtype=dtype, device=device).requires_grad_(True)
+
+        calls.clear()
+        o = fused_attnres(
+            query=query,
+            residuals=residuals,
+            rms_weight=rms_weight,
+            scale=D ** -0.5,
+            checkpoint_level=1,
+        )
+        (o * torch.randn_like(o)).sum().backward()
+        assert calls == ['fused_attnres'], (
+            f'fused_attnres not routed to the Triton-Ascend backend (dispatched: {calls})'
+        )
+    finally:
+        for name in _TRITON_ASCEND_ATTNRES_OPS:
+            delattr(backend, name)


### PR DESCRIPTION
## Summary

Add a Triton-Ascend AttnRes backend for Ascend NPU and follow up with memory fixes so the largest benchmark shape runs fwdbwd without OOM.

- Implement `triton_ascend` fused AttnRes kernels (L-chunk stacked sources, fp32 `o_mix` accumulation, D/N tiling via `ascend_ub_manager`)
- Register the NPU backend ahead of Gluon; keep GPU `fla/ops/attnres/fused.py` unchanged
- Add routing/parity tests, Ascend CI coverage, and `fused_attnres` benchmark registration
- Fix fwdbwd OOM at `L64 × T8192 × D8192` by detaching stacked benchmark residual views and lazy-allocating per-source `dv` gradients in L-chunks


## Test plan

- [x] `pytest tests/ops/test_attnres.py` — 16/16 passed on NPU
- [x] `python benchmarks/ops/run.py --op fused_attnres` — all fwd + fwdbwd shapes passed (incl. max shape)
- [x] Ascend A2 CI (`ascend-a2-ci.yml`)
- [x] Ascend A2 benchmark CI (`ascend-a2-benchmark-ci.yml`)