### PR TITLE
[Perf] Optimize Ascend chunk_delta_h bwd_dhu with dynamic BK/BV tiling and host gate precomp

### DIFF
--- a/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
@@ -19,6 +19,7 @@ from fla.utils import input_guard
 from fla.utils.ascend_ub_manager import (
     ASCEND_MAX_GRID_DIM,
     compute_row_tile_block_size,
+    get_ub_manager,
     max_grid_axis_chunks,
 )
 
@@ -28,6 +29,11 @@ _FWD_H_MEM_MULT = 8.0
 _SAFETY_MARGIN = 0.80
 _FALLBACK_BV = 16
 _MAX_BV = 64
+_DHU_BT = 64
+# Soft UB over-admit for host-precomputed gates (live-range can beat peak estimate).
+_DHU_UB_SOFT = 1.15
+# Tighter fraction when in-kernel exp2(g) inflates live UB (~1.7× analytical).
+_DHU_UB_GATE_INLINE = 0.60
 
 
 def _get_bv(K: int, V: int) -> int:
@@ -41,6 +47,61 @@ def _get_bv(K: int, V: int) -> int:
         min_block=16,
         max_block=min(_MAX_BV, triton.next_power_of_2(V)),
     )
+
+
+def _dhu_peak_bytes(BK: int, BV: int, n_slabs: int, BT: int = _DHU_BT) -> int:
+    # All K-slabs of dh stay live; q/w are one-slab at a time.
+    return (
+        n_slabs * BK * BV * 4
+        + 2 * BK * BT * 2
+        + BT * BV * 2
+        + BT * BV * 4
+        + 12 * BT
+    )
+
+
+def _dhu_tile_cost(K: int, V: int, BK: int, BV: int) -> int:
+    """Reverse-loop scalar proxy: nv × (base ptrs + ~4 per K-slab)."""
+    return triton.cdiv(V, BV) * (3 + 4 * triton.cdiv(K, BK))
+
+
+def _select_bwd_dhu_tiles(
+    K: int,
+    V: int,
+    state_v_first: bool,
+    *,
+    gate_inline: bool = False,
+) -> tuple[int, int]:
+    """Pick (BK, BV) minimizing launch×ptr cost under a soft UB cap.
+
+    ``gate_inline`` covers USE_G without host-precomputed exp2 (unaligned T / varlen).
+    """
+    if state_v_first:
+        return 64, _get_bv(K, V)
+
+    soft_cap = int(get_ub_manager().ub_capacity_bytes * (
+        _DHU_UB_GATE_INLINE if gate_inline else _DHU_UB_SOFT
+    ))
+    # bwd kernel is blockdim64: K is covered by up to four BK=64 slabs only.
+    max_bk = 64
+    desired_v = triton.next_power_of_2(V)
+    best: tuple[int, int, int] | None = None  # cost, BK, BV
+
+    bk = 64
+    while bk <= max_bk:
+        n_slabs = triton.cdiv(K, bk)
+        bv = 16
+        while bv <= min(desired_v, 256):
+            if _dhu_peak_bytes(bk, bv, n_slabs) <= soft_cap:
+                cost = _dhu_tile_cost(K, V, bk, bv)
+                if best is None or cost < best[0] or (cost == best[0] and bk > best[1]):
+                    best = (cost, bk, bv)
+            bv *= 2
+        bk *= 2
+
+    if best is None:
+        return 64, _get_bv(K, V)
+    return best[1], best[2]
 
 
 def _launch_fwd_h_kernel(kernel, *, nv_chunks: int, nh_total: int, kernel_kwargs: dict) -> None:
@@ -396,13 +457,15 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
     k,
     w,
     g,
+    g_exp,
+    g_ratio,
+    g_last_exp,
     gk,
     dht,
     dh0,
     do,
     dh,
     dv,
-    dv2,
     cu_seqlens,
     chunk_offsets,
     scale,
@@ -412,8 +475,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
+    BK: tl.constexpr,
     BV: tl.constexpr,
     USE_G: tl.constexpr,
+    USE_G_PRECOMP: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
@@ -425,42 +490,53 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
     i_v = tl.program_id(0) + V_OFFSET
     i_nh = tl.program_id(1) + NH_OFFSET
     i_n, i_h = i_nh // HV, i_nh % HV
+    # Keep tensor-width T for g strides; T_cur is the active sequence length.
+    T_cur = T
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
-        NT = tl.cdiv(T, BT)
+        T_cur = eos - bos
+        NT = tl.cdiv(T_cur, BT)
         boh = tl.load(chunk_offsets + i_n).to(tl.int32)
     else:
         bos, eos = i_n * T, i_n * T + T
-        NT = tl.cdiv(T, BT)
+        NT = tl.cdiv(T_cur, BT)
         boh = i_n * NT
 
     if STATE_V_FIRST:
-        b_dh1 = tl.zeros([BV, 64], dtype=tl.float32)
-        if K > 64:
-            b_dh2 = tl.zeros([BV, 64], dtype=tl.float32)
-        if K > 128:
-            b_dh3 = tl.zeros([BV, 64], dtype=tl.float32)
-        if K > 192:
-            b_dh4 = tl.zeros([BV, 64], dtype=tl.float32)
+        b_dh1 = tl.zeros([BV, BK], dtype=tl.float32)
+        if K > BK:
+            b_dh2 = tl.zeros([BV, BK], dtype=tl.float32)
+        if K > 2 * BK:
+            b_dh3 = tl.zeros([BV, BK], dtype=tl.float32)
+        if K > 3 * BK:
+            b_dh4 = tl.zeros([BV, BK], dtype=tl.float32)
     else:
-        b_dh1 = tl.zeros([64, BV], dtype=tl.float32)
-        if K > 64:
-            b_dh2 = tl.zeros([64, BV], dtype=tl.float32)
-        if K > 128:
-            b_dh3 = tl.zeros([64, BV], dtype=tl.float32)
-        if K > 192:
-            b_dh4 = tl.zeros([64, BV], dtype=tl.float32)
+        b_dh1 = tl.zeros([BK, BV], dtype=tl.float32)
+        if K > BK:
+            b_dh2 = tl.zeros([BK, BV], dtype=tl.float32)
+        if K > 2 * BK:
+            b_dh3 = tl.zeros([BK, BV], dtype=tl.float32)
+        if K > 3 * BK:
+            b_dh4 = tl.zeros([BK, BV], dtype=tl.float32)
 
     q += (bos * H + i_h // (HV // H)).to(tl.int64) * K
     k += (bos * H + i_h // (HV // H)).to(tl.int64) * K
     w += (bos * HV + i_h).to(tl.int64) * K
     do += (bos * HV + i_h).to(tl.int64) * V
     dv += (bos * HV + i_h).to(tl.int64) * V
-    dv2 += (bos * HV + i_h).to(tl.int64) * V
     dh += (boh * HV + i_h).to(tl.int64) * K * V
     if USE_GK:
         gk += (bos * HV + i_h).to(tl.int64) * K
+    # Host g layout is [B, HV, T] (or [1, HV, T] for varlen).
+    if USE_G:
+        if USE_G_PRECOMP:
+            g_exp += (i_n * HV + i_h).to(tl.int64) * T
+            g_ratio += (i_n * HV + i_h).to(tl.int64) * T
+            g_last_exp += (i_n * HV + i_h).to(tl.int64) * NT
+        elif IS_VARLEN:
+            g += (bos + i_h * T).to(tl.int64)
+        else:
+            g += (i_n * HV + i_h).to(tl.int64) * T
 
     if USE_INITIAL_STATE:
         dh0 += i_nh * K * V
@@ -469,71 +545,84 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
 
     if USE_FINAL_STATE_GRADIENT:
         if STATE_V_FIRST:
-            p_dht1 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_dht1 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
         else:
-            p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+            p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
         b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
-        if K > 64:
+        if K > BK:
             if STATE_V_FIRST:
-                p_dht2 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_dht2 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
             else:
-                p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+                p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (BK, i_v * BV), (BK, BV), (1, 0))
             b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
-        if K > 128:
+        if K > 2 * BK:
             if STATE_V_FIRST:
-                p_dht3 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_dht3 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
             else:
-                p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+                p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (2 * BK, i_v * BV), (BK, BV), (1, 0))
             b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
-        if K > 192:
+        if K > 3 * BK:
             if STATE_V_FIRST:
-                p_dht4 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_dht4 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
             else:
-                p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (3 * BK, i_v * BV), (BK, BV), (1, 0))
             b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
 
+    if USE_GK:
+        o_k1 = tl.arange(0, BK)
+
+    DH_CS: tl.constexpr = HV * K * V
+    dh_chunk = dh + (NT - 1).to(tl.int64) * DH_CS
+
     for i_t in range(NT - 1, -1, -1):
-        i_t_int64 = i_t.to(tl.int64)
         if STATE_V_FIRST:
-            p_dh1 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_dh1 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
         else:
-            p_dh1 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+            p_dh1 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
         tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
+        if K > BK:
             if STATE_V_FIRST:
-                p_dh2 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_dh2 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
             else:
-                p_dh2 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+                p_dh2 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (BK, i_v * BV), (BK, BV), (1, 0))
             tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
+        if K > 2 * BK:
             if STATE_V_FIRST:
-                p_dh3 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_dh3 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
             else:
-                p_dh3 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+                p_dh3 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (2 * BK, i_v * BV), (BK, BV), (1, 0))
             tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
+        if K > 3 * BK:
             if STATE_V_FIRST:
-                p_dh4 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_dh4 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
             else:
-                p_dh4 = tl.make_block_ptr(dh + i_t_int64 * HV * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                p_dh4 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (3 * BK, i_v * BV), (BK, BV), (1, 0))
             tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
 
-        last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
-            bg_last = tl.load(g + (bos + last_idx) * HV + i_h).to(tl.float32)
-            p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-            bg_last_exp = exp2(bg_last)
-            b_g_exp = exp2(b_g)
-        p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv2 = tl.make_block_ptr(dv2, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            if USE_G_PRECOMP:
+                bg_last_exp = tl.load(g_last_exp + i_t).to(tl.float32)
+                p_g_exp = tl.make_block_ptr(g_exp, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
+                p_g_ratio = tl.make_block_ptr(g_ratio, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
+                b_g_exp = tl.load(p_g_exp, boundary_check=(0,)).to(tl.float32)
+                b_g_ratio = tl.load(p_g_ratio, boundary_check=(0,)).to(tl.float32)
+            else:
+                last_idx = min((i_t + 1) * BT, T_cur) - 1
+                bg_last = tl.load(g + last_idx).to(tl.float32)
+                p_g = tl.make_block_ptr(g, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
+                b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+                bg_last_exp = exp2(bg_last)
+                b_g_exp = exp2(b_g)
+                b_g_ratio = exp2(bg_last - b_g)
+        # In-place dv correction (callers rebind the returned buffer).
+        p_dv = tl.make_block_ptr(dv, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_do = tl.make_block_ptr(do, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_do = tl.load(p_do, boundary_check=(0, 1))
 
-        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+        p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
         b_k = tl.load(p_k, boundary_check=(0, 1))
         if USE_GK:
-            o_k1 = tl.arange(0, 64)
+            last_idx = min((i_t + 1) * BT, T_cur) - 1
             b_gk_last1 = tl.load(gk + last_idx * HV * K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
         if STATE_V_FIRST:
             b_dv = tl.dot(b_dh1.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
@@ -541,11 +630,11 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
         else:
             b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype), allow_tf32=False)
 
-        if K > 64:
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, 64), (BT, 64), (1, 0))
+        if K > BK:
+            p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, BK), (BT, BK), (1, 0))
             b_k = tl.load(p_k, boundary_check=(0, 1))
             if USE_GK:
-                o_k2 = 64 + o_k1
+                o_k2 = BK + o_k1
                 b_gk_last2 = tl.load(gk + last_idx * HV * K + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
             if STATE_V_FIRST:
                 b_dv_part = tl.dot(b_dh2.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
@@ -553,11 +642,11 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
             else:
                 b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype), allow_tf32=False)
 
-        if K > 128:
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, 128), (BT, 64), (1, 0))
+        if K > 2 * BK:
+            p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, 2 * BK), (BT, BK), (1, 0))
             b_k = tl.load(p_k, boundary_check=(0, 1))
             if USE_GK:
-                o_k3 = 128 + o_k1
+                o_k3 = 2 * BK + o_k1
                 b_gk_last3 = tl.load(gk + last_idx * HV * K + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
             if STATE_V_FIRST:
                 b_dv_part = tl.dot(b_dh3.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
@@ -565,11 +654,11 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
             else:
                 b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype), allow_tf32=False)
 
-        if K > 192:
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, 192), (BT, 64), (1, 0))
+        if K > 3 * BK:
+            p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, 3 * BK), (BT, BK), (1, 0))
             b_k = tl.load(p_k, boundary_check=(0, 1))
             if USE_GK:
-                o_k4 = 192 + o_k1
+                o_k4 = 3 * BK + o_k1
                 b_gk_last4 = tl.load(gk + last_idx * HV * K + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
             if STATE_V_FIRST:
                 b_dv_part = tl.dot(b_dh4.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
@@ -578,122 +667,154 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype), allow_tf32=False)
 
         if USE_G:
-            m_t = (i_t * BT + tl.arange(0, BT)) < T
-            b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
+            if USE_G_PRECOMP:
+                b_dv *= b_g_ratio[:, None]
+            else:
+                m_t = (i_t * BT + tl.arange(0, BT)) < T_cur
+                b_dv *= tl.where(m_t, b_g_ratio, 0)[:, None]
         b_dv += tl.load(p_dv, boundary_check=(0, 1))
-        tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
-        p_w = tl.make_block_ptr(w, (K, T), (1, HV * K), (0, i_t * BT), (64, BT), (0, 1))
-        p_q = tl.make_block_ptr(q, (K, T), (1, H * K), (0, i_t * BT), (64, BT), (0, 1))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        # Decay dh once; fold gate*scale into do so K-slabs skip per-slab gating.
         if USE_G:
             b_dh1 *= bg_last_exp
-            b_q = b_q * b_g_exp[None, :]
+            if K > BK:
+                b_dh2 *= bg_last_exp
+            if K > 2 * BK:
+                b_dh3 *= bg_last_exp
+            if K > 3 * BK:
+                b_dh4 *= bg_last_exp
+            b_do = b_do * (b_g_exp * scale)[:, None]
+        else:
+            b_do = b_do * scale
+
+        p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (0, i_t * BT), (BK, BT), (0, 1))
+        p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (0, i_t * BT), (BK, BT), (0, 1))
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
         if USE_GK:
             if STATE_V_FIRST:
                 b_dh1 *= exp2(b_gk_last1)[None, :]
             else:
                 b_dh1 *= exp2(b_gk_last1[:, None])
         if STATE_V_FIRST:
-            b_dh1 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False) * scale
+            b_dh1 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
             b_dh1 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
         else:
             b_dh1 += (
-                tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False) * scale
+                tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
                 - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
             )
 
-        if K > 64:
-            p_q = tl.make_block_ptr(q, (K, T), (1, H * K), (64, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, HV * K), (64, i_t * BT), (64, BT), (0, 1))
+        if K > BK:
+            p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (BK, i_t * BT), (BK, BT), (0, 1))
+            p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (BK, i_t * BT), (BK, BT), (0, 1))
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            if USE_G:
-                b_dh2 *= bg_last_exp
-                b_q = b_q * b_g_exp[None, :]
             if USE_GK:
                 if STATE_V_FIRST:
                     b_dh2 *= exp2(b_gk_last2)[None, :]
                 else:
                     b_dh2 *= exp2(b_gk_last2[:, None])
             if STATE_V_FIRST:
-                b_dh2 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False) * scale
+                b_dh2 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
                 b_dh2 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh2 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False) * scale
+                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
                     - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
                 )
 
-        if K > 128:
-            p_q = tl.make_block_ptr(q, (K, T), (1, H * K), (128, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, HV * K), (128, i_t * BT), (64, BT), (0, 1))
+        if K > 2 * BK:
+            p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (2 * BK, i_t * BT), (BK, BT), (0, 1))
+            p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (2 * BK, i_t * BT), (BK, BT), (0, 1))
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            if USE_G:
-                b_dh3 *= bg_last_exp
-                b_q = b_q * b_g_exp[None, :]
             if USE_GK:
                 if STATE_V_FIRST:
                     b_dh3 *= exp2(b_gk_last3)[None, :]
                 else:
                     b_dh3 *= exp2(b_gk_last3[:, None])
             if STATE_V_FIRST:
-                b_dh3 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False) * scale
+                b_dh3 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
                 b_dh3 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh3 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False) * scale
+                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
                     - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
                 )
 
-        if K > 192:
-            p_q = tl.make_block_ptr(q, (K, T), (1, H * K), (192, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, HV * K), (192, i_t * BT), (64, BT), (0, 1))
+        if K > 3 * BK:
+            p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (3 * BK, i_t * BT), (BK, BT), (0, 1))
+            p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (3 * BK, i_t * BT), (BK, BT), (0, 1))
             b_q = tl.load(p_q, boundary_check=(0, 1))
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            if USE_G:
-                b_dh4 *= bg_last_exp
-                b_q = b_q * b_g_exp[None, :]
             if USE_GK:
                 if STATE_V_FIRST:
                     b_dh4 *= exp2(b_gk_last4)[None, :]
                 else:
                     b_dh4 *= exp2(b_gk_last4[:, None])
             if STATE_V_FIRST:
-                b_dh4 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False) * scale
+                b_dh4 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
                 b_dh4 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh4 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False) * scale
+                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
                     - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
                 )
 
+        dh_chunk -= DH_CS
+
     if USE_INITIAL_STATE:
         if STATE_V_FIRST:
-            p_dh0 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_dh0 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
         else:
-            p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+            p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
         tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
+        if K > BK:
             if STATE_V_FIRST:
-                p_dh1 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_dh1 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
             else:
-                p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+                p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (BK, i_v * BV), (BK, BV), (1, 0))
             tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
+        if K > 2 * BK:
             if STATE_V_FIRST:
-                p_dh2 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_dh2 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
             else:
-                p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+                p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (2 * BK, i_v * BV), (BK, BV), (1, 0))
             tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
+        if K > 3 * BK:
             if STATE_V_FIRST:
-                p_dh3 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_dh3 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
             else:
-                p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (3 * BK, i_v * BV), (BK, BV), (1, 0))
             tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+
+
+def _prepare_dhu_gate_tensors(
+    g: torch.Tensor | None,
+    *,
+    B: int,
+    T: int,
+    HV: int,
+    BT: int,
+    cu_seqlens: torch.LongTensor | None,
+) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, bool]:
+    """Transpose g to [B, HV, T]; if T%BT==0, also precompute fp32 exp2 scales."""
+    if g is None:
+        return None, None, None, None, False
+    g_log = g.transpose(1, 2).contiguous()
+    if cu_seqlens is None and (T % BT == 0):
+        NT = T // BT
+        g_f = g_log.float()
+        g_view = g_f.view(B, HV, NT, BT)
+        g_last = g_view[:, :, :, -1:]
+        # fp32 required: bf16 precomp drifts through the reverse recurrence at large NT.
+        g_ratio = torch.exp2(g_last - g_view).reshape(B, HV, T)
+        g_exp = torch.exp2(g_f)
+        g_last_exp = torch.exp2(g_last).reshape(B, HV, NT)
+        return None, g_exp, g_ratio, g_last_exp, True
+    return g_log, None, None, None, False
 
 
 @input_guard
@@ -729,8 +850,11 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
     else:
         dh = q.new_empty(B, NT, HV, K, V)
     dh0 = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
-    dv2 = torch.empty_like(dv)
-    BV = _get_bv(K, V)
+    g_log, g_exp, g_ratio, g_last_exp, use_g_precomp = _prepare_dhu_gate_tensors(
+        g, B=B, T=T, HV=HV, BT=BT, cu_seqlens=cu_seqlens,
+    )
+    gate_inline = g is not None and not use_g_precomp
+    BK, BV = _select_bwd_dhu_tiles(K, V, state_v_first, gate_inline=gate_inline)
     nv_chunks = triton.cdiv(V, BV)
     _launch_fwd_h_kernel(
         chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu,
@@ -740,14 +864,16 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
             'q': q,
             'k': k,
             'w': w,
-            'g': g,
+            'g': g_log,
+            'g_exp': g_exp,
+            'g_ratio': g_ratio,
+            'g_last_exp': g_last_exp,
             'gk': gk,
             'dht': dht,
             'dh0': dh0,
             'do': do,
             'dh': dh,
             'dv': dv,
-            'dv2': dv2,
             'cu_seqlens': cu_seqlens,
             'chunk_offsets': chunk_offsets,
             'scale': scale,
@@ -757,8 +883,10 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
             'K': K,
             'V': V,
             'BT': BT,
+            'BK': BK,
             'BV': BV,
             'USE_G': g is not None,
+            'USE_G_PRECOMP': use_g_precomp,
             'USE_GK': gk is not None,
             'USE_INITIAL_STATE': h0 is not None,
             'USE_FINAL_STATE_GRADIENT': dht is not None,
@@ -768,4 +896,4 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
             'NH_OFFSET': 0,
         },
     )
-    return dh, dh0, dv2
+    return dh, dh0, dv

--- a/tests/ops/test_gdn_kernels.py
+++ b/tests/ops/test_gdn_kernels.py
@@ -1111,14 +1111,15 @@ def chunk_gated_delta_rule_bwd_dhu_ref(
 
 
 @pytest.mark.parametrize(
-    ('B', 'T', 'H', 'HV', 'D', 'use_h0', 'dtype'),
+    ('B', 'T', 'H', 'HV', 'D', 'use_h0', 'use_g', 'dtype'),
     [
-        pytest.param(B, T, H, HV, D, use_h0, dtype,
-                     id=f"B{B}-T{T}-H{H}-HV{HV}-D{D}-use_h0{use_h0}-{dtype}")
-        for (B, T, H, HV, D, use_h0, dtype) in [
-            (2, 128, 2, 2, 64, True, torch.bfloat16),
-            (2, 128, 2, 4, 64, False, torch.bfloat16),
-            (1, 256, 4, 4, 32, True, torch.float16),
+        pytest.param(B, T, H, HV, D, use_h0, use_g, dtype,
+                     id=f"B{B}-T{T}-H{H}-HV{HV}-D{D}-use_h0{use_h0}-use_g{use_g}-{dtype}")
+        for (B, T, H, HV, D, use_h0, use_g, dtype) in [
+            (2, 128, 2, 2, 64, True, True, torch.bfloat16),
+            (2, 128, 2, 4, 64, False, True, torch.bfloat16),
+            (1, 256, 4, 4, 32, True, True, torch.float16),
+            (2, 128, 2, 2, 64, True, False, torch.bfloat16),
         ]
     ],
 )
@@ -1129,6 +1130,7 @@ def test_chunk_gated_delta_rule_bwd_dhu(
     HV: int,
     D: int,
     use_h0: bool,
+    use_g: bool,
     dtype: torch.dtype,
 ):
     torch.manual_seed(42)
@@ -1139,7 +1141,7 @@ def test_chunk_gated_delta_rule_bwd_dhu(
     w = torch.randn(B, T, HV, D, dtype=dtype, device=device)
     u = torch.randn(B, T, HV, D, dtype=dtype, device=device)
     do = torch.randn(B, T, HV, D, dtype=dtype, device=device)
-    g = _make_gate(B, T, HV)
+    g = _make_gate(B, T, HV) if use_g else None
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device) if use_h0 else None
     dht = torch.randn(B, HV, D, D, dtype=torch.float32, device=device)
 


### PR DESCRIPTION
## Summary

Add _select_bwd_dhu_tiles to pick (BK, BV) under a soft UB budget (tighter when gates are computed in-kernel), replacing the fixed BK=64 + _get_bv path for non–STATE_V_FIRST layouts.
Host-precompute fp32 g_exp / g_ratio / g_last_exp when T % BT == 0 (non-varlen); fall back to transposed g + in-kernel exp2 for unaligned T / varlen.
Fold gate×scale into do once per chunk so K-slabs skip repeated gating; update dv in place and drop the extra dv2 buffer.
Walk dh via chunk-stride pointer arithmetic and parameterize K-slab offsets by BK instead of hardcoded 64/128/192.

GDN:
<img width="1177" height="680" alt="d7d78f152a9cb0530bb0e3ae0d38f05a" src="https://github.com/user-attachments/assets/70f92053-722e-4871-a645-482547940729" />
