### PR TITLE
[Ops] Migrate kernels off tl.make_block_ptr / tl.advance for triton main compat

### DIFF
--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -74,9 +74,11 @@ def causal_conv1d_fwd_kernel(
         p_x = x + tl.cast(i_b, tl.int64) * stride_x_n
 
     o_d = i_d * BD + tl.arange(0, BD)
+    o_t = i_t * BT + tl.arange(0, BT)
     o_w = tl.arange(0, BW) + W - BW
     m_d = o_d < D
     m_w = o_w >= 0
+    m_y = (o_t < T)[:, None] & m_d[None, :]
 
     if HAS_WEIGHT:
         # [BD, BW]
@@ -85,18 +87,20 @@ def causal_conv1d_fwd_kernel(
     b_y = tl.zeros((BT, BD), dtype=tl.float32)
     if not USE_INITIAL_STATE:
         for i_w in tl.static_range(-W + 1, 1):
-            p_yi = tl.make_block_ptr(p_x, (T, D), (stride_x_t, stride_x_d), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
+            o_x = o_t + i_w
+            p_yi = p_x + o_x[:, None] * stride_x_t + o_d[None, :] * stride_x_d
             # [BT, BD]
-            b_yi = tl.load(p_yi, boundary_check=(0, 1)).to(tl.float32)
+            b_yi = tl.load(p_yi, mask=((o_x >= 0) & (o_x < T))[:, None] & m_d[None, :], other=0.0).to(tl.float32)
             if HAS_WEIGHT:
                 b_yi *= tl.sum(b_w * (o_w == (i_w + W - 1)), 1)
             b_y += b_yi
     elif i_t * BT >= W:
         # to make Triton compiler happy, we need to copy codes
         for i_w in tl.static_range(-W + 1, 1):
-            p_yi = tl.make_block_ptr(p_x, (T, D), (stride_x_t, stride_x_d), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
+            o_x = o_t + i_w
+            p_yi = p_x + o_x[:, None] * stride_x_t + o_d[None, :] * stride_x_d
             # [BT, BD]
-            b_yi = tl.load(p_yi, boundary_check=(0, 1)).to(tl.float32)
+            b_yi = tl.load(p_yi, mask=((o_x >= 0) & (o_x < T))[:, None] & m_d[None, :], other=0.0).to(tl.float32)
             if HAS_WEIGHT:
                 b_yi *= tl.sum(b_w * (o_w == (i_w + W - 1)), 1)
             b_y += b_yi
@@ -126,12 +130,12 @@ def causal_conv1d_fwd_kernel(
         b_y = b_y * tl.sigmoid(b_y)
 
     if HAS_RESIDUAL:
-        p_residual = tl.make_block_ptr(residual + bos * D, (T, D), (D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-        b_residual = tl.load(p_residual, boundary_check=(0, 1))
+        p_residual = residual + bos * D + o_t[:, None] * D + o_d[None, :]
+        b_residual = tl.load(p_residual, mask=m_y, other=0.0)
         b_y += b_residual
 
-    p_y = tl.make_block_ptr(y + bos * D, (T, D), (D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-    tl.store(p_y, tl.cast(b_y, dtype=p_y.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    p_y = y + bos * D + o_t[:, None] * D + o_d[None, :]
+    tl.store(p_y, tl.cast(b_y, dtype=p_y.dtype.element_ty, fp_downcast_rounding='rtne'), mask=m_y)
 
 
 @triton.heuristics({
@@ -206,13 +210,15 @@ def causal_conv1d_bwd_kernel(
         p_dy = dy + tl.cast(i_b, tl.int64) * stride_dy_n
 
     o_d = i_d * BD + tl.arange(0, BD)
+    o_t = i_t * BT + tl.arange(0, BT)
     o_w = tl.arange(0, BW) + W - BW
     m_d = o_d < D
     m_w = o_w >= 0
+    m_x = (o_t < T)[:, None] & m_d[None, :]
 
     if HAS_WEIGHT:
-        p_x = tl.make_block_ptr(p_x, (T, D), (stride_x_t, stride_x_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-        b_x = tl.load(p_x, boundary_check=(0, 1))
+        p_x = p_x + o_t[:, None] * stride_x_t + o_d[None, :] * stride_x_d
+        b_x = tl.load(p_x, mask=m_x, other=0.0)
         # [BD, BW]
         b_w = tl.load(weight + o_d[:, None] * W + o_w, mask=m_d[:, None] & m_w, other=0)
 
@@ -222,13 +228,13 @@ def causal_conv1d_bwd_kernel(
 
     if not USE_FINAL_STATE and not USE_INITIAL_STATE:
         for i_w in tl.static_range(0, W):
-            p_dy_blk = tl.make_block_ptr(p_dy, (T, D), (stride_dy_t, stride_dy_d),
-                                         (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
+            o_dy = o_t + i_w
+            p_dy_blk = p_dy + o_dy[:, None] * stride_dy_t + o_d[None, :] * stride_dy_d
             # [BT, BD]
-            b_dy = tl.load(p_dy_blk, boundary_check=(0, 1)).to(tl.float32)
+            b_dy = tl.load(p_dy_blk, mask=((o_dy < T)[:, None] & m_d[None, :]), other=0.0).to(tl.float32)
             if ACTIVATION == 'swish' or ACTIVATION == 'silu':
-                p_y = tl.make_block_ptr(y + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
-                b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
+                p_y = y + bos * D + o_dy[:, None] * D + o_d[None, :]
+                b_y = tl.load(p_y, mask=((o_dy < T)[:, None] & m_d[None, :]), other=0.0).to(tl.float32)
                 b_ys = tl.sigmoid(b_y)
                 b_dy = b_dy * b_ys * (1 + b_y * (1 - b_ys))
             b_wdy = b_dy
@@ -244,13 +250,13 @@ def causal_conv1d_bwd_kernel(
     elif i_t * BT >= W:
         # to make Triton compiler happy, we need to copy codes
         for i_w in tl.static_range(0, W):
-            p_dy_blk = tl.make_block_ptr(p_dy, (T, D), (stride_dy_t, stride_dy_d),
-                                         (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
+            o_dy = o_t + i_w
+            p_dy_blk = p_dy + o_dy[:, None] * stride_dy_t + o_d[None, :] * stride_dy_d
             # [BT, BD]
-            b_dy = tl.load(p_dy_blk, boundary_check=(0, 1)).to(tl.float32)
+            b_dy = tl.load(p_dy_blk, mask=((o_dy < T)[:, None] & m_d[None, :]), other=0.0).to(tl.float32)
             if ACTIVATION == 'swish' or ACTIVATION == 'silu':
-                p_y = tl.make_block_ptr(y + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
-                b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
+                p_y = y + bos * D + o_dy[:, None] * D + o_d[None, :]
+                b_y = tl.load(p_y, mask=((o_dy < T)[:, None] & m_d[None, :]), other=0.0).to(tl.float32)
                 b_ys = tl.sigmoid(b_y)
                 b_dy = b_dy * b_ys * (1 + b_y * (1 - b_ys))
             b_wdy = b_dy
@@ -267,12 +273,12 @@ def causal_conv1d_bwd_kernel(
         # which may use initial state
         o_t = i_t * BT + tl.arange(0, BT)
         for i_w in tl.static_range(0, W):
-            p_dy_blk = tl.make_block_ptr(p_dy, (T, D), (stride_dy_t, stride_dy_d),
-                                         (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
-            b_dy_shift = tl.load(p_dy_blk, boundary_check=(0, 1)).to(tl.float32)
+            o_dy = o_t + i_w
+            p_dy_blk = p_dy + o_dy[:, None] * stride_dy_t + o_d[None, :] * stride_dy_d
+            b_dy_shift = tl.load(p_dy_blk, mask=((o_dy < T)[:, None] & m_d[None, :]), other=0.0).to(tl.float32)
             if ACTIVATION == 'swish' or ACTIVATION == 'silu':
-                p_y = tl.make_block_ptr(y + bos * D, (T, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0))
-                b_y_shift = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
+                p_y = y + bos * D + o_dy[:, None] * D + o_d[None, :]
+                b_y_shift = tl.load(p_y, mask=((o_dy < T)[:, None] & m_d[None, :]), other=0.0).to(tl.float32)
                 b_ys = tl.sigmoid(b_y_shift)
                 b_dy_shift = b_dy_shift * b_ys * (1 + b_y_shift * (1 - b_ys))
             if HAS_WEIGHT:
@@ -324,8 +330,8 @@ def causal_conv1d_bwd_kernel(
     else:
         p_dx = dx + tl.cast(i_b, tl.int64) * stride_dx_n
 
-    p_dx = tl.make_block_ptr(p_dx, (T, D), (stride_dx_t, stride_dx_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-    tl.store(p_dx, tl.cast(b_dx, dtype=p_dx.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    p_dx = p_dx + o_t[:, None] * stride_dx_t + o_d[None, :] * stride_dx_d
+    tl.store(p_dx, tl.cast(b_dx, dtype=p_dx.dtype.element_ty, fp_downcast_rounding='rtne'), mask=m_x)
 
 
 @triton.heuristics({
@@ -380,15 +386,8 @@ def causal_conv1d_update_kernel(
 
     if USE_INITIAL_STATE:
         # 2. Shift Cache (Read [1:])
-        p_cache_read = tl.make_block_ptr(
-            cache + i_n * D*W,
-            shape=(D, W),
-            strides=(W, 1),
-            offsets=(i_d * BD, 1),
-            block_shape=(BD, BW),
-            order=(1, 0)
-        )
-        b_cache = tl.load(p_cache_read, boundary_check=(0, 1)).to(tl.float32)
+        p_cache_read = cache + i_n * D*W + o_d[:, None] * W + (o_w + 1)[None, :]
+        b_cache = tl.load(p_cache_read, mask=m_d[:, None] & ((o_w + 1) < W)[None, :], other=0.0).to(tl.float32)
 
         # 3. Fill x to the last position
         m_update = o_w == (W - 1)
@@ -413,16 +412,9 @@ def causal_conv1d_update_kernel(
              dtype=y.dtype.element_ty, fp_downcast_rounding='rtne'), mask=m_d)
 
     if USE_INITIAL_STATE:
-        p_cache_write = tl.make_block_ptr(
-            cache + i_n * D*W,
-            shape=(D, W),
-            strides=(W, 1),
-            offsets=(i_d * BD, 0),
-            block_shape=(BD, BW),
-            order=(1, 0)
-        )
+        p_cache_write = cache + i_n * D*W + o_d[:, None] * W + o_w[None, :]
         tl.store(p_cache_write, tl.cast(b_cache, dtype=cache.dtype.element_ty,
-                 fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+                 fp_downcast_rounding='rtne'), mask=m_d[:, None] & m_w[None, :])
 
 
 @triton.heuristics({
@@ -538,10 +530,11 @@ def causal_conv1d_states_fwd_kernel(
         seq_len = T
         p_x = x + tl.cast(i_n, tl.int64) * stride_x_n
 
-    p_x = tl.make_block_ptr(p_x, (seq_len, D), (stride_x_t, stride_x_d), (seq_len - BW, i_d * BD), (BW, BD), (1, 0))
+    o_x = seq_len - BW + tl.arange(0, BW)
+    p_x = p_x + o_x[:, None] * stride_x_t + o_d[None, :] * stride_x_d
 
     # b_x Shape: [BW, BD]
-    b_x = tl.load(p_x, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+    b_x = tl.load(p_x, mask=((o_x >= 0) & (o_x < seq_len))[:, None] & m_d[None, :], other=0.0).to(tl.float32)
 
     if USE_INITIAL_STATE:
         if seq_len < BW:

--- a/fla/modules/fused_norm_gate.py
+++ b/fla/modules/fused_norm_gate.py
@@ -56,23 +56,26 @@ def layer_norm_gated_fwd_kernel(
     HAS_WEIGHT: tl.constexpr,
     HAS_BIAS: tl.constexpr,
 ):
-    i_t = tl.program_id(0)
+    i_t = tl.program_id(0).to(tl.int64)
 
+    o_t = i_t * BT + tl.arange(0, BT)
     o_d = tl.arange(0, BD)
     m_d = o_d < D
+    m_t = o_t < T
+    m_x = m_t[:, None] & m_d[None, :]
 
-    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    p_x = x + o_t[:, None] * D + o_d[None, :]
+    b_x = tl.load(p_x, mask=m_x, other=0.0).to(tl.float32)
     if HAS_RESIDUAL:
-        p_res = tl.make_block_ptr(residual, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-        b_x += tl.load(p_res, boundary_check=(0, 1)).to(tl.float32)
+        p_res = residual + o_t[:, None] * D + o_d[None, :]
+        b_x += tl.load(p_res, mask=m_x, other=0.0).to(tl.float32)
     if STORE_RESIDUAL_OUT:
-        p_res_out = tl.make_block_ptr(residual_out, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-        tl.store(p_res_out, b_x.to(p_res_out.dtype.element_ty), boundary_check=(0, 1))
+        p_res_out = residual_out + o_t[:, None] * D + o_d[None, :]
+        tl.store(p_res_out, b_x.to(p_res_out.dtype.element_ty), mask=m_x)
     if not IS_RMS_NORM:
         b_mean = tl.sum(b_x, axis=1) / D
-        p_mean = tl.make_block_ptr(mean, (T,), (1,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_mean, b_mean.to(p_mean.dtype.element_ty), boundary_check=(0,))
+        p_mean = mean + o_t
+        tl.store(p_mean, b_mean.to(p_mean.dtype.element_ty), mask=m_t)
         b_xbar = tl.where(m_d[None, :], b_x - b_mean[:, None], 0.0)
         b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
     else:
@@ -80,8 +83,8 @@ def layer_norm_gated_fwd_kernel(
         b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
     b_rstd = 1 / tl.sqrt(b_var + eps)
 
-    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+    p_rstd = rstd + o_t
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), mask=m_t)
 
     if HAS_WEIGHT:
         b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
@@ -93,16 +96,16 @@ def layer_norm_gated_fwd_kernel(
         b_y = b_y + b_b[None, :]
 
     # swish/sigmoid output gate
-    p_g = tl.make_block_ptr(g, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    p_g = g + o_t[:, None] * D + o_d[None, :]
+    b_g = tl.load(p_g, mask=m_x, other=0.0).to(tl.float32)
     if ACTIVATION == "swish" or ACTIVATION == "silu":
         b_y = b_y * b_g * tl.sigmoid(b_g)
     elif ACTIVATION == "sigmoid":
         b_y = b_y * tl.sigmoid(b_g)
 
     # Write output
-    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+    p_y = y + o_t[:, None] * D + o_d[None, :]
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), mask=m_x)
 
 
 @triton.heuristics(
@@ -245,21 +248,24 @@ def layer_norm_gated_bwd_kernel(
     # handles the partial tail tile by zero-padding loads and skipping stores.
     # the m_t mask below further ensures dw/db only accumulate valid rows (< T).
     for i_t in range(i_s * BS, i_s * BS + BS, BT):
-        p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
-        p_dy = tl.make_block_ptr(dy, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
-        p_dx = tl.make_block_ptr(dx, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
+        o_t = (i_t + tl.arange(0, BT)).to(tl.int64)
+        m_t = o_t < T
+        m_x = m_t[:, None] & m_d[None, :]
+        p_x = x + o_t[:, None] * D + o_d[None, :]
+        p_g = g + o_t[:, None] * D + o_d[None, :]
+        p_dy = dy + o_t[:, None] * D + o_d[None, :]
+        p_dx = dx + o_t[:, None] * D + o_d[None, :]
+        p_dg = dg + o_t[:, None] * D + o_d[None, :]
         # [BT, BD]
-        b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-        b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+        b_x = tl.load(p_x, mask=m_x, other=0.0).to(tl.float32)
+        b_g = tl.load(p_g, mask=m_x, other=0.0).to(tl.float32)
+        b_dy = tl.load(p_dy, mask=m_x, other=0.0).to(tl.float32)
 
         if not IS_RMS_NORM:
-            p_mean = tl.make_block_ptr(mean, (T,), (1,), (i_t,), (BT,), (0,))
-            b_mean = tl.load(p_mean, boundary_check=(0,))
-        p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t,), (BT,), (0,))
-        b_rstd = tl.load(p_rstd, boundary_check=(0,))
+            p_mean = mean + o_t
+            b_mean = tl.load(p_mean, mask=m_t, other=0.0)
+        p_rstd = rstd + o_t
+        b_rstd = tl.load(p_rstd, mask=m_t, other=0.0)
         # Compute dx
         b_xhat = (b_x - b_mean[:, None]) * b_rstd[:, None] if not IS_RMS_NORM else b_x * b_rstd[:, None]
         b_xhat = tl.where(m_d[None, :], b_xhat, 0.0)
@@ -268,8 +274,8 @@ def layer_norm_gated_bwd_kernel(
         if HAS_BIAS:
             b_y = b_y + b_b[None, :]
         if RECOMPUTE_OUTPUT:
-            p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
-            tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+            p_y = y + o_t[:, None] * D + o_d[None, :]
+            tl.store(p_y, b_y.to(p_y.dtype.element_ty), mask=m_x)
 
         b_sigmoid_g = tl.sigmoid(b_g)
         if ACTIVATION == "swish" or ACTIVATION == "silu":
@@ -297,16 +303,16 @@ def layer_norm_gated_bwd_kernel(
             b_c1 = tl.sum(b_xhat * b_wdy, axis=1) / D
             b_dx = (b_wdy - b_xhat * b_c1[:, None]) * b_rstd[:, None]
         if HAS_DRESIDUAL:
-            p_dres = tl.make_block_ptr(dresidual, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
-            b_dres = tl.load(p_dres, boundary_check=(0, 1)).to(tl.float32)
+            p_dres = dresidual + o_t[:, None] * D + o_d[None, :]
+            b_dres = tl.load(p_dres, mask=m_x, other=0.0).to(tl.float32)
             b_dx += b_dres
         # Write dx
         if STORE_DRESIDUAL:
-            p_dres_in = tl.make_block_ptr(dresidual_in, (T, D), (D, 1), (i_t, 0), (BT, BD), (1, 0))
-            tl.store(p_dres_in, b_dx.to(p_dres_in.dtype.element_ty), boundary_check=(0, 1))
+            p_dres_in = dresidual_in + o_t[:, None] * D + o_d[None, :]
+            tl.store(p_dres_in, b_dx.to(p_dres_in.dtype.element_ty), mask=m_x)
 
-        tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), mask=m_x)
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_x)
 
     if HAS_WEIGHT:
         tl.store(dw + i_s * D + o_d, tl.sum(b_dw, axis=0), mask=m_d)

--- a/fla/modules/l2norm.py
+++ b/fla/modules/l2norm.py
@@ -92,17 +92,21 @@ def l2norm_fwd_kernel(
     NB: tl.constexpr,
     BT: tl.constexpr,
 ):
-    i_t = tl.program_id(0)
-    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
+    i_t = tl.program_id(0).to(tl.int64)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_x = m_t[:, None] & (o_d[None, :] < D)
+    p_x = x + o_t[:, None] * D + o_d[None, :]
+    p_y = y + o_t[:, None] * D + o_d[None, :]
+    p_rstd = rstd + o_t
 
-    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    b_x = tl.load(p_x, mask=m_x, other=0.0).to(tl.float32)
     b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x, 1) + eps)
     b_y = b_x * b_rstd[:, None]
 
-    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), mask=m_x)
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), mask=m_t)
 
 
 @fla_cache_autotune(
@@ -123,17 +127,21 @@ def l2norm_bwd_kernel(
     NB: tl.constexpr,
     BT: tl.constexpr,
 ):
-    i_t = tl.program_id(0)
-    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
-    p_dy = tl.make_block_ptr(dy, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_dx = tl.make_block_ptr(dx, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    i_t = tl.program_id(0).to(tl.int64)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_x = m_t[:, None] & (o_d[None, :] < D)
+    p_y = y + o_t[:, None] * D + o_d[None, :]
+    p_rstd = rstd + o_t
+    p_dy = dy + o_t[:, None] * D + o_d[None, :]
+    p_dx = dx + o_t[:, None] * D + o_d[None, :]
 
-    b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
-    b_rstd = tl.load(p_rstd, boundary_check=(0,)).to(tl.float32)
-    b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+    b_y = tl.load(p_y, mask=m_x, other=0.0).to(tl.float32)
+    b_rstd = tl.load(p_rstd, mask=m_t, other=0.0).to(tl.float32)
+    b_dy = tl.load(p_dy, mask=m_x, other=0.0).to(tl.float32)
     b_dx = b_dy * b_rstd[:, None] - tl.sum(b_dy * b_y, 1)[:, None] * b_y * b_rstd[:, None]
-    tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), mask=m_x)
 
 
 @dispatch('modules')

--- a/fla/modules/layernorm.py
+++ b/fla/modules/layernorm.py
@@ -214,25 +214,27 @@ def layer_norm_fwd_kernel(
     HAS_WEIGHT: tl.constexpr,
     HAS_BIAS: tl.constexpr,
 ):
-    i_t = tl.program_id(0)
+    i_t = tl.program_id(0).to(tl.int64)
 
     o_t = i_t * BT + tl.arange(0, BT)
     o_g = o_t % G
     o_d = tl.arange(0, BD)
     m_d = o_d < D
+    m_t = o_t < T
+    m_x = m_t[:, None] & m_d[None, :]
 
-    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    p_x = x + o_t[:, None] * D + o_d[None, :]
+    b_x = tl.load(p_x, mask=m_x, other=0.0).to(tl.float32)
     if HAS_RESIDUAL:
-        p_res = tl.make_block_ptr(res, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-        b_x += tl.load(p_res, boundary_check=(0, 1)).to(tl.float32)
+        p_res = res + o_t[:, None] * D + o_d[None, :]
+        b_x += tl.load(p_res, mask=m_x, other=0.0).to(tl.float32)
     if STORE_RESIDUAL_OUT:
-        p_res_out = tl.make_block_ptr(res_out, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-        tl.store(p_res_out, b_x.to(p_res_out.dtype.element_ty), boundary_check=(0, 1))
+        p_res_out = res_out + o_t[:, None] * D + o_d[None, :]
+        tl.store(p_res_out, b_x.to(p_res_out.dtype.element_ty), mask=m_x)
     if not IS_RMS_NORM:
         b_mean = tl.sum(b_x, axis=1) / D
-        p_mean = tl.make_block_ptr(mean, (T,), (1,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_mean, b_mean.to(p_mean.dtype.element_ty), boundary_check=(0,))
+        p_mean = mean + o_t
+        tl.store(p_mean, b_mean.to(p_mean.dtype.element_ty), mask=m_t)
         b_xbar = tl.where(m_d[None, :], b_x - b_mean[:, None], 0.0)
         b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
     else:
@@ -240,8 +242,8 @@ def layer_norm_fwd_kernel(
         b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
     b_rstd = 1 / tl.sqrt(b_var + eps)
 
-    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+    p_rstd = rstd + o_t
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), mask=m_t)
 
     if HAS_WEIGHT:
         b_w = tl.load(w + o_g[:, None] * D + o_d[None, :], mask=m_d[None, :]).to(tl.float32)
@@ -253,8 +255,8 @@ def layer_norm_fwd_kernel(
         b_y = b_y + b_b
 
     # Write output
-    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+    p_y = y + o_t[:, None] * D + o_d[None, :]
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), mask=m_x)
 
 
 @triton.autotune(
@@ -386,18 +388,21 @@ def layer_norm_bwd_kernel(
     # boundary_check handles the partial tail tile, m_t < Tg masks dw/db accumulation.
     Tg = T // G
     for i_t in range(i_sg * BS, i_sg * BS + BS, BT):
-        p_x = tl.make_block_ptr(x + i_g * D, (Tg, D), (G*D, 1), (i_t, 0), (BT, BD), (1, 0))
-        p_dy = tl.make_block_ptr(dy + i_g * D, (Tg, D), (G*D, 1), (i_t, 0), (BT, BD), (1, 0))
-        p_dx = tl.make_block_ptr(dx + i_g * D, (Tg, D), (G*D, 1), (i_t, 0), (BT, BD), (1, 0))
+        o_t = (i_t + tl.arange(0, BT)).to(tl.int64)
+        m_t = o_t < Tg
+        m_x = m_t[:, None] & m_d[None, :]
+        p_x = x + i_g * D + o_t[:, None] * (G*D) + o_d[None, :]
+        p_dy = dy + i_g * D + o_t[:, None] * (G*D) + o_d[None, :]
+        p_dx = dx + i_g * D + o_t[:, None] * (G*D) + o_d[None, :]
         # [BT, BD]
-        b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
-        b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+        b_x = tl.load(p_x, mask=m_x, other=0.0).to(tl.float32)
+        b_dy = tl.load(p_dy, mask=m_x, other=0.0).to(tl.float32)
 
         if not IS_RMS_NORM:
-            p_mean = tl.make_block_ptr(mean + i_g, (Tg,), (G,), (i_t,), (BT,), (0,))
-            b_mean = tl.load(p_mean, boundary_check=(0,))
-        p_rstd = tl.make_block_ptr(rstd + i_g, (Tg,), (G,), (i_t,), (BT,), (0,))
-        b_rstd = tl.load(p_rstd, boundary_check=(0,))
+            p_mean = mean + i_g + o_t * G
+            b_mean = tl.load(p_mean, mask=m_t, other=0.0)
+        p_rstd = rstd + i_g + o_t * G
+        b_rstd = tl.load(p_rstd, mask=m_t, other=0.0)
         # Compute dx
         b_xhat = (b_x - b_mean[:, None]) * b_rstd[:, None] if not IS_RMS_NORM else b_x * b_rstd[:, None]
         b_xhat = tl.where(m_d[None, :], b_xhat, 0.0)
@@ -406,8 +411,8 @@ def layer_norm_bwd_kernel(
         if HAS_BIAS:
             b_y = b_y + b_b[None, :]
         if RECOMPUTE_OUTPUT:
-            p_y = tl.make_block_ptr(y + i_g * D, (Tg, D), (G*D, 1), (i_t, 0), (BT, BD), (1, 0))
-            tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+            p_y = y + i_g * D + o_t[:, None] * (G*D) + o_d[None, :]
+            tl.store(p_y, b_y.to(p_y.dtype.element_ty), mask=m_x)
 
         b_wdy = b_dy
 
@@ -428,15 +433,15 @@ def layer_norm_bwd_kernel(
             b_c1 = tl.sum(b_xhat * b_wdy, axis=1) / D
             b_dx = (b_wdy - b_xhat * b_c1[:, None]) * b_rstd[:, None]
         if HAS_DRESIDUAL:
-            p_dres = tl.make_block_ptr(dres + i_g * D, (Tg, D), (G*D, 1), (i_t, 0), (BT, BD), (1, 0))
-            b_dres = tl.load(p_dres, boundary_check=(0, 1)).to(tl.float32)
+            p_dres = dres + i_g * D + o_t[:, None] * (G*D) + o_d[None, :]
+            b_dres = tl.load(p_dres, mask=m_x, other=0.0).to(tl.float32)
             b_dx += b_dres
         # Write dx
         if STORE_DRESIDUAL:
-            p_dres_in = tl.make_block_ptr(dres_in + i_g * D, (Tg, D), (G*D, 1), (i_t, 0), (BT, BD), (1, 0))
-            tl.store(p_dres_in, b_dx.to(p_dres_in.dtype.element_ty), boundary_check=(0, 1))
+            p_dres_in = dres_in + i_g * D + o_t[:, None] * (G*D) + o_d[None, :]
+            tl.store(p_dres_in, b_dx.to(p_dres_in.dtype.element_ty), mask=m_x)
 
-        tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), mask=m_x)
 
     if HAS_WEIGHT:
         tl.store(dw + i_s * D + o_d, tl.sum(b_dw, axis=0), mask=m_d)

--- a/fla/ops/abc/chunk.py
+++ b/fla/ops/abc/chunk.py
@@ -36,37 +36,45 @@ def chunk_abc_fwd_kernel_h(
 ):
     i_v, i_k, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h = tl.make_block_ptr(h0 + i_bh * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h += tl.load(p_h, boundary_check=(0, 1)).to(tl.float32)
+        p_h0 = h0 + i_bh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h0, mask=m_kv, other=0.0).to(tl.float32)
     if NORMK:
-        p_z0 = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), (i_k * BK,), (BK,), (0,))
+        p_z0 = z + i_bh * T*K + o_k
     else:
-        p_z0 = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), (i_v * BV,), (BV,), (0,))
+        p_z0 = z + i_bh * T*V + o_v
     b_zp = tl.load(p_z0).to(tl.float32)
     for i_t in range(NT):
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h + i_bh * NT*K*V + i_t * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+        m_kt = (o_k[:, None] < K) & (o_t[None, :] < T)
+        m_tv = (o_t[:, None] < T) & (o_v[None, :] < V)
+        p_k = k + i_bh * T*K + o_k[:, None] + o_t[None, :] * K
+        p_v = v + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+        p_h = h + i_bh * NT*K*V + i_t * K * V + o_k[:, None] * V + o_v[None, :]
 
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_kv)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kt, other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         if NORMK:
-            p_zc = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), ((i_t * BT + BT - 1) * K + i_k * BK,), (BK,), (0,))
+            o_zc = (i_t * BT + BT - 1).to(tl.int64) * K + i_k * BK + tl.arange(0, BK)
+            p_zc = z + i_bh * T*K + o_zc
             # [BK,]
-            b_zc = tl.load(p_zc, boundary_check=(0,))
+            b_zc = tl.load(p_zc, mask=o_zc < T*K, other=0.0)
             b_r, b_zp = exp(b_zp - b_zc), b_zc
             # [BK, BV]
             b_h = b_h * b_r[:, None]
             b_k = exp(b_k - b_zc[:, None]).to(b_k.dtype)
         else:
-            p_zc = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), ((i_t * BT + BT - 1) * V + i_v * BV,), (BV,), (0,))
+            o_zc = (i_t * BT + BT - 1).to(tl.int64) * V + i_v * BV + tl.arange(0, BV)
+            p_zc = z + i_bh * T*V + o_zc
             # [BV,]
-            b_zc = tl.load(p_zc, boundary_check=(0,))
+            b_zc = tl.load(p_zc, mask=o_zc < T*V, other=0.0)
             b_r, b_zp = exp(b_zp - b_zc), b_zc
             # [BK, BV]
             b_h = b_h * b_r[None, :]
@@ -75,8 +83,8 @@ def chunk_abc_fwd_kernel_h(
         b_h += tl.dot(b_k, b_v, allow_tf32=False)
 
     if STORE_FINAL_STATE:
-        p_h = tl.make_block_ptr(ht + i_bh * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + i_bh * K * V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_kv)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -92,41 +100,50 @@ def chunk_abc_fwd_kernel_intra_K(
     BV: tl.constexpr,
     NC: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_t, i_i = i_c // NC, i_c % NC
 
-    p_z = tl.make_block_ptr(z + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-    p_zn = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), ((i_t * BT + i_i * BC) * V + i_v * BV,), (BV,), (0,))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_rv = (o_r[:, None] < T) & (o_v[None, :] < V)
+    o_zn = (i_t * BT + i_i * BC) * V + o_v
+    p_z = z + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
+    p_zn = z + i_bh * T*V + o_zn
     # [BV,]
-    b_zn = tl.load(p_zn, boundary_check=(0,))
+    b_zn = tl.load(p_zn, mask=o_zn < T*V, other=0.0)
     # [BC, BV]
     b_o = tl.zeros([BC, BV], dtype=tl.float32)
     for i_j in range(0, i_i):
-        p_A = tl.make_block_ptr(A + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
+        o_vr = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_Aj = i_j * BC + tl.arange(0, BC)
+        m_vr = (o_vr[:, None] < T) & (o_v[None, :] < V)
+        m_A = (o_r[:, None] < T) & (o_Aj[None, :] < BT)
+        p_A = A + i_bh * T * BT + o_r[:, None] * BT + o_Aj[None, :]
+        p_v = v + i_bh * T*V + o_vr[:, None] * V + o_v[None, :]
         # [BC, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_vr, other=0.0)
         # [BC, BC]
-        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_A = tl.load(p_A, mask=m_A, other=0.0)
         b_o += tl.dot(b_A, exp(b_v - b_zn[None, :]).to(b_v.dtype), allow_tf32=False)
-    b_z = tl.load(p_z, boundary_check=(0, 1))
+    b_z = tl.load(p_z, mask=m_rv, other=0.0)
     b_o *= exp(b_zn[None, :] - b_z)
 
     o_i = tl.arange(0, BC)
     o_A = i_bh * T * BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * BT + i_i * BC
     m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
     for j in range(0, BC):
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T * V,), (1,), ((i_t * BT + i_i * BC + j) * V + i_v * BV,), (BV,), (0,))
+        o_vj = (i_t * BT + i_i * BC + j) * V + o_v
+        p_vj = v + i_bh * T*V + o_vj
         # [BC,]
         b_A = tl.load(A + o_A + j, mask=m_A, other=0)
         # [BV,]
-        b_v = tl.load(p_v, boundary_check=(0,)).to(tl.float32)
+        b_v = tl.load(p_vj, mask=o_vj < T*V, other=0.0).to(tl.float32)
         # [BC, BV]
         # avoid 0 * inf = inf
         m_i = o_i[:, None] >= j
         b_o += tl.where(m_i, b_A[:, None] * exp(b_v[None, :] - b_z), 0)
-    p_o = tl.make_block_ptr(o + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o = o + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_rv)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -146,45 +163,56 @@ def chunk_abc_fwd_kernel_K(
     BV: tl.constexpr,
     NT: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_p = tl.maximum(i_t * BT - 1, 0)
 
     o_i = tl.arange(0, BT)
     m_s = o_i[:, None] >= o_i[None, :]
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_h = tl.make_block_ptr(h + i_bh * NT*K*V + i_t * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_kt = (o_k[:, None] < K) & m_t[None, :]
+        m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_q = q + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+        p_k = k + i_bh * T*K + o_k[:, None] + o_t[None, :] * K
+        p_h = h + i_bh * NT*K*V + i_t * K * V + o_k[:, None] * V + o_v[None, :]
 
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_tk, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kt, other=0.0)
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_kv, other=0.0)
         # [BT, BV]
         b_o += tl.dot(b_q, b_h, allow_tf32=False)
         # [BT, BT]
         b_A += tl.dot(b_q, b_k, allow_tf32=False)
-    p_z = tl.make_block_ptr(z + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_z = z + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+    p_o = o + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
     # [BT, BV]
-    b_z = tl.load(p_z, boundary_check=(0, 1))
+    b_z = tl.load(p_z, mask=m_tv, other=0.0)
     # [BT, BV]
-    p_zp = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), (i_p * V + i_v * BV,), (BV,), (0,))
-    b_zp = tl.load(p_zp, boundary_check=(0,))
+    o_zp = i_p * V + o_v
+    p_zp = z + i_bh * T*V + o_zp
+    b_zp = tl.load(p_zp, mask=o_zp < T*V, other=0.0)
     b_o = b_o * exp(b_zp[None, :] - b_z)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tv)
 
-    p_A = tl.make_block_ptr(A + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + i_bh * T * BT + o_t[:, None] * BT + o_A[None, :]
     # [BT, BT]
     b_A = tl.where(m_s, b_A, 0.)
     if i_v == 0:
-        tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_AT)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -201,48 +229,53 @@ def chunk_abc_fwd_kernel_intra_V(
     BK: tl.constexpr,
     NC: tl.constexpr,
 ):
-    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_t, i_i, i_j = i_c // (NC * NC), (i_c % (NC * NC)) // NC, (i_c % (NC * NC)) % NC
     n_bh = tl.num_programs(2)
 
+    o_q = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_qk = (o_q[:, None] < T) & (o_k[None, :] < K)
     if i_i > i_j:
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
-        p_z = tl.make_block_ptr(z + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_A = tl.make_block_ptr(A + (i_k*n_bh+i_bh)*T*BT, (T, BT), (BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
-        p_zn = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), ((i_t * BT + i_i * BC) * K + i_k * BK,), (BK,), (0,))
+        o_kj = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_Aj = i_j * BC + tl.arange(0, BC)
+        o_zn = (i_t * BT + i_i * BC) * K + o_k
+        p_q = q + i_bh * T*K + o_q[:, None] * K + o_k[None, :]
+        p_k = k + i_bh * T*K + o_k[:, None] + o_kj[None, :] * K
+        p_z = z + i_bh * T*K + o_q[:, None] * K + o_k[None, :]
+        p_A = A + (i_k*n_bh+i_bh)*T*BT + o_q[:, None] * BT + o_Aj[None, :]
+        p_zn = z + i_bh * T*K + o_zn
         # [BK,]
-        b_zn = tl.load(p_zn, boundary_check=(0,))
+        b_zn = tl.load(p_zn, mask=o_zn < T*K, other=0.0)
         # [BC, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_z = tl.load(p_z, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_z = tl.load(p_z, mask=m_qk, other=0.0)
         b_q = (b_q * exp(b_zn[None, :] - b_z) * scale).to(b_q.dtype)
         # [BK, BC]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_k[:, None] < K) & (o_kj[None, :] < T), other=0.0)
         b_k = exp(b_k - b_zn[:, None]).to(b_k.dtype)
         # [BC, BC]
         b_A = tl.dot(b_q, b_k, allow_tf32=False)
-        tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_A, b_A.to(A.dtype.element_ty), mask=(o_q[:, None] < T) & (o_Aj[None, :] < BT))
     elif i_i == i_j:
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (T * K,), (1,), ((i_t * BT + i_j * BC) * K + i_k * BK,), (BK,), (0,))
-        p_z = tl.make_block_ptr(z + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+        p_q = q + i_bh * T*K + o_q[:, None] * K + o_k[None, :]
+        p_z = z + i_bh * T*K + o_q[:, None] * K + o_k[None, :]
         # [BC, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_z = tl.load(p_z, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_z = tl.load(p_z, mask=m_qk, other=0.0)
 
         o_i = tl.arange(0, BC)
         o_A = (i_bh + i_k * n_bh) * T * BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * BT + i_j * BC
         m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
         for j in range(0, BC):
+            o_kj = (i_t * BT + i_j * BC + j) * K + o_k
+            p_kj = k + i_bh * T*K + o_kj
             # [BK,]
-            b_k = tl.load(p_k, boundary_check=(0,)).to(tl.float32)
+            b_k = tl.load(p_kj, mask=o_kj < T*K, other=0.0).to(tl.float32)
             # [BC,]
             b_A = tl.sum(b_q * exp(b_k[None, :] - b_z) * scale, 1)
             b_A = tl.where(o_i >= j, b_A, 0.)
             tl.store(A + o_A + j, b_A.to(b_q.dtype), mask=m_A)
-
-            p_k = tl.advance(p_k, (K,))
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -262,39 +295,49 @@ def chunk_abc_fwd_kernel_V(
     BV: tl.constexpr,
     NT: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_p = tl.maximum(i_t * BT - 1, 0)
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_z = tl.make_block_ptr(z + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_h = tl.make_block_ptr(h + i_bh * NT*K*V + i_t * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_zp = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), (i_p * K + i_k * BK,), (BK,), (0,))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+        o_zp = i_p * K + o_k
+        p_q = q + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+        p_z = z + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+        p_h = h + i_bh * NT*K*V + i_t * K * V + o_k[:, None] * V + o_v[None, :]
+        p_zp = z + i_bh * T*K + o_zp
 
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_tk, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BT, BK]
-        b_z = tl.load(p_z, boundary_check=(0, 1))
+        b_z = tl.load(p_z, mask=m_tk, other=0.0)
         # [BT, BK]
-        b_zp = tl.load(p_zp, boundary_check=(0,))
+        b_zp = tl.load(p_zp, mask=o_zp < T*K, other=0.0)
         b_q = (b_q * exp(b_zp[None, :] - b_z)).to(b_q.dtype)
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_kv, other=0.0)
         # works but dkw, owing to divine benevolence
         # [BT, BV]
         if i_k >= 0:
             b_o += tl.dot(b_q, b_h, allow_tf32=False)
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_A = tl.make_block_ptr(A + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_v = v + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+    p_o = o + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + i_bh * T * BT + o_t[:, None] * BT + o_A[None, :]
     # [BT, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
     # [BT, BT]
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
     b_o += tl.dot(b_A.to(b_v.dtype), b_v, allow_tf32=False)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tv)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -315,40 +358,49 @@ def chunk_abc_bwd_kernel_dh(
 ):
     i_k, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     b_zp = tl.full([BK if NORMK else BV], float('inf'), dtype=tl.float32)
     for i_t in range(NT - 1, -1, -1):
         i_p = tl.maximum(i_t * BT - 1, 0)
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (K, T), (1, K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dh = tl.make_block_ptr(dh + i_bh * NT*K*V + i_t * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_kt = (o_k[:, None] < K) & m_t[None, :]
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_q = q + i_bh * T*K + o_k[:, None] + o_t[None, :] * K
+        p_do = do + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+        p_dh = dh + i_bh * NT*K*V + i_t * K*V + o_k[:, None] * V + o_v[None, :]
 
         # [BK, BT]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_kt, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
 
-        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), mask=m_kv)
         if NORMK:
-            p_z = tl.make_block_ptr(z + i_bh * T*K, (K, T), (1, K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-            p_zc = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), (i_p * K + i_k * BK,), (BK,), (0,))
+            o_zc = i_p.to(tl.int64) * K + o_k
+            p_z = z + i_bh * T*K + o_k[:, None] + o_t[None, :] * K
+            p_zc = z + i_bh * T*K + o_zc
             # [BK,]
-            b_zc = tl.load(p_zc, boundary_check=(0,))
+            b_zc = tl.load(p_zc, mask=o_zc < T*K, other=0.0)
             b_r, b_zp = exp(b_zc - b_zp), b_zc
             # [BK, BT]
-            b_z = tl.load(p_z, boundary_check=(0, 1))
+            b_z = tl.load(p_z, mask=m_kt, other=0.0)
             b_q = (b_q * exp(b_zc[:, None] - b_z)).to(b_q.dtype)
             # [BK, BV]
             b_dh = b_dh * b_r[:, None]
         else:
-            p_z = tl.make_block_ptr(z + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_zc = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), (i_p * V + i_v * BV,), (BV,), (0,))
+            o_zc = i_p.to(tl.int64) * V + o_v
+            p_z = z + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+            p_zc = z + i_bh * T*V + o_zc
             # [BV,]
-            b_zc = tl.load(p_zc, boundary_check=(0,))
+            b_zc = tl.load(p_zc, mask=o_zc < T*V, other=0.0)
             b_r, b_zp = exp(b_zc - b_zp), b_zc
             # [BT, BV]
-            b_z = tl.load(p_z, boundary_check=(0,))
+            b_z = tl.load(p_z, mask=m_t[:, None], other=0.0)
             b_do = (b_do * exp(b_zc[None, :] - b_z)).to(b_do.dtype)
             # [BK, BV]
             b_dh = b_dh * b_r[None, :]
@@ -378,76 +430,88 @@ def chunk_abc_bwd_kernel_V(
     BV: tl.constexpr,
     NT: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_p = tl.maximum(i_t * BT - 1, 0)
     n_bh = tl.num_programs(2)
 
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_zc = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), ((i_t * BT + BT - 1) * K + i_k * BK,), (BK,), (0,))
-    p_A = tl.make_block_ptr(A + i_bh * T * BT, (BT, T), (1, BT), (0, i_t * BT), (BT, BT), (0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_t = o_t < T
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    o_zc = (i_t * BT + BT - 1) * K + o_k
+    o_A = tl.arange(0, BT)
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    p_k = k + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_zc = z + i_bh * T*K + o_zc
+    p_A = A + i_bh * T * BT + o_A[:, None] + o_t[None, :] * BT
 
     # [BK,]
-    b_zc = tl.load(p_zc, boundary_check=(0,))
+    b_zc = tl.load(p_zc, mask=o_zc < T*K, other=0.0)
     # [BT, BK]
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
     b_k = exp(b_k - b_zc[None, :]).to(b_k.dtype)
     # [BT, BT]
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
 
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h + i_bh * NT*K*V + i_t * V * K, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dh = tl.make_block_ptr(dh + i_bh * NT*K*V + i_t * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (i_k*n_bh+i_bh) * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+        m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_v = v + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+        p_h = h + i_bh * NT*K*V + i_t * V * K + o_v[:, None] + o_k[None, :] * V
+        p_do = do + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+        p_dh = dh + i_bh * NT*K*V + i_t * K*V + o_k[:, None] * V + o_v[None, :]
+        p_dv = dv + (i_k*n_bh+i_bh) * T*V + o_t[:, None] * V + o_v[None, :]
 
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
         # [BK, BV]
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, mask=m_kv, other=0.0)
 
         # [BT, BV]
         b_dv = tl.dot(b_k, b_dh, allow_tf32=False)
         if i_k == 0:
             b_dv += tl.dot(b_A.to(b_do.dtype), b_do, allow_tf32=False)
         b_do = (b_do * scale).to(b_do.dtype)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
         # [BT, BT]
         b_dA += tl.dot(b_do, tl.trans(b_v), allow_tf32=False)
         # [BT, BK]
         b_dq += tl.dot(b_do, b_h, allow_tf32=False)
         # [BT, BK]
         b_dk += tl.dot(b_v, tl.trans(b_dh), allow_tf32=False)
-    p_z = tl.make_block_ptr(z + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_zp = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), (i_p * K + i_k * BK,), (BK,), (0,))
+    o_zp = i_p * K + o_k
+    p_z = z + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_zp = z + i_bh * T*K + o_zp
     # [BK,]
-    b_zp = tl.load(p_zp, boundary_check=(0,))
+    b_zp = tl.load(p_zp, mask=o_zp < T*K, other=0.0)
     # [BT, BK]
-    b_z = tl.load(p_z, boundary_check=(0, 1))
+    b_z = tl.load(p_z, mask=m_tk, other=0.0)
     b_z = exp(b_zp[None, :] - b_z)
     # [BT, BK]
     b_dq = b_dq * b_z
     b_dk = b_dk * b_k
 
-    p_dq = tl.make_block_ptr(dq + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dA = tl.make_block_ptr(dA + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_dk = dk + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_dA = dA + i_bh * T * BT + o_t[:, None] * BT + o_A[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
 
     o_i = tl.arange(0, BT)
     m_s = o_i[:, None] >= o_i[None, :]
     # [BT, BT]
     b_dA = tl.where(m_s, b_dA, 0.).to(b_k.dtype)
     if i_k == 0:
-        tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -465,25 +529,33 @@ def chunk_abc_bwd_kernel_intra_V(
     BK: tl.constexpr,
     NC: tl.constexpr,
 ):
-    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_t, i_i = i_c // NC, i_c % NC
 
-    p_z = tl.make_block_ptr(z + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_zn = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), ((i_t * BT + i_i * BC) * K + i_k * BK,), (BK,), (0,))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_rk = (o_r[:, None] < T) & (o_k[None, :] < K)
+    o_zn = (i_t * BT + i_i * BC) * K + o_k
+    p_z = z + i_bh * T*K + o_r[:, None] * K + o_k[None, :]
+    p_zn = z + i_bh * T*K + o_zn
     # [BK,]
-    b_zn = tl.load(p_zn, boundary_check=(0,))
+    b_zn = tl.load(p_zn, mask=o_zn < T*K, other=0.0)
     # [BC, BK]
-    b_z = tl.load(p_z, boundary_check=(0, 1))
+    b_z = tl.load(p_z, mask=m_rk, other=0.0)
     b_zq = exp(b_zn[None, :] - b_z)
     b_dq = tl.zeros([BC, BK], dtype=tl.float32)
     for i_j in range(0, i_i):
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-        p_dA = tl.make_block_ptr(dA + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_dAj = i_j * BC + tl.arange(0, BC)
+        m_jk = (o_j[:, None] < T) & (o_k[None, :] < K)
+        m_dA = (o_r[:, None] < T) & (o_dAj[None, :] < BT)
+        p_k = k + i_bh * T*K + o_j[:, None] * K + o_k[None, :]
+        p_dA = dA + i_bh * T * BT + o_r[:, None] * BT + o_dAj[None, :]
         # [BC, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_jk, other=0.0)
         b_kz = exp(b_k - b_zn[None, :]).to(b_k.dtype)
         # [BC, BC]
-        b_dA = tl.load(p_dA, boundary_check=(0, 1))
+        b_dA = tl.load(p_dA, mask=m_dA, other=0.0)
         # [BC, BK]
         b_dq += tl.dot(b_dA, b_kz, allow_tf32=False)
     b_dq *= b_zq
@@ -492,55 +564,62 @@ def chunk_abc_bwd_kernel_intra_V(
     o_dA = i_bh * T * BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * BT + i_i * BC
     m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
     for j in range(0, BC):
-        p_kj = tl.make_block_ptr(k + i_bh * T*K, (T * K,), (1,), ((i_t * BT + i_i*BC+j) * K + i_k * BK,), (BK,), (0,))
+        o_kj = (i_t * BT + i_i * BC + j) * K + o_k
+        p_kj = k + i_bh * T*K + o_kj
         # [BC,]
         b_dA = tl.load(dA + o_dA + j, mask=m_dA, other=0)
         # [BK,]
-        b_kj = tl.load(p_kj, boundary_check=(0,)).to(tl.float32)
+        b_kj = tl.load(p_kj, mask=o_kj < T*K, other=0.0).to(tl.float32)
         # [BC, BK]
         m_i = o_i[:, None] >= j
         # [BC, BK]
         b_dq += tl.where(m_i, b_dA[:, None] * exp(b_kj[None, :] - b_z), 0.)
-    p_dq = tl.make_block_ptr(dq + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq + i_bh * T*K + o_r[:, None] * K + o_k[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_rk)
 
     tl.debug_barrier()
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_zn = tl.make_block_ptr(z + i_bh * T*K, (T*K,), (1,), ((i_t * BT + i_i * BC + BC - 1) * K + i_k * BK,), (BK,), (0,))
+    o_zn = (i_t * BT + i_i * BC + BC - 1) * K + o_k
+    p_k = k + i_bh * T*K + o_r[:, None] * K + o_k[None, :]
+    p_zn = z + i_bh * T*K + o_zn
     # [BK,]
-    b_zn = tl.load(p_zn, boundary_check=(0,))
+    b_zn = tl.load(p_zn, mask=o_zn < T*K, other=0.0)
     # [BC, BK]
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_k = tl.load(p_k, mask=m_rk, other=0.0)
     b_kz = exp(b_k - b_zn[None, :])
     b_dk = tl.zeros([BC, BK], dtype=tl.float32)
     for i_j in range(i_i + 1, NC):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-        p_z = tl.make_block_ptr(z + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-        p_dA = tl.make_block_ptr(dA + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT + i_j * BC, i_i * BC), (BC, BC), (1, 0))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_dAi = i_i * BC + tl.arange(0, BC)
+        m_jk = (o_j[:, None] < T) & (o_k[None, :] < K)
+        m_dA2 = (o_j[:, None] < T) & (o_dAi[None, :] < BT)
+        p_q = q + i_bh * T*K + o_j[:, None] * K + o_k[None, :]
+        p_z = z + i_bh * T*K + o_j[:, None] * K + o_k[None, :]
+        p_dA = dA + i_bh * T * BT + o_j[:, None] * BT + o_dAi[None, :]
         # [BC, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_z = tl.load(p_z, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_jk, other=0.0)
+        b_z = tl.load(p_z, mask=m_jk, other=0.0)
         b_qz = (b_q * exp(b_zn[None, :] - b_z)).to(b_q.dtype)
         # [BC, BC]
-        b_dA = tl.load(p_dA, boundary_check=(0, 1))
+        b_dA = tl.load(p_dA, mask=m_dA2, other=0.0)
         # [BC, BK]
         b_dk += tl.dot(tl.trans(b_dA), b_qz, allow_tf32=False)
     b_dk *= b_kz
 
     o_dA = i_bh * T * BT + (i_t * BT + i_i * BC) * BT + i_i * BC + tl.arange(0, BC)
     for j in range(0, BC):
-        p_qj = tl.make_block_ptr(q + i_bh * T*K, (T * K,), (1,), ((i_t * BT + i_i * BC + j) * K + i_k * BK,), (BK,), (0,))
-        p_zj = tl.make_block_ptr(z + i_bh * T*K, (T * K,), (1,), ((i_t * BT + i_i * BC + j) * K + i_k * BK,), (BK,), (0,))
+        o_qj = (i_t * BT + i_i * BC + j) * K + o_k
+        p_qj = q + i_bh * T*K + o_qj
+        p_zj = z + i_bh * T*K + o_qj
         # [BC,]
         b_dA = tl.load(dA + o_dA + j * BT, mask=(i_t * BT + i_i * BC + j < T), other=0)
         # [BK,]
-        b_qj = tl.load(p_qj, boundary_check=(0,)).to(tl.float32)
-        b_zj = tl.load(p_zj, boundary_check=(0,)).to(tl.float32)
+        b_qj = tl.load(p_qj, mask=o_qj < T*K, other=0.0).to(tl.float32)
+        b_zj = tl.load(p_zj, mask=o_qj < T*K, other=0.0).to(tl.float32)
         # [BC, BK]
         m_i = o_i[:, None] <= j
         b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp(b_k - b_zj[None, :]), 0.)
-    p_dk = tl.make_block_ptr(dk + i_bh * T*K, (T, K), (K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    p_dk = dk + i_bh * T*K + o_r[:, None] * K + o_k[None, :]
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_rk)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -557,48 +636,53 @@ def chunk_abc_bwd_kernel_intra_K(
     BV: tl.constexpr,
     NC: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_t, i_i, i_j = i_c // (NC * NC), (i_c % (NC * NC)) // NC, (i_c % (NC * NC)) % NC
     n_bh = tl.num_programs(2)
 
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_rv = (o_r[:, None] < T) & (o_v[None, :] < V)
     if i_i > i_j:
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (V, T), (1, V), (i_v * BV, i_t * BT + i_j * BC), (BV, BC), (0, 1))
-        p_z = tl.make_block_ptr(z + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-        p_zn = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), ((i_t * BT + i_i * BC) * V + i_v * BV,), (BV,), (0,))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-        p_dA = tl.make_block_ptr(dA+(i_bh+i_v*n_bh)*T*BT, (T, BT), (BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
+        o_kj = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_Aj = i_j * BC + tl.arange(0, BC)
+        o_zn = (i_t * BT + i_i * BC) * V + o_v
+        p_v = v + i_bh * T*V + o_v[:, None] + o_kj[None, :] * V
+        p_z = z + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
+        p_zn = z + i_bh * T*V + o_zn
+        p_do = do + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
+        p_dA = dA+(i_bh+i_v*n_bh)*T*BT + o_r[:, None] * BT + o_Aj[None, :]
         # [BV,]
-        b_zn = tl.load(p_zn, boundary_check=(0,))
+        b_zn = tl.load(p_zn, mask=o_zn < T*V, other=0.0)
         # [BC, BV]
-        b_z = tl.load(p_z, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_z = tl.load(p_z, mask=m_rv, other=0.0)
+        b_do = tl.load(p_do, mask=m_rv, other=0.0)
         b_do = (b_do * exp(b_zn[None, :] - b_z) * scale).to(b_do.dtype)
         # [BV, BC]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=(o_v[:, None] < V) & (o_kj[None, :] < T), other=0.0)
         b_v = exp(b_v - b_zn[:, None]).to(b_v.dtype)
         # [BC, BC]
         b_dA = tl.dot(b_do, b_v, allow_tf32=False)
-        tl.store(p_dA, b_dA.to(dA.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dA, b_dA.to(dA.dtype.element_ty), mask=(o_r[:, None] < T) & (o_Aj[None, :] < BT))
     elif i_i == i_j:
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T * V,), (1,), ((i_t * BT + i_j * BC) * V + i_v * BV,), (BV,), (0,))
-        p_z = tl.make_block_ptr(z + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
+        p_z = z + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
+        p_do = do + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
         # [BC, BV]
-        b_z = tl.load(p_z, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)) * scale
+        b_z = tl.load(p_z, mask=m_rv, other=0.0)
+        b_do = tl.load(p_do, mask=m_rv, other=0.0) * scale
 
         o_i = tl.arange(0, BC)
         o_A = (i_bh + i_v * n_bh) * T * BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * BT + i_j * BC
         m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
         for j in range(0, BC):
+            o_vj = (i_t * BT + i_j * BC + j) * V + o_v
+            p_vj = v + i_bh * T*V + o_vj
             # [BV,]
-            b_v = tl.load(p_v, boundary_check=(0,)).to(tl.float32)
+            b_v = tl.load(p_vj, mask=o_vj < T*V, other=0.0).to(tl.float32)
             # [BC,]
             b_dA = tl.sum(b_do * exp(b_v[None, :] - b_z), 1)
             b_dA = tl.where(o_i >= j, b_dA, 0)
             tl.store(dA + o_A + j, b_dA.to(b_do.dtype), mask=m_A)
-
-            p_v = tl.advance(p_v, (V,))
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -624,71 +708,83 @@ def chunk_abc_bwd_kernel_K(
     BV: tl.constexpr,
     NT: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_p = tl.maximum(i_t * BT - 1, 0)
     n_bh = tl.num_programs(2)
 
     o_i = tl.arange(0, BT)
     m_s = o_i[:, None] >= o_i[None, :]
 
-    p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_A = tl.make_block_ptr(A + (i_k*n_bh+i_bh) * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_t = o_t < T
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
+    p_q = q + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_k = k + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_A = A + (i_k*n_bh+i_bh) * T * BT + o_t[:, None] * BT + o_A[None, :]
 
     # [BT, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
     # [BT, BT]
     b_A = tl.dot((b_q * scale).to(b_q.dtype), tl.trans(b_k), allow_tf32=False)
     b_A = tl.where(m_s, b_A, 0.)
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_AT)
 
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_z = tl.make_block_ptr(z + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_zp = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), (i_p * V + i_v * BV,), (BV,), (0,))
-        p_zc = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), ((i_t * BT + BT - 1) * V + i_v * BV,), (BV,), (0,))
-        p_h = tl.make_block_ptr(h + i_bh * NT*K*V + i_t * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+        m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+        o_zp = i_p * V + o_v
+        o_zc = (i_t * BT + BT - 1) * V + o_v
+        p_v = v + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+        p_z = z + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+        p_zp = z + i_bh * T*V + o_zp
+        p_zc = z + i_bh * T*V + o_zc
+        p_h = h + i_bh * NT*K*V + i_t * K*V + o_v[:, None] + o_k[None, :] * V
 
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dh = tl.make_block_ptr(dh + i_bh * NT*K*V + i_t * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (i_k*n_bh+i_bh) * T*V, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_do = do + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+        p_dh = dh + i_bh * NT*K*V + i_t * K*V + o_k[:, None] * V + o_v[None, :]
+        p_dv = dv + (i_k*n_bh+i_bh) * T*V + o_t[:, None] * V + o_v[None, :]
 
         # [BV,]
-        b_zp = tl.load(p_zp, boundary_check=(0,))
-        b_zc = tl.load(p_zc, boundary_check=(0,))
+        b_zp = tl.load(p_zp, mask=o_zp < T*V, other=0.0)
+        b_zc = tl.load(p_zc, mask=o_zc < T*V, other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         b_v = exp(b_v - b_zc[None, :]).to(b_v.dtype)
-        b_z = tl.load(p_z, boundary_check=(0, 1))
+        b_z = tl.load(p_z, mask=m_tv, other=0.0)
         b_z = exp(b_zp[None, :] - b_z)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
         b_do = (b_do * b_z * scale).to(b_do.dtype)
         # [BK, BV]
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, mask=m_kv, other=0.0)
 
         # [BT, BK]
         b_dq += tl.dot(b_do, b_h, allow_tf32=False)
         b_dk += tl.dot(b_v, tl.trans(b_dh), allow_tf32=False)
         # [BT, BV]
         b_dv = b_v * tl.dot(b_k, b_dh, allow_tf32=False)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    p_dA = tl.make_block_ptr(dA + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
+    p_dA = dA + i_bh * T * BT + o_t[:, None] * BT + o_A[None, :]
     # [BT, BT]
-    b_dA = tl.load(p_dA, boundary_check=(0, 1))
+    b_dA = tl.load(p_dA, mask=m_AT, other=0.0)
     # [BT, BK]
     b_dq += tl.dot(b_dA, b_k, allow_tf32=False)
     b_dk += tl.dot(tl.trans(b_dA).to(b_k.dtype), b_q, allow_tf32=False)
 
-    p_dq = tl.make_block_ptr(dq + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk + i_bh * T*K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_dk = dk + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -705,44 +801,54 @@ def chunk_abc_bwd_kernel_intra_KV(
     BV: tl.constexpr,
     NC: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_t, i_i = i_c // NC, i_c % NC
 
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-    p_zn = tl.make_block_ptr(z + i_bh * T*V, (T*V,), (1,), ((i_t * BT + i_i * BC + BC - 1) * V + i_v * BV,), (BV,), (0,))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_rv = (o_r[:, None] < T) & (o_v[None, :] < V)
+    o_zn = (i_t * BT + i_i * BC + BC - 1) * V + o_v
+    p_v = v + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
+    p_zn = z + i_bh * T*V + o_zn
     # [BV,]
-    b_zn = tl.load(p_zn, boundary_check=(0,))
+    b_zn = tl.load(p_zn, mask=o_zn < T*V, other=0.0)
     # [BC, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_rv, other=0.0)
     b_dv = tl.zeros([BC, BV], dtype=tl.float32)
     for i_j in range(i_i + 1, NC):
-        p_z = tl.make_block_ptr(z + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_j * BC, i_v * BV),  (BC, BV), (1, 0))
-        p_A = tl.make_block_ptr(A + i_bh * T * BT, (BT, T), (1, BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_Ai = i_i * BC + tl.arange(0, BC)
+        m_jv = (o_j[:, None] < T) & (o_v[None, :] < V)
+        m_A = (o_Ai[:, None] < BT) & (o_j[None, :] < T)
+        p_z = z + i_bh * T*V + o_j[:, None] * V + o_v[None, :]
+        p_A = A + i_bh * T * BT + o_Ai[:, None] + o_j[None, :] * BT
+        p_do = do + i_bh * T*V + o_j[:, None] * V + o_v[None, :]
         # [BC, BV]
-        b_z = tl.load(p_z, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_z = tl.load(p_z, mask=m_jv, other=0.0)
+        b_do = tl.load(p_do, mask=m_jv, other=0.0)
         b_do = (b_do * exp(b_zn[None, :] - b_z)).to(b_do.dtype)
         # [BC, BC]
-        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_A = tl.load(p_A, mask=m_A, other=0.0)
         b_dv += tl.dot(b_A, b_do, allow_tf32=False)
     b_dv *= exp(b_v - b_zn[None, :])
 
     o_i = tl.arange(0, BC)
     for j in range(0, BC):
-        p_z = tl.make_block_ptr(z + i_bh * T*V, (T * V,), (1,), ((i_t * BT + i_i * BC + j) * V + i_v * BV,), (BV,), (0,))
-        p_A = tl.make_block_ptr(A + i_bh * T * BT, (T * BT,), (1,), ((i_t * BT + i_i * BC + j) * BT + i_i * BC,), (BC,), (0,))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T * V,), (1,), ((i_t * BT + i_i * BC + j) * V + i_v * BV,), (BV,), (0,))
+        o_vj = (i_t * BT + i_i * BC + j) * V + o_v
+        o_Aj = (i_t * BT + i_i * BC + j) * BT + i_i * BC + tl.arange(0, BC)
+        p_zj = z + i_bh * T*V + o_vj
+        p_Aj = A + i_bh * T * BT + o_Aj
+        p_doj = do + i_bh * T*V + o_vj
         # [BC,]
-        b_A = tl.load(p_A, boundary_check=(0,))
+        b_A = tl.load(p_Aj, mask=o_Aj < T*BT, other=0.0)
         # [BV,]
-        b_z = tl.load(p_z, boundary_check=(0,))
-        b_do = tl.load(p_do, boundary_check=(0,))
+        b_z = tl.load(p_zj, mask=o_vj < T*V, other=0.0)
+        b_do = tl.load(p_doj, mask=o_vj < T*V, other=0.0)
         # [BC, BV]
         m_i = o_i[:, None] <= j
         b_dv += tl.where(m_i, exp(b_v - b_z[None, :]) * b_A[:, None] * b_do[None, :], 0.)
-    p_dv = tl.make_block_ptr(dv + i_bh * T*V, (T, V), (V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    p_dv = dv + i_bh * T*V + o_r[:, None] * V + o_v[None, :]
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_rv)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -759,23 +865,27 @@ def chunk_abc_bwd_kernel_rcum_inter(
 ):
     i_m, i_bh = tl.program_id(0), tl.program_id(1)
 
+    o_s = i_m * BS + tl.arange(0, BS)
     b_sp = tl.zeros([BS], dtype=tl.float32)
     b_zp = tl.full([BS], float('inf'), dtype=tl.float32)
     for i_t in range(NT - 1, -1, -1):
-        p_s = tl.make_block_ptr(s + i_bh * T*S, (T, S), (S, 1), (i_t * BT, i_m * BS), (BT, BS), (1, 0))
-        p_z = tl.make_block_ptr(z + i_bh * T*S, (T, S), (S, 1), (i_t * BT, i_m * BS), (BT, BS), (1, 0))
-        p_zc = tl.make_block_ptr(z + i_bh * T*S, (T*S,), (1,), ((i_t * BT) * S + i_m * BS,), (BS,), (0,))
-        p_ss = tl.make_block_ptr(ss + i_bh * T*S, (T, S), (S, 1), (i_t * BT, i_m * BS), (BT, BS), (1, 0))
-        p_doo = tl.make_block_ptr(doo + i_bh * T*S, (T, S), (S, 1), (i_t * BT, i_m * BS), (BT, BS), (1, 0))
+        o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+        m_ts = (o_t[:, None] < T) & (o_s[None, :] < S)
+        o_zc = i_t.to(tl.int64) * BT * S + o_s
+        p_s = s + i_bh * T*S + o_t[:, None] * S + o_s[None, :]
+        p_z = z + i_bh * T*S + o_t[:, None] * S + o_s[None, :]
+        p_zc = z + i_bh * T*S + o_zc
+        p_ss = ss + i_bh * T*S + o_t[:, None] * S + o_s[None, :]
+        p_doo = doo + i_bh * T*S + o_t[:, None] * S + o_s[None, :]
         # [BS,]
-        b_zc = tl.load(p_zc, boundary_check=(0,))
+        b_zc = tl.load(p_zc, mask=o_zc < T*S, other=0.0)
         # [BT, BS]
-        b_s = tl.load(p_s, boundary_check=(0, 1))
-        b_z = tl.load(p_z, boundary_check=(0, 1))
-        b_ss = tl.load(p_ss, boundary_check=(0, 1))
+        b_s = tl.load(p_s, mask=m_ts, other=0.0)
+        b_z = tl.load(p_z, mask=m_ts, other=0.0)
+        b_ss = tl.load(p_ss, mask=m_ts, other=0.0)
 
         b_doo = exp(b_s - b_zp[None, :]) * b_sp[None, :]
-        tl.store(p_doo, b_doo.to(p_doo.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_doo, b_doo.to(p_doo.dtype.element_ty), mask=m_ts)
         # [BS,]
         b_sp = b_sp * exp(b_zc - b_zp) + tl.sum(b_ss * exp(b_zc[None, :] - b_z), 0)
         b_zp = b_zc
@@ -794,42 +904,49 @@ def chunk_abc_bwd_kernel_rcum_intra(
     BS: tl.constexpr,
     NC: tl.constexpr,
 ):
-    i_s, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_s, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_t, i_i = i_c // NC, i_c % NC
 
     o_i = tl.arange(0, BC)
     m_o = tl.full([BC, BC], 1., dtype=tl.float32)
 
-    p_s = tl.make_block_ptr(s + i_bh * T*S, (T, S), (S, 1), (i_t * BT + i_i * BC, i_s * BS), (BC, BS), (1, 0))
-    p_zn = tl.make_block_ptr(z + i_bh * T*S, (T*S,), (1,), ((i_t * BT + i_i * BC + BC - 1) * S + i_s * BS,), (BS,), (0,))
-    p_doo = tl.make_block_ptr(doo + i_bh * T*S, (T, S), (S, 1), (i_t * BT + i_i * BC, i_s * BS), (BC, BS), (1, 0))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_s = i_s * BS + tl.arange(0, BS)
+    m_rs = (o_r[:, None] < T) & (o_s[None, :] < S)
+    o_zn = (i_t * BT + i_i * BC + BC - 1) * S + o_s
+    p_s = s + i_bh * T*S + o_r[:, None] * S + o_s[None, :]
+    p_zn = z + i_bh * T*S + o_zn
+    p_doo = doo + i_bh * T*S + o_r[:, None] * S + o_s[None, :]
     # [BC, BS]
-    b_s = tl.load(p_s, boundary_check=(0, 1))
+    b_s = tl.load(p_s, mask=m_rs, other=0.0)
     # [BS,]
-    b_zn = tl.load(p_zn, boundary_check=(0,))
+    b_zn = tl.load(p_zn, mask=o_zn < T*S, other=0.0)
 
     b_doo = tl.zeros([BC, BS], dtype=tl.float32)
     for i_j in range(i_i + 1, NC):
-        p_z = tl.make_block_ptr(z + i_bh * T*S, (T, S), (S, 1), (i_t * BT + i_j * BC, i_s * BS), (BC, BS), (1, 0))
-        p_ss = tl.make_block_ptr(ss + i_bh * T*S, (T, S), (S, 1), (i_t * BT + i_j * BC, i_s * BS), (BC, BS), (1, 0))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        m_js = (o_j[:, None] < T) & (o_s[None, :] < S)
+        p_z = z + i_bh * T*S + o_j[:, None] * S + o_s[None, :]
+        p_ss = ss + i_bh * T*S + o_j[:, None] * S + o_s[None, :]
         # [BC, BS]
-        b_z = tl.load(p_z, boundary_check=(0, 1))
-        b_ss = tl.load(p_ss, boundary_check=(0, 1))
+        b_z = tl.load(p_z, mask=m_js, other=0.0)
+        b_ss = tl.load(p_ss, mask=m_js, other=0.0)
         # [BC, BS]
         b_doo += b_ss * exp(b_zn[None, :] - b_z)
     b_doo = exp(b_s - b_zn[None, :]) * tl.dot(m_o.to(b_s.dtype), b_doo.to(b_s.dtype), allow_tf32=False)
 
     for j in range(0, BC):
-        p_z = tl.make_block_ptr(z + i_bh * T*S, (T*S,), (1,), ((i_t * BT + i_i * BC + j) * S + i_s * BS,), (BS,), (0,))
-        p_ss = tl.make_block_ptr(ss + i_bh * T*S, (T*S,), (1,), ((i_t * BT + i_i * BC + j) * S + i_s * BS,), (BS,), (0,))
+        o_sj = (i_t * BT + i_i * BC + j) * S + o_s
+        p_zj = z + i_bh * T*S + o_sj
+        p_ssj = ss + i_bh * T*S + o_sj
         # [BS,]
-        b_z = tl.load(p_z, boundary_check=(0,))
-        b_ss = tl.load(p_ss, boundary_check=(0,))
+        b_z = tl.load(p_zj, mask=o_sj < T*S, other=0.0)
+        b_ss = tl.load(p_ssj, mask=o_sj < T*S, other=0.0)
         # [BC, BS]
         m_i = o_i[:, None] <= j
         b_doo += tl.where(m_i, exp(b_s - b_z[None, :]) * b_ss[None, :], 0.)
-    b_doo += tl.load(p_doo, boundary_check=(0, 1))
-    tl.store(p_doo, b_doo.to(p_doo.dtype.element_ty), boundary_check=(0, 1))
+    b_doo += tl.load(p_doo, mask=m_rs, other=0.0)
+    tl.store(p_doo, b_doo.to(p_doo.dtype.element_ty), mask=m_rs)
 
 
 class ChunkABCFunction(torch.autograd.Function):

--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -57,10 +57,12 @@ def naive_attn_decoding_kernel(
     bos, eos = tl.load(cu_seqlens + i_b).to(tl.int32), tl.load(cu_seqlens + i_b + 1).to(tl.int32)
     T = eos - bos
 
-    p_q = tl.make_block_ptr(q + i_bh * K, (K,), (1, ), (0, ), (BK,), (0,))
-    p_o = tl.make_block_ptr(o + i_bh * V, (V,), (1, ), (i_v * BV, ), (BV,), (0,))
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    p_q = q + i_bh * K + o_d
+    p_o = o + i_bh * V + o_v
 
-    b_q = tl.load(p_q, boundary_check=(0,))
+    b_q = tl.load(p_q, mask=o_d < K, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
 
     b_o = tl.zeros([BV], dtype=tl.float32)
@@ -69,8 +71,8 @@ def naive_attn_decoding_kernel(
     b_acc = tl.zeros([1], dtype=tl.float32)
 
     if USE_G:
-        p_g = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (T-1,), (1,), (0,))
-        b_gq = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+        p_g = g_cumsum + bos * HQ + i_hq + (T - 1) * HQ
+        b_gq = tl.load(p_g, mask=(T - 1) < T, other=0.0).to(tl.float32)
     else:
         b_gq = None
 
@@ -80,21 +82,22 @@ def naive_attn_decoding_kernel(
         b_sink_bias = None
 
     for i_s in range(0, T, BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_s, 0), (BS, BK), (1, 0))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
+        o_k = (i_s + tl.arange(0, BS)).to(tl.int64)
+        m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_k[:, None] * (H*K) + o_d[None, :]
+        p_v = v + (bos * H + i_h) * V + o_k[:, None] * (H*V) + o_v[None, :]
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k[:, None] & (o_d[None, :] < K), other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
         # [BT, BS]
         b_s = tl.sum(b_q[None, :] * b_k, 1)
 
-        mask = i_s + tl.arange(0, BS) < T
-        b_s = tl.where(mask, b_s, float('-inf'))
+        b_s = tl.where(m_k, b_s, float('-inf'))
 
         if USE_G:
-            p_gk = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-            b_gk = tl.load(p_gk, boundary_check=(0,)).to(tl.float32)
+            p_gk = g_cumsum + bos * HQ + i_hq + o_k * HQ
+            b_gk = tl.load(p_gk, mask=m_k, other=0.0).to(tl.float32)
             b_s += b_gq - b_gk
         # [BT, BS]
         b_m, b_mp = tl.maximum(b_m, tl.max(b_s)), b_m
@@ -113,7 +116,7 @@ def naive_attn_decoding_kernel(
         b_m = tl.where(b_m == float('-inf'), 0., b_m)
         b_acc += exp(b_sink_bias - b_m)
     b_o = b_o / b_acc
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, ))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=o_v < V)
 
 
 def attn_decoding_one_step(

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -53,12 +53,12 @@ def parallel_attn_fwd_kernel(
     USE_WINDOW: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -66,13 +66,18 @@ def parallel_attn_fwd_kernel(
         bos, eos = (i_n * T).to(tl.int64), (i_n * T + T).to(tl.int64)
     RCP_LN2: tl.constexpr = 1.4426950216
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
+    # [BT]
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_q = o_q < T
+    p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    p_o = o + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+    p_lse = lse + bos * HQ + i_hq + o_q * HQ
 
     # the Q block is kept in the shared memory throughout the whole kernel
     # [BT, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
     # [BT, BV]
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
 
@@ -80,8 +85,8 @@ def parallel_attn_fwd_kernel(
     b_acc = tl.zeros([BT], dtype=tl.float32)
 
     if USE_G:
-        p_g = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        b_gq = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+        p_g = g_cumsum + bos * HQ + i_hq + o_q * HQ
+        b_gq = tl.load(p_g, mask=m_q, other=0.0).to(tl.float32)
     else:
         b_gq = None
 
@@ -90,25 +95,22 @@ def parallel_attn_fwd_kernel(
     else:
         b_sink_bias = None
 
-    # [BT]
-    o_q = i_t * BT + tl.arange(0, BT)
-
     # for sliding window, skip key blocks that are entirely outside the window.
     # the earliest key position any query in this block needs: max(0, i_t*BT - W + 1)
     i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0) if USE_WINDOW else 0
 
     for i_s in range(i_start, i_t * BT, BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
+        o_k = i_s + tl.arange(0, BS)
+        m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_k[:, None] * (H*V) + o_v[None, :]
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
         # [BT, BS]
         b_s = tl.dot(b_q, b_k) * scale * RCP_LN2
 
-        o_k = i_s + tl.arange(0, BS)
-        m_k = o_k < T
         if USE_G:
             b_gk = tl.load(g_cumsum + (bos + o_k) * HQ + i_hq, mask=m_k, other=0).to(tl.float32)
             b_s += b_gq[:, None] - b_gk[None, :]
@@ -131,16 +133,16 @@ def parallel_attn_fwd_kernel(
         b_mp = b_m
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-
         # [BS]
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_k[:, None] * (H*V) + o_v[None, :]
+
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
         # [BT, BS]
         b_s = tl.dot(b_q, b_k) * scale * RCP_LN2
 
@@ -176,9 +178,9 @@ def parallel_attn_fwd_kernel(
 
     b_o = b_o / b_acc[:, None]
     b_m += log2(b_acc)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_q[:, None] & (o_v[None, :] < V))
     if i_v == 0:
-        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty), mask=m_q)
 
 
 @triton.jit
@@ -235,12 +237,12 @@ def parallel_attn_bwd_kernel_dq(
     USE_WINDOW: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -249,44 +251,46 @@ def parallel_attn_bwd_kernel_dq(
     # NOTE: we must multiply RCP_LN2 after tl.dot for high precision
     RCP_LN2: tl.constexpr = 1.4426950216
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_do = tl.make_block_ptr(do + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-    p_delta = tl.make_block_ptr(delta + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_q = o_q < T
+    p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    p_dq = dq + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    p_do = do + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+    p_lse = lse + bos * HQ + i_hq + o_q * HQ
+    p_delta = delta + bos * HQ + i_hq + o_q * HQ
 
     # [BT, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
     # [BT, BV]
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    b_do = tl.load(p_do, mask=m_q[:, None] & (o_v[None, :] < V), other=0.0)
     # [BT]
-    b_lse = tl.load(p_lse, boundary_check=(0,))
-    b_delta = tl.load(p_delta, boundary_check=(0,))
+    b_lse = tl.load(p_lse, mask=m_q, other=0.0)
+    b_delta = tl.load(p_delta, mask=m_q, other=0.0)
 
     # [BT, BK]
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
     if USE_G:
         b_dg = tl.zeros([BT], dtype=tl.float32)
-        p_gq = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        b_gq = tl.load(p_gq, boundary_check=(0,)).to(tl.float32)
+        p_gq = g_cumsum + bos * HQ + i_hq + o_q * HQ
+        b_gq = tl.load(p_gq, mask=m_q, other=0.0).to(tl.float32)
     else:
         b_gq = None
         b_dg = None
 
-    o_q = i_t * BT + tl.arange(0, BT)
-
     i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0) if USE_WINDOW else 0
 
     for i_s in range(i_start, i_t * BT, BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
-
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_v[:, None] + o_k[None, :] * (H*V)
+
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
         # [BV, BS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_k[None, :], other=0.0)
         # [BT, BS]
         b_s = tl.dot(b_q, b_k) * scale * RCP_LN2
         if USE_G:
@@ -305,22 +309,22 @@ def parallel_attn_bwd_kernel_dq(
             b_dg += tl.sum(b_ds, 1)
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
-
         # [BS]
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_v[:, None] + o_k[None, :] * (H*V)
+
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
         # [BV, BS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_k[None, :], other=0.0)
         # [BT, BS]
         b_s = tl.dot(b_q, b_k) * scale * RCP_LN2
 
         if USE_G:
-            p_gk = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-            b_gk = tl.load(p_gk, boundary_check=(0,)).to(tl.float32)
+            p_gk = g_cumsum + bos * HQ + i_hq + o_k * HQ
+            b_gk = tl.load(p_gk, mask=m_k, other=0.0).to(tl.float32)
             b_s += b_gq[:, None] - b_gk[None, :]
         if USE_WINDOW:
             b_p = tl.where(
@@ -339,10 +343,10 @@ def parallel_attn_bwd_kernel_dq(
             b_dg += tl.sum(b_ds, 1)
 
     b_dq *= scale
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q[:, None] & (o_d[None, :] < K))
     if USE_G:
-        p_dg = tl.make_block_ptr(dg_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+        p_dg = dg_cumsum + bos * HQ + i_hq + o_q * HQ
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_q)
 
 
 @triton.heuristics({
@@ -381,12 +385,12 @@ def parallel_attn_bwd_kernel_dkv(
     USE_WINDOW: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -394,49 +398,51 @@ def parallel_attn_bwd_kernel_dkv(
         bos, eos = (i_n * T).to(tl.int64), (i_n * T + T).to(tl.int64)
     RCP_LN2: tl.constexpr = 1.4426950216
 
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    o_k = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < T
+    p_k = k + (bos * H + i_h) * K + o_k[:, None] * (H*K) + o_d[None, :]
+    p_v = v + (bos * H + i_h) * V + o_k[:, None] * (H*V) + o_v[None, :]
+    p_dk = dk + (bos * HQ + i_hq) * K + o_k[:, None] * (HQ*K) + o_d[None, :]
+    p_dv = dv + (bos * HQ + i_hq) * V + o_k[:, None] * (HQ*V) + o_v[None, :]
 
     # [BT, BK]
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_k = tl.load(p_k, mask=m_k[:, None] & (o_d[None, :] < K), other=0.0)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     # [BT, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
     b_dv = tl.zeros([BT, BV], dtype=tl.float32)
 
-    o_k = i_t * BT + tl.arange(0, BT)
-
     if USE_G:
-        p_gk = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        b_gk = tl.load(p_gk, boundary_check=(0,)).to(tl.float32)
+        p_gk = g_cumsum + bos * HQ + i_hq + o_k * HQ
+        b_gk = tl.load(p_gk, mask=m_k, other=0.0).to(tl.float32)
         b_dg = tl.zeros([BT], dtype=tl.float32)
     else:
         b_gk = None
         b_dg = None
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (BS, BK), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-        p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-        p_delta = tl.make_block_ptr(delta + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-
         # [BS]
         o_q = i_s + tl.arange(0, BS)
         m_q = o_q < T
+        p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+        p_do = do + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_lse = lse + bos * HQ + i_hq + o_q * HQ
+        p_delta = delta + bos * HQ + i_hq + o_q * HQ
+
         # [BS, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
         # [BS, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_q[:, None] & (o_v[None, :] < V), other=0.0)
         # [BS]
-        b_lse = tl.load(p_lse, boundary_check=(0,))
-        b_delta = tl.load(p_delta, boundary_check=(0,))
+        b_lse = tl.load(p_lse, mask=m_q, other=0.0)
+        b_delta = tl.load(p_delta, mask=m_q, other=0.0)
         # [BT, BS]
         b_s = tl.dot(b_k, tl.trans(b_q)) * scale * RCP_LN2
         if USE_G:
-            p_gq = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-            b_gq = tl.load(p_gq, boundary_check=(0,)).to(tl.float32)
+            p_gq = g_cumsum + bos * HQ + i_hq + o_q * HQ
+            b_gq = tl.load(p_gq, mask=m_q, other=0.0).to(tl.float32)
             b_s += b_gq[None, :] - b_gk[:, None]
         if USE_WINDOW:
             b_p = tl.where(
@@ -462,26 +468,26 @@ def parallel_attn_bwd_kernel_dkv(
     i_end = min(tl.cdiv(T, BS) * BS, (i_t + 1) * BT + W - 1) if USE_WINDOW else tl.cdiv(T, BS) * BS
 
     for i_s in range((i_t + 1) * BT, i_end, BS):
-        p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (BS, BK), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-        p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-        p_delta = tl.make_block_ptr(delta + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-
         # [BS]
         o_q = i_s + tl.arange(0, BS)
         m_q = o_q < T
+        p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+        p_do = do + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_lse = lse + bos * HQ + i_hq + o_q * HQ
+        p_delta = delta + bos * HQ + i_hq + o_q * HQ
+
         # [BS, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
         # [BS, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_q[:, None] & (o_v[None, :] < V), other=0.0)
         # [BS]
-        b_lse = tl.load(p_lse, boundary_check=(0,))
-        b_delta = tl.load(p_delta, boundary_check=(0,))
+        b_lse = tl.load(p_lse, mask=m_q, other=0.0)
+        b_delta = tl.load(p_delta, mask=m_q, other=0.0)
         # [BT, BS]
         b_s = tl.dot(b_k, tl.trans(b_q)) * scale * RCP_LN2
         if USE_G:
-            p_gq = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-            b_gq = tl.load(p_gq, boundary_check=(0,)).to(tl.float32)
+            p_gq = g_cumsum + bos * HQ + i_hq + o_q * HQ
+            b_gq = tl.load(p_gq, mask=m_q, other=0.0).to(tl.float32)
             b_s += b_gq[None, :] - b_gk[:, None]
         if USE_WINDOW:
             b_p = tl.where((o_q[None, :] - o_k[:, None] < W) & m_q[None, :], exp2(b_s - b_lse[None, :]), 0)
@@ -499,11 +505,11 @@ def parallel_attn_bwd_kernel_dkv(
             b_dg -= tl.sum(b_ds, 1)
 
     b_dk = b_dk * scale
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k[:, None] & (o_d[None, :] < K))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_k[:, None] & (o_v[None, :] < V))
     if USE_G:
-        p_dg = tl.make_block_ptr(dg_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+        p_dg = dg_cumsum + bos * HQ + i_hq + o_k * HQ
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_k)
 
 
 @dispatch('attn')

--- a/fla/ops/attnres/fused.py
+++ b/fla/ops/attnres/fused.py
@@ -70,7 +70,7 @@ def attnres_fwd_kernel(
     b_o = tl.zeros([BD], dtype=tl.float32)
     for i_l in range(tl.cdiv(L, BL)):
         # [BL]
-        o_l = i_l * BL + tl.arange(0, BL)
+        o_l = (i_l * BL).to(tl.int64) + tl.arange(0, BL)
         m_l = o_l < L
         # per-tile base pointers from the length-L2 padded tuple; OOB rows keep res[0] and are masked by m_l
         p_v = res[0] + o_l * 0
@@ -100,25 +100,25 @@ def attnres_fwd_kernel(
         b_o = b_o * b_r + tl.sum(b_p[:, None] * b_v, axis=0)
 
         # rstd and logit saved for bwd_dv
-        p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (i_l * BL,), (BL,), (0,))
-        p_logit = tl.make_block_ptr(logit + i_n, (L,), (N,), (i_l * BL,), (BL,), (0,))
-        tl.store(p_rstd, b_rstd.to(rstd.dtype.element_ty), boundary_check=(0,))
-        tl.store(p_logit, b_logit.to(logit.dtype.element_ty), boundary_check=(0,))
+        p_rstd = rstd + i_n + o_l * N
+        p_logit = logit + i_n + o_l * N
+        tl.store(p_rstd, b_rstd.to(rstd.dtype.element_ty), mask=m_l)
+        tl.store(p_logit, b_logit.to(logit.dtype.element_ty), mask=m_l)
 
     tl.store(lse + i_n, b_m + tl.log(b_acc))
 
     # [BD] pre-norm mixed residual sum_l p_l * v_l
     b_o = b_o / b_acc
     if SAVE_OPRE:
-        p_o_pre = tl.make_block_ptr(o_pre + i_n * D, (D,), (1,), (0,), (BD,), (0,))
-        tl.store(p_o_pre, b_o.to(p_o_pre.dtype.element_ty), boundary_check=(0,))
+        p_o_pre = o_pre + i_n * D + o_d
+        tl.store(p_o_pre, b_o.to(p_o_pre.dtype.element_ty), mask=m_d)
     # fold the optional output RMSNorm into the returned output o (o_rstd is recomputed from o_pre in bwd, not stored)
     if HAS_ONORM:
         b_o_rstd = tl.rsqrt(tl.sum(tl.where(m_d, b_o * b_o, 0.0), axis=0) / D + eps)
         b_ow = tl.load(ow + o_d, mask=m_d, other=0.).to(tl.float32)
         b_o = b_o * b_o_rstd * b_ow
-    p_o = tl.make_block_ptr(o + i_n * D, (D,), (1,), (0,), (BD,), (0,))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+    p_o = o + i_n * D + o_d
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_d)
 
 
 @fla_cache_autotune(
@@ -163,16 +163,16 @@ def attnres_bwd_kernel_dv(
     m_d = o_d < D
     b_qw = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32) * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
     b_lse = tl.load(lse + i_n).to(tl.float32)
-    p_do = tl.make_block_ptr(do + i_n * D, (D,), (1,), (0,), (BD,), (0,))
-    b_do = tl.load(p_do, boundary_check=(0,), padding_option="zero").to(tl.float32)
+    p_do = do + i_n * D + o_d
+    b_do = tl.load(p_do, mask=m_d, other=0.0).to(tl.float32)
     if SAVE_OPRE:
-        p_o_pre = tl.make_block_ptr(o_pre + i_n * D, (D,), (1,), (0,), (BD,), (0,))
-        b_o_pre = tl.load(p_o_pre, boundary_check=(0,), padding_option="zero").to(tl.float32)
+        p_o_pre = o_pre + i_n * D + o_d
+        b_o_pre = tl.load(p_o_pre, mask=m_d, other=0.0).to(tl.float32)
     else:
         # level 1: recompute the mix sum_l p_l * v_l from V
         b_o_pre = tl.zeros([BD], dtype=tl.float32)
         for i_l in range(tl.cdiv(L, BL)):
-            o_l = i_l * BL + tl.arange(0, BL)
+            o_l = (i_l * BL).to(tl.int64) + tl.arange(0, BL)
             m_l = o_l < L
             p_v = res[0] + o_l * 0
             for i in tl.static_range(1, L2):
@@ -183,8 +183,8 @@ def attnres_bwd_kernel_dv(
                 mask=m_l[:, None] & m_d[None, :],
                 other=0.0,
             ).to(tl.float32)
-            p_logit = tl.make_block_ptr(logit + i_n, (L,), (N,), (i_l * BL,), (BL,), (0,))
-            b_logit = tl.load(p_logit, boundary_check=(0,), padding_option="zero").to(tl.float32)
+            p_logit = logit + i_n + o_l * N
+            b_logit = tl.load(p_logit, mask=m_l, other=0.0).to(tl.float32)
             b_p = tl.where(m_l, exp(b_logit * scale - b_lse), 0.0)
             b_o_pre += tl.sum(b_p[:, None] * b_v, axis=0)
 
@@ -194,8 +194,8 @@ def attnres_bwd_kernel_dv(
         b_ow = tl.load(ow + o_d, mask=m_d, other=0.).to(tl.float32)
         b_xhat = b_o_pre * b_o_rstd
         b_c1 = tl.sum(tl.where(m_d, b_xhat * b_ow * b_do, 0.0), axis=0) / D
-        p_dow = tl.make_block_ptr(dow_partial + i_n * D, (D,), (1,), (0,), (BD,), (0,))
-        tl.store(p_dow, (b_xhat * b_do).to(p_dow.dtype.element_ty), boundary_check=(0,))
+        p_dow = dow_partial + i_n * D + o_d
+        tl.store(p_dow, (b_xhat * b_do).to(p_dow.dtype.element_ty), mask=m_d)
         b_do = (b_ow * b_do - b_xhat * b_c1) * b_o_rstd
     # delta = sum_l p*dp = <do_pre, o_pre>
     b_delta = tl.sum(tl.where(m_d, b_do * b_o_pre, 0.0), axis=0)
@@ -204,7 +204,7 @@ def attnres_bwd_kernel_dv(
     b_dqw = tl.zeros([BD], dtype=tl.float32)
     for i_l in range(tl.cdiv(L, BL)):
         # [BL]
-        o_l = i_l * BL + tl.arange(0, BL)
+        o_l = (i_l * BL).to(tl.int64) + tl.arange(0, BL)
         m_l = o_l < L
         m_v = m_l[:, None] & m_d[None, :]
         # per-tile source / dv base pointers from the length-L2 padded tuple
@@ -222,11 +222,11 @@ def attnres_bwd_kernel_dv(
             other=0.0,
         ).to(tl.float32)
 
-        p_rstd = tl.make_block_ptr(rstd + i_n, (L,), (N,), (i_l * BL,), (BL,), (0,))
-        p_logit = tl.make_block_ptr(logit + i_n, (L,), (N,), (i_l * BL,), (BL,), (0,))
+        p_rstd = rstd + i_n + o_l * N
+        p_logit = logit + i_n + o_l * N
         # [BL]; recompute probs from logit + lse, OOB rows masked to 0
-        b_rstd = tl.load(p_rstd, boundary_check=(0,), padding_option="zero").to(tl.float32)
-        b_logit = tl.load(p_logit, boundary_check=(0,), padding_option="zero").to(tl.float32)
+        b_rstd = tl.load(p_rstd, mask=m_l, other=0.0).to(tl.float32)
+        b_logit = tl.load(p_logit, mask=m_l, other=0.0).to(tl.float32)
         b_p = tl.where(m_l, exp(b_logit * scale - b_lse), 0.0)
 
         # softmax bwd with delta already known
@@ -243,8 +243,8 @@ def attnres_bwd_kernel_dv(
         # [BD]
         b_dqw += tl.sum(b_ds[:, None] * b_k, axis=0)
 
-    p_dqw = tl.make_block_ptr(dqw + i_n * D, (D,), (1,), (0,), (BD,), (0,))
-    tl.store(p_dqw, b_dqw, boundary_check=(0,))
+    p_dqw = dqw + i_n * D + o_d
+    tl.store(p_dqw, b_dqw, mask=m_d)
 
 
 @fla_cache_autotune(
@@ -282,11 +282,13 @@ def attnres_bwd_kernel_dqdw(
     b_dqw = tl.zeros([BD], dtype=tl.float32)
     b_dow = tl.zeros([BD], dtype=tl.float32)
     for i_n in range(0, N, BN):
-        p_dqw = tl.make_block_ptr(dqw, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
-        b_dqw += tl.sum(tl.load(p_dqw, boundary_check=(0, 1), padding_option="zero").to(tl.float32), axis=0)
+        o_n = i_n.to(tl.int64) + tl.arange(0, BN)
+        m_nd = (o_n[:, None] < N) & m_d[None, :]
+        p_dqw = dqw + o_n[:, None] * D + o_d[None, :]
+        b_dqw += tl.sum(tl.load(p_dqw, mask=m_nd, other=0.0).to(tl.float32), axis=0)
         if HAS_ONORM:
-            p_dow = tl.make_block_ptr(dow_partial, (N, D), (D, 1), (i_n, i_d * BD), (BN, BD), (1, 0))
-            b_dow += tl.sum(tl.load(p_dow, boundary_check=(0, 1), padding_option="zero").to(tl.float32), axis=0)
+            p_dow = dow_partial + o_n[:, None] * D + o_d[None, :]
+            b_dow += tl.sum(tl.load(p_dow, mask=m_nd, other=0.0).to(tl.float32), axis=0)
 
     # the logit uses the q * w product, so dq = (sum_n dqw) * w and dw = (sum_n dqw) * q
     # [BD]

--- a/fla/ops/based/fused_chunk.py
+++ b/fla/ops/based/fused_chunk.py
@@ -44,10 +44,8 @@ def fused_chunk_based_fwd_kernel(
     b_h_2o = tl.zeros([BK*BK, BV], dtype=tl.float32)
 
     # make block pointers
-    p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (0, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k * BK, 0), (BK, BT), (0, 1))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (0, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o + (i_bh + i_k*B*H) * T*V, (T, V), (V, 1), (0, i_v * BV), (BT, BV), (1, 0))
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
 
     p_z = z + (i_bh + i_k * B * H) * T + tl.arange(0, BT)
     k_2o = tl.zeros([1, BK * BK], dtype=tl.float32)
@@ -55,15 +53,24 @@ def fused_chunk_based_fwd_kernel(
     k_0o = 0
 
     for i in range(0, tl.cdiv(T, BT)):
+        o_t = (i * BT).to(tl.int64) + tl.arange(0, BT)
+        m_t = o_t < T
+        m_q = m_t[:, None] & (o_kk[None, :] < K)
+        m_k = (o_kk[:, None] < K) & m_t[None, :]
+        m_v = m_t[:, None] & (o_vv[None, :] < V)
+        p_q = q + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
+        p_k = k + i_bh * T*K + o_kk[:, None] + o_t[None, :] * K
+        p_v = v + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+        p_o = o + (i_bh + i_k*B*H) * T*V + o_t[:, None] * V + o_vv[None, :]
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BK*BK, BT]
         b_k_2o = b_k[:, None, :] * b_k[None, :, :]
         b_k_2o = tl.reshape(b_k_2o, [BK * BK, BT]).to(b_k.dtype)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BT, BK]
-        b_q = (tl.load(p_q, boundary_check=(0, 1)) * scale).to(b_k.dtype)
+        b_q = (tl.load(p_q, mask=m_q, other=0.0) * scale).to(b_k.dtype)
         b_o = tl.zeros([BT, BV], dtype=tl.float32)
         b_z = tl.zeros([BT], dtype=tl.float32)
 
@@ -93,7 +100,7 @@ def fused_chunk_based_fwd_kernel(
         b_z += tl.sum(b_s, axis=1)
         b_o += tl.dot(b_s.to(b_q.dtype), b_v, allow_tf32=False)
         # [TB, BV]
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
         # only one V-split program writes z: its address does not depend on
         # i_v, so all i_v programs would store the same values to the same
         # locations concurrently (an unsynchronized same-value WAW). The bwd
@@ -107,10 +114,6 @@ def fused_chunk_based_fwd_kernel(
         b_h_1o = b_h_1o + tl.dot(b_k, b_v, allow_tf32=False)
         b_h_0o = b_h_0o + tl.sum(b_v, axis=0)
 
-        p_q = tl.advance(p_q, (BT, 0))
-        p_k = tl.advance(p_k, (0, BT))
-        p_v = tl.advance(p_v, (BT, 0))
-        p_o = tl.advance(p_o, (BT, 0))
         p_z += BT
 
 
@@ -151,24 +154,31 @@ def fused_chunk_based_bwd_kernel(
     k_1o = tl.zeros([1, BK], dtype=tl.float32)
     k_2o = tl.zeros([1, BK * BK], dtype=tl.float32)
 
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
     for i in range(0, tl.cdiv(T, BT)):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i * BT, i_k * BK), (BT, BK), (1, 0))
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (V, T), (1, V), (i_v * BV, i * BT), (BV, BT), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dq = tl.make_block_ptr(dq + (i_bh + i_v*B*H) * T*K, (T, K), (K, 1), (i*BT, i_k*BK), (BT, BK), (1, 0))
+        o_t = (i * BT).to(tl.int64) + tl.arange(0, BT)
+        m_t = o_t < T
+        m_q = m_t[:, None] & (o_kk[None, :] < K)
+        m_v = m_t[:, None] & (o_vv[None, :] < V)
+        m_kv = (o_vv[:, None] < V) & m_t[None, :]
+        p_q = q + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
+        p_k = k + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
+        p_v = v + i_bh * T*V + o_vv[:, None] + o_t[None, :] * V
+        p_do = do + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+        p_dq = dq + (i_bh + i_v*B*H) * T*K + o_t[:, None] * K + o_kk[None, :]
         p_dz = dz + (i_bh) * T + tl.arange(0, BT) + i * BT
         b_dq = tl.zeros([BT, BK], dtype=tl.float32)
 
         # load tensors
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)
+        b_k = tl.load(p_k, mask=m_q, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0).to(b_q.dtype)
         b_dz = tl.load(p_dz, mask=(tl.arange(0, BT) + i * BT) < T)
         # [BV, BT]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
 
         # inter-chunk
         b_dq += tl.dot(b_do, (b_h_1o).to(b_do.dtype), allow_tf32=False)
@@ -193,7 +203,7 @@ def fused_chunk_based_bwd_kernel(
         b_dq += tl.dot((b_ds * (1 + b_s)).to(b_q.dtype), b_k, allow_tf32=False)
 
         # store
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q)
 
         # update hidden state
         # [BT, BK*BK]
@@ -224,21 +234,26 @@ def fused_chunk_based_bwd_kernel(
     dq_2o = tl.zeros([BK * BK, 1], dtype=tl.float32)
 
     for i in range(tl.cdiv(T, BT) * BT - BT, -BT, -BT):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (K, T), (1, K), (i_k * BK, i), (BK, BT), (0, 1))
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i, i_k * BK), (BT, BK), (1, 0))
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i, i_v * BV), (BT, BV), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (i_bh+i_v*B*H) * T*K, (T, K), (K, 1), (i, i_k*BK), (BT, BK), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (i_bh+i_k*B*H) * T*V, (T, V), (V, 1), (i, i_v*BV), (BT, BV), (1, 0))
+        o_t = i.to(tl.int64) + tl.arange(0, BT)
+        m_t = o_t < T
+        m_q = (o_kk[:, None] < K) & m_t[None, :]
+        m_k = m_t[:, None] & (o_kk[None, :] < K)
+        m_v = m_t[:, None] & (o_vv[None, :] < V)
+        p_q = q + i_bh * T*K + o_kk[:, None] + o_t[None, :] * K
+        p_k = k + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
+        p_v = v + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+        p_do = do + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+        p_dk = dk + (i_bh+i_v*B*H) * T*K + o_t[:, None] * K + o_kk[None, :]
+        p_dv = dv + (i_bh+i_k*B*H) * T*V + o_t[:, None] * V + o_vv[None, :]
         p_dz = dz + (i_bh) * T + tl.arange(0, BT) + i
 
         b_dk = tl.zeros([BT, BK], dtype=tl.float32)
         b_dv = tl.zeros([BT, BV], dtype=tl.float32)
 
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0).to(b_q.dtype)
         b_dz = tl.load(p_dz, mask=(tl.arange(0, BT)+i) < T)
         b_q = (b_q * scale).to(b_k.dtype)
 
@@ -289,8 +304,8 @@ def fused_chunk_based_bwd_kernel(
             dq_1o += (tl.sum(b_dz[None, :] * b_q, axis=1))[None, :]
             dq_2o += (tl.sum(b_dz[None, :] * b_q_2o, axis=1) * 0.5)[:, None]
 
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
 
 class FusedChunkBasedFunction(torch.autograd.Function):

--- a/fla/ops/based/parallel.py
+++ b/fla/ops/based/parallel.py
@@ -34,29 +34,38 @@ def parallel_based_fwd_kernel(
     BV: tl.constexpr,
 ):
     # i_c: chunk index. used for sequence parallelism
-    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     NV = tl.cdiv(V, BV)
     i_k = i_kv // (NV)
     i_v = i_kv % (NV)
 
-    p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_c * BTL, i_k * BK), (BTL, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k * BK, 0), (BK, BTS), (0, 1))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (0, i_v * BV), (BTS, BV), (1, 0))
+    o_t = i_c * BTL + tl.arange(0, BTL)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_q = m_t[:, None] & (o_kk[None, :] < K)
+    m_o = m_t[:, None] & (o_vv[None, :] < V)
+    p_q = q + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
 
     # [BQ, BD] block Q, in the shared memory throughout the whole kernel
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
     b_o = tl.zeros([BTL, BV], dtype=tl.float32)
     b_z = tl.zeros([BTL], dtype=tl.float32)
 
     # Q block and K block have no overlap
     # no need for mask, thereby saving flops
-    for _ in range(0, i_c * BTL, BTS):
+    for i_s in range(0, i_c * BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_v = (o_s[:, None] < T) & (o_vv[None, :] < V)
+        p_k = k + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_v = v + i_bh * T*V + o_s[:, None] * V + o_vv[None, :]
         # [BK, BTS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
 
         # [BTS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         b_s = tl.dot(b_q, (b_k), allow_tf32=False)
         b_s = 1 + b_s + 0.5 * b_s * b_s
@@ -64,8 +73,6 @@ def parallel_based_fwd_kernel(
 
         # [BQ, BD]
         b_o = b_o + tl.dot(b_s.to(b_v.dtype), b_v, allow_tf32=False)
-        p_k = tl.advance(p_k, (0, BTS))
-        p_v = tl.advance(p_v, (BTS, 0))
 
     # # rescale interchunk output
     tl.debug_barrier()
@@ -74,14 +81,17 @@ def parallel_based_fwd_kernel(
     # tl.debug_barrier()
 
     o_k = tl.arange(0, BTS)
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k * BK, i_c * BTL), (BK, BTS), (0, 1))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_c * BTL, i_v * BV), (BTS, BV), (1, 0))
     # Q block and K block have overlap. masks required
-    for _ in range(i_c * BTL, (i_c + 1) * BTL, BTS):
+    for i_s in range(i_c * BTL, (i_c + 1) * BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_v = (o_s[:, None] < T) & (o_vv[None, :] < V)
+        p_k = k + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_v = v + i_bh * T*V + o_s[:, None] * V + o_vv[None, :]
         # [BK, BTS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BTS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         m_s = o_q[:, None] >= o_k[None, :]
         b_s = tl.dot(b_q, b_k, allow_tf32=False)
@@ -91,13 +101,11 @@ def parallel_based_fwd_kernel(
         # [BTL, BV]
         b_o += tl.dot(b_s.to(b_q.dtype), b_v, allow_tf32=False)
 
-        p_k = tl.advance(p_k, (0, BTS))
-        p_v = tl.advance(p_v, (BTS, 0))
         o_k += BTS
 
-    p_o = tl.make_block_ptr(o + (i_bh + B * H * i_k) * T*V, (T, V), (V, 1), (i_c*BTL, i_v*BV), (BTL, BV), (1, 0))
+    p_o = o + (i_bh + B * H * i_k) * T*V + o_t[:, None] * V + o_vv[None, :]
     p_z = z + (i_bh + B * H * i_k) * T + i_c * BTL + tl.arange(0, BTL)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_o)
     tl.store(p_z, b_z.to(p_z.dtype.element_ty), mask=((i_c * BTL + tl.arange(0, BTL)) < T))
 
 
@@ -124,23 +132,32 @@ def _parallel_based_bwd_dq(
     K: tl.constexpr,
     V: tl.constexpr,
 ):
-    p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_c * BTL, i_v * BV), (BTL, BV), (1, 0))
-    p_q = tl.make_block_ptr(q + (i_bh) * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    o_t = i_c * BTL + tl.arange(0, BTL)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_q = m_t[:, None] & (o_kk[None, :] < K)
+    m_o = m_t[:, None] & (o_vv[None, :] < V)
+    p_do = do + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+    p_q = q + (i_bh) * T*K + o_t[:, None] * K + o_kk[None, :]
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
 
-    b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)
+    b_do = tl.load(p_do, mask=m_o, other=0.0).to(b_q.dtype)
     b_dq = tl.zeros([BTL, BK], dtype=tl.float32)
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (0, i_k * BK), (BTS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (V, T), (1, V), (i_v * BV, 0), (BV, BTS), (0, 1))
     p_dz = dz + i_bh * T + i_c * BTL + tl.arange(0, BTL)
     b_dz = tl.load(p_dz, mask=(i_c * BTL + tl.arange(0, BTL)) < T)
 
-    for _ in range(0, i_c * BTL, BTS):
+    for i_s in range(0, i_c * BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_s[:, None] < T) & (o_kk[None, :] < K)
+        m_v = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_k = k + i_bh * T*K + o_s[:, None] * K + o_kk[None, :]
+        p_v = v + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         # [BTS, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BV, BTS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         b_ds = tl.dot(b_do, b_v, allow_tf32=False)
         if i_v == 0:
@@ -150,20 +167,21 @@ def _parallel_based_bwd_dq(
         b_s = tl.dot(b_q, tl.trans(b_k), allow_tf32=False)
         # [BQ, BD]
         b_dq += tl.dot((b_ds * (1 + b_s)).to(b_v.dtype), b_k, allow_tf32=False)
-        p_k = tl.advance(p_k, (BTS, 0))
-        p_v = tl.advance(p_v, (0, BTS))
 
     b_dq *= scale
     o_q = tl.arange(0, BTL)
     o_k = tl.arange(0, BTS)
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_c * BTL, i_k * BK), (BTS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (V, T), (1, V), (i_v * BV, i_c * BTL), (BV, BTS), (0, 1))
     # Q block and K block have overlap. masks required
-    for _ in range(i_c * BTL, (i_c + 1) * BTL, BTS):
+    for i_s in range(i_c * BTL, (i_c + 1) * BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_s[:, None] < T) & (o_kk[None, :] < K)
+        m_v = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_k = k + i_bh * T*K + o_s[:, None] * K + o_kk[None, :]
+        p_v = v + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         # [BTS, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BV, BTS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         m_s = o_q[:, None] >= o_k[None, :]
         b_ds = tl.dot(b_do, b_v, allow_tf32=False)
@@ -176,11 +194,9 @@ def _parallel_based_bwd_dq(
         b_s = tl.where(m_s, b_s, 0)
         # [BTL, BK]
         b_dq += tl.dot((b_ds + b_ds * b_s).to(b_k.dtype), b_k, allow_tf32=False)
-        p_k = tl.advance(p_k, (BTS, 0))
-        p_v = tl.advance(p_v, (0, BTS))
         o_k += BTS
-    p_dq = tl.make_block_ptr(dq + (i_bh + B * H * i_v) * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq + (i_bh + B * H * i_v) * T*K + o_t[:, None] * K + o_kk[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q)
     return
 
 
@@ -209,17 +225,26 @@ def _parallel_based_bwd_dkv(
     V: tl.constexpr,
 ):
     # compute dk dv
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_c * BTL, i_k * BK), (BTL, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_c * BTL, i_v * BV), (BTL, BV), (1, 0))
-    b_k, b_v = tl.load(p_k, boundary_check=(0, 1)), tl.load(p_v, boundary_check=(0, 1))
+    o_t = i_c * BTL + tl.arange(0, BTL)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_k = m_t[:, None] & (o_kk[None, :] < K)
+    m_v = m_t[:, None] & (o_vv[None, :] < V)
+    p_k = k + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
+    p_v = v + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+    b_k, b_v = tl.load(p_k, mask=m_k, other=0.0), tl.load(p_v, mask=m_v, other=0.0)
     b_dk, b_dv = tl.zeros([BTL, BK], dtype=tl.float32), tl.zeros([BTL, BV], dtype=tl.float32)
 
     for i in range((tl.cdiv(T, BTS) * BTS)-BTS, (i_c + 1) * BTL - BTS, -BTS):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (K, T), (1, K), (i_k * BK, i), (BK, BTS), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (V, T), (1, V), (i_v * BV, i), (BV, BTS), (0, 1))
+        o_s = i + tl.arange(0, BTS)
+        m_q = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_o = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_q = q + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_do = do + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         p_dz = dz + i_bh * T + i + tl.arange(0, BTS)
-        b_q = tl.load(p_q, boundary_check=(0, 1))  # [BK, BTS]
-        b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)  # [BV, BTS]
+        b_q = tl.load(p_q, mask=m_q, other=0.0)  # [BK, BTS]
+        b_do = tl.load(p_do, mask=m_o, other=0.0).to(b_q.dtype)  # [BV, BTS]
         b_dz = tl.load(p_dz, mask=(i + tl.arange(0, BTS)) < T)
         b_s = tl.dot(b_k.to(b_q.dtype), b_q, allow_tf32=False) * scale  # [BTL, BTS]
         b_s2 = 1 + b_s + 0.5 * b_s * b_s
@@ -234,11 +259,14 @@ def _parallel_based_bwd_dkv(
     tl.debug_barrier()
     o_q, o_k = tl.arange(0, BTS), tl.arange(0, BTL)
     for i in range(i_c*BTL, (i_c+1)*BTL, BTS):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (K, T), (1, K), (i_k * BK, i), (BK, BTS), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (V, T), (1, V), (i_v * BV, i), (BV, BTS), (0, 1))
+        o_s = i + tl.arange(0, BTS)
+        m_q = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_o = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_q = q + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_do = do + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         p_dz = dz + i_bh * T + i + tl.arange(0, BTS)
-        b_q = tl.load(p_q, boundary_check=(0, 1))  # [BD, BQ]
-        b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)
+        b_q = tl.load(p_q, mask=m_q, other=0.0)  # [BD, BQ]
+        b_do = tl.load(p_do, mask=m_o, other=0.0).to(b_q.dtype)
         b_dz = tl.load(p_dz, mask=(i + tl.arange(0, BTS)) < T)
         # [BK, BQ]
         m_s = o_k[:, None] <= o_q[None, :]
@@ -258,10 +286,10 @@ def _parallel_based_bwd_dkv(
         b_dk += tl.dot((b_ds + b_ds * b_s).to(b_q.dtype), tl.trans(b_q), allow_tf32=False)
         o_q += BTS
 
-    p_dk = tl.make_block_ptr(dk + (i_bh + B * H * i_v) * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (i_bh + B * H * i_k) * T*V, (T, V), (V, 1), (i_c*BTL, i_v*BV), (BTL, BV), (1, 0))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    p_dk = dk + (i_bh + B * H * i_v) * T*K + o_t[:, None] * K + o_kk[None, :]
+    p_dv = dv + (i_bh + B * H * i_k) * T*V + o_t[:, None] * V + o_vv[None, :]
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
     return
 
 
@@ -286,7 +314,7 @@ def parallel_based_bwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
 ):
-    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     NV = tl.cdiv(V, BV)
     i_k = i_kv // (NV)
     i_v = i_kv % NV

--- a/fla/ops/comba/utils.py
+++ b/fla/ops/comba/utils.py
@@ -40,26 +40,28 @@ def chunk_comba_cumsum_scalar_fwd_kernel(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_g = tl.make_block_ptr(g + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_g0 = tl.make_block_ptr(g0 + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_g1 = tl.make_block_ptr(g1 + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_g = g + bos*H + i_h + o_t * H
+    p_g0 = g0 + bos*H + i_h + o_t * H
+    p_g1 = g1 + bos*H + i_h + o_t * H
     # [BT]
-    b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+    b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
     if HAS_SCALE:
         b_g = b_g * scale
     b_g1 = tl.cumsum(b_g, axis=0)
     b_g0 = b_g1 - b_g
-    tl.store(p_g0, b_g0.to(p_g0.dtype.element_ty), boundary_check=(0,))
-    tl.store(p_g1, b_g1.to(p_g1.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_g0, b_g0.to(p_g0.dtype.element_ty), mask=m_t)
+    tl.store(p_g1, b_g1.to(p_g1.dtype.element_ty), mask=m_t)
 
 
 def chunk_comba_cumsum_scalar_fwd(
@@ -116,17 +118,19 @@ def chunk_comba_cumsum_scalar_bwd_kernel(
     BT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_dg0 = tl.make_block_ptr(dg0 + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dgr = tl.make_block_ptr(dgr + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_dg0 = dg0 + bos*H + i_h + o_t * H
+    p_dgr = dgr + bos*H + i_h + o_t * H
     # [BT]
     """
     b_dg:   1,2,3,4
@@ -135,11 +139,11 @@ def chunk_comba_cumsum_scalar_bwd_kernel(
     b_dz:   6
     b_dgr:  6,5,3,0
     """
-    b_dg0 = tl.load(p_dg0, boundary_check=(0,)).to(tl.float32)
+    b_dg0 = tl.load(p_dg0, mask=m_t, other=0.0).to(tl.float32)
     b_temp = tl.cumsum(b_dg0, axis=0)
     b_dz = tl.sum(b_dg0, axis=0)
     b_dgr = -b_temp + b_dz[None]
-    tl.store(p_dgr, b_dgr.to(p_dgr.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_dgr, b_dgr.to(p_dgr.dtype.element_ty), mask=m_t)
 
 
 def chunk_comba_cumsum_scalar_bwd(

--- a/fla/ops/comba/wy_fast.py
+++ b/fla/ops/comba/wy_fast.py
@@ -46,10 +46,10 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -57,29 +57,32 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
 
-    p_beta = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
+    p_beta = beta + bos*H + i_h + o_t * H
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_p = tl.make_block_ptr(p + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_p = tl.load(p_p, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_p = p + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_p = tl.load(p_p, mask=m_k, other=0.0)
         b_pb = b_p * b_beta[:, None]
         b_A += tl.dot(b_pb.to(b_k.dtype), tl.trans(b_k))
 
     if USE_G:
-        p_g0 = tl.make_block_ptr(g0 + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_g = tl.make_block_ptr(g + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        b_g0 = tl.load(p_g0, boundary_check=(0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g0 = g0 + bos*H + i_h + o_t * H
+        p_g = g + bos*H + i_h + o_t * H
+        b_g0 = tl.load(p_g0, mask=m_t, other=0.0)
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_A = b_A * exp2(b_g0[:, None] - b_g[None, :])
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (BT*H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (BT*H) + o_A[None, :]
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
 
 
 def chunk_scaled_dot_comba_pkt_fwd(
@@ -183,59 +186,65 @@ def prepare_wy_repr_bwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_beta = tl.make_block_ptr(beta + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_g0 = tl.make_block_ptr(g0 + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_g = tl.make_block_ptr(g + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    p_beta = beta + (bos*H + i_h) + o_t * H
+    p_g0 = g0 + (bos*H + i_h) + o_t * H
+    p_g = g + (bos*H + i_h) + o_t * H
+    p_A = A + (bos*H + i_h) * BT + o_A[:, None] + o_t[None, :] * (H*BT)
 
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
-    b_g0 = tl.load(p_g0, boundary_check=(0,))
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_g0 = tl.load(p_g0, mask=m_t, other=0.0)
     b_g0_exp = exp2(b_g0)
-    b_g = tl.load(p_g, boundary_check=(0,))
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
 
     b_dbeta = tl.zeros([BT], dtype=tl.float32)
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     b_dg0 = tl.zeros([BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_p = tl.make_block_ptr(p + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dp = tl.make_block_ptr(dp + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_p = tl.load(p_p, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_p = p + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dp = dp + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dw = dw + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_p = tl.load(p_p, mask=m_k, other=0.0)
         b_p_beta_g0 = (b_p * b_beta[:, None] * b_g0_exp[:, None]).to(b_p.dtype)
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+        b_dw = tl.load(p_dw, mask=m_k, other=0.0)
         b_dA += tl.dot(b_dw, tl.trans(b_p_beta_g0))
         b_dp_beta_g0 = tl.dot(b_A, b_dw)
         b_dp = b_dp_beta_g0 * b_beta[:, None] * b_g0_exp[:, None]
         b_dbeta += tl.sum(b_dp_beta_g0 * b_p * b_g0_exp[:, None], 1)
         b_dg0 += tl.sum(b_dp * b_p, 1)
-        tl.store(p_dp, b_dp.to(p_dp.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dp, b_dp.to(p_dp.dtype.element_ty), mask=m_k)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv = dv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_du = du + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_v_beta = (b_v * b_beta[:, None]).to(b_v.dtype)
-        b_du = tl.load(p_du, boundary_check=(0, 1))
+        b_du = tl.load(p_du, mask=m_v, other=0.0)
         b_dA += tl.dot(b_du, tl.trans(b_v_beta))
         b_dv_beta = tl.dot(b_A, b_du)
         b_dv = b_dv_beta * b_beta[:, None]
         b_dbeta += tl.sum(b_dv_beta * b_v, 1)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA, 0)
     b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
@@ -245,31 +254,33 @@ def prepare_wy_repr_bwd_kernel(
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_p = tl.make_block_ptr(p + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dp = tl.make_block_ptr(dp + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_p = tl.load(p_p, boundary_check=(0, 1))
-        b_dp = tl.load(p_dp, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_p = p + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dp = dp + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_p = tl.load(p_p, mask=m_k, other=0.0)
+        b_dp = tl.load(p_dp, mask=m_k, other=0.0)
         b_p_beta = (b_p * b_beta[:, None]).to(b_p.dtype)
         b_A += tl.dot(b_p_beta, tl.trans(b_k))
         b_dp_beta = tl.dot(b_dA, b_k)
         b_dbeta += tl.sum(b_dp_beta * b_p, 1)
         b_dk = tl.dot(tl.trans(b_dA), b_p_beta)
         b_dp += b_dp_beta * b_beta[:, None]
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dp, b_dp.to(p_dp.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+        tl.store(p_dp, b_dp.to(p_dp.dtype.element_ty), mask=m_k)
 
     b_dA_A = b_dA * b_A
     b_dg0 += tl.sum(b_dA_A, axis=1)
     b_dg = - tl.sum(b_dA_A, axis=0)
-    p_dg = tl.make_block_ptr(dg + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dg0 = tl.make_block_ptr(dg0 + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dbeta = tl.make_block_ptr(dbeta + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
-    tl.store(p_dg0, b_dg0.to(p_dg0.dtype.element_ty), boundary_check=(0,))
-    tl.store(p_dbeta, b_dbeta.to(p_dbeta.dtype.element_ty), boundary_check=(0,))
+    p_dg = dg + (bos*H + i_h) + o_t * H
+    p_dg0 = dg0 + (bos*H + i_h) + o_t * H
+    p_dbeta = dbeta + (bos*H + i_h) + o_t * H
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
+    tl.store(p_dg0, b_dg0.to(p_dg0.dtype.element_ty), mask=m_t)
+    tl.store(p_dbeta, b_dbeta.to(p_dbeta.dtype.element_ty), mask=m_t)
 
 
 @triton.heuristics({
@@ -304,36 +315,44 @@ def recompute_w_u_fwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
-    p_beta = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_g = tl.make_block_ptr(g + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_g = exp2(tl.load(p_g, boundary_check=(0,)))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_beta = beta + bos*H + i_h + o_t * H
+    p_g = g + (bos*H + i_h) + o_t * H
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
+    b_g = exp2(tl.load(p_g, mask=m_t, other=0.0))
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_u = u + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb, allow_tf32=False)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), mask=m_v)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_w = tl.make_block_ptr(w + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_w = w + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_kb = (b_k * b_beta[:, None] * b_g[:, None]).to(b_k.dtype)
         b_w = tl.dot(b_A, b_kb)
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_k)
 
 
 def recompute_w_u_fwd(

--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -117,98 +117,125 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         ht = ht + i_nh * K*V
 
     # load initial state
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    o_k1 = tl.arange(0, 64)
+    m_k1 = o_k1 < K
+    o_k2 = 64 + o_k1
+    m_k2 = o_k2 < K
+    o_k3 = 128 + o_k1
+    m_k3 = o_k3 < K
+    o_k4 = 192 + o_k1
+    m_k4 = o_k4 < K
     if USE_INITIAL_STATE:
         if STATE_V_FIRST:
-            p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_h0_1 = h0 + o_v[:, None] * K + o_k1[None, :]
+            m_h0_1 = m_v[:, None] & m_k1[None, :]
         else:
-            p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_1 = h0 + o_k1[:, None] * V + o_v[None, :]
+            m_h0_1 = m_k1[:, None] & m_v[None, :]
+        b_h1 += tl.load(p_h0_1, mask=m_h0_1, other=0.0).to(tl.float32)
         if K > 64:
             if STATE_V_FIRST:
-                p_h0_2 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_h0_2 = h0 + o_v[:, None] * K + o_k2[None, :]
+                m_h0_2 = m_v[:, None] & m_k2[None, :]
             else:
-                p_h0_2 = tl.make_block_ptr(h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+                p_h0_2 = h0 + o_k2[:, None] * V + o_v[None, :]
+                m_h0_2 = m_k2[:, None] & m_v[None, :]
+            b_h2 += tl.load(p_h0_2, mask=m_h0_2, other=0.0).to(tl.float32)
         if K > 128:
             if STATE_V_FIRST:
-                p_h0_3 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_h0_3 = h0 + o_v[:, None] * K + o_k3[None, :]
+                m_h0_3 = m_v[:, None] & m_k3[None, :]
             else:
-                p_h0_3 = tl.make_block_ptr(h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+                p_h0_3 = h0 + o_k3[:, None] * V + o_v[None, :]
+                m_h0_3 = m_k3[:, None] & m_v[None, :]
+            b_h3 += tl.load(p_h0_3, mask=m_h0_3, other=0.0).to(tl.float32)
         if K > 192:
             if STATE_V_FIRST:
-                p_h0_4 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_h0_4 = h0 + o_v[:, None] * K + o_k4[None, :]
+                m_h0_4 = m_v[:, None] & m_k4[None, :]
             else:
-                p_h0_4 = tl.make_block_ptr(h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+                p_h0_4 = h0 + o_k4[:, None] * V + o_v[None, :]
+                m_h0_4 = m_k4[:, None] & m_v[None, :]
+            b_h4 += tl.load(p_h0_4, mask=m_h0_4, other=0.0).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
         i_t_int64 = i_t.to(tl.int64)
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
         if STATE_V_FIRST:
-            p_h1 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_h1 = h + i_t_int64 * HV*K*V + o_v[:, None] * K + o_k1[None, :]
+            m_h1 = m_v[:, None] & m_k1[None, :]
         else:
-            p_h1 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+            p_h1 = h + i_t_int64 * HV*K*V + o_k1[:, None] * V + o_v[None, :]
+            m_h1 = m_k1[:, None] & m_v[None, :]
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), mask=m_h1)
         if K > 64:
             if STATE_V_FIRST:
-                p_h2 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_h2 = h + i_t_int64 * HV*K*V + o_v[:, None] * K + o_k2[None, :]
+                m_h2 = m_v[:, None] & m_k2[None, :]
             else:
-                p_h2 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+                p_h2 = h + i_t_int64 * HV*K*V + o_k2[:, None] * V + o_v[None, :]
+                m_h2 = m_k2[:, None] & m_v[None, :]
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), mask=m_h2)
         if K > 128:
             if STATE_V_FIRST:
-                p_h3 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_h3 = h + i_t_int64 * HV*K*V + o_v[:, None] * K + o_k3[None, :]
+                m_h3 = m_v[:, None] & m_k3[None, :]
             else:
-                p_h3 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+                p_h3 = h + i_t_int64 * HV*K*V + o_k3[:, None] * V + o_v[None, :]
+                m_h3 = m_k3[:, None] & m_v[None, :]
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), mask=m_h3)
         if K > 192:
             if STATE_V_FIRST:
-                p_h4 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_h4 = h + i_t_int64 * HV*K*V + o_v[:, None] * K + o_k4[None, :]
+                m_h4 = m_v[:, None] & m_k4[None, :]
             else:
-                p_h4 = tl.make_block_ptr(h + i_t_int64 * HV*K*V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+                p_h4 = h + i_t_int64 * HV*K*V + o_k4[:, None] * V + o_v[None, :]
+                m_h4 = m_k4[:, None] & m_v[None, :]
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), mask=m_h4)
 
-        p_w = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        p_w = w + o_t[:, None] * (HV*K) + o_k1[None, :]
+        b_w = tl.load(p_w, mask=m_t[:, None] & m_k1[None, :], other=0.0)
         if STATE_V_FIRST:
             b_v = tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))
         else:
             b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
         if K > 64:
-            p_w = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * (HV*K) + o_k2[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k2[None, :], other=0.0)
             if STATE_V_FIRST:
                 b_v += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
             else:
                 b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
         if K > 128:
-            p_w = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * (HV*K) + o_k3[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k3[None, :], other=0.0)
             if STATE_V_FIRST:
                 b_v += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
             else:
                 b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
         if K > 192:
-            p_w = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * (HV*K) + o_k4[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k4[None, :], other=0.0)
             if STATE_V_FIRST:
                 b_v += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
             else:
                 b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
-        p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+        p_v = v + o_t[:, None] * (HV*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_t[:, None] & m_v[None, :], other=0.0) - b_v
 
         if SAVE_NEW_VALUE:
-            p_v = tl.make_block_ptr(v_new, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+            p_v = v_new + o_t[:, None] * (HV*V) + o_v[None, :]
+            tl.store(p_v, b_v.to(p_v.dtype.element_ty), mask=m_t[:, None] & m_v[None, :])
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
-            m_t = (i_t * BT + tl.arange(0, BT)) < T
             b_g_last = tl.load(g + (bos * HV + last_idx * HV + i_h).to(tl.int64)).to(tl.float32)
-            p_g = tl.make_block_ptr(g + (bos * HV + i_h).to(tl.int64), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+            p_g = g + (bos * HV + i_h).to(tl.int64) + o_t * HV
+            b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
             b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
             b_g_last = exp2(b_g_last)
             b_h1 *= b_g_last
@@ -249,29 +276,29 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                     b_h4 *= exp2(b_gk_last4)[:, None]
         b_v = b_v.to(k.dtype.element_ty)
 
-        p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (0, i_t * BT), (64, BT), (0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_k1[:, None] + o_t[None, :] * (H*K)
+        b_k = tl.load(p_k, mask=m_k1[:, None] & m_t[None, :], other=0.0)
         if STATE_V_FIRST:
             b_h1 += tl.trans(tl.dot(b_k, b_v))
         else:
             b_h1 += tl.dot(b_k, b_v)
         if K > 64:
-            p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (64, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k2[:, None] + o_t[None, :] * (H*K)
+            b_k = tl.load(p_k, mask=m_k2[:, None] & m_t[None, :], other=0.0)
             if STATE_V_FIRST:
                 b_h2 += tl.trans(tl.dot(b_k, b_v))
             else:
                 b_h2 += tl.dot(b_k, b_v)
         if K > 128:
-            p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (128, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k3[:, None] + o_t[None, :] * (H*K)
+            b_k = tl.load(p_k, mask=m_k3[:, None] & m_t[None, :], other=0.0)
             if STATE_V_FIRST:
                 b_h3 += tl.trans(tl.dot(b_k, b_v))
             else:
                 b_h3 += tl.dot(b_k, b_v)
         if K > 192:
-            p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (192, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k4[:, None] + o_t[None, :] * (H*K)
+            b_k = tl.load(p_k, mask=m_k4[:, None] & m_t[None, :], other=0.0)
             if STATE_V_FIRST:
                 b_h4 += tl.trans(tl.dot(b_k, b_v))
             else:
@@ -279,28 +306,36 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     if STORE_FINAL_STATE:
         if STATE_V_FIRST:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_ht = ht + o_v[:, None] * K + o_k1[None, :]
+            m_ht = m_v[:, None] & m_k1[None, :]
         else:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k1[:, None] * V + o_v[None, :]
+            m_ht = m_k1[:, None] & m_v[None, :]
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), mask=m_ht)
         if K > 64:
             if STATE_V_FIRST:
-                p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_ht = ht + o_v[:, None] * K + o_k2[None, :]
+                m_ht = m_v[:, None] & m_k2[None, :]
             else:
-                p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+                p_ht = ht + o_k2[:, None] * V + o_v[None, :]
+                m_ht = m_k2[:, None] & m_v[None, :]
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), mask=m_ht)
         if K > 128:
             if STATE_V_FIRST:
-                p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_ht = ht + o_v[:, None] * K + o_k3[None, :]
+                m_ht = m_v[:, None] & m_k3[None, :]
             else:
-                p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+                p_ht = ht + o_k3[:, None] * V + o_v[None, :]
+                m_ht = m_k3[:, None] & m_v[None, :]
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), mask=m_ht)
         if K > 192:
             if STATE_V_FIRST:
-                p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_ht = ht + o_v[:, None] * K + o_k4[None, :]
+                m_ht = m_v[:, None] & m_k4[None, :]
             else:
-                p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+                p_ht = ht + o_k4[:, None] * V + o_v[None, :]
+                m_ht = m_k4[:, None] & m_v[None, :]
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), mask=m_ht)
 
 
 @triton.heuristics({
@@ -395,73 +430,101 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
     if USE_FINAL_STATE_GRADIENT:
         dht += i_nh * K*V
 
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    o_k1 = tl.arange(0, 64)
+    m_k1 = o_k1 < K
+    o_k2 = 64 + o_k1
+    m_k2 = o_k2 < K
+    o_k3 = 128 + o_k1
+    m_k3 = o_k3 < K
+    o_k4 = 192 + o_k1
+    m_k4 = o_k4 < K
     if USE_FINAL_STATE_GRADIENT:
         if STATE_V_FIRST:
-            p_dht1 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_dht1 = dht + o_v[:, None] * K + o_k1[None, :]
+            m_dht1 = m_v[:, None] & m_k1[None, :]
         else:
-            p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
+            p_dht1 = dht + o_k1[:, None] * V + o_v[None, :]
+            m_dht1 = m_k1[:, None] & m_v[None, :]
+        b_dh1 += tl.load(p_dht1, mask=m_dht1, other=0.0)
         if K > 64:
             if STATE_V_FIRST:
-                p_dht2 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_dht2 = dht + o_v[:, None] * K + o_k2[None, :]
+                m_dht2 = m_v[:, None] & m_k2[None, :]
             else:
-                p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
+                p_dht2 = dht + o_k2[:, None] * V + o_v[None, :]
+                m_dht2 = m_k2[:, None] & m_v[None, :]
+            b_dh2 += tl.load(p_dht2, mask=m_dht2, other=0.0)
         if K > 128:
             if STATE_V_FIRST:
-                p_dht3 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_dht3 = dht + o_v[:, None] * K + o_k3[None, :]
+                m_dht3 = m_v[:, None] & m_k3[None, :]
             else:
-                p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
+                p_dht3 = dht + o_k3[:, None] * V + o_v[None, :]
+                m_dht3 = m_k3[:, None] & m_v[None, :]
+            b_dh3 += tl.load(p_dht3, mask=m_dht3, other=0.0)
         if K > 192:
             if STATE_V_FIRST:
-                p_dht4 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_dht4 = dht + o_v[:, None] * K + o_k4[None, :]
+                m_dht4 = m_v[:, None] & m_k4[None, :]
             else:
-                p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
+                p_dht4 = dht + o_k4[:, None] * V + o_v[None, :]
+                m_dht4 = m_k4[:, None] & m_v[None, :]
+            b_dh4 += tl.load(p_dht4, mask=m_dht4, other=0.0)
 
     for i_t in range(NT - 1, -1, -1):
         i_t_int64 = i_t.to(tl.int64)
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
         if STATE_V_FIRST:
-            p_dh1 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_dh1 = dh + i_t_int64*HV*K*V + o_v[:, None] * K + o_k1[None, :]
+            m_dh1 = m_v[:, None] & m_k1[None, :]
         else:
-            p_dh1 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+            p_dh1 = dh + i_t_int64*HV*K*V + o_k1[:, None] * V + o_v[None, :]
+            m_dh1 = m_k1[:, None] & m_v[None, :]
+        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), mask=m_dh1)
         if K > 64:
             if STATE_V_FIRST:
-                p_dh2 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_dh2 = dh + i_t_int64*HV*K*V + o_v[:, None] * K + o_k2[None, :]
+                m_dh2 = m_v[:, None] & m_k2[None, :]
             else:
-                p_dh2 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+                p_dh2 = dh + i_t_int64*HV*K*V + o_k2[:, None] * V + o_v[None, :]
+                m_dh2 = m_k2[:, None] & m_v[None, :]
+            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), mask=m_dh2)
         if K > 128:
             if STATE_V_FIRST:
-                p_dh3 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_dh3 = dh + i_t_int64*HV*K*V + o_v[:, None] * K + o_k3[None, :]
+                m_dh3 = m_v[:, None] & m_k3[None, :]
             else:
-                p_dh3 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+                p_dh3 = dh + i_t_int64*HV*K*V + o_k3[:, None] * V + o_v[None, :]
+                m_dh3 = m_k3[:, None] & m_v[None, :]
+            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), mask=m_dh3)
         if K > 192:
             if STATE_V_FIRST:
-                p_dh4 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_dh4 = dh + i_t_int64*HV*K*V + o_v[:, None] * K + o_k4[None, :]
+                m_dh4 = m_v[:, None] & m_k4[None, :]
             else:
-                p_dh4 = tl.make_block_ptr(dh + i_t_int64*HV*K*V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+                p_dh4 = dh + i_t_int64*HV*K*V + o_k4[:, None] * V + o_v[None, :]
+                m_dh4 = m_k4[:, None] & m_v[None, :]
+            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), mask=m_dh4)
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
             bg_last = tl.load(g + (bos + last_idx) * HV + i_h).to(tl.float32)
-            p_g = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+            p_g = g + bos * HV + i_h + o_t * HV
+            b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
             bg_last_exp = exp2(bg_last)
             b_g_exp = exp2(b_g)
-        p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv2 = tl.make_block_ptr(dv2, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = dv + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_dv2 = dv2 + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_do = do + o_t[:, None] * (HV*V) + o_v[None, :]
 
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_t[:, None] & m_v[None, :], other=0.0)
 
         # Update dv
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_t[:, None] * (H*K) + o_k1[None, :]
+        b_k = tl.load(p_k, mask=m_t[:, None] & m_k1[None, :], other=0.0)
         if USE_GK:
             o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(gk + last_idx * HV*K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
@@ -471,10 +534,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
 
         if K > 64:
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * (H*K) + o_k2[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k2[None, :], other=0.0)
             if USE_GK:
-                o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(gk + last_idx * HV*K + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
             if STATE_V_FIRST:
                 b_dv += tl.dot(b_k, tl.trans(b_dh2).to(b_k.dtype))
@@ -482,10 +544,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
 
         if K > 128:
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * (H*K) + o_k3[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k3[None, :], other=0.0)
             if USE_GK:
-                o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(gk + last_idx * HV*K + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
             if STATE_V_FIRST:
                 b_dv += tl.dot(b_k, tl.trans(b_dh3).to(b_k.dtype))
@@ -493,10 +554,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
 
         if K > 192:
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * (H*K) + o_k4[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k4[None, :], other=0.0)
             if USE_GK:
-                o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(gk + last_idx * HV*K + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
             if STATE_V_FIRST:
                 b_dv += tl.dot(b_k, tl.trans(b_dh4).to(b_k.dtype))
@@ -504,16 +564,15 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
 
         if USE_G:
-            m_t = (i_t * BT + tl.arange(0, BT)) < T
             b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
-        b_dv += tl.load(p_dv, boundary_check=(0, 1))
+        b_dv += tl.load(p_dv, mask=m_t[:, None] & m_v[None, :], other=0.0)
 
-        tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), mask=m_t[:, None] & m_v[None, :])
         # Update dh
-        p_w = tl.make_block_ptr(w, (K, T), (1, HV*K), (0, i_t * BT), (64, BT), (0, 1))
-        p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (0, i_t * BT), (64, BT), (0, 1))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_w = w + o_k1[:, None] + o_t[None, :] * (HV*K)
+        p_q = q + o_k1[:, None] + o_t[None, :] * (H*K)
+        b_w = tl.load(p_w, mask=m_k1[:, None] & m_t[None, :], other=0.0)
+        b_q = tl.load(p_q, mask=m_k1[:, None] & m_t[None, :], other=0.0)
         if USE_G:
             b_dh1 *= bg_last_exp
             b_q = b_q * b_g_exp[None, :]
@@ -527,10 +586,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
         else:
             b_dh1 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 64:
-            p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (64, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, HV*K), (64, i_t * BT), (64, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k2[:, None] + o_t[None, :] * (H*K)
+            p_w = w + o_k2[:, None] + o_t[None, :] * (HV*K)
+            b_q = tl.load(p_q, mask=m_k2[:, None] & m_t[None, :], other=0.0)
+            b_w = tl.load(p_w, mask=m_k2[:, None] & m_t[None, :], other=0.0)
             if USE_G:
                 b_dh2 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -544,10 +603,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             else:
                 b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 128:
-            p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (128, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, HV*K), (128, i_t * BT), (64, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k3[:, None] + o_t[None, :] * (H*K)
+            p_w = w + o_k3[:, None] + o_t[None, :] * (HV*K)
+            b_q = tl.load(p_q, mask=m_k3[:, None] & m_t[None, :], other=0.0)
+            b_w = tl.load(p_w, mask=m_k3[:, None] & m_t[None, :], other=0.0)
             if USE_G:
                 b_dh3 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -561,10 +620,10 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             else:
                 b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 192:
-            p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (192, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, HV*K), (192, i_t * BT), (64, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k4[:, None] + o_t[None, :] * (H*K)
+            p_w = w + o_k4[:, None] + o_t[None, :] * (HV*K)
+            b_q = tl.load(p_q, mask=m_k4[:, None] & m_t[None, :], other=0.0)
+            b_w = tl.load(p_w, mask=m_k4[:, None] & m_t[None, :], other=0.0)
             if USE_G:
                 b_dh4 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -580,28 +639,36 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
 
     if USE_INITIAL_STATE:
         if STATE_V_FIRST:
-            p_dh0 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+            p_dh0 = dh0 + o_v[:, None] * K + o_k1[None, :]
+            m_dh0 = m_v[:, None] & m_k1[None, :]
         else:
-            p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+            p_dh0 = dh0 + o_k1[:, None] * V + o_v[None, :]
+            m_dh0 = m_k1[:, None] & m_v[None, :]
+        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), mask=m_dh0)
         if K > 64:
             if STATE_V_FIRST:
-                p_dh1 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+                p_dh1 = dh0 + o_v[:, None] * K + o_k2[None, :]
+                m_dh1 = m_v[:, None] & m_k2[None, :]
             else:
-                p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+                p_dh1 = dh0 + o_k2[:, None] * V + o_v[None, :]
+                m_dh1 = m_k2[:, None] & m_v[None, :]
+            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), mask=m_dh1)
         if K > 128:
             if STATE_V_FIRST:
-                p_dh2 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+                p_dh2 = dh0 + o_v[:, None] * K + o_k3[None, :]
+                m_dh2 = m_v[:, None] & m_k3[None, :]
             else:
-                p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+                p_dh2 = dh0 + o_k3[:, None] * V + o_v[None, :]
+                m_dh2 = m_k3[:, None] & m_v[None, :]
+            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), mask=m_dh2)
         if K > 192:
             if STATE_V_FIRST:
-                p_dh3 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+                p_dh3 = dh0 + o_v[:, None] * K + o_k4[None, :]
+                m_dh3 = m_v[:, None] & m_k4[None, :]
             else:
-                p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+                p_dh3 = dh0 + o_k4[:, None] * V + o_v[None, :]
+                m_dh3 = m_k4[:, None] & m_v[None, :]
+            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), mask=m_dh3)
 
 
 @dispatch('common')

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -82,31 +82,37 @@ def chunk_fwd_kernel_h(
 
     # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K], applied at the load/store below.
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
     if USE_INITIAL_STATE:
         if STATE_V_FIRST:
-            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            b_h = tl.trans(tl.load(p_h0, boundary_check=(0, 1))).to(tl.float32)
+            p_h0 = h0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+            b_h = tl.trans(tl.load(p_h0, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
         else:
-            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+            p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_h = tl.load(p_h0, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
 
     for i_t in range(NT):
         i_s = i_t // NTS
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        p_k = k + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
 
         o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K*V
         if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h + o_h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = h + o_h + o_v[:, None] * K + o_k[None, :]
+            m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
         else:
-            p_h = tl.make_block_ptr(h + o_h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_h = h + o_h + o_k[:, None] * V + o_v[None, :]
+            m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
 
         if i_t % NTS == 0:
-            tl.store(p_h, (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_h, (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty), mask=m_h)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
         last_idx = min((i_t + 1) * BT, T) - 1
 
         # scalar decay
@@ -124,21 +130,21 @@ def chunk_fwd_kernel_h(
 
         # vector decay, h = Diag(gk) @ h
         if USE_GK:
-            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            p_gk = gk + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
             p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
             b_h *= exp2(b_gk_last)[:, None]
             b_k = (b_k * exp2(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
 
         # vector decay, h = h @ Diag(gv)
         if USE_GV:
-            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
             p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
 
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
             b_h *= exp2(b_gv_last)[None, :]
             b_v = (b_v * exp2(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
 
@@ -146,11 +152,11 @@ def chunk_fwd_kernel_h(
 
     if STORE_FINAL_STATE:
         if STATE_V_FIRST:
-            p_ht = tl.make_block_ptr(ht + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            tl.store(p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+            tl.store(p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))
         else:
-            p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
 
 
 @triton.heuristics({
@@ -223,32 +229,38 @@ def chunk_bwd_kernel_dh(
 
     # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K], applied at the load/store below.
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
     if USE_FINAL_STATE_GRADIENT:
         if STATE_V_FIRST:
-            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            b_dh += tl.trans(tl.load(p_dht, boundary_check=(0, 1))).to(tl.float32)
+            p_dht = dht + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+            b_dh += tl.trans(tl.load(p_dht, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
         else:
-            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh += tl.load(p_dht, boundary_check=(0, 1)).to(tl.float32)
+            p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_dh += tl.load(p_dht, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
 
     for i_t in range(NT - 1, -1, -1):
         i_s = i_t // (BS // BT)
         o_dh = ((boh + i_s) * H + i_h).to(tl.int64) * K*V
         if STATE_V_FIRST:
-            p_dh = tl.make_block_ptr(dh + o_dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_dh = dh + o_dh + o_v[:, None] * K + o_k[None, :]
+            m_dh = (o_v[:, None] < V) & (o_k[None, :] < K)
         else:
-            p_dh = tl.make_block_ptr(dh + o_dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_dh = dh + o_dh + o_k[:, None] * V + o_v[None, :]
+            m_dh = (o_k[:, None] < K) & (o_v[None, :] < V)
 
         if i_t % (BS // BT) == 0:
-            tl.store(p_dh, (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dh, (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty), mask=m_dh)
         last_idx = min(i_t * BT + BT, T) - 1
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
         # [BK, BT]
-        p_q = tl.make_block_ptr(q + (bos*HQ + i_hq) * K, (K, T), (1, HQ*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_do = tl.make_block_ptr(do + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + (bos*HQ + i_hq) * K + o_k[:, None] + o_t[None, :] * (HQ*K)
+        p_do = do + (bos*HQ + i_hq) * V + o_t[:, None] * (HQ*V) + o_v[None, :]
+        b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
 
         if USE_G:
             p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
@@ -263,19 +275,19 @@ def chunk_bwd_kernel_dh(
             b_dh *= exp2(b_g_last)
 
         if USE_GK:
-            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            p_gk = gk + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
             p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
             b_q = (b_q * exp2(b_gk)).to(b_q.dtype)
             b_dh *= exp2(b_gk_last)[:, None]
 
         if USE_GV:
-            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
             p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
 
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
             b_do = (b_do * exp2(b_gv))
             b_dh *= exp2(b_gv_last)[None, :]
@@ -284,11 +296,11 @@ def chunk_bwd_kernel_dh(
 
     if STORE_INITIAL_STATE_GRADIENT:
         if STATE_V_FIRST:
-            p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            tl.store(p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+            p_dh0 = dh0 + i_nh * K*V + o_v[:, None] * K + o_k[None, :]
+            tl.store(p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))
         else:
-            p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+            p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
 
 
 def chunk_fwd_h(

--- a/fla/ops/common/chunk_h_parallel.py
+++ b/fla/ops/common/chunk_h_parallel.py
@@ -61,7 +61,7 @@ def chunk_fwd_kernel_h_parallel(
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
 
     NV = tl.cdiv(V, BV)
     # i_b: batch index
@@ -73,7 +73,7 @@ def chunk_fwd_kernel_h_parallel(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -83,22 +83,27 @@ def chunk_fwd_kernel_h_parallel(
         i_n, i_tg = i_b, i_b * NT + i_t
     i_nh = i_n * H + i_h
 
-    p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-    p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+    p_k = k + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
+    p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+    p_h = h + (i_tg * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
 
     if i_t == 0:
         if USE_INITIAL_STATE:
-            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+            p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_h = tl.load(p_h0, mask=m_kv, other=0.0).to(tl.float32)
         else:
             b_h = tl.zeros([BK, BV], dtype=tl.float32)
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_kv)
 
     # [BK, BT]
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_k = tl.load(p_k, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
     # [BT, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
 
     last_idx = min(i_t * BT + BT, T) - 1
     # scalar decay
@@ -110,29 +115,29 @@ def chunk_fwd_kernel_h_parallel(
 
     # vector decay, h = Diag(gk) @ h
     if USE_GK:
-        p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+        p_gk = gk + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
         p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
         b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
 
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
         b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
 
     # vector decay, h = h @ Diag(gv)
     if USE_GV:
-        p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
         p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
 
         b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
         b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
 
     b_h = tl.dot(b_k, b_v)
     if i_t < NT - 1:
-        p_h = tl.make_block_ptr(h + ((i_tg + 1) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        p_h = h + ((i_tg + 1) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_kv)
     elif STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_kv)
 
 
 @triton.heuristics({
@@ -187,11 +192,14 @@ def chunk_fwd_kernel_h_reduction(
 
     # [BK, BV]
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     for i_t in range(NT):
-        p_h = tl.make_block_ptr(h + ((boh + i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h += tl.load(p_h, boundary_check=(0, 1)).to(tl.float32)
+        p_h = h + ((boh + i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h, mask=m_kv, other=0.0).to(tl.float32)
         if i_t > 0:
-            tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_kv)
 
         last_idx = min(i_t * BT + BT, T) - 1
         # scalar decay
@@ -214,10 +222,10 @@ def chunk_fwd_kernel_h_reduction(
             b_h *= exp(b_gv_last)[None, :]
 
     if STORE_FINAL_STATE:
-        p_kvt = tl.make_block_ptr(kvt + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h += tl.load(p_kvt, boundary_check=(0, 1)).to(tl.float32)
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_kvt = kvt + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_kvt, mask=m_kv, other=0.0).to(tl.float32)
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_kv)
 
 
 @triton.heuristics({
@@ -265,7 +273,7 @@ def chunk_bwd_kernel_dh_parallel(
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
 
     NV = tl.cdiv(V, BV)
     i_k, i_v = i_kv // NV, i_kv % NV
@@ -273,7 +281,7 @@ def chunk_bwd_kernel_dh_parallel(
     i_h = i_hq // NG
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -283,23 +291,28 @@ def chunk_bwd_kernel_dh_parallel(
         i_n, i_tg = i_b, i_b * NT + i_t
     i_nh = i_n * HQ + i_hq
 
-    p_q = tl.make_block_ptr(q + (bos*HQ + i_hq) * K, (K, T), (1, HQ*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-    p_do = tl.make_block_ptr(do + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+    p_q = q + (bos*HQ + i_hq) * K + o_k[:, None] + o_t[None, :] * (HQ*K)
+    p_do = do + (bos*HQ + i_hq) * V + o_t[:, None] * (HQ*V) + o_v[None, :]
+    p_dh = dh + (i_tg * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
 
     if i_t == NT - 1:
         if USE_FINAL_STATE_GRADIENT:
-            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh = tl.load(p_dht, boundary_check=(0, 1)).to(tl.float32)
+            p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_dh = tl.load(p_dht, mask=m_kv, other=0.0).to(tl.float32)
         else:
             b_dh = tl.zeros([BK, BV], dtype=tl.float32)
-        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), mask=m_kv)
 
     # [BK, BT]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
     # [BT, BV]
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
 
     if USE_G:
         p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
@@ -307,22 +320,22 @@ def chunk_bwd_kernel_dh_parallel(
         b_q = (b_q * exp(b_g)[None, :]).to(b_q.dtype)
 
     if USE_GK:
-        p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        p_gk = gk + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
+        b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
         b_q = (b_q * exp(b_gk)).to(b_q.dtype)
 
     if USE_GV:
-        p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
         b_do = (b_do * exp(b_gv)).to(b_do.dtype)
 
     b_dh = tl.dot(b_q, b_do)
     if i_t > 0:
-        p_dh = tl.make_block_ptr(dh + ((i_tg - 1) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+        p_dh = dh + ((i_tg - 1) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), mask=m_kv)
     elif STORE_INITIAL_STATE_GRADIENT:
-        p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_kv)
 
 
 @triton.heuristics({
@@ -380,11 +393,14 @@ def chunk_bwd_kernel_dh_reduction(
 
     # [BK, BV]
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     for i_t in range(NT - 1, -1, -1):
-        p_dh = tl.make_block_ptr(dh + ((boh+i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_dh += tl.load(p_dh, boundary_check=(0, 1)).to(tl.float32)
+        p_dh = dh + ((boh+i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dh, mask=m_kv, other=0.0).to(tl.float32)
         if i_t < NT - 1:
-            tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), mask=m_kv)
 
         last_idx = min(i_t * BT + BT, T) - 1
         if USE_G:
@@ -402,10 +418,10 @@ def chunk_bwd_kernel_dh_reduction(
             b_dh *= exp(b_gv_last)[None, :]
 
     if STORE_INITIAL_STATE_GRADIENT:
-        p_doq0 = tl.make_block_ptr(doq0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_dh += tl.load(p_doq0, boundary_check=(0, 1)).to(tl.float32)
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_doq0 = doq0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_doq0, mask=m_kv, other=0.0).to(tl.float32)
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_kv)
 
 
 def chunk_fwd_h(

--- a/fla/ops/common/chunk_h_split.py
+++ b/fla/ops/common/chunk_h_split.py
@@ -76,20 +76,25 @@ def chunk_fwd_kernel_h_split(
 
     # [BK, BV]
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     # for the first split, we directly store the state as the final result
     if i_s == 0:
         if USE_INITIAL_STATE:
-            p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_h += tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
-        p_hr = tl.make_block_ptr(hr + i_sh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_hr, b_h.to(p_hr.dtype.element_ty), boundary_check=(0, 1))
+            p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_h += tl.load(p_h0, mask=m_kv, other=0.0).to(tl.float32)
+        p_hr = hr + i_sh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_hr, b_h.to(p_hr.dtype.element_ty), mask=m_kv)
     for i_t in range(tl.cdiv(i_s * S, BT), tl.cdiv(min(i_s * S + S, T), BT)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        p_k = k + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
         last_idx = min(i_t * BT + BT, T) - 1
 
         # scalar decay
@@ -102,24 +107,24 @@ def chunk_fwd_kernel_h_split(
 
         # vector decay, h = Diag(gk) @ h
         if USE_GK:
-            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            p_gk = gk + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
             p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
             b_h *= exp(b_gk_last)[:, None]
 
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
             b_k = (b_k * exp(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
 
         # vector decay, h = h @ Diag(gv)
         if USE_GV:
-            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
             p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
 
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
             b_h *= exp(b_gv_last)[None, :]
 
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
             b_v = (b_v * exp(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
 
         b_h += tl.dot(b_k, b_v)
@@ -127,11 +132,11 @@ def chunk_fwd_kernel_h_split(
     # if there are more than one splits, we store the result to (unreduced) hs
     # otherwise, we store the result to ht as the final state
     if NS > 1:
-        p_hs = tl.make_block_ptr(hs + i_sh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_hs, b_h.to(p_hs.dtype.element_ty), boundary_check=(0, 1))
+        p_hs = hs + i_sh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_hs, b_h.to(p_hs.dtype.element_ty), mask=m_kv)
     elif STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_kv)
 
 
 @triton.heuristics({
@@ -186,12 +191,15 @@ def chunk_fwd_kernel_h_reduction(
         boh = i_n * NS
 
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     # skip the first split
     for i_s in range(1, NS):
-        p_hs = tl.make_block_ptr(hs + ((boh + i_s-1) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_hr = tl.make_block_ptr(hr + ((boh + i_s) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h += tl.load(p_hs, boundary_check=(0, 1)).to(tl.float32)
-        tl.store(p_hr, b_h.to(p_hr.dtype.element_ty), boundary_check=(0, 1))
+        p_hs = hs + ((boh + i_s-1) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        p_hr = hr + ((boh + i_s) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_hs, mask=m_kv, other=0.0).to(tl.float32)
+        tl.store(p_hr, b_h.to(p_hr.dtype.element_ty), mask=m_kv)
 
         for i_t in range(tl.cdiv(i_s * S, BT), tl.cdiv(min(i_s * S + S, T), BT)):
             last_idx = min(i_t * BT + BT, T) - 1
@@ -214,10 +222,10 @@ def chunk_fwd_kernel_h_reduction(
 
     if NS > 1:
         if STORE_FINAL_STATE:
-            p_hs = tl.make_block_ptr(hs + ((boh + NS-1) * H + i_h)*K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_h += tl.load(p_hs, boundary_check=(0, 1)).to(tl.float32)
-            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_hs = hs + ((boh + NS-1) * H + i_h)*K*V + o_k[:, None] * V + o_v[None, :]
+            p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_h += tl.load(p_hs, mask=m_kv, other=0.0).to(tl.float32)
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_kv)
 
 
 @triton.heuristics({
@@ -287,21 +295,26 @@ def chunk_bwd_kernel_dh_split(
 
     # [BK, BV]
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     if i_s == NS - 1:
         if USE_FINAL_STATE_GRADIENT:
-            p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh += tl.load(p_dht, boundary_check=(0, 1)).to(tl.float32)
-        p_dhr = tl.make_block_ptr(dhr + i_sh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dhr, b_dh.to(p_dhr.dtype.element_ty), boundary_check=(0, 1))
+            p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_dh += tl.load(p_dht, mask=m_kv, other=0.0).to(tl.float32)
+        p_dhr = dhr + i_sh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dhr, b_dh.to(p_dhr.dtype.element_ty), mask=m_kv)
 
     for i_t in range(tl.cdiv(min(i_s * S + S, T), BT) - 1, tl.cdiv(i_s * S, BT) - 1, -1):
-        p_q = tl.make_block_ptr(q + (bos*HQ + i_hq) * K, (K, T), (1, HQ*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_do = tl.make_block_ptr(do + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        p_q = q + (bos*HQ + i_hq) * K + o_k[:, None] + o_t[None, :] * (HQ*K)
+        p_do = do + (bos*HQ + i_hq) * V + o_t[:, None] * (HQ*V) + o_v[None, :]
 
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
 
         last_idx = min(i_t * BT + BT, T) - 1
         if USE_G:
@@ -312,19 +325,19 @@ def chunk_bwd_kernel_dh_split(
             b_dh *= exp(b_g_last)
 
         if USE_GK:
-            p_gk = tl.make_block_ptr(gk + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            p_gk = gk + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
             p_gk_last = gk + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
             b_q = (b_q * exp(b_gk)).to(b_q.dtype)
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
             b_dh *= exp(b_gk_last)[:, None]
 
         if USE_GV:
-            p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
             p_gv_last = gv + (bos + last_idx) * H*V + i_h * V + i_v * BV + tl.arange(0, BV)
 
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
             b_do = (b_do * exp(b_gv)).to(b_do.dtype)
 
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.)
@@ -333,11 +346,11 @@ def chunk_bwd_kernel_dh_split(
         b_dh += tl.dot(b_q, b_do)
 
     if NS > 1:
-        p_dhs = tl.make_block_ptr(dhs + i_sh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dhs, b_dh.to(p_dhs.dtype.element_ty), boundary_check=(0, 1))
+        p_dhs = dhs + i_sh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dhs, b_dh.to(p_dhs.dtype.element_ty), mask=m_kv)
     elif STORE_INITIAL_STATE_GRADIENT:
-        p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_kv)
 
 
 @triton.heuristics({
@@ -395,11 +408,14 @@ def chunk_bwd_kernel_dh_reduction(
         boh = i_n * NS
 
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     for i_s in range(NS - 2, -1, -1):
-        p_dhs = tl.make_block_ptr(dhs + ((boh+i_s+1) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_dhr = tl.make_block_ptr(dhr + ((boh+i_s) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_dh += tl.load(p_dhs, boundary_check=(0, 1)).to(tl.float32)
-        tl.store(p_dhr, b_dh.to(p_dhr.dtype.element_ty), boundary_check=(0, 1))
+        p_dhs = dhs + ((boh+i_s+1) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        p_dhr = dhr + ((boh+i_s) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dhs, mask=m_kv, other=0.0).to(tl.float32)
+        tl.store(p_dhr, b_dh.to(p_dhr.dtype.element_ty), mask=m_kv)
 
         for i_t in range(tl.cdiv(min(i_s * S + S, T), BT) - 1, tl.cdiv(i_s * S, BT) - 1, -1):
             last_idx = min(i_t * BT + BT, T) - 1
@@ -420,10 +436,10 @@ def chunk_bwd_kernel_dh_reduction(
 
     if NS > 1:
         if STORE_INITIAL_STATE_GRADIENT:
-            p_dhs = tl.make_block_ptr(dhs + (boh * H + i_h)*K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh += tl.load(p_dhs, boundary_check=(0, 1)).to(tl.float32)
-            tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+            p_dhs = dhs + (boh * H + i_h)*K*V + o_k[:, None] * V + o_v[None, :]
+            p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+            b_dh += tl.load(p_dhs, mask=m_kv, other=0.0).to(tl.float32)
+            tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_kv)
 
 
 def chunk_fwd_h(

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -64,12 +64,12 @@ def chunk_fwd_kernel_o(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2).to(tl.int64)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // HV, i_bh % HV
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -88,18 +88,25 @@ def chunk_fwd_kernel_o(
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    o_v = i_v * BV + tl.arange(0, BV)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k = k + o_k[:, None] + o_t[None, :] * (H*K)
         if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = h + o_v[:, None] * K + o_k[None, :]
+            m_h = (o_v[:, None] < V) & m_k[None, :]
         else:
-            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_h = h + o_k[:, None] * V + o_v[None, :]
+            m_h = m_k[:, None] & (o_v[None, :] < V)
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_t[:, None] & m_k[None, :], other=0.0)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k[:, None] & m_t[None, :], other=0.0)
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
 
         # [BT, BK] @ [BK, BV] -> [BT, BV]
         if STATE_V_FIRST:
@@ -111,8 +118,8 @@ def chunk_fwd_kernel_o(
 
     if USE_G:
         g += bos * HV + i_h
-        p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g = g + o_t * HV
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_o = b_o * exp2(b_g)[:, None]
         b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
     if USE_G_GAMMA:
@@ -120,19 +127,17 @@ def chunk_fwd_kernel_o(
         b_g = b_gamma * (tl.arange(0, BT) + 1)
         b_o = b_o * exp2(b_g)[:, None]
         b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
 
-    p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    p_v = v + o_t[:, None] * (HV*V) + o_v[None, :]
+    p_o = o + o_t[:, None] * (HV*V) + o_v[None, :]
 
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
     # to fix mma -> mma layout conversion
     # already solved by triton v3.2 or higher
     b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_t[:, None] & (o_v < V)[None, :])
 
 
 @triton.heuristics({
@@ -183,13 +188,13 @@ def chunk_bwd_kernel_dqkwg(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2).to(tl.int64)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // HV, i_bh % HV
 
     all = B * T
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -225,21 +230,30 @@ def chunk_bwd_kernel_dqkwg(
     b_ds = tl.zeros([BT, BT], dtype=tl.float32)
     b_dw = tl.zeros([BT, BK], dtype=tl.float32) if USE_DW else None
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+    m_qk = m_t[:, None] & m_k[None, :]
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        m_hv = m_t[:, None] & m_v[None, :]
+        p_v = v + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_do = do + o_t[:, None] * (HV*V) + o_v[None, :]
         if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = h + o_v[:, None] * K + o_k[None, :]
+            p_dh = dh + o_v[:, None] * K + o_k[None, :]
         else:
-            p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            p_h = h + o_v[:, None] + o_k[None, :] * V
+            p_dh = dh + o_v[:, None] + o_k[None, :] * V
+        m_h = m_v[:, None] & m_k[None, :]
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_hv, other=0.0)
+        b_do = tl.load(p_do, mask=m_hv, other=0.0)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
+        b_dh = tl.load(p_dh, mask=m_h, other=0.0)
         if USE_G:
             b_dg_last += (tl.sum(b_h * b_dh))
         # [BT, BV] @ [BV, BT] -> [BT, BT]
@@ -249,31 +263,29 @@ def chunk_bwd_kernel_dqkwg(
         # [BT, BV] @ [BV, BK] -> [BT, BK]
         b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
         if USE_DW:
-            p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+            p_dv = dv + o_t[:, None] * (HV*V) + o_v[None, :]
+            b_dv = tl.load(p_dv, mask=m_hv, other=0.0)
             b_dw += tl.dot(b_dv.to(b_v.dtype), b_h.to(b_v.dtype))
 
     if USE_DW:
-        p_dw = tl.make_block_ptr(dw, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        tl.store(p_dw, -b_dw.to(p_dw.dtype.element_ty), boundary_check=(0, 1))
+        p_dw = dw + o_t[:, None] * (HV*K) + o_k[None, :]
+        tl.store(p_dw, -b_dw.to(p_dw.dtype.element_ty), mask=m_qk)
 
     tl.debug_barrier()
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_k = tl.load(p_k, mask=m_qk, other=0.0)
 
-    p_dq = tl.make_block_ptr(dq, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_dq = dq + o_t[:, None] * (HV*K) + o_k[None, :]
+    p_dk = dk + o_t[:, None] * (HV*K) + o_k[None, :]
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
     if USE_G:
         g += bos * HV + i_h
         dg += bos * HV + i_h
-        p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g = g + o_t * HV
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_g_last = tl.load(g + (min(i_t * BT + BT, T) - 1) * HV)
         b_dg_last *= exp2(b_g_last)
         b_dq = b_dq * exp2(b_g)[:, None] * scale
@@ -288,13 +300,13 @@ def chunk_bwd_kernel_dqkwg(
 
         b_dg = tl.sum(b_dq * b_q, axis=1) - tl.sum(b_dk * b_k, axis=1)
 
-        p_dg = tl.make_block_ptr(dg, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        p_dg = dg + o_t * HV
         # (SY 09/21) revcumsum in a separate kernel due to strange triton compiler issue
         # b_dg = tl.dot(tl.where(o_t[:, None] <= o_t[None, :], 1., 0.), b_dg, allow_tf32=False) + b_dg_last)
         b_dg = tl.where(o_t < min(i_t * BT + BT, T) - 1, b_dg, b_dg + b_dg_last)
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_qk)
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_qk)
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
 
     elif USE_G_GAMMA:
         b_dq = b_dq * exp2(b_g)[:, None] * scale
@@ -304,8 +316,8 @@ def chunk_bwd_kernel_dqkwg(
         # [BT, BK]
         b_dq += tl.dot(b_ds, b_k)
         b_dk += tl.dot(tl.trans(b_ds), b_q)
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_qk)
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_qk)
 
     else:
         b_ds = tl.where(m_A, b_ds, 0)
@@ -313,8 +325,8 @@ def chunk_bwd_kernel_dqkwg(
         b_dq += tl.dot(b_ds, b_k)
         b_dk += tl.dot(tl.trans(b_ds), b_q) * scale
         b_dq *= scale
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_qk)
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_qk)
 
 
 @triton.heuristics({
@@ -356,11 +368,11 @@ def chunk_bwd_kernel_dv(
     IS_VARLEN: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2).to(tl.int64)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -378,27 +390,30 @@ def chunk_bwd_kernel_dv(
     dv += (bos * HV + i_h) * V
     dh += (i_tg * HV + i_h).to(tl.int64) * K*V
 
-    b_A = tl.zeros([BT, BT], dtype=tl.float32)
-    for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_A += tl.dot(b_k, b_q)
-        if STATE_V_FIRST:
-            p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            b_dh = tl.trans(tl.load(p_dh, boundary_check=(0, 1)))
-        else:
-            p_dh = tl.make_block_ptr(dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh = tl.load(p_dh, boundary_check=(0, 1))
-        b_dv += tl.dot(b_k, b_dh.to(b_k.dtype))
-
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
+    o_v = i_v * BV + tl.arange(0, BV)
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        p_q = q + o_k[:, None] + o_t[None, :] * (H*K)
+        b_q = tl.load(p_q, mask=m_k[:, None] & m_t[None, :], other=0.0)
+        b_k = tl.load(p_k, mask=m_t[:, None] & m_k[None, :], other=0.0)
+        b_A += tl.dot(b_k, b_q)
+        if STATE_V_FIRST:
+            p_dh = dh + o_v[:, None] * K + o_k[None, :]
+            b_dh = tl.trans(tl.load(p_dh, mask=(o_v[:, None] < V) & m_k[None, :], other=0.0))
+        else:
+            p_dh = dh + o_k[:, None] * V + o_v[None, :]
+            b_dh = tl.load(p_dh, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
+        b_dv += tl.dot(b_k, b_dh.to(b_k.dtype))
+
     if USE_G:
         g += bos * HV + i_h
-        p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g = g + o_t * HV
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_g_last = tl.load(g + (min(i_t * BT + BT, T) - 1) * HV)
     if USE_G_GAMMA:
         b_gamma = tl.load(g_gamma + i_h)
@@ -411,11 +426,11 @@ def chunk_bwd_kernel_dv(
         b_dv *= tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
     else:
         b_A = tl.where(m_A, b_A * scale, 0).to(do.dtype.element_ty)
-    p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    p_do = do + o_t[:, None] * (HV*V) + o_v[None, :]
+    p_dv = dv + o_t[:, None] * (HV*V) + o_v[None, :]
+    b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
     b_dv += tl.dot(b_A.to(b_do.dtype), b_do)
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_t[:, None] & (o_v < V)[None, :])
 
 
 @triton.heuristics({
@@ -458,10 +473,10 @@ def chunk_bwd_kernel_dv_local(
     USE_A: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -473,39 +488,43 @@ def chunk_bwd_kernel_dv_local(
     do += (bos * HV + i_h) * V
     dv += (bos * HV + i_h) * V
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
     if USE_A:
-        p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
-        b_A = tl.load(p_A, boundary_check=(0, 1))
+        p_A = A + (bos * HV + i_h) * BT + tl.arange(0, BT)[:, None] + o_t[None, :] * (HV*BT)
+        b_A = tl.load(p_A, mask=m_t[None, :], other=0.0)
     else:
         if USE_G:
             g += bos * HV + i_h
-            p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,))
+            p_g = g + o_t * HV
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
         if USE_G_GAMMA:
             b_gamma = tl.load(g_gamma + i_h)
             b_g = b_gamma * (tl.arange(0, BT) + 1)
 
         b_A = tl.zeros([BT, BT], dtype=tl.float32)
         for i_k in range(tl.cdiv(K, BK)):
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+            p_q = q + o_k[:, None] + o_t[None, :] * (H*K)
 
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k[None, :], other=0.0)
+            b_q = tl.load(p_q, mask=m_k[:, None] & m_t[None, :], other=0.0)
             b_A += tl.dot(b_k, b_q) * scale
         if USE_G or USE_G_GAMMA:
             b_A *= exp2(b_g[None, :] - b_g[:, None])
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        p_do = do + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_dv = dv + o_t[:, None] * (HV*V) + o_v[None, :]
+        b_do = tl.load(p_do, mask=m_t[:, None] & m_v[None, :], other=0.0)
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_t[:, None] & m_v[None, :])
 
 
 @dispatch('common')

--- a/fla/ops/common/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/chunk_scaled_dot_kkt.py
@@ -46,10 +46,10 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -57,26 +57,27 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
 
-    p_b = tl.make_block_ptr(beta + bos*HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    p_b = beta + bos*HV + i_h + o_t * HV
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h // (HV // H)) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        p_k = k + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_t[:, None] & (o_k < K)[None, :], other=0.0)
         b_A += tl.dot(b_k, tl.trans(b_k))
 
     if USE_G:
-        p_g = tl.make_block_ptr(g + bos*HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g = g + bos*HV + i_h + o_t * HV
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_g_diff = b_g[:, None] - b_g[None, :]
         b_A *= exp2(b_g_diff)
     b_A *= b_b[:, None]
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
-    p_A = tl.make_block_ptr(A + (bos*HV + i_h) * BT, (T, BT), (BT*HV, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    p_A = A + (bos*HV + i_h) * BT + o_t[:, None] * (BT*HV) + tl.arange(0, BT)[None, :]
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_t[:, None])
 
 
 @dispatch('common')

--- a/fla/ops/common/fused_chunk.py
+++ b/fla/ops/common/fused_chunk.py
@@ -101,24 +101,28 @@ def fused_chunk_fwd_kernel(
     # [BK, BV]
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h = tl.load(p_h, boundary_check=(0, 1)).to(tl.float32)
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_h = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
 
     for i_t in range(0, NT):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_o = tl.make_block_ptr(o, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-
         o_t = i_t * BT + tl.arange(0, BT)
         m_t = o_t < T
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k = k + o_k[:, None] + o_t[None, :] * (H*K)
+        p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+        p_o = o + o_t[:, None] * (H*V) + o_v[None, :]
+
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_t[:, None] & (o_k < K)[None, :], other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
         last_idx = min(i_t * BT + BT, T) - 1
 
         # [BT, BT]
@@ -153,11 +157,13 @@ def fused_chunk_fwd_kernel(
 
         b_h += tl.dot(b_k, b_v)
 
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_t[:, None] & (o_v < V)[None, :])
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
 
 
 @triton.heuristics({
@@ -241,24 +247,28 @@ def fused_chunk_bwd_kernel(
     # [BV, BK]
     b_h = tl.zeros([BV, BK], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h = tl.make_block_ptr(h0 + i_nh * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        b_h = tl.load(p_h, boundary_check=(0, 1)).to(tl.float32)
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_h = h0 + i_nh * K*V + o_v[:, None] + o_k[None, :] * V
+        b_h = tl.load(p_h, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0).to(tl.float32)
 
     for i_t in range(0, NT):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-
         o_t = i_t * BT + tl.arange(0, BT)
         m_t = o_t < T
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        p_v = v + o_v[:, None] + o_t[None, :] * (H*V)
+        p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dq = dq + o_t[:, None] * (H*K) + o_k[None, :]
+
         # [BT, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_t[:, None] & (o_k < K)[None, :], other=0.0)
         # [BV, BT]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_t[None, :], other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
         last_idx = min(i_t * BT + BT, T) - 1
 
         # [BT, BT]
@@ -279,7 +289,7 @@ def fused_chunk_bwd_kernel(
             b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
             b_ds = b_ds * b_gs
             # [BT, BK]
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_q = tl.load(p_q, mask=m_t[:, None] & (o_k < K)[None, :], other=0.0)
             b_dq = tl.dot(b_ds.to(b_k.dtype), b_k) + tl.dot((b_do * b_gq[:, None] * scale).to(b_k.dtype), b_h.to(b_k.dtype))
             # [BT]
             b_dg_t = tl.sum(b_q * b_dq, 1)
@@ -296,7 +306,7 @@ def fused_chunk_bwd_kernel(
             b_gs = tl.where(m_s & m_t, exp2(b_g[:, None] - b_g[None, :]), 0)
             b_ds = b_ds * b_gs
             # [BT, BK]
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_q = tl.load(p_q, mask=m_t[:, None] & (o_k < K)[None, :], other=0.0)
             b_dq = tl.dot(b_ds.to(b_k.dtype), b_k) + tl.dot((b_do * b_gq[:, None] * scale).to(b_k.dtype), b_h.to(b_k.dtype))
             # [BV, BK]
             b_h = b_h * b_gn + tl.dot(b_v, (b_k * b_gk[:, None]).to(b_k.dtype))
@@ -309,13 +319,15 @@ def fused_chunk_bwd_kernel(
             # [BV, BK]
             b_h += tl.dot(b_v, b_k)
 
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_t[:, None] & (o_k < K)[None, :])
 
     # [BK, BV]
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_FINAL_STATE:
-        p_dh = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_dh += tl.load(p_dh, boundary_check=(0, 1)).to(tl.float32)
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_dh = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dh, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
 
     if USE_G:
         b_dg = tl.zeros([BT], dtype=tl.float32)
@@ -326,23 +338,25 @@ def fused_chunk_bwd_kernel(
     tl.debug_barrier()
 
     for i_t in range(NT - 1, -1, -1):
-        p_q = tl.make_block_ptr(q, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        # [BK, BT]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        # [BT, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
-        last_idx = min(i_t * BT + BT, T) - 1
-
         o_t = i_t * BT + tl.arange(0, BT)
         m_t = o_t < T
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_q = q + o_k[:, None] + o_t[None, :] * (H*K)
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+        p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dk = dk + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dv = dv + o_t[:, None] * (H*V) + o_v[None, :]
+        # [BK, BT]
+        b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
+        # [BT, BK]
+        b_k = tl.load(p_k, mask=m_t[:, None] & (o_k < K)[None, :], other=0.0)
+        # [BT, BV]
+        b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
+        b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
+        last_idx = min(i_t * BT + BT, T) - 1
+
         # [BT, BT]
         b_s = tl.dot(b_k, b_q)
         b_ds = tl.dot(b_v, tl.trans(b_do))
@@ -402,12 +416,14 @@ def fused_chunk_bwd_kernel(
             # [BK, BV]
             b_dh += tl.dot(b_q, (b_do * scale).to(b_do.dtype))
 
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_t[:, None] & (o_k < K)[None, :])
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_t[:, None] & (o_v < V)[None, :])
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        o_v = i_v * BV + tl.arange(0, BV)
+        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
 
 
 def fused_chunk_fwd(

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -116,43 +116,55 @@ def pre_process_fwd_kernel_merged(
         if K > 192:
             b_h4 = tl.zeros([64, BLOCK_SIZE], dtype=tl.float32)
 
+        o_vb = i_v * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        m_vb = o_vb < V
+        o_k1 = tl.arange(0, 64)
+        m_k1 = o_k1 < K
+        o_k2 = 64 + o_k1
+        m_k2 = o_k2 < K
+        o_k3 = 128 + o_k1
+        m_k3 = o_k3 < K
+        o_k4 = 192 + o_k1
+        m_k4 = o_k4 < K
+
         # Main recurrence for h
         for i_t in range(NT):
+            o_t = i_t * BT + tl.arange(0, BT)
+            m_t = o_t < T
             # Compute decayed v
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_w + o_k1[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k1[None, :], other=0.0)
             b_v_decay = tl.dot(b_w, b_h1.to(b_w.dtype))
             if K > 64:
-                p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-                b_w = tl.load(p_w, boundary_check=(0, 1))
+                p_w = w + o_t[:, None] * stride_w + o_k2[None, :]
+                b_w = tl.load(p_w, mask=m_t[:, None] & m_k2[None, :], other=0.0)
                 b_v_decay += tl.dot(b_w, b_h2.to(b_w.dtype))
             if K > 128:
-                p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-                b_w = tl.load(p_w, boundary_check=(0, 1))
+                p_w = w + o_t[:, None] * stride_w + o_k3[None, :]
+                b_w = tl.load(p_w, mask=m_t[:, None] & m_k3[None, :], other=0.0)
                 b_v_decay += tl.dot(b_w, b_h3.to(b_w.dtype))
             if K > 192:
-                p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-                b_w = tl.load(p_w, boundary_check=(0, 1))
+                p_w = w + o_t[:, None] * stride_w + o_k4[None, :]
+                b_w = tl.load(p_w, mask=m_t[:, None] & m_k4[None, :], other=0.0)
                 b_v_decay += tl.dot(b_w, b_h4.to(b_w.dtype))
 
-            p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, i_v * BLOCK_SIZE), (BT, BLOCK_SIZE), (1, 0))
+            p_v = v + o_t[:, None] * stride_v + o_vb[None, :]
             if USE_BG:
                 # DPLR mode: v2 = w @ h + u, h += kg^T @ v + bg^T @ v2
-                b_v_orig = tl.load(p_v, boundary_check=(0, 1))
-                p_u = tl.make_block_ptr(u, (T, V), (stride_v, 1), (i_t * BT, i_v * BLOCK_SIZE), (BT, BLOCK_SIZE), (1, 0))
-                b_v = b_v_decay + tl.load(p_u, boundary_check=(0, 1))
+                b_v_orig = tl.load(p_v, mask=m_t[:, None] & m_vb[None, :], other=0.0)
+                p_u = u + o_t[:, None] * stride_v + o_vb[None, :]
+                b_v = b_v_decay + tl.load(p_u, mask=m_t[:, None] & m_vb[None, :], other=0.0)
             else:
                 # GDN/KDA mode: v_new = v - w @ h
-                b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v_decay
+                b_v = tl.load(p_v, mask=m_t[:, None] & m_vb[None, :], other=0.0) - b_v_decay
 
             last_idx = min((i_t + 1) * BT, T) - 1
 
             # Apply g decay
             if USE_G:
-                m_t = (i_t * BT + tl.arange(0, BT)) < T
                 b_g_last = tl.load(g + last_idx * HV).to(tl.float32)
-                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-                b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+                p_g = g + o_t * HV
+                b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
                 b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
                 b_h1 *= b_g_last
@@ -184,60 +196,60 @@ def pre_process_fwd_kernel_merged(
             b_v = b_v.to(k.dtype.element_ty)
 
             # Update h
-            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k1[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k1[:, None] & m_t[None, :], other=0.0)
             if USE_BG:
                 # DPLR mode: h += kg^T @ v + bg^T @ v2
-                p_bg = tl.make_block_ptr(bg, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
-                b_bg = tl.load(p_bg, boundary_check=(0, 1))
+                p_bg = bg + o_k1[:, None] + o_t[None, :] * stride_k
+                b_bg = tl.load(p_bg, mask=m_k1[:, None] & m_t[None, :], other=0.0)
                 b_h1 += tl.dot(b_k, b_v_orig.to(b_k.dtype)) + tl.dot(b_bg, b_v)
                 if K > 64:
-                    p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
-                    p_bg = tl.make_block_ptr(bg, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
-                    b_bg = tl.load(p_bg, boundary_check=(0, 1))
+                    p_k = k + o_k2[:, None] + o_t[None, :] * stride_k
+                    b_k = tl.load(p_k, mask=m_k2[:, None] & m_t[None, :], other=0.0)
+                    p_bg = bg + o_k2[:, None] + o_t[None, :] * stride_k
+                    b_bg = tl.load(p_bg, mask=m_k2[:, None] & m_t[None, :], other=0.0)
                     b_h2 += tl.dot(b_k, b_v_orig.to(b_k.dtype)) + tl.dot(b_bg, b_v)
                 if K > 128:
-                    p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
-                    p_bg = tl.make_block_ptr(bg, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
-                    b_bg = tl.load(p_bg, boundary_check=(0, 1))
+                    p_k = k + o_k3[:, None] + o_t[None, :] * stride_k
+                    b_k = tl.load(p_k, mask=m_k3[:, None] & m_t[None, :], other=0.0)
+                    p_bg = bg + o_k3[:, None] + o_t[None, :] * stride_k
+                    b_bg = tl.load(p_bg, mask=m_k3[:, None] & m_t[None, :], other=0.0)
                     b_h3 += tl.dot(b_k, b_v_orig.to(b_k.dtype)) + tl.dot(b_bg, b_v)
                 if K > 192:
-                    p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
-                    p_bg = tl.make_block_ptr(bg, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
-                    b_bg = tl.load(p_bg, boundary_check=(0, 1))
+                    p_k = k + o_k4[:, None] + o_t[None, :] * stride_k
+                    b_k = tl.load(p_k, mask=m_k4[:, None] & m_t[None, :], other=0.0)
+                    p_bg = bg + o_k4[:, None] + o_t[None, :] * stride_k
+                    b_bg = tl.load(p_bg, mask=m_k4[:, None] & m_t[None, :], other=0.0)
                     b_h4 += tl.dot(b_k, b_v_orig.to(b_k.dtype)) + tl.dot(b_bg, b_v)
             else:
                 # GDN/KDA mode: h += k^T @ v_new
                 b_h1 += tl.dot(b_k, b_v)
                 if K > 64:
-                    p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    p_k = k + o_k2[:, None] + o_t[None, :] * stride_k
+                    b_k = tl.load(p_k, mask=m_k2[:, None] & m_t[None, :], other=0.0)
                     b_h2 += tl.dot(b_k, b_v)
                 if K > 128:
-                    p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    p_k = k + o_k3[:, None] + o_t[None, :] * stride_k
+                    b_k = tl.load(p_k, mask=m_k3[:, None] & m_t[None, :], other=0.0)
                     b_h3 += tl.dot(b_k, b_v)
                 if K > 192:
-                    p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    p_k = k + o_k4[:, None] + o_t[None, :] * stride_k
+                    b_k = tl.load(p_k, mask=m_k4[:, None] & m_t[None, :], other=0.0)
                     b_h4 += tl.dot(b_k, b_v)
 
         # Store h results
         stride_hm_kv = K + V
-        p_h1 = tl.make_block_ptr(hm, (K, V), (stride_hm_kv, 1), (0, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        p_h1 = hm + o_k1[:, None] * stride_hm_kv + o_vb[None, :]
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), mask=m_k1[:, None] & m_vb[None, :])
         if K > 64:
-            p_h2 = tl.make_block_ptr(hm, (K, V), (stride_hm_kv, 1), (64, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+            p_h2 = hm + o_k2[:, None] * stride_hm_kv + o_vb[None, :]
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), mask=m_k2[:, None] & m_vb[None, :])
         if K > 128:
-            p_h3 = tl.make_block_ptr(hm, (K, V), (stride_hm_kv, 1), (128, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+            p_h3 = hm + o_k3[:, None] * stride_hm_kv + o_vb[None, :]
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), mask=m_k3[:, None] & m_vb[None, :])
         if K > 192:
-            p_h4 = tl.make_block_ptr(hm, (K, V), (stride_hm_kv, 1), (192, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+            p_h4 = hm + o_k4[:, None] * stride_hm_kv + o_vb[None, :]
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), mask=m_k4[:, None] & m_vb[None, :])
     else:
         # ====== Stage 2: Compute m (K x K) ======
         # i_col is for m part, map to K dimension
@@ -256,24 +268,25 @@ def pre_process_fwd_kernel_merged(
         b_m = tl.where(row[:, None] == col[None, :], 1.0, 0.0)
 
         for i_t in range(NT):
+            o_t = i_t * BT + tl.arange(0, BT)
+            m_t = o_t < T
             # Load k and w with full BK1 rows
             if USE_BG:
                 # DPLR mode: use bg for transition matrix
                 # bg was already offset at the beginning of the kernel
-                p_k = tl.make_block_ptr(bg, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, BK1), (1, 0))
+                p_k = bg + o_t[:, None] * stride_k + row[None, :]
             else:
-                p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, BK1), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, BK1), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+                p_k = k + o_t[:, None] * stride_k + row[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & (row < K)[None, :], other=0.0)
+            p_w = w + o_t[:, None] * stride_w + row[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & (row < K)[None, :], other=0.0)
 
             last_idx = min((i_t + 1) * BT, T) - 1
 
             if USE_G:
-                m_t = (i_t * BT + tl.arange(0, BT)) < T
                 b_g_last = tl.load(g + last_idx * HV).to(tl.float32)
-                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-                b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+                p_g = g + o_t * HV
+                b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
                 b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_g_last, 0.0)
@@ -298,8 +311,8 @@ def pre_process_fwd_kernel_merged(
 
         # Store m result
         stride_hm_kv = K + V
-        p_m = tl.make_block_ptr(hm + V, (K, K), (stride_hm_kv, 1), (0, i_k_col * BLOCK_SIZE), (BK1, BLOCK_SIZE), (1, 0))
-        tl.store(p_m, b_m.to(p_m.dtype.element_ty), boundary_check=(0, 1))
+        p_m = hm + V + row[:, None] * stride_hm_kv + col[None, :]
+        tl.store(p_m, b_m.to(p_m.dtype.element_ty), mask=(row < K)[:, None] & (col < K)[None, :])
 
 
 @triton.heuristics({
@@ -352,6 +365,10 @@ def merge_fwd_bwd_kernel(
     The recurrence h' = M @ h + he becomes h_T' = h_T @ M^T + he^T.
     """
     i_v = tl.program_id(0)
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
     if INTRACARD_MODE:
         i_seq = tl.program_id(1)
         i_h = tl.program_id(2)
@@ -372,17 +389,11 @@ def merge_fwd_bwd_kernel(
         if HAS_H0:
             orig_seq_id = tl.load(h0_seq_ids + i_seq).to(tl.int32)
             if STATE_V_FIRST:
-                p_h0 = tl.make_block_ptr(
-                    h0 + (orig_seq_id * HV + i_h) * V * K,
-                    (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0)
-                )
-                b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+                p_h0 = h0 + (orig_seq_id * HV + i_h) * V * K + o_v[:, None] * K + o_k[None, :]
+                b_h = tl.load(p_h0, mask=m_v[:, None] & m_k[None, :], other=0.0).to(tl.float32)
             else:
-                p_h0 = tl.make_block_ptr(
-                    h0 + (orig_seq_id * HV + i_h) * K * V,
-                    (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0)
-                )
-                b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+                p_h0 = h0 + (orig_seq_id * HV + i_h) * K * V + o_k[:, None] * V + o_v[None, :]
+                b_h = tl.load(p_h0, mask=m_k[:, None] & m_v[None, :], other=0.0).to(tl.float32)
         else:
             if STATE_V_FIRST:
                 b_h = tl.zeros([BV, BK], dtype=tl.float32)
@@ -395,14 +406,10 @@ def merge_fwd_bwd_kernel(
             base = i_ss * stride_hm_s + i_h * stride_hm_h
 
             # he and m are always in [K, V+K] layout from pre_scan
-            p_he = tl.make_block_ptr(
-                ag_hm + base, (K, V), (V + K, 1), (0, i_v * BV), (BK, BV), (1, 0)
-            )
-            b_he = tl.load(p_he, boundary_check=(0, 1)).to(tl.float32)
-            p_m = tl.make_block_ptr(
-                ag_hm + base + V, (K, K), (V + K, 1), (0, 0), (BK, BK), (1, 0)
-            )
-            b_m = tl.load(p_m, boundary_check=(0, 1)).to(tl.float32)
+            p_he = ag_hm + base + o_k[:, None] * (V + K) + o_v[None, :]
+            b_he = tl.load(p_he, mask=m_k[:, None] & m_v[None, :], other=0.0).to(tl.float32)
+            p_m = ag_hm + base + V + o_k[:, None] * (V + K) + o_k[None, :]
+            b_m = tl.load(p_m, mask=m_k[:, None] & m_k[None, :], other=0.0).to(tl.float32)
             if STATE_V_FIRST:
                 # h_T' = h_T @ M^T + he^T
                 b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_m)) + tl.trans(b_he)
@@ -414,16 +421,12 @@ def merge_fwd_bwd_kernel(
                 init_idx = init_base + idx
                 stride_init = HV * K * V
                 if STATE_V_FIRST:
-                    p_out = tl.make_block_ptr(
-                        h + init_idx * stride_init + i_h * V * K,
-                        (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0)
-                    )
+                    p_out = h + init_idx * stride_init + i_h * V * K + o_v[:, None] * K + o_k[None, :]
+                    m_out = m_v[:, None] & m_k[None, :]
                 else:
-                    p_out = tl.make_block_ptr(
-                        h + init_idx * stride_init + i_h * K * V,
-                        (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0)
-                    )
-                tl.store(p_out, b_h.to(p_out.dtype.element_ty), boundary_check=(0, 1))
+                    p_out = h + init_idx * stride_init + i_h * K * V + o_k[:, None] * V + o_v[None, :]
+                    m_out = m_k[:, None] & m_v[None, :]
+                tl.store(p_out, b_h.to(p_out.dtype.element_ty), mask=m_out)
     else:
         # CP mode
         i_h = tl.program_id(1)
@@ -440,19 +443,21 @@ def merge_fwd_bwd_kernel(
                 cur_rank = rank - num_ranks + idx
             else:
                 cur_rank = rank + num_ranks - idx
-            p_ag_h = tl.make_block_ptr(ag_hm + cur_rank * stride, (K, V), (K + V, 1), (0, i_v * BV), (BK, BV), (1, 0))
-            b_ag_h = tl.load(p_ag_h, boundary_check=(0, 1))
-            p_ag_m = tl.make_block_ptr(ag_hm + cur_rank * stride + V, (K, K), (K + V, 1), (0, 0), (BK, BK), (1, 0))
-            b_ag_m = tl.load(p_ag_m, boundary_check=(0, 1))
+            p_ag_h = ag_hm + cur_rank * stride + o_k[:, None] * (K + V) + o_v[None, :]
+            b_ag_h = tl.load(p_ag_h, mask=m_k[:, None] & m_v[None, :], other=0.0)
+            p_ag_m = ag_hm + cur_rank * stride + V + o_k[:, None] * (K + V) + o_k[None, :]
+            b_ag_m = tl.load(p_ag_m, mask=m_k[:, None] & m_k[None, :], other=0.0)
             if STATE_V_FIRST:
                 b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_ag_m).to(tl.float32)) + tl.trans(b_ag_h).to(tl.float32)
             else:
                 b_h = tl.dot(b_ag_m.to(tl.float32), b_h.to(tl.float32)) + b_ag_h.to(tl.float32)
         if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
+            p_h = h + o_v[:, None] * K + o_k[None, :]
+            m_h = m_v[:, None] & m_k[None, :]
         else:
-            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+            p_h = h + o_k[:, None] * V + o_v[None, :]
+            m_h = m_k[:, None] & m_v[None, :]
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_h)
 
 
 @triton.heuristics({
@@ -547,64 +552,72 @@ def pre_process_bwd_kernel_merged(
         if K > 192:
             b_dh4 = tl.zeros([64, BLOCK_SIZE], dtype=tl.float32)
 
+        o_vb = i_v * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        m_vb = o_vb < V
+        o_k1 = tl.arange(0, 64)
+        m_k1 = o_k1 < K
+        o_k2 = 64 + o_k1
+        m_k2 = o_k2 < K
+        o_k3 = 128 + o_k1
+        m_k3 = o_k3 < K
+        o_k4 = 192 + o_k1
+        m_k4 = o_k4 < K
+
         # Main recurrence for dh (reverse order)
         for i_t in range(NT - 1, -1, -1):
             last_idx = min((i_t + 1) * BT, T) - 1
+            o_t = i_t * BT + tl.arange(0, BT)
+            m_t = o_t < T
 
             if USE_G:
                 bg_last = tl.load(g + last_idx * HV).to(tl.float32)
-                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-                b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+                p_g = g + o_t * HV
+                b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
                 bg_last_exp = exp2(bg_last)
                 b_g_exp = exp2(b_g)
 
-            p_dv = tl.make_block_ptr(dv, (T, V), (stride_v, 1), (i_t * BT, i_v * BLOCK_SIZE), (BT, BLOCK_SIZE), (1, 0))
-            p_do = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, i_v * BLOCK_SIZE), (BT, BLOCK_SIZE), (1, 0))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
+            p_dv = dv + o_t[:, None] * stride_v + o_vb[None, :]
+            p_do = do + o_t[:, None] * stride_v + o_vb[None, :]
+            b_do = tl.load(p_do, mask=m_t[:, None] & m_vb[None, :], other=0.0)
 
             # Update dv
-            p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_qk + o_k1[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k1[None, :], other=0.0)
             if USE_GK:
-                o_k1 = tl.arange(0, 64)
                 p_gk_last = gk + last_idx * HV * K
                 b_gk_last1 = tl.load(p_gk_last + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
             b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
 
             if K > 64:
-                p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-                b_k = tl.load(p_k, boundary_check=(0, 1))
+                p_k = k + o_t[:, None] * stride_qk + o_k2[None, :]
+                b_k = tl.load(p_k, mask=m_t[:, None] & m_k2[None, :], other=0.0)
                 if USE_GK:
-                    o_k2 = 64 + o_k1
                     b_gk_last2 = tl.load(p_gk_last + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
 
             if K > 128:
-                p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-                b_k = tl.load(p_k, boundary_check=(0, 1))
+                p_k = k + o_t[:, None] * stride_qk + o_k3[None, :]
+                b_k = tl.load(p_k, mask=m_t[:, None] & m_k3[None, :], other=0.0)
                 if USE_GK:
-                    o_k3 = 128 + o_k1
                     b_gk_last3 = tl.load(p_gk_last + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
 
             if K > 192:
-                p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-                b_k = tl.load(p_k, boundary_check=(0, 1))
+                p_k = k + o_t[:, None] * stride_qk + o_k4[None, :]
+                b_k = tl.load(p_k, mask=m_t[:, None] & m_k4[None, :], other=0.0)
                 if USE_GK:
-                    o_k4 = 192 + o_k1
                     b_gk_last4 = tl.load(p_gk_last + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
                 b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
 
             if USE_G:
-                m_t = (i_t * BT + tl.arange(0, BT)) < T
                 b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
-            b_dv += tl.load(p_dv, boundary_check=(0, 1))
+            b_dv += tl.load(p_dv, mask=m_t[:, None] & m_vb[None, :], other=0.0)
 
             # Update dh
-            p_w = tl.make_block_ptr(w, (K, T), (1, stride_w), (0, i_t * BT), (64, BT), (0, 1))
-            p_q = tl.make_block_ptr(q, (K, T), (1, stride_qk), (0, i_t * BT), (64, BT), (0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            p_w = w + o_k1[:, None] + o_t[None, :] * stride_w
+            p_q = q + o_k1[:, None] + o_t[None, :] * stride_qk
+            b_w = tl.load(p_w, mask=m_k1[:, None] & m_t[None, :], other=0.0)
+            b_q = tl.load(p_q, mask=m_k1[:, None] & m_t[None, :], other=0.0)
             if USE_G:
                 b_dh1 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -617,10 +630,10 @@ def pre_process_bwd_kernel_merged(
                 b_dh1 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
 
             if K > 64:
-                p_q = tl.make_block_ptr(q, (K, T), (1, stride_qk), (64, i_t * BT), (64, BT), (0, 1))
-                p_w = tl.make_block_ptr(w, (K, T), (1, stride_w), (64, i_t * BT), (64, BT), (0, 1))
-                b_q = tl.load(p_q, boundary_check=(0, 1))
-                b_w = tl.load(p_w, boundary_check=(0, 1))
+                p_q = q + o_k2[:, None] + o_t[None, :] * stride_qk
+                p_w = w + o_k2[:, None] + o_t[None, :] * stride_w
+                b_q = tl.load(p_q, mask=m_k2[:, None] & m_t[None, :], other=0.0)
+                b_w = tl.load(p_w, mask=m_k2[:, None] & m_t[None, :], other=0.0)
                 if USE_G:
                     b_dh2 *= bg_last_exp
                     b_q = b_q * b_g_exp[None, :]
@@ -632,10 +645,10 @@ def pre_process_bwd_kernel_merged(
                     b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
 
             if K > 128:
-                p_q = tl.make_block_ptr(q, (K, T), (1, stride_qk), (128, i_t * BT), (64, BT), (0, 1))
-                p_w = tl.make_block_ptr(w, (K, T), (1, stride_w), (128, i_t * BT), (64, BT), (0, 1))
-                b_q = tl.load(p_q, boundary_check=(0, 1))
-                b_w = tl.load(p_w, boundary_check=(0, 1))
+                p_q = q + o_k3[:, None] + o_t[None, :] * stride_qk
+                p_w = w + o_k3[:, None] + o_t[None, :] * stride_w
+                b_q = tl.load(p_q, mask=m_k3[:, None] & m_t[None, :], other=0.0)
+                b_w = tl.load(p_w, mask=m_k3[:, None] & m_t[None, :], other=0.0)
                 if USE_G:
                     b_dh3 *= bg_last_exp
                     b_q = b_q * b_g_exp[None, :]
@@ -647,10 +660,10 @@ def pre_process_bwd_kernel_merged(
                     b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
 
             if K > 192:
-                p_q = tl.make_block_ptr(q, (K, T), (1, stride_qk), (192, i_t * BT), (64, BT), (0, 1))
-                p_w = tl.make_block_ptr(w, (K, T), (1, stride_w), (192, i_t * BT), (64, BT), (0, 1))
-                b_q = tl.load(p_q, boundary_check=(0, 1))
-                b_w = tl.load(p_w, boundary_check=(0, 1))
+                p_q = q + o_k4[:, None] + o_t[None, :] * stride_qk
+                p_w = w + o_k4[:, None] + o_t[None, :] * stride_w
+                b_q = tl.load(p_q, mask=m_k4[:, None] & m_t[None, :], other=0.0)
+                b_w = tl.load(p_w, mask=m_k4[:, None] & m_t[None, :], other=0.0)
                 if USE_G:
                     b_dh4 *= bg_last_exp
                     b_q = b_q * b_g_exp[None, :]
@@ -662,17 +675,17 @@ def pre_process_bwd_kernel_merged(
                     b_dh4 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(b_w, b_dv.to(b_w.dtype))
 
         # Store dh results
-        p_dh1 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (0, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+        p_dh1 = dhm + o_k1[:, None] * (V + K) + o_vb[None, :]
+        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), mask=m_k1[:, None] & m_vb[None, :])
         if K > 64:
-            p_dh2 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (64, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+            p_dh2 = dhm + o_k2[:, None] * (V + K) + o_vb[None, :]
+            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), mask=m_k2[:, None] & m_vb[None, :])
         if K > 128:
-            p_dh3 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (128, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+            p_dh3 = dhm + o_k3[:, None] * (V + K) + o_vb[None, :]
+            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), mask=m_k3[:, None] & m_vb[None, :])
         if K > 192:
-            p_dh4 = tl.make_block_ptr(dhm, (K, V), (V + K, 1), (192, i_v * BLOCK_SIZE), (64, BLOCK_SIZE), (1, 0))
-            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+            p_dh4 = dhm + o_k4[:, None] * (V + K) + o_vb[None, :]
+            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), mask=m_k4[:, None] & m_vb[None, :])
     else:
         # ====== Stage 2: Compute dm (K x K) ======
         # i_col is for dm part, map to K dimension
@@ -690,20 +703,21 @@ def pre_process_bwd_kernel_merged(
         for _i_t in range(NT):
             # Reverse order for backward
             i_t = NT - 1 - _i_t
+            o_t = i_t * BT + tl.arange(0, BT)
+            m_t = o_t < T
 
             # Load k and w with full BK1 rows
-            p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, 0), (BT, BK1), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, BK1), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_qk + row[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & (row < K)[None, :], other=0.0)
+            p_w = w + o_t[:, None] * stride_w + row[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & (row < K)[None, :], other=0.0)
 
             last_idx = min((i_t + 1) * BT, T) - 1
 
             if USE_G:
-                m_t = (i_t * BT + tl.arange(0, BT)) < T
                 b_g_last = tl.load(g + last_idx * HV).to(tl.float32)
-                p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-                b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+                p_g = g + o_t * HV
+                b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
                 b_k = b_k * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
                 b_diag = tl.where(row[:, None] == row[None, :], b_g_last, 0.0)
@@ -726,8 +740,8 @@ def pre_process_bwd_kernel_merged(
             b_m = tl.dot(b_m_i.to(tl.float32), b_m.to(tl.float32))
 
         # Store dm result
-        p_m = tl.make_block_ptr(dhm + V, (K, K), (V + K, 1), (0, i_k_col * BLOCK_SIZE), (BK1, BLOCK_SIZE), (1, 0))
-        tl.store(p_m, b_m.to(p_m.dtype.element_ty), boundary_check=(0, 1))
+        p_m = dhm + V + row[:, None] * (V + K) + col[None, :]
+        tl.store(p_m, b_m.to(p_m.dtype.element_ty), mask=(row < K)[:, None] & (col < K)[None, :])
 
 
 def chunk_gated_delta_rule_fwd_h_pre_process(

--- a/fla/ops/delta_rule/parallel.py
+++ b/fla/ops/delta_rule/parallel.py
@@ -42,17 +42,25 @@ def chunk_transform_qk_fwd_kernel(
     BT: tl.constexpr,
     OUTPUT_ATTENTIONS: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
-    p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_q = (tl.load(p_q, boundary_check=(0, 1)) * scale).to(p_q.dtype.element_ty)
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    o_T = tl.arange(0, BT)
+    m_b = o_t < T
+    m_qk = m_b[:, None] & (o_k[None, :] < K)
+    m_v = m_b[:, None] & (o_v[None, :] < V)
+    m_T = m_b[:, None] & (o_T[None, :] < BT)
+    p_q = q + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_k = k + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    p_v = v + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+    b_q = (tl.load(p_q, mask=m_qk, other=0.0) * scale).to(p_q.dtype.element_ty)
+    b_k = tl.load(p_k, mask=m_qk, other=0.0)
+    b_v = tl.load(p_v, mask=m_v, other=0.0)
 
-    p_T = tl.make_block_ptr(A + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_T = tl.load(p_T, boundary_check=(0, 1))
+    p_T = A + i_bh * T * BT + o_t[:, None] * BT + o_T[None, :]
+    b_T = tl.load(p_T, mask=m_T, other=0.0)
 
     o_i = tl.arange(0, BT)
     m_t = o_i[:, None] >= o_i[None, :]
@@ -60,26 +68,26 @@ def chunk_transform_qk_fwd_kernel(
     m_t = o_i[:, None] > o_i[None, :]
     b_kk = tl.where(m_t, tl.dot(b_k, tl.trans(b_k), allow_tf32=False), 0).to(b_k.dtype)
 
-    p_beta = tl.make_block_ptr(beta + i_bh * T, (T, ), (1, ), (i_t * BT, ), (BT, ), (0, ))
-    b_beta = tl.load(p_beta, boundary_check=(0, ))
+    p_beta = beta + i_bh * T + o_t
+    b_beta = tl.load(p_beta, mask=m_b, other=0.0)
     b_k_beta = (b_k * b_beta[:, None]).to(b_k.dtype)
 
     b_qkT = tl.dot(b_qk, b_T, allow_tf32=False).to(b_k.dtype)
 
     if OUTPUT_ATTENTIONS:
-        p_a = tl.make_block_ptr(A_local + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-        tl.store(p_a, b_qkT.to(p_a.dtype.element_ty), boundary_check=(0, 1))
+        p_a = A_local + i_bh * T * BT + o_t[:, None] * BT + o_T[None, :]
+        tl.store(p_a, b_qkT.to(p_a.dtype.element_ty), mask=m_T)
 
     b_kkT = tl.dot(b_kk, b_T, allow_tf32=False).to(b_k.dtype)
-    p_o = tl.make_block_ptr(o + i_bh * T*V, (T, V), (V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    tl.store(p_o, tl.dot(b_qkT, b_v).to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o = o + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+    tl.store(p_o, tl.dot(b_qkT, b_v).to(p_o.dtype.element_ty), mask=m_v)
 
-    p_q_new = tl.make_block_ptr(q_new + i_bh * T*K, (T, K), (K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_q_new, (b_q - tl.dot(b_qkT, b_k_beta, allow_tf32=False)).to(p_q_new.dtype.element_ty), boundary_check=(0, 1))
+    p_q_new = q_new + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
+    tl.store(p_q_new, (b_q - tl.dot(b_qkT, b_k_beta, allow_tf32=False)).to(p_q_new.dtype.element_ty), mask=m_qk)
 
-    p_k_new = tl.make_block_ptr(k_new + i_bh * T*K, (T, K), (K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    p_k_new = k_new + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
     b_k_new = b_k - tl.dot(tl.trans(b_kkT), b_k_beta, allow_tf32=False)
-    tl.store(p_k_new, b_k_new.to(p_k_new.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_k_new, b_k_new.to(p_k_new.dtype.element_ty), mask=m_qk)
 
 
 def chunk_transform_qk_fwd(
@@ -137,11 +145,16 @@ def save_intra_chunk_attn(
     T,
     BT: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    p_A = tl.make_block_ptr(A + i_bh * T * T, (T, T), (T, 1), (i_t * BT, i_t * BT), (BT, BT), (1, 0))
-    p_A_local = tl.make_block_ptr(A_local + i_bh * T * BT, (T, BT), (BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_A_local = tl.load(p_A_local, boundary_check=(0, 1))
-    tl.store(p_A, b_A_local.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_l = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_t[None, :] < T)
+    m_L = m_t[:, None] & (o_l[None, :] < BT)
+    p_A = A + i_bh * T * T + o_t[:, None] * T + o_t[None, :]
+    p_A_local = A_local + i_bh * T * BT + o_t[:, None] * BT + o_l[None, :]
+    b_A_local = tl.load(p_A_local, mask=m_L, other=0.0)
+    tl.store(p_A, b_A_local.to(p_A.dtype.element_ty), mask=m_A)
 
 
 @triton.heuristics({
@@ -166,72 +179,88 @@ def parallel_delta_rule_fwd_kernel(
     BV: tl.constexpr,
     OUTPUT_ATTENTIONS: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_t = o_t < T
+    m_q = m_t[:, None] & (o_k[None, :] < K)
+    m_o = m_t[:, None] & (o_v[None, :] < V)
+    p_q = q + i_bh * T*K + o_t[:, None] * K + o_k[None, :]
 
     # the Q block is kept in the shared memory throughout the whole kernel
     # [BT, BK]
     b_q = tl.zeros([BT, BK], dtype=tl.float32)
-    b_q += tl.load(p_q, boundary_check=(0, 1))
+    b_q += tl.load(p_q, mask=m_q, other=0.0)
 
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
-    p_o = tl.make_block_ptr(o + i_bh * T*V, (T, V), (V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_o += tl.load(p_o, boundary_check=(0, 1))
+    p_o = o + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+    b_o += tl.load(p_o, mask=m_o, other=0.0)
 
     # As opposed to Flashattention, this kernel requires scanning the KV blocks from right to left
     # Q block and K block have overlap.
     # masks required
     for offset in range((i_t + 1) * BT - 2 * BS, i_t * BT - BS, -BS):
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (0, offset), (BK, BS), (0, 1))
-        p_k2 = tl.make_block_ptr(k2 + i_bh * T*K, (T, K), (K, 1), (offset, 0), (BS, BK), (1, 0))
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (offset, 0), (BS, BV), (1, 0))
-        p_beta = tl.make_block_ptr(beta + i_bh * T, (T, ), (1, ), (offset, ), (BS, ), (0,))
+        o_s = offset + tl.arange(0, BS)
+        m_k = (o_k[:, None] < K) & (o_s[None, :] < T)
+        m_k2 = (o_s[:, None] < T) & (o_k[None, :] < K)
+        m_v = (o_s[:, None] < T) & (o_v[None, :] < V)
+        m_a = m_t[:, None] & (o_s[None, :] < T)
+        p_k = k + i_bh * T*K + o_k[:, None] + o_s[None, :] * K
+        p_k2 = k2 + i_bh * T*K + o_s[:, None] * K + o_k[None, :]
+        p_v = v + i_bh * T*V + o_s[:, None] * V + o_v[None, :]
+        p_beta = beta + i_bh * T + o_s
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BS]
-        b_beta = tl.load(p_beta, boundary_check=(0,))
+        b_beta = tl.load(p_beta, mask=o_s < T, other=0.0)
         # [BT, BS]
         m_s = tl.arange(0, BT) >= (offset - i_t*BT + BS)
         b_s = tl.dot(b_q.to(b_k.dtype), b_k, allow_tf32=False)
         b_s = tl.where(m_s[:, None], b_s, 0)
 
         b_o += tl.dot(b_s.to(b_v.dtype), b_v, allow_tf32=False)
-        b_k2 = (tl.load(p_k2, boundary_check=(0, 1)) * b_beta[:, None]).to(b_v.dtype)
+        b_k2 = (tl.load(p_k2, mask=m_k2, other=0.0) * b_beta[:, None]).to(b_v.dtype)
         b_q -= tl.dot(b_s.to(b_v.dtype), b_k2, allow_tf32=False)
 
         if OUTPUT_ATTENTIONS:
-            p_a = tl.make_block_ptr(attn + i_bh * T * T, (T, T), (T, 1), (i_t * BT, offset), (BT, BS), (1, 0))
-            tl.store(p_a, b_s.to(p_a.dtype.element_ty), boundary_check=(0, 1))
+            p_a = attn + i_bh * T * T + o_t[:, None] * T + o_s[None, :]
+            tl.store(p_a, b_s.to(p_a.dtype.element_ty), mask=m_a)
 
     # Q block and K block have no overlap
     # no need for mask, thereby saving flops
     for offset in range(i_t * BT - BS, -BS, -BS):
-        p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (0, offset), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (offset, 0), (BS, BV), (1, 0))
-        p_beta = tl.make_block_ptr(beta + i_bh * T, (T, ), (1, ), (offset, ), (BS, ), (0,))
-        p_k2 = tl.make_block_ptr(k2 + i_bh * T*K, (T, K), (K, 1), (offset, 0), (BS, BK), (1, 0))
+        o_s = offset + tl.arange(0, BS)
+        m_k = (o_k[:, None] < K) & (o_s[None, :] < T)
+        m_k2 = (o_s[:, None] < T) & (o_k[None, :] < K)
+        m_v = (o_s[:, None] < T) & (o_v[None, :] < V)
+        m_a = m_t[:, None] & (o_s[None, :] < T)
+        p_k = k + i_bh * T*K + o_k[:, None] + o_s[None, :] * K
+        p_v = v + i_bh * T*V + o_s[:, None] * V + o_v[None, :]
+        p_beta = beta + i_bh * T + o_s
+        p_k2 = k2 + i_bh * T*K + o_s[:, None] * K + o_k[None, :]
 
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BS]
-        b_beta = tl.load(p_beta, boundary_check=(0,))
+        b_beta = tl.load(p_beta, mask=o_s < T, other=0.0)
         # [BT, BS]
         b_s = (tl.dot(b_q.to(b_k.dtype), b_k, allow_tf32=False))
         # [BT, BV]
         b_o += tl.dot(b_s.to(b_v.dtype), b_v, allow_tf32=False)
-        b_k2 = (tl.load(p_k2, boundary_check=(0, 1)) * b_beta[:, None]).to(b_v.dtype)
+        b_k2 = (tl.load(p_k2, mask=m_k2, other=0.0) * b_beta[:, None]).to(b_v.dtype)
         b_q -= tl.dot(b_s.to(b_v.dtype), b_k2, allow_tf32=False).to(b_q.dtype)
 
         if OUTPUT_ATTENTIONS:
-            p_a = tl.make_block_ptr(attn + i_bh * T * T, (T, T), (T, 1), (i_t * BT, offset), (BT, BS), (1, 0))
-            tl.store(p_a, b_s.to(p_a.dtype.element_ty), boundary_check=(0, 1))
+            p_a = attn + i_bh * T * T + o_t[:, None] * T + o_s[None, :]
+            tl.store(p_a, b_s.to(p_a.dtype.element_ty), mask=m_a)
 
-    p_o_new = tl.make_block_ptr(o_new + i_bh * T*V, (T, V), (V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-    tl.store(p_o_new, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o_new = o_new + i_bh * T*V + o_t[:, None] * V + o_v[None, :]
+    tl.store(p_o_new, b_o.to(p_o.dtype.element_ty), mask=m_o)
 
 
 class ParallelDeltaRuleFunction(torch.autograd.Function):

--- a/fla/ops/delta_rule/wy_fast.py
+++ b/fla/ops/delta_rule/wy_fast.py
@@ -53,35 +53,43 @@ def recompute_w_u_fwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_beta = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_beta = beta + bos*H + i_h + o_t * H
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_u = u + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A.to(b_vb.dtype), b_vb, allow_tf32=False)
-        tl.store(p_u, (b_u).to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, (b_u).to(p_u.dtype.element_ty), mask=m_v)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_w = tl.make_block_ptr(w + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_w = w + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_kb = (b_k * b_beta[:, None]).to(b_k.dtype)
         b_w = tl.dot(b_A.to(b_kb.dtype), b_kb, allow_tf32=False)
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_k)
 
 
 @triton.heuristics({
@@ -118,51 +126,59 @@ def prepare_wy_repr_bwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_beta = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_A[:, None] < BT) & m_t[None, :]
+    p_beta = beta + bos*H + i_h + o_t * H
+    p_A = A + (bos*H + i_h) * BT + o_A[:, None] + o_t[None, :] * (H*BT)
 
-    b_beta = tl.load(p_beta, boundary_check=(0,))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
 
     b_dbeta = tl.zeros([BT], dtype=tl.float32)
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv = dv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_du = du + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
 
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_v_beta = (b_v * b_beta[:, None]).to(b_v.dtype)
-        b_du = tl.load(p_du, boundary_check=(0, 1))
+        b_du = tl.load(p_du, mask=m_v, other=0.0)
         b_dA += tl.dot(b_du, tl.trans(b_v_beta), allow_tf32=False)
         b_dv_beta = tl.dot(b_A, b_du, allow_tf32=False)
         b_dv = b_dv_beta * b_beta[:, None]
         b_dbeta += tl.sum(b_dv_beta * b_v, 1)
 
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dw = dw + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_k_beta = (b_k * b_beta[:, None]).to(b_k.dtype)
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+        b_dw = tl.load(p_dw, mask=m_k, other=0.0)
         b_dA += tl.dot(b_dw, tl.trans(b_k_beta), allow_tf32=False)
         b_dk_beta = tl.dot(b_A, b_dw, allow_tf32=False)
         b_dk = b_dk_beta * b_beta[:, None]
         b_dbeta += tl.sum(b_dk_beta * b_k, 1)
 
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
 
     b_dA = tl.where(tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :], b_dA, 0)
     b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
@@ -170,20 +186,22 @@ def prepare_wy_repr_bwd_kernel(
     b_dA = tl.where(tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :], -b_dA, 0).to(k.dtype.element_ty)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_dk = tl.load(p_dk, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_dk = tl.load(p_dk, mask=m_k, other=0.0)
         b_k_beta = (b_k * b_beta[:, None]).to(b_k.dtype)
 
         b_dk_beta = tl.dot(b_dA, b_k, allow_tf32=False)
         b_dbeta += tl.sum(b_dk_beta * b_k, 1)
         b_dk += safe_dot(tl.trans(b_dA), b_k_beta, allow_tf32=False)
         b_dk += b_dk_beta * b_beta[:, None]
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
 
-    p_dbeta = tl.make_block_ptr(dbeta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dbeta, b_dbeta.to(p_dbeta.dtype.element_ty), boundary_check=(0,))
+    p_dbeta = dbeta + bos*H + i_h + o_t * H
+    tl.store(p_dbeta, b_dbeta.to(p_dbeta.dtype.element_ty), mask=m_t)
 
 
 def prepare_wy_repr_fwd(

--- a/fla/ops/deltaformer/parallel.py
+++ b/fla/ops/deltaformer/parallel.py
@@ -150,7 +150,7 @@ def parallel_deltaformer_fwd_kernel(
     BLOCK_C: tl.constexpr,
     BLOCK_T: tl.constexpr,
 ):
-    pid_c = tl.program_id(axis=0)
+    pid_c = tl.program_id(axis=0).to(tl.int64)
     pid_h = tl.program_id(axis=1)
 
     rowid_block = tl.arange(0, BLOCK_C) + pid_c * BLOCK_C
@@ -160,26 +160,16 @@ def parallel_deltaformer_fwd_kernel(
     rowsum = tl.zeros([BLOCK_C], dtype=tl.float32) + 1
     acc = tl.zeros([BLOCK_C, D], dtype=tl.float32)
 
-    q_blk_ptr = tl.make_block_ptr(
-        base=q_ptr + pid_h * D,
-        shape=(C, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    q = tl.load(q_blk_ptr, boundary_check=(0,))
+    o_d = tl.arange(0, D)
+    m_c = rowid_block < C
+    q_blk_ptr = q_ptr + pid_h * D + rowid_block[:, None] * (H * D) + o_d[None, :]
+    q = tl.load(q_blk_ptr, mask=m_c[:, None], other=0.0)
 
     for kv_i in range(0, T, BLOCK_T):
-        k_blk_ptr = tl.make_block_ptr(
-            base=k_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_T),
-            order=(0, 1),
-        )
-        k = tl.load(k_blk_ptr, boundary_check=(1,))
+        o_kv = kv_i.to(tl.int64) + colid_block
+        m_kv = o_kv < T
+        k_blk_ptr = k_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        k = tl.load(k_blk_ptr, mask=m_kv[None, :], other=0.0)
         qk = tl.dot(q, k) * qk_scale
 
         if kv_i >= T - C:
@@ -197,15 +187,8 @@ def parallel_deltaformer_fwd_kernel(
         rowmax = rowmax_i
 
         if kv_i < T - C:
-            u_blk_ptr = tl.make_block_ptr(
-                base=u_ptr + pid_h * D,
-                shape=(T, D),
-                strides=(H * D, 1),
-                offsets=(kv_i, 0),
-                block_shape=(BLOCK_T, D),
-                order=(1, 0),
-            )
-            u = tl.load(u_blk_ptr, boundary_check=(0,))
+            u_blk_ptr = u_ptr + pid_h * D + o_kv[:, None] * (H * D) + o_d[None, :]
+            u = tl.load(u_blk_ptr, mask=m_kv[:, None], other=0.0)
             acc = tl.dot(p.to(u_ptr.dtype.element_ty), u, acc)
 
     lse = rowmax + tl.math.log2(rowsum)
@@ -213,64 +196,32 @@ def parallel_deltaformer_fwd_kernel(
     lse_mask = rowid_block < C
     tl.store(lse_block_ptr, lse, mask=lse_mask)
 
-    v_ptr = tl.make_block_ptr(
-        base=v_ptr + pid_h * D,
-        shape=(C, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
+    v_ptr = v_ptr + pid_h * D + rowid_block[:, None] * (H * D) + o_d[None, :]
     acc = acc / rowsum[:, None]
 
-    beta_ptr = tl.make_block_ptr(
-        base=beta_ptr + pid_h,
-        shape=(C,),
-        strides=(H,),
-        offsets=(pid_c * BLOCK_C,),
-        block_shape=(BLOCK_C,),
-        order=(0,),
-    )
-    beta = tl.load(beta_ptr, boundary_check=(0,))
+    beta_ptr = beta_ptr + pid_h + rowid_block * H
+    beta = tl.load(beta_ptr, mask=m_c, other=0.0)
     acc = acc * beta[:, None]
 
-    v = tl.load(v_ptr, boundary_check=(0,))
+    v = tl.load(v_ptr, mask=m_c[:, None], other=0.0)
     u = v - acc.to(v_ptr.dtype.element_ty)
-    u_block_ptr = tl.make_block_ptr(
-        base=u_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(T - C + pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    tl.store(u_block_ptr, u, boundary_check=(0, 1))
+    o_ur = T - C + rowid_block
+    u_block_ptr = u_ptr + pid_h * D + o_ur[:, None] * (H * D) + o_d[None, :]
+    tl.store(u_block_ptr, u, mask=(o_ur[:, None] < T) & (o_d[None, :] < D))
 
     for kv_i in range(T - C, T, BLOCK_T):
-        k_blk_ptr = tl.make_block_ptr(
-            base=k_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_T),
-            order=(0, 1),
-        )
-        k = tl.load(k_blk_ptr, boundary_check=(1,))
+        o_kv = kv_i.to(tl.int64) + colid_block
+        k_blk_ptr = k_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        k = tl.load(k_blk_ptr, mask=(o_kv < T)[None, :], other=0.0)
         qk = tl.dot(q, k) * qk_scale
 
         mask = (T - C - kv_i + rowid_block[:, None] - colid_block[None, :] < 1)
         qk -= rowmax[:, None]
         p = tl.math.exp2(qk) / rowsum[:, None]
         p = tl.where(mask, 0, p)
-        w_blk_ptr = tl.make_block_ptr(
-            base=w_ptr + pid_h * C,
-            shape=(C, C),
-            strides=(H * C, 1),
-            offsets=(pid_c * BLOCK_C, kv_i - (T - C)),
-            block_shape=(BLOCK_C, BLOCK_T),
-            order=(1, 0),
-        )
-        tl.store(w_blk_ptr, p.to(w_ptr.dtype.element_ty), boundary_check=(0, 1))
+        o_wc = o_kv - (T - C)
+        w_blk_ptr = w_ptr + pid_h * C + rowid_block[:, None] * (H * C) + o_wc[None, :]
+        tl.store(w_blk_ptr, p.to(w_ptr.dtype.element_ty), mask=m_c[:, None] & (o_wc[None, :] < C))
 
 
 @triton.autotune(configs=_config_deltaformer(), key=['C', 'D'])
@@ -290,74 +241,37 @@ def parallel_deltaformer_bwd_kernel_u(
     BLOCK_C: tl.constexpr,
     BLOCK_T: tl.constexpr,
 ):
-    pid_c = tl.program_id(axis=0)
+    pid_c = tl.program_id(axis=0).to(tl.int64)
     pid_h = tl.program_id(axis=1)
 
     acc = tl.zeros([BLOCK_C, D], dtype=tl.float32)
 
-    q_blk_ptr = tl.make_block_ptr(
-        base=q_ptr + pid_h * D,
-        shape=(C, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    q = tl.load(q_blk_ptr, boundary_check=(0,))
+    o_c = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+    o_d = tl.arange(0, D)
+    m_c = o_c < C
+    q_blk_ptr = q_ptr + pid_h * D + o_c[:, None] * (H * D) + o_d[None, :]
+    q = tl.load(q_blk_ptr, mask=m_c[:, None], other=0.0)
 
     for kv_i in range(0, T, BLOCK_T):
-        k_blk_ptr = tl.make_block_ptr(
-            base=k_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_T),
-            order=(0, 1),
-        )
-        k = tl.load(k_blk_ptr, boundary_check=(1,))
+        o_kv = kv_i.to(tl.int64) + tl.arange(0, BLOCK_T)
+        m_kv = o_kv < T
+        k_blk_ptr = k_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        k = tl.load(k_blk_ptr, mask=m_kv[None, :], other=0.0)
         qk = tl.dot(q, k) * fa_scale
 
-        lse_blk_ptr = tl.make_block_ptr(
-            base=lse_ptr + pid_h,
-            shape=(T,),
-            strides=(H,),
-            offsets=(kv_i,),
-            block_shape=(BLOCK_T,),
-            order=(0,),
-        )
-        lse = tl.load(lse_blk_ptr, boundary_check=(0,))
-        beta_blk_ptr = tl.make_block_ptr(
-            base=beta_ptr + pid_h,
-            shape=(T,),
-            strides=(H,),
-            offsets=(kv_i,),
-            block_shape=(BLOCK_T,),
-            order=(0,),
-        )
-        beta = tl.load(beta_blk_ptr, boundary_check=(0,))
+        lse_blk_ptr = lse_ptr + pid_h + o_kv * H
+        lse = tl.load(lse_blk_ptr, mask=m_kv, other=0.0)
+        beta_blk_ptr = beta_ptr + pid_h + o_kv * H
+        beta = tl.load(beta_blk_ptr, mask=m_kv, other=0.0)
 
         p = tl.math.exp2(qk - lse[None, :]) * beta[None, :]
 
-        v_blk_ptr = tl.make_block_ptr(
-            base=v_ptr + pid_h * D,
-            shape=(T, D),
-            strides=(H * D, 1),
-            offsets=(kv_i, 0),
-            block_shape=(BLOCK_T, D),
-            order=(1, 0),
-        )
-        v = tl.load(v_blk_ptr, boundary_check=(0,))
+        v_blk_ptr = v_ptr + pid_h * D + o_kv[:, None] * (H * D) + o_d[None, :]
+        v = tl.load(v_blk_ptr, mask=m_kv[:, None], other=0.0)
         acc = tl.dot(p.to(v_ptr.dtype.element_ty), v, acc)
 
-    o_blk_ptr = tl.make_block_ptr(
-        base=o_ptr + pid_h * D,
-        shape=(C, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    tl.store(o_blk_ptr, acc.to(o_ptr.dtype.element_ty), boundary_check=(0,))
+    o_blk_ptr = o_ptr + pid_h * D + o_c[:, None] * (H * D) + o_d[None, :]
+    tl.store(o_blk_ptr, acc.to(o_ptr.dtype.element_ty), mask=m_c[:, None])
 
 
 @triton.autotune(configs=_config_deltaformer(), key=['T', 'D'])
@@ -376,7 +290,7 @@ def parallel_deltaformer_bwd_kernel_row_sum(
     BLOCK_C: tl.constexpr,
     BLOCK_T: tl.constexpr,
 ):
-    pid_c = tl.program_id(axis=0)
+    pid_c = tl.program_id(axis=0).to(tl.int64)
     pid_h = tl.program_id(axis=1)
 
     rowid_block = tl.arange(0, BLOCK_C) + pid_c * BLOCK_C
@@ -384,71 +298,33 @@ def parallel_deltaformer_bwd_kernel_row_sum(
 
     acc = tl.zeros([BLOCK_C], dtype=tl.float32)
 
-    k_row_blk_ptr = tl.make_block_ptr(
-        base=q_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    k_row = tl.load(k_row_blk_ptr, boundary_check=(0,))
-    lse_blk_ptr = tl.make_block_ptr(
-        base=lse_ptr + pid_h,
-        shape=(T,),
-        strides=(H,),
-        offsets=(pid_c * BLOCK_C,),
-        block_shape=(BLOCK_C,),
-        order=(0,),
-    )
-    lse = tl.load(lse_blk_ptr, boundary_check=(0,))
-    grad_v_blk_ptr = tl.make_block_ptr(
-        base=grad_v_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    grad_v_row = -tl.load(grad_v_blk_ptr, boundary_check=(0,))
+    o_d = tl.arange(0, D)
+    m_r = rowid_block < T
+    k_row_blk_ptr = q_ptr + pid_h * D + rowid_block[:, None] * (H * D) + o_d[None, :]
+    k_row = tl.load(k_row_blk_ptr, mask=m_r[:, None], other=0.0)
+    lse_blk_ptr = lse_ptr + pid_h + rowid_block * H
+    lse = tl.load(lse_blk_ptr, mask=m_r, other=0.0)
+    grad_v_blk_ptr = grad_v_ptr + pid_h * D + rowid_block[:, None] * (H * D) + o_d[None, :]
+    grad_v_row = -tl.load(grad_v_blk_ptr, mask=m_r[:, None], other=0.0)
 
     for kv_i in range(0, (pid_c + 1) * BLOCK_C, BLOCK_T):
-        k_blk_ptr = tl.make_block_ptr(
-            base=k_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_T),
-            order=(0, 1),
-        )
-        k = tl.load(k_blk_ptr, boundary_check=(1,))
+        o_kv = kv_i.to(tl.int64) + colid_block
+        m_kv = o_kv < T
+        k_blk_ptr = k_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        k = tl.load(k_blk_ptr, mask=m_kv[None, :], other=0.0)
         qk = tl.dot(k_row, k) * fa_scale
         p = tl.math.exp2(qk - lse[:, None])
 
-        u_blk_ptr = tl.make_block_ptr(
-            base=u_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_T),
-            order=(0, 1),
-        )
-        ut = tl.load(u_blk_ptr, boundary_check=(1,))
+        u_blk_ptr = u_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        ut = tl.load(u_blk_ptr, mask=m_kv[None, :], other=0.0)
         dp = tl.dot(grad_v_row, ut)
         if kv_i + BLOCK_T >= pid_c * BLOCK_C:
             mask = (rowid_block[:, None] <= colid_block[None, :] + kv_i)
             p = tl.where(mask, 0., p)
             dp = tl.where(mask, 0., dp)
         acc += tl.sum(p * dp, axis=1)
-    row_dot_block_ptr = tl.make_block_ptr(
-        base=row_dot_ptr + pid_h,
-        shape=(T,),
-        strides=(H,),
-        offsets=(pid_c * BLOCK_C,),
-        block_shape=(BLOCK_C,),
-        order=(0,),
-    )
-    tl.store(row_dot_block_ptr, acc, boundary_check=(0,))
+    row_dot_block_ptr = row_dot_ptr + pid_h + rowid_block * H
+    tl.store(row_dot_block_ptr, acc, mask=m_r)
 
 
 @triton.autotune(configs=[triton.Config({'BLOCK_C': BC}, num_stages=ns, num_warps=nw)
@@ -473,104 +349,45 @@ def parallel_deltaformer_bwd_kernel_qk(
     qk_scale: tl.constexpr,
     BLOCK_C: tl.constexpr,
 ):
-    pid_c = tl.program_id(axis=0)
+    pid_c = tl.program_id(axis=0).to(tl.int64)
     pid_h = tl.program_id(axis=1)
     block_i = tl.arange(0, BLOCK_C)
 
     acc = tl.zeros([BLOCK_C, D], dtype=tl.float32)
 
-    k_row_blk_ptr = tl.make_block_ptr(
-        base=q_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    k_row = tl.load(k_row_blk_ptr, boundary_check=(0,))
-    lse_blk_ptr = tl.make_block_ptr(
-        base=lse_ptr + pid_h,
-        shape=(T,),
-        strides=(H,),
-        offsets=(pid_c * BLOCK_C,),
-        block_shape=(BLOCK_C,),
-        order=(0,),
-    )
-    lse = tl.load(lse_blk_ptr, boundary_check=(0,))
-    beta_blk_ptr = tl.make_block_ptr(
-        base=beta_ptr + pid_h,
-        shape=(T,),
-        strides=(H,),
-        offsets=(pid_c * BLOCK_C,),
-        block_shape=(BLOCK_C,),
-        order=(0,),
-    )
-    beta = tl.load(beta_blk_ptr, boundary_check=(0,))
-    grad_v_blk_ptr = tl.make_block_ptr(
-        base=grad_v_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    grad_v_row = -tl.load(grad_v_blk_ptr, boundary_check=(0,))
-    row_dot_blk_ptr = tl.make_block_ptr(
-        base=row_dot_ptr + pid_h,
-        shape=(T,),
-        strides=(H,),
-        offsets=(pid_c * BLOCK_C,),
-        block_shape=(BLOCK_C,),
-        order=(0,),
-    )
-    row_dot_row = tl.load(row_dot_blk_ptr, boundary_check=(0,)).to(k_ptr.dtype.element_ty)
+    o_c = pid_c * BLOCK_C + block_i
+    o_d = tl.arange(0, D)
+    m_c = o_c < T
+    k_row_blk_ptr = q_ptr + pid_h * D + o_c[:, None] * (H * D) + o_d[None, :]
+    k_row = tl.load(k_row_blk_ptr, mask=m_c[:, None], other=0.0)
+    lse_blk_ptr = lse_ptr + pid_h + o_c * H
+    lse = tl.load(lse_blk_ptr, mask=m_c, other=0.0)
+    beta_blk_ptr = beta_ptr + pid_h + o_c * H
+    beta = tl.load(beta_blk_ptr, mask=m_c, other=0.0)
+    grad_v_blk_ptr = grad_v_ptr + pid_h * D + o_c[:, None] * (H * D) + o_d[None, :]
+    grad_v_row = -tl.load(grad_v_blk_ptr, mask=m_c[:, None], other=0.0)
+    row_dot_blk_ptr = row_dot_ptr + pid_h + o_c * H
+    row_dot_row = tl.load(row_dot_blk_ptr, mask=m_c, other=0.0).to(k_ptr.dtype.element_ty)
 
     for kv_i in range(0, pid_c * BLOCK_C, BLOCK_C):
-        k_blk_ptr = tl.make_block_ptr(
-            base=k_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_C),
-            order=(0, 1),
-        )
-        kt = tl.load(k_blk_ptr, boundary_check=(1,))
+        o_kv = kv_i.to(tl.int64) + block_i
+        k_blk_ptr = k_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        kt = tl.load(k_blk_ptr, mask=(o_kv < T)[None, :], other=0.0)
         qk = tl.dot(k_row, kt) * fa_scale
         p = tl.math.exp2(qk - lse[:, None]) * beta[:, None]
 
-        u_blk_ptr = tl.make_block_ptr(
-            base=u_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_C),
-            order=(0, 1),
-        )
+        u_blk_ptr = u_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
         ut = tl.load(u_blk_ptr)
         dp = tl.dot(grad_v_row, ut)
         da = p * (dp - row_dot_row[:, None])
         k = tl.trans(kt, 1, 0)
         acc = tl.dot(da.to(k.dtype), k, acc)
 
-    k_row_blk_ptr = tl.make_block_ptr(
-        base=k_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(pid_c * BLOCK_C, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
-    k_row_true = tl.load(k_row_blk_ptr, boundary_check=(0,))
+    k_row_blk_ptr = k_ptr + pid_h * D + o_c[:, None] * (H * D) + o_d[None, :]
+    k_row_true = tl.load(k_row_blk_ptr, mask=m_c[:, None], other=0.0)
     qk = tl.dot(k_row, tl.trans(k_row_true, 1, 0)) * fa_scale
     p = tl.math.exp2(qk - lse[:, None]) * beta[:, None]
-    u_blk_ptr = tl.make_block_ptr(
-        base=u_ptr + pid_h * D,
-        shape=(D, T),
-        strides=(1, H * D),
-        offsets=(0, pid_c * BLOCK_C),
-        block_shape=(D, BLOCK_C),
-        order=(0, 1),
-    )
+    u_blk_ptr = u_ptr + pid_h * D + o_d[:, None] + o_c[None, :] * (H * D)
     ut = tl.load(u_blk_ptr)
     dp = tl.dot(grad_v_row, ut)
     dpm = dp - row_dot_row[:, None]
@@ -581,85 +398,38 @@ def parallel_deltaformer_bwd_kernel_qk(
     daat = da
     acc = tl.dot(daat.to(k_row.dtype), k_row_true, acc)
 
-    grad_q_blk_ptr = tl.make_block_ptr(
-        base=grad_q_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(BLOCK_C * pid_c, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
+    grad_q_blk_ptr = grad_q_ptr + pid_h * D + o_c[:, None] * (H * D) + o_d[None, :]
     acc = acc * qk_scale
-    tl.store(grad_q_blk_ptr, acc.to(grad_q_ptr.dtype.element_ty), boundary_check=(0,))
+    tl.store(grad_q_blk_ptr, acc.to(grad_q_ptr.dtype.element_ty), mask=m_c[:, None])
 
     daat = tl.trans(da, 1, 0)
     acc = tl.dot(daat.to(k_row.dtype), k_row)
     k_row = k_row_true
     nu = -tl.trans(ut, 1, 0)
     for kv_i in range((pid_c + 1) * BLOCK_C, T, BLOCK_C):
-        k_blk_ptr = tl.make_block_ptr(
-            base=q_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_C),
-            order=(0, 1),
-        )
-        kt = tl.load(k_blk_ptr, boundary_check=(1,))
-        lse_blk_ptr = tl.make_block_ptr(
-            base=lse_ptr + pid_h,
-            shape=(T,),
-            strides=(H,),
-            offsets=(kv_i,),
-            block_shape=(BLOCK_C,),
-            order=(0,),
-        )
-        lse = tl.load(lse_blk_ptr, boundary_check=(0,))
-        beta_blk_ptr = tl.make_block_ptr(
-            base=beta_ptr + pid_h,
-            shape=(T,),
-            strides=(H,),
-            offsets=(kv_i,),
-            block_shape=(BLOCK_C,),
-            order=(0,),
-        )
-        beta = tl.load(beta_blk_ptr, boundary_check=(0,))
+        o_kv = kv_i.to(tl.int64) + block_i
+        m_kv = o_kv < T
+        k_blk_ptr = q_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        kt = tl.load(k_blk_ptr, mask=m_kv[None, :], other=0.0)
+        lse_blk_ptr = lse_ptr + pid_h + o_kv * H
+        lse = tl.load(lse_blk_ptr, mask=m_kv, other=0.0)
+        beta_blk_ptr = beta_ptr + pid_h + o_kv * H
+        beta = tl.load(beta_blk_ptr, mask=m_kv, other=0.0)
         qk = tl.dot(k_row, kt) * fa_scale
         p = tl.math.exp2(qk - lse[None, :]) * beta[None, :]
 
-        grad_vt_blk_ptr = tl.make_block_ptr(
-            base=grad_v_ptr + pid_h * D,
-            shape=(D, T),
-            strides=(1, H * D),
-            offsets=(0, kv_i),
-            block_shape=(D, BLOCK_C),
-            order=(0, 1),
-        )
-        grad_vt = tl.load(grad_vt_blk_ptr, boundary_check=(1,))
-        row_dot_blk_ptr = tl.make_block_ptr(
-            base=row_dot_ptr + pid_h,
-            shape=(T,),
-            strides=(H,),
-            offsets=(kv_i,),
-            block_shape=(BLOCK_C,),
-            order=(0,),
-        )
-        row_dot = tl.load(row_dot_blk_ptr, boundary_check=(0,)).to(k_ptr.dtype.element_ty)
+        grad_vt_blk_ptr = grad_v_ptr + pid_h * D + o_d[:, None] + o_kv[None, :] * (H * D)
+        grad_vt = tl.load(grad_vt_blk_ptr, mask=m_kv[None, :], other=0.0)
+        row_dot_blk_ptr = row_dot_ptr + pid_h + o_kv * H
+        row_dot = tl.load(row_dot_blk_ptr, mask=m_kv, other=0.0).to(k_ptr.dtype.element_ty)
         dp = tl.dot(nu, grad_vt)
         da = p * (dp - row_dot[None, :])
         k = tl.trans(kt, 1, 0)
         acc = tl.dot(da.to(k.dtype), k, acc)
 
-    grad_k_blk_ptr = tl.make_block_ptr(
-        base=grad_k_ptr + pid_h * D,
-        shape=(T, D),
-        strides=(H * D, 1),
-        offsets=(BLOCK_C * pid_c, 0),
-        block_shape=(BLOCK_C, D),
-        order=(1, 0),
-    )
+    grad_k_blk_ptr = grad_k_ptr + pid_h * D + o_c[:, None] * (H * D) + o_d[None, :]
     acc = acc * qk_scale
-    tl.store(grad_k_blk_ptr, acc.to(grad_k_ptr.dtype.element_ty), boundary_check=(0,))
+    tl.store(grad_k_blk_ptr, acc.to(grad_k_ptr.dtype.element_ty), mask=m_c[:, None])
 
 
 class ParallelDeltaformerFunction(torch.autograd.Function):

--- a/fla/ops/gated_delta_product/chunk_deltaproduct_h.py
+++ b/fla/ops/gated_delta_product/chunk_deltaproduct_h.py
@@ -94,67 +94,80 @@ def chunk_gated_delta_product_fwd_kernel_h_blockdim64(
     if STORE_FINAL_STATE:
         ht = ht + i_nh * K*V
 
+    o_k1 = tl.arange(0, 64)
+    o_k2 = 64 + tl.arange(0, 64)
+    o_k3 = 128 + tl.arange(0, 64)
+    o_k4 = 192 + tl.arange(0, 64)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    m_h1 = (o_k1[:, None] < K) & m_v[None, :]
+    m_h2 = (o_k2[:, None] < K) & m_v[None, :]
+    m_h3 = (o_k3[:, None] < K) & m_v[None, :]
+    m_h4 = (o_k4[:, None] < K) & m_v[None, :]
+
     # load initial state
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        p_h0_1 = h0 + o_k1[:, None] * V + o_v[None, :]
+        b_h1 += tl.load(p_h0_1, mask=m_h1, other=0.0).to(tl.float32)
         if K > 64:
-            p_h0_2 = tl.make_block_ptr(h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_2 = h0 + o_k2[:, None] * V + o_v[None, :]
+            b_h2 += tl.load(p_h0_2, mask=m_h2, other=0.0).to(tl.float32)
         if K > 128:
-            p_h0_3 = tl.make_block_ptr(h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_3 = h0 + o_k3[:, None] * V + o_v[None, :]
+            b_h3 += tl.load(p_h0_3, mask=m_h3, other=0.0).to(tl.float32)
         if K > 192:
-            p_h0_4 = tl.make_block_ptr(h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_4 = h0 + o_k4[:, None] * V + o_v[None, :]
+            b_h4 += tl.load(p_h0_4, mask=m_h4, other=0.0).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
         if i_t % num_householder == 0:
             i_t_true = i_t // num_householder
-            p_h1 = tl.make_block_ptr(h + i_t_true * stride_h, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+            p_h1 = h + i_t_true * stride_h + o_k1[:, None] * V + o_v[None, :]
+            tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), mask=m_h1)
             if K > 64:
-                p_h2 = tl.make_block_ptr(h + i_t_true * stride_h, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-                tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+                p_h2 = h + i_t_true * stride_h + o_k2[:, None] * V + o_v[None, :]
+                tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), mask=m_h2)
             if K > 128:
-                p_h3 = tl.make_block_ptr(h + i_t_true * stride_h, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-                tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+                p_h3 = h + i_t_true * stride_h + o_k3[:, None] * V + o_v[None, :]
+                tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), mask=m_h3)
             if K > 192:
-                p_h4 = tl.make_block_ptr(h + i_t_true * stride_h, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-                tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+                p_h4 = h + i_t_true * stride_h + o_k4[:, None] * V + o_v[None, :]
+                tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), mask=m_h4)
 
-        p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v_new = tl.make_block_ptr(v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV),
-                                    (BT, BV), (1, 0)) if SAVE_NEW_VALUE else None
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_vv = m_t[:, None] & m_v[None, :]
+        p_v = v + o_t[:, None] * stride_v + o_v[None, :]
+        p_v_new = v_new + o_t[:, None] * stride_v + o_v[None, :] if SAVE_NEW_VALUE else None
         b_v_new = tl.zeros([BT, BV], dtype=tl.float32)
-        p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        p_w = w + o_t[:, None] * stride_k + o_k1[None, :]
+        b_w = tl.load(p_w, mask=m_t[:, None] & (o_k1[None, :] < K), other=0.0)
         b_v_new += tl.dot(b_w, b_h1.to(b_w.dtype))
         if K > 64:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_k + o_k2[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & (o_k2[None, :] < K), other=0.0)
             b_v_new += tl.dot(b_w, b_h2.to(b_w.dtype))
         if K > 128:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_k + o_k3[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & (o_k3[None, :] < K), other=0.0)
             b_v_new += tl.dot(b_w, b_h3.to(b_w.dtype))
         if K > 192:
-            p_w = tl.make_block_ptr(w, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_k + o_k4[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & (o_k4[None, :] < K), other=0.0)
             b_v_new += tl.dot(b_w, b_h4.to(b_w.dtype))
-        b_v_new = -b_v_new + tl.load(p_v, boundary_check=(0, 1))
+        b_v_new = -b_v_new + tl.load(p_v, mask=m_vv, other=0.0)
 
         if SAVE_NEW_VALUE:
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            tl.store(p_v_new, b_v_new.to(p_v_new.dtype.element_ty), boundary_check=(0, 1))
+            p_v_new = v_new + o_t[:, None] * stride_v + o_v[None, :]
+            tl.store(p_v_new, b_v_new.to(p_v_new.dtype.element_ty), mask=m_vv)
 
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
             last_idx = min((i_t + 1) * BT, T) - 1
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,))
+            p_g = g + bos * H + i_h + o_t * H
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
             b_v_new = b_v_new * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
             b_g_last = exp2(b_g_last)
             b_h1 = b_h1 * b_g_last
@@ -165,34 +178,34 @@ def chunk_gated_delta_product_fwd_kernel_h_blockdim64(
             if K > 192:
                 b_h4 = b_h4 * b_g_last
         b_v_new = b_v_new.to(k.dtype.element_ty)
-        p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_k1[:, None] + o_t[None, :] * stride_k
+        b_k = tl.load(p_k, mask=(o_k1[:, None] < K) & m_t[None, :], other=0.0)
         b_h1 += tl.dot(b_k, b_v_new)
         if K > 64:
-            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k2[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=(o_k2[:, None] < K) & m_t[None, :], other=0.0)
             b_h2 += tl.dot(b_k, b_v_new)
         if K > 128:
-            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k3[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=(o_k3[:, None] < K) & m_t[None, :], other=0.0)
             b_h3 += tl.dot(b_k, b_v_new)
         if K > 192:
-            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k4[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=(o_k4[:, None] < K) & m_t[None, :], other=0.0)
             b_h4 += tl.dot(b_k, b_v_new)
     # epilogue
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), mask=m_h4)
 
 
 @triton.heuristics({
@@ -274,38 +287,52 @@ def chunk_gated_delta_product_bwd_kernel_dhu_blockdim64(
     if USE_FINAL_STATE_GRADIENT:
         dht += i_nh * K*V
 
+    o_k1 = tl.arange(0, 64)
+    o_k2 = 64 + tl.arange(0, 64)
+    o_k3 = 128 + tl.arange(0, 64)
+    o_k4 = 192 + tl.arange(0, 64)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    m_h1 = (o_k1[:, None] < K) & m_v[None, :]
+    m_h2 = (o_k2[:, None] < K) & m_v[None, :]
+    m_h3 = (o_k3[:, None] < K) & m_v[None, :]
+    m_h4 = (o_k4[:, None] < K) & m_v[None, :]
+
     if USE_FINAL_STATE_GRADIENT:
-        p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
+        p_dht1 = dht + o_k1[:, None] * V + o_v[None, :]
+        b_dh1 += tl.load(p_dht1, mask=m_h1, other=0.0)
         if K > 64:
-            p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
+            p_dht2 = dht + o_k2[:, None] * V + o_v[None, :]
+            b_dh2 += tl.load(p_dht2, mask=m_h2, other=0.0)
         if K > 128:
-            p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
+            p_dht3 = dht + o_k3[:, None] * V + o_v[None, :]
+            b_dh3 += tl.load(p_dht3, mask=m_h3, other=0.0)
         if K > 192:
-            p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
+            p_dht4 = dht + o_k4[:, None] * V + o_v[None, :]
+            b_dh4 += tl.load(p_dht4, mask=m_h4, other=0.0)
 
     for i_t in range(NT - 1, -1, -1):
-        p_dh1 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_vv = m_t[:, None] & m_v[None, :]
+        p_dh1 = dh + i_t*stride_h + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_dh2 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+            p_dh2 = dh + i_t*stride_h + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_dh3 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+            p_dh3 = dh + i_t*stride_h + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_dh4 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+            p_dh4 = dh + i_t*stride_h + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), mask=m_h4)
 
         if USE_G:
             last_idx = min((i_t + 1) * BT, T) - 1
             bg_last = tl.load(g + (bos + last_idx) * H + i_h)
             bg_last_exp = exp2(bg_last)
-            p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,))
+            p_g = g + bos * H + i_h + o_t * H
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
             b_g_exp = exp2(b_g)
         else:
             bg_last = None
@@ -313,74 +340,74 @@ def chunk_gated_delta_product_bwd_kernel_dhu_blockdim64(
             b_g = None
             b_g_exp = None
 
-        p_dv = tl.make_block_ptr(dv, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_wo = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv2 = tl.make_block_ptr(dv2, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = dv + o_t[:, None] * stride_v + o_v[None, :]
+        p_wo = do + o_t[:, None] * stride_v + o_v[None, :]
+        p_dv2 = dv2 + o_t[:, None] * stride_v + o_v[None, :]
 
-        b_wo = tl.load(p_wo, boundary_check=(0, 1))
+        b_wo = tl.load(p_wo, mask=m_vv, other=0.0)
         b_dv = tl.zeros([BT, BV], dtype=tl.float32)
 
         # Update dv
-        p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_t[:, None] * stride_k + o_k1[None, :]
+        b_k = tl.load(p_k, mask=m_t[:, None] & (o_k1[None, :] < K), other=0.0)
         b_dv += tl.dot(b_k, b_dh1.to(b_k.dtype))
 
         if K > 64:
-            p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_k + o_k2[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & (o_k2[None, :] < K), other=0.0)
             b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
 
         if K > 128:
-            p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_k + o_k3[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & (o_k3[None, :] < K), other=0.0)
             b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
 
         if K > 192:
-            p_k = tl.make_block_ptr(k, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_k + o_k4[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & (o_k4[None, :] < K), other=0.0)
             b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
 
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
             b_dv *= tl.where(m_t, exp2(bg_last - b_g), 0)[:, None]
-        b_dv += tl.load(p_dv, boundary_check=(0, 1))
+        b_dv += tl.load(p_dv, mask=m_vv, other=0.0)
 
-        tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), mask=m_vv)
         # Update dh
-        p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
-        p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_w = w + o_k1[:, None] + o_t[None, :] * stride_k
+        p_q = q + o_k1[:, None] + o_t[None, :] * stride_k
+        b_w = tl.load(p_w, mask=(o_k1[:, None] < K) & m_t[None, :], other=0.0)
+        b_q = tl.load(p_q, mask=(o_k1[:, None] < K) & m_t[None, :], other=0.0)
         if USE_G:
             b_dh1 *= bg_last_exp
             b_q = b_q * b_g_exp[None, :]
         b_q = (b_q * scale).to(b_q.dtype)
         b_dh1 += tl.dot(b_q, b_wo.to(b_q.dtype))-tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 64:
-            p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k2[:, None] + o_t[None, :] * stride_k
+            p_w = w + o_k2[:, None] + o_t[None, :] * stride_k
+            b_q = tl.load(p_q, mask=(o_k2[:, None] < K) & m_t[None, :], other=0.0)
+            b_w = tl.load(p_w, mask=(o_k2[:, None] < K) & m_t[None, :], other=0.0)
             if USE_G:
                 b_dh2 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
             b_q = (b_q * scale).to(b_q.dtype)
             b_dh2 += tl.dot(b_q, b_wo.to(b_q.dtype))-tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 128:
-            p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k3[:, None] + o_t[None, :] * stride_k
+            p_w = w + o_k3[:, None] + o_t[None, :] * stride_k
+            b_q = tl.load(p_q, mask=(o_k3[:, None] < K) & m_t[None, :], other=0.0)
+            b_w = tl.load(p_w, mask=(o_k3[:, None] < K) & m_t[None, :], other=0.0)
             if USE_G:
                 b_dh3 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
             b_q = (b_q * scale).to(b_q.dtype)
             b_dh3 += tl.dot(b_q, b_wo.to(b_q.dtype))-tl.dot(b_w, b_dv.to(b_w.dtype))
         if K > 192:
-            p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k4[:, None] + o_t[None, :] * stride_k
+            p_w = w + o_k4[:, None] + o_t[None, :] * stride_k
+            b_q = tl.load(p_q, mask=(o_k4[:, None] < K) & m_t[None, :], other=0.0)
+            b_w = tl.load(p_w, mask=(o_k4[:, None] < K) & m_t[None, :], other=0.0)
             if USE_G:
                 b_dh4 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -388,17 +415,17 @@ def chunk_gated_delta_product_bwd_kernel_dhu_blockdim64(
             b_dh4 += tl.dot(b_q, b_wo.to(b_q.dtype))-tl.dot(b_w, b_dv.to(b_w.dtype))
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+            p_dh1 = dh0 + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+            p_dh2 = dh0 + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
-            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+            p_dh3 = dh0 + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), mask=m_h4)
 
 
 def chunk_gated_delta_product_fwd_h(

--- a/fla/ops/gated_delta_product/chunk_deltaproduct_o.py
+++ b/fla/ops/gated_delta_product/chunk_deltaproduct_o.py
@@ -54,12 +54,12 @@ def chunk_fwd_kernel_o(
     USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -75,24 +75,29 @@ def chunk_fwd_kernel_o(
     o += (bos * H + i_h) * V
     h += (i_tg * H + i_h).to(tl.int64) * K*V
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_v = m_t[:, None] & (o_v[None, :] < V)
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_q = m_t[:, None] & (o_k[None, :] < K)
+        m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+        p_h = h + o_k[:, None] * V + o_v[None, :]
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
         # [BT, BK] @ [BK, BV] -> [BT, BV]
         b_o += tl.dot(b_q, b_h)
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     if USE_G:
         g += bos * H + i_h
-        p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g = g + o_t * H
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
         b_m = tl.where(m_A, exp2(b_g[:, None] - b_g[None, :]), 0)
         b_o = b_o * exp2(b_g)[:, None]
@@ -102,21 +107,24 @@ def chunk_fwd_kernel_o(
     for i_dp in range(num_householder):
         b_A = tl.zeros([BT, BT], dtype=tl.float32)
         for i_k in range(tl.cdiv(K, BK)):
-            p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            p_k = tl.make_block_ptr(k+i_dp*H*K, (K, T), (1, num_householder*H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_q = m_t[:, None] & (o_k[None, :] < K)
+            m_k = (o_k[:, None] < K) & m_t[None, :]
+            p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+            p_k = k+i_dp*H*K + o_k[:, None] + o_t[None, :] * (num_householder*H*K)
             # [BT, BK]
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_q = tl.load(p_q, mask=m_q, other=0.0)
             # [BK, BT]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=m_k, other=0.0)
             # [BT, BK] @ [BK, BT] -> [BT, BT]
             b_A += tl.dot(b_q, b_k)
         b_A = b_A * b_m
-        p_v = tl.make_block_ptr(v+i_dp*H*V, (T, V), (H*V*num_householder, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        p_v = v+i_dp*H*V + o_t[:, None] * (H*V*num_householder) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_o += tl.dot(b_A.to(b_v.dtype), b_v)
     b_o = b_o * scale
-    p_o = tl.make_block_ptr(o, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o = o + o_t[:, None] * (H*V) + o_v[None, :]
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
 
 
 def chunk_gated_delta_product_fwd_o(

--- a/fla/ops/gated_delta_rule/chunk_fwd.py
+++ b/fla/ops/gated_delta_rule/chunk_fwd.py
@@ -67,11 +67,11 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     4. Block merge to get full (I+A)^{-1}
     5. Write result to A (output)
     """
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // HV, i_bh % HV
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -95,26 +95,26 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     m_tc3 = (i_tc3 + o_i) < T
 
     # load beta for each sub-chunk
-    p_b0 = tl.make_block_ptr(beta + bos * HV + i_h, (T,), (HV,), (i_tc0,), (BC,), (0,))
-    p_b1 = tl.make_block_ptr(beta + bos * HV + i_h, (T,), (HV,), (i_tc1,), (BC,), (0,))
-    p_b2 = tl.make_block_ptr(beta + bos * HV + i_h, (T,), (HV,), (i_tc2,), (BC,), (0,))
-    p_b3 = tl.make_block_ptr(beta + bos * HV + i_h, (T,), (HV,), (i_tc3,), (BC,), (0,))
-    b_b0 = tl.load(p_b0, boundary_check=(0,)).to(tl.float32)
-    b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
-    b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
-    b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+    p_b0 = beta + bos * HV + i_h + (i_tc0 + o_i) * HV
+    p_b1 = beta + bos * HV + i_h + (i_tc1 + o_i) * HV
+    p_b2 = beta + bos * HV + i_h + (i_tc2 + o_i) * HV
+    p_b3 = beta + bos * HV + i_h + (i_tc3 + o_i) * HV
+    b_b0 = tl.load(p_b0, mask=m_tc0, other=0.0).to(tl.float32)
+    b_b1 = tl.load(p_b1, mask=m_tc1, other=0.0).to(tl.float32)
+    b_b2 = tl.load(p_b2, mask=m_tc2, other=0.0).to(tl.float32)
+    b_b3 = tl.load(p_b3, mask=m_tc3, other=0.0).to(tl.float32)
 
     # load gate if used
     if USE_G:
-        p_g0 = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_tc0,), (BC,), (0,))
-        p_g1 = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_tc1,), (BC,), (0,))
-        p_g2 = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_tc2,), (BC,), (0,))
-        p_g3 = tl.make_block_ptr(g + bos * HV + i_h, (T,), (HV,), (i_tc3,), (BC,), (0,))
+        p_g0 = g + bos * HV + i_h + (i_tc0 + o_i) * HV
+        p_g1 = g + bos * HV + i_h + (i_tc1 + o_i) * HV
+        p_g2 = g + bos * HV + i_h + (i_tc2 + o_i) * HV
+        p_g3 = g + bos * HV + i_h + (i_tc3 + o_i) * HV
 
-        b_g0 = tl.load(p_g0, boundary_check=(0,)).to(tl.float32)
-        b_g1 = tl.load(p_g1, boundary_check=(0,)).to(tl.float32)
-        b_g2 = tl.load(p_g2, boundary_check=(0,)).to(tl.float32)
-        b_g3 = tl.load(p_g3, boundary_check=(0,)).to(tl.float32)
+        b_g0 = tl.load(p_g0, mask=m_tc0, other=0.0).to(tl.float32)
+        b_g1 = tl.load(p_g1, mask=m_tc1, other=0.0).to(tl.float32)
+        b_g2 = tl.load(p_g2, mask=m_tc2, other=0.0).to(tl.float32)
+        b_g3 = tl.load(p_g3, mask=m_tc3, other=0.0).to(tl.float32)
 
     ############################################################################
     # Step 1: compute all 10 lower-triangular [BC, BC] blocks of K @ K^T
@@ -135,22 +135,23 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     b_A32 = tl.zeros([BC, BC], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k0 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-        b_k0 = tl.load(p_k0, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        p_k0 = k + (i_tc0 + o_i)[:, None] * (H*K) + o_k[None, :]
+        b_k0 = tl.load(p_k0, mask=m_tc0[:, None] & (o_k[None, :] < K), other=0.0)
         # diagonal block 0
         b_A00 += tl.dot(b_k0, tl.trans(b_k0))
 
         if i_tc1 < T:
-            p_k1 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            b_k1 = tl.load(p_k1, boundary_check=(0, 1))
+            p_k1 = k + (i_tc1 + o_i)[:, None] * (H*K) + o_k[None, :]
+            b_k1 = tl.load(p_k1, mask=m_tc1[:, None] & (o_k[None, :] < K), other=0.0)
             # diagonal block 1
             b_A11 += tl.dot(b_k1, tl.trans(b_k1))
             # off-diagonal (1,0)
             b_A10 += tl.dot(b_k1, tl.trans(b_k0))
 
             if i_tc2 < T:
-                p_k2 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+                p_k2 = k + (i_tc2 + o_i)[:, None] * (H*K) + o_k[None, :]
+                b_k2 = tl.load(p_k2, mask=m_tc2[:, None] & (o_k[None, :] < K), other=0.0)
                 # diagonal block 2
                 b_A22 += tl.dot(b_k2, tl.trans(b_k2))
                 # off-diagonal (2,0), (2,1)
@@ -158,8 +159,8 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
                 b_A21 += tl.dot(b_k2, tl.trans(b_k1))
 
                 if i_tc3 < T:
-                    p_k3 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    b_k3 = tl.load(p_k3, boundary_check=(0, 1))
+                    p_k3 = k + (i_tc3 + o_i)[:, None] * (H*K) + o_k[None, :]
+                    b_k3 = tl.load(p_k3, mask=m_tc3[:, None] & (o_k[None, :] < K), other=0.0)
                     # diagonal block 3
                     b_A33 += tl.dot(b_k3, tl.trans(b_k3))
                     # off-diagonal (3,0), (3,1), (3,2)
@@ -293,27 +294,38 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     # Step 5: store full (I + A)^{-1} to output A
     ############################################################################
 
-    p_A00 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_A10 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_A11 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
-    p_A20 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_A21 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-    p_A22 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
-    p_A30 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    p_A31 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-    p_A32 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
-    p_A33 = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
+    p_A00 = A + (i_tc0 + o_i)[:, None] * (HV*BT) + o_i[None, :]
+    p_A10 = A + (i_tc1 + o_i)[:, None] * (HV*BT) + o_i[None, :]
+    p_A11 = A + (i_tc1 + o_i)[:, None] * (HV*BT) + (BC + o_i)[None, :]
+    p_A20 = A + (i_tc2 + o_i)[:, None] * (HV*BT) + o_i[None, :]
+    p_A21 = A + (i_tc2 + o_i)[:, None] * (HV*BT) + (BC + o_i)[None, :]
+    p_A22 = A + (i_tc2 + o_i)[:, None] * (HV*BT) + (2*BC + o_i)[None, :]
+    p_A30 = A + (i_tc3 + o_i)[:, None] * (HV*BT) + o_i[None, :]
+    p_A31 = A + (i_tc3 + o_i)[:, None] * (HV*BT) + (BC + o_i)[None, :]
+    p_A32 = A + (i_tc3 + o_i)[:, None] * (HV*BT) + (2*BC + o_i)[None, :]
+    p_A33 = A + (i_tc3 + o_i)[:, None] * (HV*BT) + (3*BC + o_i)[None, :]
 
-    tl.store(p_A00, b_Ai00.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A10, b_Ai10.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A11, b_Ai11.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A20, b_Ai20.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A21, b_Ai21.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A22, b_Ai22.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A30, b_Ai30.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A31, b_Ai31.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A32, b_Ai32.to(A.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A33, b_Ai33.to(A.dtype.element_ty), boundary_check=(0, 1))
+    m_A0 = m_tc0[:, None] & (o_i[None, :] < BT)
+    m_A1 = m_tc1[:, None] & (o_i[None, :] < BT)
+    m_A2 = m_tc2[:, None] & (o_i[None, :] < BT)
+    m_A3 = m_tc3[:, None] & (o_i[None, :] < BT)
+    m_A11 = m_tc1[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A21 = m_tc2[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A22 = m_tc2[:, None] & ((2*BC + o_i)[None, :] < BT)
+    m_A31 = m_tc3[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A32 = m_tc3[:, None] & ((2*BC + o_i)[None, :] < BT)
+    m_A33 = m_tc3[:, None] & ((3*BC + o_i)[None, :] < BT)
+
+    tl.store(p_A00, b_Ai00.to(A.dtype.element_ty), mask=m_A0)
+    tl.store(p_A10, b_Ai10.to(A.dtype.element_ty), mask=m_A1)
+    tl.store(p_A11, b_Ai11.to(A.dtype.element_ty), mask=m_A11)
+    tl.store(p_A20, b_Ai20.to(A.dtype.element_ty), mask=m_A2)
+    tl.store(p_A21, b_Ai21.to(A.dtype.element_ty), mask=m_A21)
+    tl.store(p_A22, b_Ai22.to(A.dtype.element_ty), mask=m_A22)
+    tl.store(p_A30, b_Ai30.to(A.dtype.element_ty), mask=m_A3)
+    tl.store(p_A31, b_Ai31.to(A.dtype.element_ty), mask=m_A31)
+    tl.store(p_A32, b_Ai32.to(A.dtype.element_ty), mask=m_A32)
+    tl.store(p_A33, b_Ai33.to(A.dtype.element_ty), mask=m_A33)
 
 
 @dispatch('gated_delta_rule')

--- a/fla/ops/gated_delta_rule/gate.py
+++ b/fla/ops/gated_delta_rule/gate.py
@@ -76,20 +76,22 @@ def gdn_gate_chunk_cumsum_scalar_kernel(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_o = tl.make_block_ptr(o + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_g = g + bos * H + i_h + o_t * H
+    p_o = o + bos * H + i_h + o_t * H
 
-    b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+    b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
     if HAS_BIAS:
         b_g = b_g + tl.load(dt_bias + i_h).to(tl.float32)
     b_A = tl.load(A_log + i_h).to(tl.float32)
@@ -101,7 +103,7 @@ def gdn_gate_chunk_cumsum_scalar_kernel(
         b_o = -b_o + b_z[None] + b_gate
     if HAS_SCALE:
         b_o *= scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_t)
 
 
 @triton.heuristics({
@@ -128,16 +130,18 @@ def gdn_gate_bwd_kernel(
     BT: tl.constexpr,
     HAS_BIAS: tl.constexpr,
 ):
-    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
     b_A = tl.load(A_log + i_h).to(tl.float32)
 
-    p_g = tl.make_block_ptr(g + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dg = tl.make_block_ptr(dg + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dyg = tl.make_block_ptr(dyg + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_g = g + i_h + o_t * H
+    p_dg = dg + i_h + o_t * H
+    p_dyg = dyg + i_h + o_t * H
 
-    b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-    b_dyg = tl.load(p_dyg, boundary_check=(0,)).to(tl.float32)
+    b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
+    b_dyg = tl.load(p_dyg, mask=m_t, other=0.0).to(tl.float32)
 
     if HAS_BIAS:
         b_g = b_g + tl.load(dt_bias + i_h).to(tl.float32)
@@ -150,7 +154,7 @@ def gdn_gate_bwd_kernel(
     b_dg = b_neg_expA * (b_dyg * tl.sigmoid(b_g))
     b_dA = tl.sum(b_dyg * b_yg, 0)
 
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
     tl.store(dA + i_t * H + i_h, b_dA)
 
 
@@ -247,17 +251,19 @@ def gdn_gate_fwd_kernel(
     BT: tl.constexpr,
     HAS_BIAS: tl.constexpr,
 ):
-    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
     b_A = tl.load(A_log + i_h).to(tl.float32)
 
-    p_g = tl.make_block_ptr(g + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_yg = tl.make_block_ptr(yg + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_g = g + i_h + o_t * H
+    p_yg = yg + i_h + o_t * H
+    b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
     if HAS_BIAS:
         b_g = b_g + tl.load(dt_bias + i_h).to(tl.float32)
     b_yg = -exp(b_A) * softplus(b_g)
-    tl.store(p_yg, b_yg.to(p_yg.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_yg, b_yg.to(p_yg.dtype.element_ty), mask=m_t)
 
 
 @dispatch('gated_delta_rule')

--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -57,41 +57,49 @@ def recompute_w_u_fwd_kernel(
     USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
-    p_b = tl.make_block_ptr(beta + bos*HV + i_h, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_b = beta + bos*HV + i_h + o_t * HV
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
 
-    p_A = tl.make_block_ptr(A + (bos*HV + i_h) * BT, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    p_A = A + (bos*HV + i_h) * BT + o_t[:, None] * (HV*BT) + o_A[None, :]
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*HV + i_h) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*HV + i_h) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_u = u + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb, allow_tf32=False)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), mask=m_v)
 
     if USE_G:
-        p_g = tl.make_block_ptr(g + (bos*HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = exp2(tl.load(p_g, boundary_check=(0,)))
+        p_g = g + (bos*HV + i_h) + o_t * HV
+        b_g = exp2(tl.load(p_g, mask=m_t, other=0.0))
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h // (HV // H)) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_w = tl.make_block_ptr(w + (bos*HV + i_h) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_w = w + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_kb = b_k * b_b[:, None]
         if USE_G:
             b_kb *= b_g[:, None]
         b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_k)
 
 
 @triton.heuristics({
@@ -133,41 +141,47 @@ def prepare_wy_repr_bwd_kernel(
     USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_b = tl.make_block_ptr(beta + (bos*HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db + (bos*HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*HV + i_h) * BT, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    p_b = beta + (bos*HV + i_h) + o_t * HV
+    p_db = db + (bos*HV + i_h) + o_t * HV
+    p_A = A + (bos*HV + i_h) * BT + o_A[:, None] + o_t[None, :] * (HV*BT)
 
-    b_b = tl.load(p_b, boundary_check=(0,))
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
     b_db = tl.zeros([BT], dtype=tl.float32)
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
     if USE_G:
-        p_g = tl.make_block_ptr(g + (bos*HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g = g + (bos*HV + i_h) + o_t * HV
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_g_exp = exp2(b_g)
         b_dg = tl.zeros([BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h // (HV // H)) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*HV + i_h) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos*HV + i_h) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dw = dw + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
         # [BT, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         if USE_G:
             b_kbg = b_k * (b_b * b_g_exp)[:, None]
         else:
             b_kbg = b_k * b_b[:, None]
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+        b_dw = tl.load(p_dw, mask=m_k, other=0.0)
 
         b_dA += tl.dot(b_dw, tl.trans(b_kbg).to(b_dw.dtype))
         b_dkbg = tl.dot(b_A, b_dw)
@@ -178,23 +192,23 @@ def prepare_wy_repr_bwd_kernel(
         else:
             b_dk = b_dkbg * b_b[:, None]
             b_db += tl.sum(b_dkbg * b_k, 1)
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*HV + i_h) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos*HV + i_h) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos*HV + i_h) * V, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_dv = dv + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_du = du + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
-        b_du = tl.load(p_du, boundary_check=(0, 1))
+        b_du = tl.load(p_du, mask=m_v, other=0.0)
         b_dA += tl.dot(b_du, tl.trans(b_vb))
         b_dvb = tl.dot(b_A, b_du)
         b_dv = b_dvb * b_b[:, None]
         b_db += tl.sum(b_dvb * b_v, 1)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA, 0)
     b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
@@ -208,9 +222,11 @@ def prepare_wy_repr_bwd_kernel(
 
     tl.debug_barrier()
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h // (HV // H)) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*HV + i_h) * K, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_kt = tl.trans(b_k)
         b_kb = b_k * b_b[:, None]
 
@@ -218,17 +234,17 @@ def prepare_wy_repr_bwd_kernel(
         b_dkb = tl.dot(b_dA, b_k)
         b_db += tl.sum(b_dkb * b_k, 1)
         b_dk = b_dkb * b_b[:, None] + tl.trans(tl.dot(tl.trans(b_kb).to(b_dA.dtype), b_dA))
-        b_dk += tl.load(p_dk, boundary_check=(0, 1))
+        b_dk += tl.load(p_dk, mask=m_k, other=0.0)
 
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_t)
 
     b_A *= b_b[:, None]
     if USE_G:
         b_AdA = b_dA * b_A
-        p_dg = tl.make_block_ptr(dg + (bos*HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        p_dg = dg + (bos*HV + i_h) + o_t * HV
         b_dg += tl.sum(b_AdA, axis=1) - tl.sum(b_AdA, axis=0)
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
 
 
 @dispatch('gated_delta_rule')

--- a/fla/ops/gated_oja_rule/chunk_h.py
+++ b/fla/ops/gated_oja_rule/chunk_h.py
@@ -94,61 +94,66 @@ def chunk_oja_fwd_kernel_h_blockdim64(
     if STORE_FINAL_STATE:
         ht = ht + i_nh * K*V
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v1 = tl.arange(0, 64)
     # load initial state
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (i_k * BK, 0), (BK, 64), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        p_h0_1 = h0 + o_k[:, None] * V + o_v1[None, :]
+        b_h1 += tl.load(p_h0_1, mask=(o_k[:, None] < K) & (o_v1[None, :] < V), other=0.0).to(tl.float32)
         if V > 64:
-            p_h0_2 = tl.make_block_ptr(h0, (K, V), (V, 1), (i_k * BK, 64), (BK, 64), (1, 0))
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_2 = h0 + o_k[:, None] * V + (64 + o_v1)[None, :]
+            b_h2 += tl.load(p_h0_2, mask=(o_k[:, None] < K) & ((64 + o_v1)[None, :] < V), other=0.0).to(tl.float32)
         if V > 128:
-            p_h0_3 = tl.make_block_ptr(h0, (K, V), (V, 1), (i_k * BK, 128), (BK, 64), (1, 0))
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_3 = h0 + o_k[:, None] * V + (128 + o_v1)[None, :]
+            b_h3 += tl.load(p_h0_3, mask=(o_k[:, None] < K) & ((128 + o_v1)[None, :] < V), other=0.0).to(tl.float32)
         if V > 192:
-            p_h0_4 = tl.make_block_ptr(h0, (K, V), (V, 1), (i_k * BK, 192), (BK, 64), (1, 0))
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_4 = h0 + o_k[:, None] * V + (192 + o_v1)[None, :]
+            b_h4 += tl.load(p_h0_4, mask=(o_k[:, None] < K) & ((192 + o_v1)[None, :] < V), other=0.0).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
-        p_h1 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1), (i_k * BK, 0), (BK, 64), (1, 0))
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_kv1 = (o_k[:, None] < K) & (o_v1[None, :] < V)
+        p_h1 = h + i_t * stride_h + o_k[:, None] * V + o_v1[None, :]
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), mask=m_kv1)
         if V > 64:
-            p_h2 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1), (i_k * BK, 64), (BK, 64), (1, 0))
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+            p_h2 = h + i_t * stride_h + o_k[:, None] * V + (64 + o_v1)[None, :]
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), mask=(o_k[:, None] < K) & ((64 + o_v1)[None, :] < V))
         if V > 128:
-            p_h3 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1), (i_k * BK, 128), (BK, 64), (1, 0))
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+            p_h3 = h + i_t * stride_h + o_k[:, None] * V + (128 + o_v1)[None, :]
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), mask=(o_k[:, None] < K) & ((128 + o_v1)[None, :] < V))
         if V > 192:
-            p_h4 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1), (i_k * BK, 192), (BK, 64), (1, 0))
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+            p_h4 = h + i_t * stride_h + o_k[:, None] * V + (192 + o_v1)[None, :]
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), mask=(o_k[:, None] < K) & ((192 + o_v1)[None, :] < V))
 
-        p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        p_w = w + o_t[:, None] * stride_v + o_v1[None, :]
+        b_w = tl.load(p_w, mask=m_t[:, None] & (o_v1[None, :] < V), other=0.0)
         b_k = tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))  # BT BK
         if V > 64:
-            p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_v + (64 + o_v1)[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & ((64 + o_v1)[None, :] < V), other=0.0)
             b_k += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
         if V > 128:
-            p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_v + (128 + o_v1)[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & ((128 + o_v1)[None, :] < V), other=0.0)
             b_k += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
         if V > 192:
-            p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_v + (192 + o_v1)[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & ((192 + o_v1)[None, :] < V), other=0.0)
             b_k += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
 
-        p_u = tl.make_block_ptr(u, (T, K), (stride_k, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_u, boundary_check=(0, 1)) - b_k
+        p_u = u + o_t[:, None] * stride_k + o_k[None, :]
+        b_k = tl.load(p_u, mask=m_tk, other=0.0) - b_k
 
         if SAVE_NEW_KEY:
-            p_k = tl.make_block_ptr(k_new, (T, K), (stride_k, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            tl.store(p_k, b_k.to(p_k.dtype.element_ty), boundary_check=(0, 1))
+            p_k = k_new + o_t[:, None] * stride_k + o_k[None, :]
+            tl.store(p_k, b_k.to(p_k.dtype.element_ty), mask=m_tk)
 
         last_idx = min((i_t + 1) * BT, T) - 1
 
         if USE_GV:
-            o_v1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(gv + (bos + last_idx) * H*V + i_h * V + o_v1, mask=(o_v1 < V), other=0.)
             b_h1 *= exp(b_gk_last1)[None, :]
             if V > 64:
@@ -166,34 +171,34 @@ def chunk_oja_fwd_kernel_h_blockdim64(
 
         b_k = b_k.to(v.dtype.element_ty)  # BT BK
 
-        p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))  # BT BV
+        p_v = v + o_t[:, None] * stride_v + o_v1[None, :]
+        b_v = tl.load(p_v, mask=m_t[:, None] & (o_v1[None, :] < V), other=0.0)  # BT BV
         b_h1 += tl.dot(tl.trans(b_k), b_v)
         if V > 64:
-            p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_v = v + o_t[:, None] * stride_v + (64 + o_v1)[None, :]
+            b_v = tl.load(p_v, mask=m_t[:, None] & ((64 + o_v1)[None, :] < V), other=0.0)
             b_h2 += tl.dot(tl.trans(b_k), b_v)
         if V > 128:
-            p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_v = v + o_t[:, None] * stride_v + (128 + o_v1)[None, :]
+            b_v = tl.load(p_v, mask=m_t[:, None] & ((128 + o_v1)[None, :] < V), other=0.0)
             b_h3 += tl.dot(tl.trans(b_k), b_v)
         if V > 192:
-            p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_v = v + o_t[:, None] * stride_v + (192 + o_v1)[None, :]
+            b_v = tl.load(p_v, mask=m_t[:, None] & ((192 + o_v1)[None, :] < V), other=0.0)
             b_h4 += tl.dot(tl.trans(b_k), b_v)
     # epilogue
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (i_k * BK, 0), (BK, 64), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + o_k[:, None] * V + o_v1[None, :]
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v1[None, :] < V))
         if V > 64:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (i_k * BK, 64), (BK, 64), (1, 0))
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k[:, None] * V + (64 + o_v1)[None, :]
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & ((64 + o_v1)[None, :] < V))
         if V > 128:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (i_k * BK, 128), (BK, 64), (1, 0))
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k[:, None] * V + (128 + o_v1)[None, :]
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & ((128 + o_v1)[None, :] < V))
         if V > 192:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (i_k * BK, 192), (BK, 64), (1, 0))
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k[:, None] * V + (192 + o_v1)[None, :]
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & ((192 + o_v1)[None, :] < V))
 
 
 def chunk_oja_fwd_h(
@@ -325,76 +330,83 @@ def chunk_oja_bwd_kernel_dhu_blockdim64(
     if USE_FINAL_STATE_GRADIENT:
         dht += i_nh * K*V
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v1 = tl.arange(0, 64)
+    m_kv1 = (o_k[:, None] < K) & (o_v1[None, :] < V)
     if USE_FINAL_STATE_GRADIENT:
-        p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (i_k * BK, 0), (BK, 64), (1, 0))  # [BK, BV]
-        b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
+        p_dht1 = dht + o_k[:, None] * V + o_v1[None, :]  # [BK, BV]
+        b_dh1 += tl.load(p_dht1, mask=(o_k[:, None] < K) & (o_v1[None, :] < V), other=0.0)
         if V > 64:
-            p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (i_k * BK, 64), (BK, 64), (1, 0))
-            b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
+            p_dht2 = dht + o_k[:, None] * V + (64 + o_v1)[None, :]
+            b_dh2 += tl.load(p_dht2, mask=(o_k[:, None] < K) & ((64 + o_v1)[None, :] < V), other=0.0)
         if V > 128:
-            p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (i_k * BK, 128), (BK, 64), (1, 0))
-            b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
+            p_dht3 = dht + o_k[:, None] * V + (128 + o_v1)[None, :]
+            b_dh3 += tl.load(p_dht3, mask=(o_k[:, None] < K) & ((128 + o_v1)[None, :] < V), other=0.0)
         if V > 192:
-            p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (i_k * BK, 192), (BK, 64), (1, 0))
-            b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
+            p_dht4 = dht + o_k[:, None] * V + (192 + o_v1)[None, :]
+            b_dh4 += tl.load(p_dht4, mask=(o_k[:, None] < K) & ((192 + o_v1)[None, :] < V), other=0.0)
 
     for i_t in range(NT - 1, -1, -1):
-        p_dh1 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (i_k * BK, 0), (BK, 64), (1, 0))
-        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_kv1 = (o_k[:, None] < K) & (o_v1[None, :] < V)
+        m_tv1 = m_t[:, None] & (o_v1[None, :] < V)
+        p_dh1 = dh + i_t*stride_h + o_k[:, None] * V + o_v1[None, :]
+        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), mask=m_kv1)
         if V > 64:
-            p_dh2 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (i_k * BK, 64), (BK, 64), (1, 0))
-            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+            p_dh2 = dh + i_t*stride_h + o_k[:, None] * V + (64 + o_v1)[None, :]
+            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), mask=(o_k[:, None] < K) & ((64 + o_v1)[None, :] < V))
         if V > 128:
-            p_dh3 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (i_k * BK, 128), (BK, 64), (1, 0))
-            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+            p_dh3 = dh + i_t*stride_h + o_k[:, None] * V + (128 + o_v1)[None, :]
+            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), mask=(o_k[:, None] < K) & ((128 + o_v1)[None, :] < V))
         if V > 192:
-            p_dh4 = tl.make_block_ptr(dh + i_t*stride_h, (K, V), (V, 1), (i_k * BK, 192), (BK, 64), (1, 0))
-            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+            p_dh4 = dh + i_t*stride_h + o_k[:, None] * V + (192 + o_v1)[None, :]
+            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), mask=(o_k[:, None] < K) & ((192 + o_v1)[None, :] < V))
 
         last_idx = min((i_t + 1) * BT, T) - 1
 
         # Update dk_new, 按K切分
-        p_dk = tl.make_block_ptr(dk, (T, K), (stride_k, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))  # [BT, BK]
-        p_dk2 = tl.make_block_ptr(dk2, (T, K), (stride_k, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))  # [BT, BK]
+        p_dk = dk + o_t[:, None] * stride_k + o_k[None, :]  # [BT, BK]
+        p_dk2 = dk2 + o_t[:, None] * stride_k + o_k[None, :]  # [BT, BK]
 
         if V > 0:
-            p_v = tl.make_block_ptr(vg, (T, V), (stride_v, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))  # [BT, BV]
+            p_v = vg + o_t[:, None] * stride_v + o_v1[None, :]
+            b_v = tl.load(p_v, mask=m_tv1, other=0.0)  # [BT, BV]
             b_dk = tl.dot(b_v, tl.trans(b_dh1).to(b_v.dtype))  # [BT, BV] @ [BV, BK] -> [BT, BK]
 
         if V > 64:
-            p_v = tl.make_block_ptr(vg, (T, V), (stride_v, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_v = vg + o_t[:, None] * stride_v + (64 + o_v1)[None, :]
+            b_v = tl.load(p_v, mask=m_t[:, None] & ((64 + o_v1)[None, :] < V), other=0.0)
             b_dk += tl.dot(b_v, tl.trans(b_dh2).to(b_v.dtype))
 
         if V > 128:
-            p_v = tl.make_block_ptr(vg, (T, V), (stride_v, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_v = vg + o_t[:, None] * stride_v + (128 + o_v1)[None, :]
+            b_v = tl.load(p_v, mask=m_t[:, None] & ((128 + o_v1)[None, :] < V), other=0.0)
             b_dk += tl.dot(b_v, tl.trans(b_dh3).to(b_v.dtype))
 
         if V > 192:
-            p_v = tl.make_block_ptr(vg, (T, V), (stride_v, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_v = vg + o_t[:, None] * stride_v + (192 + o_v1)[None, :]
+            b_v = tl.load(p_v, mask=m_t[:, None] & ((192 + o_v1)[None, :] < V), other=0.0)
             b_dk += tl.dot(b_v, tl.trans(b_dh4).to(b_v.dtype))
 
-        b_dk += tl.load(p_dk, boundary_check=(0, 1))
+        b_dk += tl.load(p_dk, mask=m_tk, other=0.0)
 
-        tl.store(p_dk2, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk2, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
 
         # Update dh, 按照K切分，收集所有V维度，q一次就好，wdo要收集所有
 
-        p_q = tl.make_block_ptr(q, (K, T), (1, stride_k), (i_k * BK, i_t * BT), (BK, BT), (0, 1))  # [BK, BT]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + o_k[:, None] + o_t[None, :] * stride_k  # [BK, BT]
+        b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0)
 
         if V > 0:
-            p_do = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, 0), (BT, 64), (1, 0))  # [BT, BV]
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 0), (BT, 64), (1, 0))  # [BT, BV]
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            p_gv = tl.make_block_ptr(gv, (T, V), (stride_v, 1), (i_t * BT, 0), (BT, 64), (1, 0))  # [BT, BV]
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            p_do = do + o_t[:, None] * stride_v + o_v1[None, :]  # [BT, BV]
+            b_do = tl.load(p_do, mask=m_tv1, other=0.0)
+            p_w = w + o_t[:, None] * stride_v + o_v1[None, :]  # [BT, BV]
+            b_w = tl.load(p_w, mask=m_tv1, other=0.0)
+            p_gv = gv + o_t[:, None] * stride_v + o_v1[None, :]  # [BT, BV]
+            b_gv = tl.load(p_gv, mask=m_tv1, other=0.0)
             if USE_GV:
-                o_v1 = tl.arange(0, 64)
                 b_gv_last1 = tl.load(gv + last_idx * H*V + o_v1, mask=(o_v1 < V), other=0.)
                 b_dh1 *= exp(b_gv_last1[None, :])
                 b_do *= exp(b_gv)
@@ -402,12 +414,12 @@ def chunk_oja_bwd_kernel_dhu_blockdim64(
                 tl.dot(tl.trans(b_dk).to(b_w.dtype), b_w)  # [BK, BT] @ [BT, BV] - [BK, BT] @ [BT, BV]
 
         if V > 64:
-            p_do = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 64), (BT, 64), (1, 0))  # [BT, BV]
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            p_gv = tl.make_block_ptr(gv, (T, V), (stride_v, 1), (i_t * BT, 64), (BT, 64), (1, 0))  # [BT, BV]
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            p_do = do + o_t[:, None] * stride_v + (64 + o_v1)[None, :]
+            b_do = tl.load(p_do, mask=m_t[:, None] & ((64 + o_v1)[None, :] < V), other=0.0)
+            p_w = w + o_t[:, None] * stride_v + (64 + o_v1)[None, :]  # [BT, BV]
+            b_w = tl.load(p_w, mask=m_t[:, None] & ((64 + o_v1)[None, :] < V), other=0.0)
+            p_gv = gv + o_t[:, None] * stride_v + (64 + o_v1)[None, :]  # [BT, BV]
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & ((64 + o_v1)[None, :] < V), other=0.0)
             if USE_GV:
                 o_v2 = 64 + o_v1
                 b_gv_last2 = tl.load(gv + last_idx * H*V + o_v2, mask=(o_v2 < V), other=0.)
@@ -416,12 +428,12 @@ def chunk_oja_bwd_kernel_dhu_blockdim64(
             b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(tl.trans(b_dk).to(b_w.dtype), b_w)
 
         if V > 128:
-            p_do = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 128), (BT, 64), (1, 0))  # [BT, BV]
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            p_gv = tl.make_block_ptr(gv, (T, V), (stride_v, 1), (i_t * BT, 128), (BT, 64), (1, 0))  # [BT, BV]
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            p_do = do + o_t[:, None] * stride_v + (128 + o_v1)[None, :]
+            b_do = tl.load(p_do, mask=m_t[:, None] & ((128 + o_v1)[None, :] < V), other=0.0)
+            p_w = w + o_t[:, None] * stride_v + (128 + o_v1)[None, :]  # [BT, BV]
+            b_w = tl.load(p_w, mask=m_t[:, None] & ((128 + o_v1)[None, :] < V), other=0.0)
+            p_gv = gv + o_t[:, None] * stride_v + (128 + o_v1)[None, :]  # [BT, BV]
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & ((128 + o_v1)[None, :] < V), other=0.0)
             if USE_GV:
                 o_v3 = 128 + o_v1
                 b_gv_last3 = tl.load(gv + last_idx * H*V + o_v3, mask=(o_v3 < V), other=0.)
@@ -430,12 +442,12 @@ def chunk_oja_bwd_kernel_dhu_blockdim64(
             b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(tl.trans(b_dk).to(b_w.dtype), b_w)
 
         if V > 192:
-            p_do = tl.make_block_ptr(do, (T, V), (stride_v, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            p_w = tl.make_block_ptr(w, (T, V), (stride_v, 1), (i_t * BT, 192), (BT, 64), (1, 0))  # [BT, BV]
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            p_gv = tl.make_block_ptr(gv, (T, V), (stride_v, 1), (i_t * BT, 192), (BT, 64), (1, 0))  # [BT, BV]
-            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            p_do = do + o_t[:, None] * stride_v + (192 + o_v1)[None, :]
+            b_do = tl.load(p_do, mask=m_t[:, None] & ((192 + o_v1)[None, :] < V), other=0.0)
+            p_w = w + o_t[:, None] * stride_v + (192 + o_v1)[None, :]  # [BT, BV]
+            b_w = tl.load(p_w, mask=m_t[:, None] & ((192 + o_v1)[None, :] < V), other=0.0)
+            p_gv = gv + o_t[:, None] * stride_v + (192 + o_v1)[None, :]  # [BT, BV]
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & ((192 + o_v1)[None, :] < V), other=0.0)
             if USE_GV:
                 o_v4 = 192 + o_v1
                 b_gv_last4 = tl.load(gv + last_idx * H*V + o_v4, mask=(o_v4 < V), other=0.)
@@ -444,17 +456,17 @@ def chunk_oja_bwd_kernel_dhu_blockdim64(
             b_dh4 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype)) * scale - tl.dot(tl.trans(b_dk).to(b_w.dtype), b_w)
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (i_k * BK, 0), (BK, 64), (1, 0))
-        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + o_k[:, None] * V + o_v1[None, :]
+        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), mask=m_kv1)
         if V > 64:
-            p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (i_k * BK, 64), (BK, 64), (1, 0))
-            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+            p_dh1 = dh0 + o_k[:, None] * V + (64 + o_v1)[None, :]
+            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), mask=(o_k[:, None] < K) & ((64 + o_v1)[None, :] < V))
         if V > 128:
-            p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (i_k * BK, 128), (BK, 64), (1, 0))
-            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+            p_dh2 = dh0 + o_k[:, None] * V + (128 + o_v1)[None, :]
+            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), mask=(o_k[:, None] < K) & ((128 + o_v1)[None, :] < V))
         if V > 192:
-            p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (i_k * BK, 192), (BK, 64), (1, 0))
-            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+            p_dh3 = dh0 + o_k[:, None] * V + (192 + o_v1)[None, :]
+            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), mask=(o_k[:, None] < K) & ((192 + o_v1)[None, :] < V))
 
 
 def chunk_oja_bwd_dhu(
@@ -553,12 +565,12 @@ def chunk_gsa_bwd_k_kernel_dqkvg(
     NG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -573,46 +585,55 @@ def chunk_gsa_bwd_k_kernel_dqkvg(
     o_t = min(i_t * BT + BT, T)
     m_s = o_i[:, None] >= o_i[None, :]
 
-    p_q = tl.make_block_ptr(q + (bos*HQ+i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos*H+i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_A = tl.make_block_ptr(A + ((i_k*all+bos)*HQ+i_hq)*BT, (T, BT), (HQ*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_tt = i_t * BT + tl.arange(0, BT)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_t = o_tt < T
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
+    p_q = q + (bos*HQ+i_hq) * K + o_tt[:, None] * (HQ*K) + o_k[None, :]
+    p_k = k + (bos*H+i_h) * K + o_tt[:, None] * (H*K) + o_k[None, :]
+    p_A = A + ((i_k*all+bos)*HQ+i_hq)*BT + o_tt[:, None] * (HQ*BT) + o_A[None, :]
 
     # [BT, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
     # [BT, BT]
     b_A = tl.dot((b_q * scale).to(b_q.dtype), tl.trans(b_k))
     b_A = tl.where(m_s, b_A, 0.)
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_AT)
 
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
         o_v = i_v * BV + tl.arange(0, BV)
-        p_v = tl.make_block_ptr(v + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_g = tl.make_block_ptr(g + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+        m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_v = v + (bos*H+i_h)*V + o_tt[:, None] * (H*V) + o_v[None, :]
+        p_g = g + (bos*H+i_h)*V + o_tt[:, None] * (H*V) + o_v[None, :]
         p_gn = g + (bos + o_t - 1) * H*V + i_h * V + o_v
-        p_do = tl.make_block_ptr(do + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + ((i_k*all+bos)*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dg = tl.make_block_ptr(dg + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dgv = tl.make_block_ptr(dgv+((i_k*all+bos)*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dh = tl.make_block_ptr(dh + (i_tg * HQ + i_hq) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        p_do = do + (bos*HQ+i_hq)*V + o_tt[:, None] * (HQ*V) + o_v[None, :]
+        p_dv = dv + ((i_k*all+bos)*HQ+i_hq)*V + o_tt[:, None] * (HQ*V) + o_v[None, :]
+        p_dg = dg + (bos*HQ+i_hq)*V + o_tt[:, None] * (HQ*V) + o_v[None, :]
+        p_dgv = dgv+((i_k*all+bos)*HQ+i_hq)*V + o_tt[:, None] * (HQ*V) + o_v[None, :]
+        p_h = h + (i_tg * H + i_h) * K*V + o_v[:, None] + o_k[None, :] * V
+        p_dh = dh + (i_tg * HQ + i_hq) * K*V + o_k[:, None] * V + o_v[None, :]
         m_v = o_v < V
 
         # [BV,]
         b_gn = tl.load(p_gn, mask=m_v, other=0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
+        b_g = tl.load(p_g, mask=m_tv, other=0.0)
         b_gv = exp(b_gn[None, :] - b_g)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
         b_do = (b_do * exp(b_g) * scale).to(b_do.dtype)
         # [BK, BV]
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, mask=m_kv, other=0.0)
         # [BV]
         b_dg = tl.sum(tl.trans(b_h) * b_dh, 0) * exp(b_gn)
 
@@ -626,23 +647,23 @@ def chunk_gsa_bwd_k_kernel_dqkvg(
         b_dg += tl.sum(b_dv * b_v, 0)
 
         if i_k == 0:
-            b_dgv = tl.load(p_dg, boundary_check=(0, 1)) + b_dg[None, :]
+            b_dgv = tl.load(p_dg, mask=m_tv, other=0.0) + b_dg[None, :]
         else:
             b_dgv = tl.zeros([BT, BV], dtype=tl.float32) + b_dg[None, :]
 
-        tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    p_dA = tl.make_block_ptr(dA + (bos*HQ + i_hq) * BT, (T, BT), (HQ*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_dq = tl.make_block_ptr(dq + (bos*HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (bos*HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), mask=m_tv)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
+    p_dA = dA + (bos*HQ + i_hq) * BT + o_tt[:, None] * (HQ*BT) + o_A[None, :]
+    p_dq = dq + (bos*HQ + i_hq) * K + o_tt[:, None] * (HQ*K) + o_k[None, :]
+    p_dk = dk + (bos*HQ + i_hq) * K + o_tt[:, None] * (HQ*K) + o_k[None, :]
     # [BT, BT]
-    b_dA = tl.load(p_dA, boundary_check=(0, 1))
+    b_dA = tl.load(p_dA, mask=m_AT, other=0.0)
     # [BT, BK]
     b_dq += tl.dot(b_dA, b_k)
     b_dk += tl.dot(tl.trans(b_dA).to(b_k.dtype), b_q)
 
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
 
 
 @triton.heuristics({
@@ -683,12 +704,12 @@ def chunk_oja_bwd_kernel_dvwg_h(
     HAVE_GK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -712,23 +733,28 @@ def chunk_oja_bwd_kernel_dvwg_h(
     b_dw = tl.zeros([BT, BV], dtype=tl.float32)
     b_dgv_last = tl.zeros([BV,], dtype=tl.float32)
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    m_tv = (o_t[:, None] < T) & (o_v[None, :] < V)
     if USE_GV:
-        o_v = i_v * BV + tl.arange(0, BV)
-        m_v = o_v < V
         p_gn = gv + (min(T, i_t * BT + BT) - 1) * H*V + o_v
-        p_gv = tl.make_block_ptr(gv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_gv = gv + o_t[:, None] * (H*V) + o_v[None, :]
         b_gn = tl.load(p_gn, mask=m_v, other=0)
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        b_gv = tl.load(p_gv, mask=m_tv, other=0.0)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_dh = tl.make_block_ptr(dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))  # BT BK
-        b_dk = tl.load(p_dk, boundary_check=(0, 1))  # BT BK
-        b_h = tl.load(p_h, boundary_check=(0, 1))  # BK BV
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))  # BK BV
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = (o_t[:, None] < T) & (o_k[None, :] < K)
+        m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + o_t[:, None] * (H*K) + o_k[None, :]
+        p_h = h + o_k[:, None] * V + o_v[None, :]
+        p_dh = dh + o_k[:, None] * V + o_v[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)  # BT BK
+        b_dk = tl.load(p_dk, mask=m_tk, other=0.0)  # BT BK
+        b_h = tl.load(p_h, mask=m_kv, other=0.0)  # BK BV
+        b_dh = tl.load(p_dh, mask=m_kv, other=0.0)  # BK BV
 
         b_dvg += tl.dot(b_k, b_dh.to(b_k.dtype))  # BT BK @ BK BV -> BT BV
         b_dw += tl.dot(b_dk.to(b_k.dtype), b_h.to(b_k.dtype))  # BT BK @ BK BV -> BT BV
@@ -737,26 +763,26 @@ def chunk_oja_bwd_kernel_dvwg_h(
     if USE_GV:
         b_dv = b_dvg * exp(b_gn[None, :] - b_gv)
 
-    p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dw = tl.make_block_ptr(dw, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dgv_last = tl.make_block_ptr(dgv_last, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+    p_dv = dv + o_t[:, None] * (H*V) + o_v[None, :]
+    p_dw = dw + o_t[:, None] * (H*V) + o_v[None, :]
+    p_dgv_last = dgv_last + o_t[:, None] * (H*V) + o_v[None, :]
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
 
     b_dgv_last += tl.sum(b_dv * b_v, axis=0)
 
     # 留给GSA2的接口
     if HAVE_GK:
         dgk += (bos * H + i_h) * V
-        p_dgk = tl.make_block_ptr(dgk, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_dgk = tl.load(p_dgk, boundary_check=(0, 1))
+        p_dgk = dgk + o_t[:, None] * (H*V) + o_v[None, :]
+        b_dgk = tl.load(p_dgk, mask=m_tv, other=0.0)
         b_dgv_last = b_dgk + b_dgv_last[None, :]
     else:
         b_dgv_last = tl.zeros([BT, BV], dtype=tl.float32) + b_dgv_last[None, :]
 
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dw, -b_dw.to(p_dw.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dgv_last, b_dgv_last.to(p_dgv_last.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
+    tl.store(p_dw, -b_dw.to(p_dw.dtype.element_ty), mask=m_tv)
+    tl.store(p_dgv_last, b_dgv_last.to(p_dgv_last.dtype.element_ty), mask=m_tv)
 
 
 def chunk_oja_bwd_dvwg_h(

--- a/fla/ops/gated_oja_rule/chunk_kkt.py
+++ b/fla/ops/gated_oja_rule/chunk_kkt.py
@@ -42,10 +42,10 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -53,26 +53,30 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
 
-    p_b = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    p_b = beta + bos*H + i_h + o_t * H
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
         b_A += tl.dot(b_k, tl.trans(b_k))
 
     if USE_G:
-        p_g = tl.make_block_ptr(g + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        p_g = g + bos*H + i_h + o_t * H
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_g_diff = b_g[:, None] - b_g[None, :]
         b_A *= exp(b_g_diff)
     b_A *= b_b[:, None]
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (BT*H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (BT*H) + o_A[None, :]
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_AT)
 
 
 @triton.heuristics({
@@ -104,11 +108,11 @@ def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_c, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_i, i_j = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -123,32 +127,38 @@ def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
     g += (bos * H + i_h) * K
     A += (bos * H + i_h) * BT
 
-    p_b = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_t * BT + i_i * BC,), (BC,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_r = o_r < T
+    p_b = beta + bos * H + i_h + o_r * H
+    b_b = tl.load(p_b, mask=m_r, other=0.0)
 
     b_A = tl.zeros([BC, BC], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        b_kt = tl.make_block_ptr(k, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
-        p_gk = tl.make_block_ptr(g, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
-
+        o_kj = i_t * BT + i_j * BC + tl.arange(0, BC)
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
+        m_rk = m_r[:, None] & m_k[None, :]
+        m_kj = m_k[:, None] & (o_kj[None, :] < T)
+        p_k = k + o_r[:, None] * (H*K) + o_k[None, :]
+        p_g = g + o_r[:, None] * (H*K) + o_k[None, :]
+        b_kt = k + o_k[:, None] + o_kj[None, :] * (H*K)
+        p_gk = g + o_k[:, None] + o_kj[None, :] * (H*K)
+
         # [BK,]
         b_gn = tl.load(g + (i_t * BT + i_i * BC) * H*K + o_k, mask=m_k, other=0)
         # [BC, BK]
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1)) * exp(b_g - b_gn[None, :])
+        b_g = tl.load(p_g, mask=m_rk, other=0.0)
+        b_k = tl.load(p_k, mask=m_rk, other=0.0) * exp(b_g - b_gn[None, :])
         # [BK, BC]
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        b_kt = tl.load(b_kt, boundary_check=(0, 1)) * exp(b_gn[:, None] - b_gk)
+        b_gk = tl.load(p_gk, mask=m_kj, other=0.0)
+        b_kt = tl.load(b_kt, mask=m_kj, other=0.0) * exp(b_gn[:, None] - b_gk)
         # [BC, BC]
         b_A += tl.dot(b_k, b_kt)
     b_A *= b_b[:, None]
 
-    p_A = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
-    tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
+    o_Aj = i_j * BC + tl.arange(0, BC)
+    p_A = A + o_r[:, None] * (H*BT) + o_Aj[None, :]
+    tl.store(p_A, b_A.to(A.dtype.element_ty), mask=m_r[:, None] & (o_Aj[None, :] < BT))
 
 
 @triton.heuristics({
@@ -179,10 +189,10 @@ def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_intra(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -197,12 +207,14 @@ def chunk_scaled_dot_kkt_fwd_kernel_intra_sub_intra(
     m_A = (i_t * BT + i_i * BC + o_i) < T
     o_A = (bos + i_t * BT + i_i * BC + o_i) * H*BT + i_h * BT + i_i * BC
 
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
+    o_r = i_t * BT + i_i * BC + o_i
+    m_rk = m_A[:, None] & m_k[None, :]
+    p_k = k + (bos * H + i_h) * K + o_r[:, None] * (H*K) + o_k[None, :]
+    p_g = g + (bos * H + i_h) * K + o_r[:, None] * (H*K) + o_k[None, :]
     p_b = beta + (bos + i_t * BT + i_i * BC + o_i) * H + i_h
 
-    b_k = tl.load(p_k, boundary_check=(0, 1)) * tl.load(p_b, mask=m_A, other=0)[:, None]
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_k = tl.load(p_k, mask=m_rk, other=0.0) * tl.load(p_b, mask=m_A, other=0)[:, None]
+    b_g = tl.load(p_g, mask=m_rk, other=0.0)
 
     p_kt = k + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gk = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
@@ -248,13 +260,13 @@ def chunk_scaled_dot_kkt_bwd_kernel_gk(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_t, i_i = i_c // NC, i_c % NC
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -274,27 +286,33 @@ def chunk_scaled_dot_kkt_bwd_kernel_gk(
     dg += (bos * H + i_h) * K
     db += (i_k * all + bos) * H + i_h
 
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_b = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT + i_i * BC,), (BC,), (0,))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_r = o_r < T
+    m_rk = m_r[:, None] & m_k[None, :]
+    p_g = g + o_r[:, None] * (H*K) + o_k[None, :]
+    p_b = beta + o_r * H
     # [BC, BK]
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_g = tl.load(p_g, mask=m_rk, other=0.0)
     b_dk = tl.zeros([BC, BK], dtype=tl.float32)
     # [BC]
-    b_b = tl.load(p_b, boundary_check=(0,))
+    b_b = tl.load(p_b, mask=m_r, other=0.0)
     if i_i > 0:
         p_gn = g + (i_t * BT + i_i * BC) * H*K + o_k
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(0, i_i):
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
+            o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+            m_jk = (o_j[:, None] < T) & m_k[None, :]
+            o_dAj = i_j * BC + tl.arange(0, BC)
+            p_k = k + o_j[:, None] * (H*K) + o_k[None, :]
+            p_gk = g + o_j[:, None] * (H*K) + o_k[None, :]
+            p_dA = dA + o_r[:, None] * (H*BT) + o_dAj[None, :]
             # [BC, BK]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=m_jk, other=0.0)
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0)
             b_kg = b_k * exp(b_gn[None, :] - b_gk)
             # [BC, BC]
-            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            b_dA = tl.load(p_dA, mask=m_r[:, None] & (o_dAj[None, :] < BT), other=0.0)
             # [BC, BK]
             b_dkb = tl.dot(b_dA, b_kg) * exp(b_g - b_gn[None, :])
             b_dk += b_dkb
@@ -305,8 +323,8 @@ def chunk_scaled_dot_kkt_bwd_kernel_gk(
     p_kj = k + (i_t * BT + i_i * BC) * H*K + o_k
     p_gkj = g + (i_t * BT + i_i * BC) * H*K + o_k
 
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    p_k = k + o_r[:, None] * (H*K) + o_k[None, :]
+    b_k = tl.load(p_k, mask=m_rk, other=0.0)
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         # [BC]
         b_dA = tl.load(dA + o_dA + j, mask=m_dA, other=0)
@@ -323,8 +341,8 @@ def chunk_scaled_dot_kkt_bwd_kernel_gk(
         p_gkj += H*K
     b_db = tl.sum(b_dk * b_k, 1)
     b_dk *= b_b[:, None]
-    p_db = tl.make_block_ptr(db, (T,), (H,), (i_t * BT + i_i * BC,), (BC,), (0,))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    p_db = db + o_r * H
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_r)
 
     tl.debug_barrier()
     # [BC, BK]
@@ -336,21 +354,23 @@ def chunk_scaled_dot_kkt_bwd_kernel_gk(
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(i_i + 1, NC):
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k*BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA, (BT, T), (1, H*BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-            p_b = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT + i_j * BC,), (BC,), (0,))
-
-            o_j = i_t * BT + i_j * BC + o_i
+            o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
             m_j = o_j < T
+            m_jk = m_j[:, None] & m_k[None, :]
+            o_dAi = i_i * BC + tl.arange(0, BC)
+            p_k = k + o_j[:, None] * (H*K) + o_k[None, :]
+            p_gk = g + o_j[:, None] * (H*K) + o_k[None, :]
+            p_dA = dA + o_dAi[:, None] + o_j[None, :] * (H*BT)
+            p_b = beta + o_j * H
+
             # [BC]
-            b_b = tl.load(p_b, boundary_check=(0,))
+            b_b = tl.load(p_b, mask=m_j, other=0.0)
             # [BC, BK]
-            b_kb = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32) * b_b[:, None]
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_kb = tl.load(p_k, mask=m_jk, other=0.0).to(tl.float32) * b_b[:, None]
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0)
             b_kbg = b_kb * tl.where(m_j[:, None], exp(b_gk - b_gn[None, :]), 0)
             # [BC, BC]
-            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            b_dA = tl.load(p_dA, mask=(o_dAi[:, None] < BT) & m_j[None, :], other=0.0)
             # [BC, BK]
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dkt += tl.dot(b_dA, b_kbg)
@@ -377,10 +397,10 @@ def chunk_scaled_dot_kkt_bwd_kernel_gk(
     b_dg = (b_dk - b_dkt) * b_k
     b_dk += b_dkt
 
-    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    p_dk = dk + o_r[:, None] * (H*K) + o_k[None, :]
+    p_dg = dg + o_r[:, None] * (H*K) + o_k[None, :]
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_rk)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_rk)
 
 
 def chunk_scaled_dot_kkt_fwd(

--- a/fla/ops/gated_oja_rule/chunk_o.py
+++ b/fla/ops/gated_oja_rule/chunk_o.py
@@ -52,12 +52,12 @@ def chunk_oja_fwd_inter(
     NG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -69,36 +69,46 @@ def chunk_oja_fwd_inter(
     o_i = tl.arange(0, BT)
     m_s = o_i[:, None] >= o_i[None, :]
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_kt = (o_k[:, None] < K) & m_t[None, :]
+        m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_q = q + (bos * HQ + i_hq) * K + o_t[:, None] * (HQ*K) + o_k[None, :]
+        p_k = k + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_h = h + (i_tg * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
 
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_tk, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kt, other=0.0)
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_kv, other=0.0)
         # [BT, BV]
         b_o += tl.dot(b_q, b_h)
         # [BT, BT]
         b_A += tl.dot(b_q, b_k)
-    p_g = tl.make_block_ptr(gv + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_A = tl.make_block_ptr(A + (bos * HQ + i_hq) * BT, (T, BT), (HQ*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_g = gv + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+    p_o = o + (bos * HQ + i_hq) * V + o_t[:, None] * (HQ*V) + o_v[None, :]
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + (bos * HQ + i_hq) * BT + o_t[:, None] * (HQ*BT) + o_A[None, :]
     # [BT, BV]
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_g = tl.load(p_g, mask=m_tv, other=0.0)
     b_o = b_o * exp(b_g)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tv)
 
     # [BT, BT]
     b_A = tl.where(m_s, b_A, 0.)
     if i_v == 0:
-        tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_AT)
 
 
 @triton.heuristics({
@@ -123,12 +133,12 @@ def chunk_oja_fwd_intra(
     NG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
     i_t, i_i = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -140,45 +150,51 @@ def chunk_oja_fwd_intra(
     if i_t * BT + i_i * BC >= T:
         return
 
-    p_g = tl.make_block_ptr(gv + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_rv = (o_r[:, None] < T) & (o_v[None, :] < V)
+    p_g = gv + (bos * H + i_h) * V + o_r[:, None] * (H*V) + o_v[None, :]
     p_gn = gv + (bos + min(i_t * BT + i_i * BC, T)) * H*V + i_h * V + o_v
     # [BV,]
     b_gn = tl.load(p_gn, mask=m_v, other=0)
     # [BC, BV]
     b_o = tl.zeros([BC, BV], dtype=tl.float32)
     for i_j in range(0, i_i):
-        p_A = tl.make_block_ptr(A + (bos*HQ+i_hq) * BT, (T, BT), (HQ*BT, 1), (i_t*BT+i_i*BC, i_j * BC), (BC, BC), (1, 0))
-        p_v = tl.make_block_ptr(v + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
-        p_gv = tl.make_block_ptr(gv + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_Aj = i_j * BC + tl.arange(0, BC)
+        m_jv = (o_j[:, None] < T) & (o_v[None, :] < V)
+        m_A = (o_r[:, None] < T) & (o_Aj[None, :] < BT)
+        p_A = A + (bos*HQ+i_hq) * BT + o_r[:, None] * (HQ*BT) + o_Aj[None, :]
+        p_v = v + (bos*H+i_h) * V + o_j[:, None] * (H*V) + o_v[None, :]
+        p_gv = gv + (bos*H+i_h) * V + o_j[:, None] * (H*V) + o_v[None, :]
         # [BC, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_jv, other=0.0)
+        b_gv = tl.load(p_gv, mask=m_jv, other=0.0)
         b_vg = (b_v * exp(b_gn[None, :] - b_gv)).to(b_v.dtype)
         # [BC, BC]
-        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_A = tl.load(p_A, mask=m_A, other=0.0)
         b_o += tl.dot(b_A, b_vg)
     # [BC, BV]
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_g = tl.load(p_g, mask=m_rv, other=0.0)
     b_o *= exp(b_g - b_gn[None, :])
 
     o_i = tl.arange(0, BC)
     o_A = (bos + i_t * BT + i_i * BC + tl.arange(0, BC)) * HQ*BT + i_hq * BT + i_i * BC
     m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
-        p_v = v + (bos + i_t * BT + i_i * BC + j) * H*V + i_h * V + o_v
-        p_gv = gv + (bos + i_t * BT + i_i * BC + j) * H*V + i_h * V + o_v
+        p_vj = v + (bos + i_t * BT + i_i * BC + j) * H*V + i_h * V + o_v
+        p_gvj = gv + (bos + i_t * BT + i_i * BC + j) * H*V + i_h * V + o_v
         # [BC,]
         b_A = tl.load(A + o_A + j, mask=m_A, other=0)
         # [BV,]
-        b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
-        b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+        b_v = tl.load(p_vj, mask=m_v, other=0).to(tl.float32)
+        b_gv = tl.load(p_gvj, mask=m_v, other=0).to(tl.float32)
         # [BC, BV]
         b_vg = b_v[None, :] * exp(b_g - b_gv[None, :])
         # avoid 0 * inf = inf
         b_o += tl.where(o_i[:, None] >= j, b_A[:, None] * b_vg, 0.)
-    p_o = tl.make_block_ptr(o + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-    b_o += tl.load(p_o, boundary_check=(0, 1))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o = o + (bos*HQ + i_hq) * V + o_r[:, None] * (HQ*V) + o_v[None, :]
+    b_o += tl.load(p_o, mask=m_rv, other=0.0)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_rv)
 
 
 def chunk_oja_fwd_o(
@@ -278,11 +294,11 @@ def chunk_oja_bwd_kernel_dA(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_t, i_i, i_j = i_c // (NC * NC), (i_c % (NC * NC)) // NC, (i_c % (NC * NC)) % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -299,31 +315,37 @@ def chunk_oja_bwd_kernel_dA(
     # [BC, BC]
     b_dA = tl.zeros([BC, BC], dtype=tl.float32)
     if i_i > i_j:
-        p_v = tl.make_block_ptr(v + (bos*H+i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t*BT + i_j*BC), (BV, BC), (0, 1))
-        p_gv = tl.make_block_ptr(gv + (bos*H+i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t*BT + i_j*BC), (BV, BC), (0, 1))
+        o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+        o_kj = i_t * BT + i_j * BC + tl.arange(0, BC)
+        m_rv = (o_r[:, None] < T) & (o_v[None, :] < V)
+        m_vj = (o_v[:, None] < V) & (o_kj[None, :] < T)
+        p_v = v + (bos*H+i_h) * V + o_v[:, None] + o_kj[None, :] * (H*V)
+        p_gv = gv + (bos*H+i_h) * V + o_v[:, None] + o_kj[None, :] * (H*V)
         p_gn = gv + (bos + i_t*BT + i_i*BC) * H*V + i_h * V + o_v
-        p_g = tl.make_block_ptr(gv + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
+        p_g = gv + (bos*H+i_h) * V + o_r[:, None] * (H*V) + o_v[None, :]
+        p_do = do + (bos*H+i_h) * V + o_r[:, None] * (H*V) + o_v[None, :]
         # [BV,]
         b_gn = tl.load(p_gn, mask=m_v, other=0.)
         # [BC, BV]
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_g = tl.load(p_g, mask=m_rv, other=0.0)
+        b_do = tl.load(p_do, mask=m_rv, other=0.0)
         b_do = (b_do * exp(b_g - b_gn[None, :]) * scale).to(b_do.dtype)
         # [BV, BC]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_vj, other=0.0)
+        b_gv = tl.load(p_gv, mask=m_vj, other=0.0)
         b_vg = (b_v * exp(b_gn[:, None] - b_gv)).to(b_v.dtype)
         # [BC, BC]
         b_dA = tl.dot(b_do, b_vg)
     elif i_i == i_j:
-        p_g = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-        p_v = v + (bos + i_t*BT + i_j*BC) * H*V + i_h * V + o_v
-        p_gv = gv + (bos + i_t*BT + i_j*BC) * H*V + i_h * V + o_v
+        o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+        m_rv = (o_r[:, None] < T) & (o_v[None, :] < V)
+        p_g = gv + (bos*H + i_h) * V + o_r[:, None] * (H*V) + o_v[None, :]
+        p_do = do + (bos*H + i_h) * V + o_r[:, None] * (H*V) + o_v[None, :]
+        p_vj = v + (bos + i_t*BT + i_j*BC) * H*V + i_h * V + o_v
+        p_gvj = gv + (bos + i_t*BT + i_j*BC) * H*V + i_h * V + o_v
         # [BC, BV]
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)) * scale
+        b_g = tl.load(p_g, mask=m_rv, other=0.0)
+        b_do = tl.load(p_do, mask=m_rv, other=0.0) * scale
         m_v = o_v < V
 
         o_i = tl.arange(0, BC)
@@ -331,18 +353,20 @@ def chunk_oja_bwd_kernel_dA(
         m_dA = o_i[:, None] >= o_i[None, :]
         for j in range(0, min(BC, T - i_t * BT - i_j * BC)):
             # [BV,]
-            b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
-            b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+            b_v = tl.load(p_vj, mask=m_v, other=0).to(tl.float32)
+            b_gv = tl.load(p_gvj, mask=m_v, other=0).to(tl.float32)
             # [BC,]
             b_dAj = tl.sum(b_do * b_v[None, :] * exp(b_g - b_gv[None, :]), 1)
             b_dA = tl.where((o_i == j)[None, :], b_dAj[:, None], b_dA)
 
-            p_v += H*V
-            p_gv += H*V
+            p_vj += H*V
+            p_gvj += H*V
         b_dA = tl.where(m_dA, b_dA, 0.)
 
-    p_dA = tl.make_block_ptr(dA+((i_v*all+bos)*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t*BT+i_i*BC, i_j*BC), (BC, BC), (1, 0))
-    tl.store(p_dA, b_dA.to(dA.dtype.element_ty), boundary_check=(0, 1))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_Aj = i_j * BC + tl.arange(0, BC)
+    p_dA = dA+((i_v*all+bos)*H+i_h)*BT + o_r[:, None] * (H*BT) + o_Aj[None, :]
+    tl.store(p_dA, b_dA.to(dA.dtype.element_ty), mask=(o_r[:, None] < T) & (o_Aj[None, :] < BT))
 
 
 def chunk_oja_bwd_dA(
@@ -425,11 +449,11 @@ def chunk_oja_bwd_kernel_dqk(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -443,42 +467,51 @@ def chunk_oja_bwd_kernel_dqk(
     o_i = tl.arange(0, BT)
     m_s = o_i[:, None] >= o_i[None, :]
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_t = o_t < T
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
     # [B, T, H, BT]
-    p_q = tl.make_block_ptr(q + (bos*H+i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos*H+i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_A = tl.make_block_ptr(A + ((i_k*all+bos)*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    p_q = q + (bos*H+i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + (bos*H+i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_A = A + ((i_k*all+bos)*H+i_h)*BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
 
     b_A = tl.dot((b_q * scale).to(b_q.dtype), tl.trans(b_k))
     b_A = tl.where(m_s, b_A, 0.)
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_AT)
 
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
 
     # 先计算do对应的dq
     for i_v in range(tl.cdiv(V, BV)):
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_do = tl.make_block_ptr(do + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_gv = tl.make_block_ptr(gv + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_h = h + (i_tg * H + i_h) * K*V + o_v[:, None] + o_k[None, :] * V
+        p_do = do + (bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_gv = gv + (bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
+        b_gv = tl.load(p_gv, mask=m_tv, other=0.0)
         b_do = (b_do * exp(b_gv) * scale).to(b_do.dtype)
         b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
 
     # 接着计算dA对应的dq, dk
-    p_dA = tl.make_block_ptr(dA + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_dq = tl.make_block_ptr(dq + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_dA = dA + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_dq = dq + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dk = dk + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
     # [BT, BT]
-    b_dA = tl.load(p_dA, boundary_check=(0, 1))
+    b_dA = tl.load(p_dA, mask=m_AT, other=0.0)
     # [BT, BK]
     b_dq += tl.dot(b_dA.to(b_q.dtype), b_k)
     b_dk = tl.dot(tl.trans(b_dA).to(b_q.dtype), b_q)
 
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
 
 
 def chunk_oja_bwd_dqk(
@@ -560,11 +593,11 @@ def chunk_oja_bwd_kernel_dv_o(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_t, i_i = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -576,22 +609,28 @@ def chunk_oja_bwd_kernel_dv_o(
     if i_t * BT + i_i * BC >= T:
         return
 
-    p_gv = tl.make_block_ptr(g + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_rv = (o_r[:, None] < T) & (o_v[None, :] < V)
+    p_gv = g + (bos*H+i_h)*V + o_r[:, None] * (H*V) + o_v[None, :]
     p_gn = g + (bos + min(i_t * BT + i_i * BC + BC, T)-1)*H*V + i_h*V + o_v
     # [BV,]
     b_gn = tl.load(p_gn, mask=m_v, other=0)
     # [BC, BV]
-    b_gv = tl.load(p_gv, boundary_check=(0, 1))
+    b_gv = tl.load(p_gv, mask=m_rv, other=0.0)
     b_dvg = tl.zeros([BC, BV], dtype=tl.float32)
     for i_j in range(i_i + 1, NC):
-        p_g = tl.make_block_ptr(g + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
-        p_A = tl.make_block_ptr(A + (bos*H+i_h) * BT, (BT, T), (1, H*BT), (i_i*BC, i_t*BT + i_j*BC), (BC, BC), (0, 1))
-        p_do = tl.make_block_ptr(do + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t*BT + i_j*BC, i_v*BV), (BC, BV), (1, 0))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_Ai = i_i * BC + tl.arange(0, BC)
+        m_jv = (o_j[:, None] < T) & (o_v[None, :] < V)
+        m_A = (o_Ai[:, None] < BT) & (o_j[None, :] < T)
+        p_g = g + (bos*H+i_h) * V + o_j[:, None] * (H*V) + o_v[None, :]
+        p_A = A + (bos*H+i_h) * BT + o_Ai[:, None] + o_j[None, :] * (H*BT)
+        p_do = do + (bos*H+i_h) * V + o_j[:, None] * (H*V) + o_v[None, :]
         # [BC, BV]
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)) * exp(b_g - b_gn[None, :])
+        b_g = tl.load(p_g, mask=m_jv, other=0.0)
+        b_do = tl.load(p_do, mask=m_jv, other=0.0) * exp(b_g - b_gn[None, :])
         # [BC, BC]
-        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_A = tl.load(p_A, mask=m_A, other=0.0)
         # [BC, BV]
         b_dvg += tl.dot(b_A, b_do.to(b_A.dtype))
     b_dv = b_dvg * exp(b_gn[None, :] - b_gv)
@@ -615,20 +654,20 @@ def chunk_oja_bwd_kernel_dv_o(
         p_g += H * V
         p_A += H * BT
         p_do += H * V
-    p_o = tl.make_block_ptr(o + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_do = tl.make_block_ptr(do + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_dv2 = tl.make_block_ptr(dv2 + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_dg = tl.make_block_ptr(dg + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
+    p_o = o + (bos*H+i_h)*V + o_r[:, None] * (H*V) + o_v[None, :]
+    p_v = v + (bos*H+i_h)*V + o_r[:, None] * (H*V) + o_v[None, :]
+    p_do = do + (bos*H+i_h)*V + o_r[:, None] * (H*V) + o_v[None, :]
+    p_dv = dv + (bos*H+i_h)*V + o_r[:, None] * (H*V) + o_v[None, :]
+    p_dv2 = dv2 + (bos*H+i_h)*V + o_r[:, None] * (H*V) + o_v[None, :]
+    p_dg = dg + (bos*H+i_h)*V + o_r[:, None] * (H*V) + o_v[None, :]
 
-    b_o = tl.load(p_o, boundary_check=(0, 1)).to(tl.float32)
-    b_v = tl.load(p_v, boundary_check=(0, 1)).to(tl.float32)
-    b_do = tl.load(p_do, boundary_check=(0, 1)).to(tl.float32)
-    b_dv = b_dv + tl.load(p_dv, boundary_check=(0, 1)).to(tl.float32)
+    b_o = tl.load(p_o, mask=m_rv, other=0.0).to(tl.float32)
+    b_v = tl.load(p_v, mask=m_rv, other=0.0).to(tl.float32)
+    b_do = tl.load(p_do, mask=m_rv, other=0.0).to(tl.float32)
+    b_dv = b_dv + tl.load(p_dv, mask=m_rv, other=0.0).to(tl.float32)
     b_dg = b_o * b_do - b_v * b_dv
-    tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), mask=m_rv)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_rv)
 
 
 def chunk_oja_bwd_dv_o(

--- a/fla/ops/gated_oja_rule/wy_fast.py
+++ b/fla/ops/gated_oja_rule/wy_fast.py
@@ -48,50 +48,57 @@ def recompute_w_u_fwd_kernel(
     STORE_VG: tl.constexpr,
     IS_VARLEN: tl.constexpr
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
-    p_b = tl.make_block_ptr(beta + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_b = beta + bos*H + i_h + o_t * H
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    m_AT = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_w = tl.make_block_ptr(w + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_w = w + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         b_vb = b_v * b_b[:, None]
 
-        p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_gv = tl.load(p_gv, mask=m_tv, other=0.0)
         b_vb *= exp(b_gv)
         if STORE_VG:
             last_idx = min(i_t * BT + BT, T) - 1
 
-            o_v = i_v * BV + tl.arange(0, BV)
             m_v = o_v < V
             b_gn = tl.load(gv + ((bos + last_idx) * H + i_h) * V + o_v, mask=m_v, other=0.)
             b_vg = b_v * exp(b_gn - b_gv)
 
-            p_vg = tl.make_block_ptr(vg + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            tl.store(p_vg, b_vg.to(p_vg.dtype.element_ty), boundary_check=(0, 1))
+            p_vg = vg + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+            tl.store(p_vg, b_vg.to(p_vg.dtype.element_ty), mask=m_tv)
 
         b_w = tl.dot(b_A, b_vb.to(b_v.dtype))
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_tv)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_u = u + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
         b_kb = (b_k * b_b[:, None]).to(b_k.dtype)
         b_u = tl.dot(b_A, b_kb, allow_tf32=False)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), mask=m_tk)
 
 
 @triton.heuristics({
@@ -130,33 +137,39 @@ def prepare_wy_repr_bwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_b = tl.make_block_ptr(beta + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    o_A = tl.arange(0, BT)
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    p_b = beta + (bos*H + i_h) + o_t * H
+    p_db = db + (bos*H + i_h) + o_t * H
+    p_A = A + (bos*H + i_h) * BT + o_A[:, None] + o_t[None, :] * (H*BT)
 
-    b_b = tl.load(p_b, boundary_check=(0,))
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
     b_db = tl.zeros([BT], dtype=tl.float32)
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        p_gv = tl.make_block_ptr(gv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_gv_exp = exp(tl.load(p_gv, boundary_check=(0, 1)))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv = dv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dw = dw + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
+        p_gv = gv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_gv_exp = exp(tl.load(p_gv, mask=m_tv, other=0.0))
         b_vbg = b_v * b_b[:, None] * b_gv_exp
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+        b_dw = tl.load(p_dw, mask=m_tv, other=0.0)
 
         b_dA += tl.dot(b_dw, tl.trans(b_vbg).to(b_dw.dtype))
         b_dvbg = tl.dot(b_A, b_dw)
@@ -164,26 +177,26 @@ def prepare_wy_repr_bwd_kernel(
         b_db += tl.sum(b_dvbg * b_v * b_gv_exp, 1)
         b_dgv = b_dvbg * b_vbg
 
-        p_dgv = tl.make_block_ptr(dgv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        p_dgv = dgv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), mask=m_tv)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_du = du + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
         # [BT, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
         b_kb = (b_k * b_b[:, None]).to(b_k.dtype)  # BT BK
-        b_du = tl.load(p_du, boundary_check=(0, 1))  # BT BK
+        b_du = tl.load(p_du, mask=m_tk, other=0.0)  # BT BK
         b_dA += tl.dot(b_du, tl.trans(b_kb))  # BT BT
         b_dkb = tl.dot(b_A, b_du)  # BT BK
         b_dk = b_dkb * b_b[:, None]
         b_db += tl.sum(b_dkb * b_k, 1)
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA, 0)
     b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
@@ -192,9 +205,10 @@ def prepare_wy_repr_bwd_kernel(
     b_dA = tl.where(m_A, -b_dA, 0)
 
     # if USE_GV:
-    p_dA = tl.make_block_ptr(dA + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    m_AT2 = m_t[:, None] & (o_A[None, :] < BT)
+    p_dA = dA + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_AT2)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_t)
 
 
 def recompute_w_u_fwd(

--- a/fla/ops/gdn2/chunk_bwd.py
+++ b/fla/ops/gdn2/chunk_bwd.py
@@ -97,12 +97,12 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         NT = tl.cdiv(T, BT)
@@ -112,8 +112,11 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
         bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
 
     o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
     m_t = o_t < T
     m_last = (o_t == min(T, i_t * BT + BT) - 1)
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    m_dA = m_t[:, None] & (o_A[None, :] < BT)
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
@@ -135,8 +138,8 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
     dw += (bos * H + i_h) * V
     dA += (bos * H + i_h) * BT
 
-    p_A = tl.make_block_ptr(A, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    p_A = A + o_A[:, None] + o_t[None, :] * (H * BT)
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
@@ -144,12 +147,13 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_b = tl.make_block_ptr(b, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-        b_b = tl.load(p_b, boundary_check=(0, 1))
+        m_kk = m_t[:, None] & m_k[None, :]
+        p_k = k + o_t[:, None] * (H * K) + o_k[None, :]
+        p_g = g + o_t[:, None] * (H * K) + o_k[None, :]
+        p_b = b + o_t[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
+        b_g = tl.load(p_g, mask=m_kk, other=0.0).to(tl.float32)
+        b_b = tl.load(p_b, mask=m_kk, other=0.0)
 
         p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * H * K + o_k
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
@@ -160,20 +164,23 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
         b_dgk = tl.zeros([BK], dtype=tl.float32)
 
         for i_v in range(tl.cdiv(V, BV)):
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_do = tl.make_block_ptr(do, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            o_v = i_v * BV + tl.arange(0, BV)
+            m_vv = m_t[:, None] & (o_v[None, :] < V)
+            m_hv = (o_v[:, None] < V) & m_k[None, :]
+            p_v_new = v_new + o_t[:, None] * (H * V) + o_v[None, :]
+            p_do = do + o_t[:, None] * (H * V) + o_v[None, :]
             if STATE_V_FIRST:
-                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_h = h + o_v[:, None] * K + o_k[None, :]
+                p_dh = dh + o_v[:, None] * K + o_k[None, :]
             else:
-                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dv = tl.make_block_ptr(dv, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            b_h = tl.load(p_h, boundary_check=(0, 1))
-            b_dh = tl.load(p_dh, boundary_check=(0, 1))
-            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+                p_h = h + o_v[:, None] + o_k[None, :] * V
+                p_dh = dh + o_v[:, None] + o_k[None, :] * V
+            p_dv = dv + o_t[:, None] * (H * V) + o_v[None, :]
+            b_v_new = tl.load(p_v_new, mask=m_vv, other=0.0)
+            b_do = tl.load(p_do, mask=m_vv, other=0.0)
+            b_h = tl.load(p_h, mask=m_hv, other=0.0)
+            b_dh = tl.load(p_dh, mask=m_hv, other=0.0)
+            b_dv = tl.load(p_dv, mask=m_vv, other=0.0)
 
             b_dgk += tl.sum(b_h * b_dh, axis=0)
             b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
@@ -182,13 +189,13 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
             tl.debug_barrier()
 
             if i_k == 0:
-                p_v = tl.make_block_ptr(v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-                p_dv2 = tl.make_block_ptr(dv2, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-                p_wg = tl.make_block_ptr(w_gate, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-                p_dw_gate = tl.make_block_ptr(dw, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_v = v + o_t[:, None] * (H * V) + o_v[None, :]
+                p_dv2 = dv2 + o_t[:, None] * (H * V) + o_v[None, :]
+                p_wg = w_gate + o_t[:, None] * (H * V) + o_v[None, :]
+                p_dw_gate = dw + o_t[:, None] * (H * V) + o_v[None, :]
 
-                b_v = tl.load(p_v, boundary_check=(0, 1))
-                b_wg = tl.load(p_wg, boundary_check=(0, 1))
+                b_v = tl.load(p_v, mask=m_vv, other=0.0)
+                b_wg = tl.load(p_wg, mask=m_vv, other=0.0)
                 # dA gets (w_gate * v) on the value side - the GDN-2 channel-wise twist.
                 b_dA += tl.dot(b_dv, tl.trans(b_v * b_wg))
 
@@ -196,8 +203,8 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
                 b_dv2 = b_dvb * b_wg
                 b_dw_gate = b_dvb * b_v
 
-                tl.store(p_dv2, b_dv2.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
-                tl.store(p_dw_gate, b_dw_gate.to(p_dw_gate.dtype.element_ty), boundary_check=(0, 1))
+                tl.store(p_dv2, b_dv2.to(p_dv2.dtype.element_ty), mask=m_vv)
+                tl.store(p_dw_gate, b_dw_gate.to(p_dw_gate.dtype.element_ty), mask=m_vv)
 
         b_gk_exp = exp2(b_g)
         b_gb = b_gk_exp * b_b
@@ -212,31 +219,31 @@ def chunk_gdn2_bwd_kernel_wy_dqkg_fused(
         b_dA += tl.dot(b_dw_flow, tl.trans((b_kg * b_b).to(b_A.dtype)))
 
         b_dkgb = tl.dot(b_A, b_dw_flow)
-        p_db = tl.make_block_ptr(db, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_db = db + o_t[:, None] * (H * K) + o_k[None, :]
         b_db_partial = b_dkgb * b_kg
-        tl.store(p_db, b_db_partial.to(p_db.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_db, b_db_partial.to(p_db.dtype.element_ty), mask=m_kk)
 
-        p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + o_t[:, None] * (H * K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_kk, other=0.0)
         b_kdk = b_k * b_dk
         b_dgk += tl.sum(b_kdk, axis=0)
         b_dg = b_q * b_dq - b_kdk + m_last[:, None] * b_dgk + b_kg * b_dkgb * b_b
         b_dk = b_dk + b_dkgb * b_gb
 
-        p_dq = tl.make_block_ptr(dq, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+        p_dq = dq + o_t[:, None] * (H * K) + o_k[None, :]
+        p_dk = dk + o_t[:, None] * (H * K) + o_k[None, :]
+        p_dg = dg + o_t[:, None] * (H * K) + o_k[None, :]
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_kk)
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_kk)
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_kk)
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA, 0)
     b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
     b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
     b_dA = tl.where(m_A, -b_dA, 0)
-    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    p_dA = dA + o_t[:, None] * (H * BT) + o_A[None, :]
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_dA)
 
 
 def chunk_gdn2_bwd_wy_dqkg_fused(

--- a/fla/ops/gdn2/chunk_intra.py
+++ b/fla/ops/gdn2/chunk_intra.py
@@ -69,11 +69,11 @@ def chunk_gdn2_fwd_kernel_intra_sub_chunk(
     IS_VARLEN: tl.constexpr,
     USE_GATHER: tl.constexpr,
 ):
-    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -93,15 +93,17 @@ def chunk_gdn2_fwd_kernel_intra_sub_chunk(
     Aqk = Aqk + (bos * H + i_h) * BT
     Akk = Akk + (bos * H + i_h) * BC
 
-    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_b = tl.make_block_ptr(b, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_kc = m_c[:, None] & (o_k[None, :] < K)
+    p_q = q + o_c[:, None] * (H * K) + o_k[None, :]
+    p_k = k + o_c[:, None] * (H * K) + o_k[None, :]
+    p_g = g + o_c[:, None] * (H * K) + o_k[None, :]
+    p_b = b + o_c[:, None] * (H * K) + o_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
-    b_b = tl.load(p_b, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_kc, other=0.0)
+    b_k = tl.load(p_k, mask=m_kc, other=0.0)
+    b_g = tl.load(p_g, mask=m_kc, other=0.0)
+    b_b = tl.load(p_b, mask=m_kc, other=0.0)
 
     if USE_GATHER:
         b_gn = gather(b_g, tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16), axis=0)
@@ -129,10 +131,12 @@ def chunk_gdn2_fwd_kernel_intra_sub_chunk(
     b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
     b_Akk = tl.where(m_Akk, b_Akk, 0.0)
 
-    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-    p_Akk = tl.make_block_ptr(Akk, (T, BC), (H * BC, 1), (i_ti, 0), (BC, BC), (1, 0))
-    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    m_Aqk = m_c[:, None] & ((i_i * BC + o_i)[None, :] < BT)
+    m_Akk = m_c[:, None] & (o_i[None, :] < BC)
+    p_Aqk = Aqk + o_c[:, None] * (H * BT) + (i_i * BC + o_i)[None, :]
+    p_Akk = Akk + o_c[:, None] * (H * BC) + o_i[None, :]
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), mask=m_Aqk)
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), mask=m_Akk)
 
     tl.debug_barrier()
 
@@ -143,7 +147,7 @@ def chunk_gdn2_fwd_kernel_intra_sub_chunk(
         b_a += tl.sum(b_a[:, None] * b_Ai, 0)
         b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
     b_Ai += m_I
-    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), mask=m_Akk)
 
 
 @triton.heuristics({
@@ -179,11 +183,11 @@ def chunk_gdn2_fwd_kernel_inter_solve_fused(
     IS_VARLEN: tl.constexpr,
     USE_SAFE_GATE: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -206,6 +210,7 @@ def chunk_gdn2_fwd_kernel_inter_solve_fused(
     Akkd += (bos * H + i_h) * BC
 
     o_i = tl.arange(0, BC)
+    m_tc0 = (i_tc0 + o_i) < T
     m_tc1 = (i_tc1 + o_i) < T
     m_tc2 = (i_tc2 + o_i) < T
     m_tc3 = (i_tc3 + o_i) < T
@@ -229,20 +234,20 @@ def chunk_gdn2_fwd_kernel_inter_solve_fused(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_k0 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-        p_g0 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-        b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
-        b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+        p_k0 = k + (i_tc0 + o_i)[:, None] * (H * K) + o_k[None, :]
+        p_g0 = g + (i_tc0 + o_i)[:, None] * (H * K) + o_k[None, :]
+        b_k0 = tl.load(p_k0, mask=m_tc0[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+        b_g0 = tl.load(p_g0, mask=m_tc0[:, None] & m_k[None, :], other=0.0).to(tl.float32)
 
         if i_tc1 < T:
-            p_q1 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_k1 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_g1 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_b1 = tl.make_block_ptr(b, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
-            b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
-            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
-            b_b1 = tl.load(p_b1, boundary_check=(0, 1)).to(tl.float32)
+            p_q1 = q + (i_tc1 + o_i)[:, None] * (H * K) + o_k[None, :]
+            p_k1 = k + (i_tc1 + o_i)[:, None] * (H * K) + o_k[None, :]
+            p_g1 = g + (i_tc1 + o_i)[:, None] * (H * K) + o_k[None, :]
+            p_b1 = b + (i_tc1 + o_i)[:, None] * (H * K) + o_k[None, :]
+            b_q1 = tl.load(p_q1, mask=m_tc1[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+            b_k1 = tl.load(p_k1, mask=m_tc1[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+            b_g1 = tl.load(p_g1, mask=m_tc1[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+            b_b1 = tl.load(p_b1, mask=m_tc1[:, None] & m_k[None, :], other=0.0).to(tl.float32)
             b_gn1 = tl.load(g + i_tc1 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
             b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
             b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0))
@@ -251,14 +256,14 @@ def chunk_gdn2_fwd_kernel_inter_solve_fused(
             b_Akk10 += tl.dot(b_bk1 * b_gqn, b_kgt)
 
             if i_tc2 < T:
-                p_q2 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                p_k2 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                p_g2 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                p_b2 = tl.make_block_ptr(b, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
-                b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
-                b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
-                b_b2 = tl.load(p_b2, boundary_check=(0, 1)).to(tl.float32)
+                p_q2 = q + (i_tc2 + o_i)[:, None] * (H * K) + o_k[None, :]
+                p_k2 = k + (i_tc2 + o_i)[:, None] * (H * K) + o_k[None, :]
+                p_g2 = g + (i_tc2 + o_i)[:, None] * (H * K) + o_k[None, :]
+                p_b2 = b + (i_tc2 + o_i)[:, None] * (H * K) + o_k[None, :]
+                b_q2 = tl.load(p_q2, mask=m_tc2[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+                b_k2 = tl.load(p_k2, mask=m_tc2[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+                b_g2 = tl.load(p_g2, mask=m_tc2[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+                b_b2 = tl.load(p_b2, mask=m_tc2[:, None] & m_k[None, :], other=0.0).to(tl.float32)
                 b_gn2 = tl.load(g + i_tc2 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
                 b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
                 b_qg2 = b_q2 * b_gqn2
@@ -271,14 +276,14 @@ def chunk_gdn2_fwd_kernel_inter_solve_fused(
                 b_Akk21 += tl.dot(b_bkg2, b_kgt)
 
                 if i_tc3 < T:
-                    p_q3 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    p_k3 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    p_g3 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    p_b3 = tl.make_block_ptr(b, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
-                    b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
-                    b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
-                    b_b3 = tl.load(p_b3, boundary_check=(0, 1)).to(tl.float32)
+                    p_q3 = q + (i_tc3 + o_i)[:, None] * (H * K) + o_k[None, :]
+                    p_k3 = k + (i_tc3 + o_i)[:, None] * (H * K) + o_k[None, :]
+                    p_g3 = g + (i_tc3 + o_i)[:, None] * (H * K) + o_k[None, :]
+                    p_b3 = b + (i_tc3 + o_i)[:, None] * (H * K) + o_k[None, :]
+                    b_q3 = tl.load(p_q3, mask=m_tc3[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+                    b_k3 = tl.load(p_k3, mask=m_tc3[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+                    b_g3 = tl.load(p_g3, mask=m_tc3[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+                    b_b3 = tl.load(p_b3, mask=m_tc3[:, None] & m_k[None, :], other=0.0).to(tl.float32)
                     b_gn3 = tl.load(g + i_tc3 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
                     b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
                     b_qg3 = b_q3 * b_gqn3
@@ -294,29 +299,29 @@ def chunk_gdn2_fwd_kernel_inter_solve_fused(
                     b_Akk32 += tl.dot(b_bkg3, b_kgt)
 
     if i_tc1 < T:
-        p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk10 = Aqk + (i_tc1 + o_i)[:, None] * (H * BT) + o_i[None, :]
+        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), mask=m_tc1[:, None] & (o_i[None, :] < BT))
     if i_tc2 < T:
-        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk20 = Aqk + (i_tc2 + o_i)[:, None] * (H * BT) + o_i[None, :]
+        p_Aqk21 = Aqk + (i_tc2 + o_i)[:, None] * (H * BT) + (BC + o_i)[None, :]
+        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), mask=m_tc2[:, None] & (o_i[None, :] < BT))
+        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), mask=m_tc2[:, None] & ((BC + o_i)[None, :] < BT))
     if i_tc3 < T:
-        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0))
-        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk30 = Aqk + (i_tc3 + o_i)[:, None] * (H * BT) + o_i[None, :]
+        p_Aqk31 = Aqk + (i_tc3 + o_i)[:, None] * (H * BT) + (BC + o_i)[None, :]
+        p_Aqk32 = Aqk + (i_tc3 + o_i)[:, None] * (H * BT) + (2 * BC + o_i)[None, :]
+        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), mask=m_tc3[:, None] & (o_i[None, :] < BT))
+        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), mask=m_tc3[:, None] & ((BC + o_i)[None, :] < BT))
+        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), mask=m_tc3[:, None] & ((2 * BC + o_i)[None, :] < BT))
 
-    p_Akk00 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+    p_Akk00 = Akkd + (i_tc0 + o_i)[:, None] * (H * BC) + o_i[None, :]
+    p_Akk11 = Akkd + (i_tc1 + o_i)[:, None] * (H * BC) + o_i[None, :]
+    p_Akk22 = Akkd + (i_tc2 + o_i)[:, None] * (H * BC) + o_i[None, :]
+    p_Akk33 = Akkd + (i_tc3 + o_i)[:, None] * (H * BC) + o_i[None, :]
+    b_Ai00 = tl.load(p_Akk00, mask=m_tc0[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, mask=m_tc1[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+    b_Ai22 = tl.load(p_Akk22, mask=m_tc2[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
+    b_Ai33 = tl.load(p_Akk33, mask=m_tc3[:, None] & (o_i[None, :] < BC), other=0.0).to(tl.float32)
 
     if not USE_SAFE_GATE:
         m_A = o_i[:, None] > o_i[None, :]
@@ -389,27 +394,27 @@ def chunk_gdn2_fwd_kernel_inter_solve_fused(
         input_precision=SOLVE_TRIL_DOT_PRECISION,
     )
 
-    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
-    p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-    p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0))
-    p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-    p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0))
-    p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0))
+    p_Akk00 = Akk + (i_tc0 + o_i)[:, None] * (H * BT) + o_i[None, :]
+    p_Akk10 = Akk + (i_tc1 + o_i)[:, None] * (H * BT) + o_i[None, :]
+    p_Akk11 = Akk + (i_tc1 + o_i)[:, None] * (H * BT) + (BC + o_i)[None, :]
+    p_Akk20 = Akk + (i_tc2 + o_i)[:, None] * (H * BT) + o_i[None, :]
+    p_Akk21 = Akk + (i_tc2 + o_i)[:, None] * (H * BT) + (BC + o_i)[None, :]
+    p_Akk22 = Akk + (i_tc2 + o_i)[:, None] * (H * BT) + (2 * BC + o_i)[None, :]
+    p_Akk30 = Akk + (i_tc3 + o_i)[:, None] * (H * BT) + o_i[None, :]
+    p_Akk31 = Akk + (i_tc3 + o_i)[:, None] * (H * BT) + (BC + o_i)[None, :]
+    p_Akk32 = Akk + (i_tc3 + o_i)[:, None] * (H * BT) + (2 * BC + o_i)[None, :]
+    p_Akk33 = Akk + (i_tc3 + o_i)[:, None] * (H * BT) + (3 * BC + o_i)[None, :]
 
-    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), mask=m_tc0[:, None] & (o_i[None, :] < BT))
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), mask=m_tc1[:, None] & (o_i[None, :] < BT))
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), mask=m_tc1[:, None] & ((BC + o_i)[None, :] < BT))
+    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), mask=m_tc2[:, None] & (o_i[None, :] < BT))
+    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), mask=m_tc2[:, None] & ((BC + o_i)[None, :] < BT))
+    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), mask=m_tc2[:, None] & ((2 * BC + o_i)[None, :] < BT))
+    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & (o_i[None, :] < BT))
+    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & ((BC + o_i)[None, :] < BT))
+    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & ((2 * BC + o_i)[None, :] < BT))
+    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), mask=m_tc3[:, None] & ((3 * BC + o_i)[None, :] < BT))
 
 
 @triton.heuristics({
@@ -453,13 +458,13 @@ def chunk_gdn2_bwd_kernel_intra(
     SAFE_GATE: tl.constexpr,
     USE_GATHER: tl.constexpr,
 ):
-    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_k, i_i = i_kc // NC, i_kc % NC
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -487,11 +492,15 @@ def chunk_gdn2_bwd_kernel_intra(
     dg2 += (bos * H + i_h) * K
     db += (i_k * all + bos) * H * BK + i_h * BK
 
-    p_g = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    o_i = tl.arange(0, BC)
+    o_c = i_ti + o_i
+    m_c = o_c < T
+    m_kc = m_c[:, None] & m_k[None, :]
+    p_g = g + o_c[:, None] * (H * K) + o_k[None, :]
+    b_g = tl.load(p_g, mask=m_kc, other=0.0).to(tl.float32)
 
-    p_b = tl.make_block_ptr(b, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_b = tl.load(p_b, boundary_check=(0, 1))
+    p_b = b + o_c[:, None] * (H * K) + o_k[None, :]
+    b_b = tl.load(p_b, mask=m_kc, other=0.0)
 
     b_dq2 = tl.zeros([BC, BK], dtype=tl.float32)
     b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
@@ -500,31 +509,34 @@ def chunk_gdn2_bwd_kernel_intra(
         p_gn = g + i_ti * H * K + o_k
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
         for i_j in range(0, i_i):
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
-            p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
-            b_kj = tl.load(p_k, boundary_check=(0, 1))
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            o_j = i_t * BT + i_j * BC + o_i
+            m_j = o_j < T
+            m_jk = m_j[:, None] & m_k[None, :]
+            m_dj = m_c[:, None] & ((i_j * BC + o_i)[None, :] < BT)
+            p_k = k + o_j[:, None] * (H * K) + o_k[None, :]
+            p_gk = g + o_j[:, None] * (H * K) + o_k[None, :]
+            p_dAqk = dAqk + o_c[:, None] * (H * BT) + (i_j * BC + o_i)[None, :]
+            p_dAkk = dAkk + o_c[:, None] * (H * BT) + (i_j * BC + o_i)[None, :]
+            b_kj = tl.load(p_k, mask=m_jk, other=0.0)
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0)
             b_kg = b_kj * exp2(b_gn - b_gk)
-            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
+            b_dAqk = tl.load(p_dAqk, mask=m_dj, other=0.0)
+            b_dAkk = tl.load(p_dAkk, mask=m_dj, other=0.0)
             b_dq2 += tl.dot(b_dAqk, b_kg)
             b_dk2 += tl.dot(b_dAkk, b_kg)
         b_gqn = exp2(b_g - b_gn)
         b_dq2 *= b_gqn
         b_dk2 *= b_gqn
 
-    o_i = tl.arange(0, BC)
     m_dA = (i_ti + o_i) < T
     o_dA = (i_ti + o_i) * H * BT + i_i * BC
     p_kj = k + i_ti * H * K + o_k
     p_gkj = g + i_ti * H * K + o_k
 
-    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    p_q = q + o_c[:, None] * (H * K) + o_k[None, :]
+    p_k = k + o_c[:, None] * (H * K) + o_k[None, :]
+    b_q = tl.load(p_q, mask=m_kc, other=0.0)
+    b_k = tl.load(p_k, mask=m_kc, other=0.0)
 
     if SAFE_GATE:
         if USE_GATHER:
@@ -533,10 +545,11 @@ def chunk_gdn2_bwd_kernel_intra(
             p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H * K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0)[None, :]
 
-        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (H * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (H * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        b_dAqk_diag_qk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_qk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+        m_dd = m_c[:, None] & ((i_i * BC + o_i)[None, :] < BT)
+        p_dAqk = dAqk + o_c[:, None] * (H * BT) + (i_i * BC + o_i)[None, :]
+        p_dAkk = dAkk + o_c[:, None] * (H * BT) + (i_i * BC + o_i)[None, :]
+        b_dAqk_diag_qk = tl.load(p_dAqk, mask=m_dd, other=0.0).to(tl.float32)
+        b_dAkk_diag_qk = tl.load(p_dAkk, mask=m_dd, other=0.0).to(tl.float32)
 
         m_i_diag_qk = (o_i[:, None] >= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
         m_j_diag_qk = (i_ti + o_i[:, None]) < T
@@ -569,14 +582,16 @@ def chunk_gdn2_bwd_kernel_intra(
     b_db_tile = b_dk2 * b_k
     b_dk2 = b_dk2 * b_b
 
-    p_dq = tl.make_block_ptr(dq, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dq2 = tl.make_block_ptr(dq2, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_db = tl.make_block_ptr(db, (T, BK), (H * BK, 1), (i_ti, 0), (BC, BK), (1, 0))
+    o_db = tl.arange(0, BK)
+    m_db = m_c[:, None] & (o_db[None, :] < BK)
+    p_dq = dq + o_c[:, None] * (H * K) + o_k[None, :]
+    p_dq2 = dq2 + o_c[:, None] * (H * K) + o_k[None, :]
+    p_db = db + o_c[:, None] * (H * BK) + o_db[None, :]
 
     b_dg2 = b_q * b_dq2
-    b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
-    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db_tile.to(p_db.dtype.element_ty), boundary_check=(0, 1))
+    b_dq2 = b_dq2 + tl.load(p_dq, mask=m_kc, other=0.0)
+    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), mask=m_kc)
+    tl.store(p_db, b_db_tile.to(p_db.dtype.element_ty), mask=m_db)
 
     tl.debug_barrier()
     b_dkt = tl.zeros([BC, BK], dtype=tl.float32)
@@ -586,21 +601,22 @@ def chunk_gdn2_bwd_kernel_intra(
         p_gn = g + (min(i_ti + BC, T) - 1) * H * K + o_k
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
         for i_j in range(i_i + 1, NC):
-            p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_bj = tl.make_block_ptr(b, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, H * BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-            p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, H * BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-            b_bj = tl.load(p_bj, boundary_check=(0, 1))
-            b_qj = tl.load(p_q, boundary_check=(0, 1))
-            b_kbj = tl.load(p_k, boundary_check=(0, 1)) * b_bj
-            b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
-            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
-
             o_j = i_t * BT + i_j * BC + o_i
             m_j = o_j < T
+            m_jk = m_j[:, None] & m_k[None, :]
+            m_dj = ((i_i * BC + o_i)[:, None] < BT) & m_j[None, :]
+            p_q = q + o_j[:, None] * (H * K) + o_k[None, :]
+            p_k = k + o_j[:, None] * (H * K) + o_k[None, :]
+            p_gk = g + o_j[:, None] * (H * K) + o_k[None, :]
+            p_bj = b + o_j[:, None] * (H * K) + o_k[None, :]
+            p_dAqk = dAqk + (i_i * BC + o_i)[:, None] + o_j[None, :] * (H * BT)
+            p_dAkk = dAkk + (i_i * BC + o_i)[:, None] + o_j[None, :] * (H * BT)
+            b_bj = tl.load(p_bj, mask=m_jk, other=0.0)
+            b_qj = tl.load(p_q, mask=m_jk, other=0.0)
+            b_kbj = tl.load(p_k, mask=m_jk, other=0.0) * b_bj
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0).to(tl.float32)
+            b_dAqk = tl.load(p_dAqk, mask=m_dj, other=0.0)
+            b_dAkk = tl.load(p_dAkk, mask=m_dj, other=0.0)
             b_gkn = exp2(b_gk - b_gn)
             b_qg = b_qj * tl.where(m_j[:, None], b_gkn, 0)
             b_kbg = b_kbj * tl.where(m_j[:, None], b_gkn, 0)
@@ -620,12 +636,13 @@ def chunk_gdn2_bwd_kernel_intra(
         else:
             p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H * K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
-        p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, H * BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, H * BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        b_dAqk_diag_kk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_kk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+        p_q = q + o_c[:, None] * (H * K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_kc, other=0.0)
+        m_dk = ((i_i * BC + o_i)[:, None] < BT) & m_c[None, :]
+        p_dAqk = dAqk + (i_i * BC + o_i)[:, None] + o_c[None, :] * (H * BT)
+        p_dAkk = dAkk + (i_i * BC + o_i)[:, None] + o_c[None, :] * (H * BT)
+        b_dAqk_diag_kk = tl.load(p_dAqk, mask=m_dk, other=0.0).to(tl.float32)
+        b_dAkk_diag_kk = tl.load(p_dAkk, mask=m_dk, other=0.0).to(tl.float32)
 
         m_i_diag_kk = (o_i[:, None] <= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
         m_j_diag_kk = (i_ti + o_i[:, None]) < T
@@ -660,17 +677,17 @@ def chunk_gdn2_bwd_kernel_intra(
             p_gkj += H * K
             p_bj_ptr += H * K
 
-    p_dk = tl.make_block_ptr(dk, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dk2 = tl.make_block_ptr(dk2, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg2 = tl.make_block_ptr(dg2, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk = dk + o_c[:, None] * (H * K) + o_k[None, :]
+    p_dk2 = dk2 + o_c[:, None] * (H * K) + o_k[None, :]
+    p_dg = dg + o_c[:, None] * (H * K) + o_k[None, :]
+    p_dg2 = dg2 + o_c[:, None] * (H * K) + o_k[None, :]
 
-    b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, boundary_check=(0, 1))
-    b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
+    b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, mask=m_kc, other=0.0)
+    b_dk2 += tl.load(p_dk, mask=m_kc, other=0.0)
     b_dk2 += b_dkt
 
-    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), mask=m_kc)
+    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), mask=m_kc)
 
 
 def chunk_gdn2_fwd_intra(

--- a/fla/ops/gdn2/chunk_intra_token_parallel.py
+++ b/fla/ops/gdn2/chunk_intra_token_parallel.py
@@ -57,7 +57,7 @@ def chunk_gdn2_fwd_kernel_intra_token_parallel(
     BH: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_tg, i_hg = tl.program_id(0), tl.program_id(1)
+    i_tg, i_hg = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
     if IS_VARLEN:
         i_n = 0
@@ -98,24 +98,24 @@ def chunk_gdn2_fwd_kernel_intra_token_parallel(
     m_h = (i_hg * BH + o_h) < H
     m_k = o_k < K
 
-    p_q = tl.make_block_ptr(q + i_t * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_t * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_g = tl.make_block_ptr(g + i_t * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_b = tl.make_block_ptr(b + i_t * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_q = q + i_t * H * K + (i_hg * BH + o_h)[:, None] * K + o_k[None, :]
+    p_k = k + i_t * H * K + (i_hg * BH + o_h)[:, None] * K + o_k[None, :]
+    p_g = g + i_t * H * K + (i_hg * BH + o_h)[:, None] * K + o_k[None, :]
+    p_b = b + i_t * H * K + (i_hg * BH + o_h)[:, None] * K + o_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
-    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-    b_b = tl.load(p_b, boundary_check=(0, 1)).to(tl.float32)
+    b_q = tl.load(p_q, mask=m_h[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+    b_k = tl.load(p_k, mask=m_h[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+    b_g = tl.load(p_g, mask=m_h[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+    b_b = tl.load(p_b, mask=m_h[:, None] & m_k[None, :], other=0.0).to(tl.float32)
 
     # Fold channel-wise erase gate into the key tile.
     b_k = b_k * b_b
 
     for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
-        p_kj = tl.make_block_ptr(k + j * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-        p_gj = tl.make_block_ptr(g + j * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-        b_kj = tl.load(p_kj, boundary_check=(0, 1)).to(tl.float32)
-        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+        p_kj = k + j * H * K + (i_hg * BH + o_h)[:, None] * K + o_k[None, :]
+        p_gj = g + j * H * K + (i_hg * BH + o_h)[:, None] * K + o_k[None, :]
+        b_kj = tl.load(p_kj, mask=m_h[:, None] & m_k[None, :], other=0.0).to(tl.float32)
+        b_gj = tl.load(p_gj, mask=m_h[:, None] & m_k[None, :], other=0.0).to(tl.float32)
 
         b_kgj = b_kj * exp2(b_g - b_gj)
         b_kgj = tl.where(m_k[None, :], b_kgj, 0.0)

--- a/fla/ops/gdn2/wy_fast.py
+++ b/fla/ops/gdn2/wy_fast.py
@@ -73,76 +73,54 @@ def recompute_w_u_fwd_gdn2_kernel(
     STORE_KG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_A = tl.make_block_ptr(
-        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1),
-        (i_t * BT, 0), (BT, BT), (1, 0),
-    )
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + (bos * H + i_h) * BT + o_t[:, None] * (H * BT) + o_A[None, :]
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(
-            v + (bos * H + i_h) * V, (T, V), (H * V, 1),
-            (i_t * BT, i_v * BV), (BT, BV), (1, 0),
-        )
-        p_u = tl.make_block_ptr(
-            u + (bos * H + i_h) * V, (T, V), (H * V, 1),
-            (i_t * BT, i_v * BV), (BT, BV), (1, 0),
-        )
-        p_wg = tl.make_block_ptr(
-            w_gate + (bos * H + i_h) * V, (T, V), (H * V, 1),
-            (i_t * BT, i_v * BV), (BT, BV), (1, 0),
-        )
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_wg = tl.load(p_wg, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        p_u = u + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        p_wg = w_gate + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
+        b_wg = tl.load(p_wg, mask=m_v, other=0.0)
         b_vb = (b_v * b_wg).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), mask=m_v)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_w = tl.make_block_ptr(
-            w + (bos * H + i_h) * K, (T, K), (H * K, 1),
-            (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-        )
-        p_k = tl.make_block_ptr(
-            k + (bos * H + i_h) * K, (T, K), (H * K, 1),
-            (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-        )
-        p_b = tl.make_block_ptr(
-            b + (bos * H + i_h) * K, (T, K), (H * K, 1),
-            (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_b = tl.load(p_b, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_kk = m_t[:, None] & (o_k[None, :] < K)
+        p_w = w + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+        p_k = k + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+        p_b = b + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
+        b_b = tl.load(p_b, mask=m_kk, other=0.0)
         b_kb = b_k * b_b
 
-        p_gk = tl.make_block_ptr(
-            gk + (bos * H + i_h) * K, (T, K), (H * K, 1),
-            (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-        )
-        b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+        p_gk = gk + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+        b_gk = tl.load(p_gk, mask=m_kk, other=0.0).to(tl.float32)
         b_kb *= exp2(b_gk)
 
         if STORE_QG:
-            p_q = tl.make_block_ptr(
-                q + (bos * H + i_h) * K, (T, K), (H * K, 1),
-                (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-            )
-            p_qg = tl.make_block_ptr(
-                qg + (bos * H + i_h) * K, (T, K), (H * K, 1),
-                (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-            )
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            p_q = q + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+            p_qg = qg + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+            b_q = tl.load(p_q, mask=m_kk, other=0.0)
             b_qg = b_q * exp2(b_gk)
-            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), mask=m_kk)
 
         if STORE_KG:
             last_idx = min(i_t * BT + BT, T) - 1
@@ -157,14 +135,11 @@ def recompute_w_u_fwd_gdn2_kernel(
                 exp2(b_gn[None, :] - b_gk),
                 0,
             )
-            p_kg = tl.make_block_ptr(
-                kg + (bos * H + i_h) * K, (T, K), (H * K, 1),
-                (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-            )
-            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+            p_kg = kg + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), mask=m_kk)
 
         b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_kk)
 
 
 def recompute_w_u_fwd_gdn2(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_bwd.py
@@ -62,10 +62,10 @@ def chunk_dplr_bwd_kernel_intra(
     IS_VARLEN: tl.constexpr,
     GATHER_SUPPORTED: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -99,37 +99,41 @@ def chunk_dplr_bwd_kernel_intra(
     stride_qk = H*K
     stride_A = H*BT
 
-    p_ge = tl.make_block_ptr(ge, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_gi = tl.make_block_ptr(gi, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
+    o_i = tl.arange(0, BC)
+    o_c = i_t * BT + o_i
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_c = o_c < T
+    m_k = o_k < K
+    m_kc = m_c[:, None] & m_k[None, :]
+    p_ge = ge + o_c[:, None] * stride_qk + o_k[None, :]
+    p_gi = gi + o_c[:, None] * stride_qk + o_k[None, :]
     # [BC, BK]
-    b_ge = tl.load(p_ge, boundary_check=(0, 1))
-    b_gi = tl.load(p_gi, boundary_check=(0, 1))
+    b_ge = tl.load(p_ge, mask=m_kc, other=0.0)
+    b_gi = tl.load(p_gi, mask=m_kc, other=0.0)
     b_dq = tl.zeros([BC, BK], dtype=tl.float32)
     b_da = tl.zeros([BC, BK], dtype=tl.float32)
     b_dk = tl.zeros([BC, BK], dtype=tl.float32)
     b_db = tl.zeros([BC, BK], dtype=tl.float32)
     # intra chunk gradient calculation
-    p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (stride_A, 1), (i_t*BT, 0), (BC, BC), (1, 0))
-    p_dAab = tl.make_block_ptr(dAab, (T, BT), (stride_A, 1), (i_t*BT, 0), (BC, BC), (1, 0))
-    p_dAqb = tl.make_block_ptr(dAqb, (T, BT), (stride_A, 1), (i_t*BT, 0), (BC, BC), (1, 0))
-    p_dAak = tl.make_block_ptr(dAak, (T, BT), (stride_A, 1), (i_t*BT, 0), (BC, BC), (1, 0))
-    o_i = tl.arange(0, BC)
-    p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t*BT, i_k*BK), (BC, BK), (1, 0))
-    p_b = tl.make_block_ptr(b, (T, K), (stride_qk, 1), (i_t*BT, i_k*BK), (BC, BK), (1, 0))
-    p_a = tl.make_block_ptr(a, (T, K), (stride_qk, 1), (i_t*BT, i_k*BK), (BC, BK), (1, 0))
-    p_q = tl.make_block_ptr(q, (T, K), (stride_qk, 1), (i_t*BT, i_k*BK), (BC, BK), (1, 0))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_b = tl.load(p_b, boundary_check=(0, 1))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_a = tl.load(p_a, boundary_check=(0, 1))
-    b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-    b_dAab = tl.load(p_dAab, boundary_check=(0, 1))
-    b_dAqb = tl.load(p_dAqb, boundary_check=(0, 1))
-    b_dAak = tl.load(p_dAak, boundary_check=(0, 1))
+    m_dA = m_c[:, None] & (o_i[None, :] < BT)
+    p_dAqk = dAqk + o_c[:, None] * stride_A + o_i[None, :]
+    p_dAab = dAab + o_c[:, None] * stride_A + o_i[None, :]
+    p_dAqb = dAqb + o_c[:, None] * stride_A + o_i[None, :]
+    p_dAak = dAak + o_c[:, None] * stride_A + o_i[None, :]
+    p_k = k + o_c[:, None] * stride_qk + o_k[None, :]
+    p_b = b + o_c[:, None] * stride_qk + o_k[None, :]
+    p_a = a + o_c[:, None] * stride_qk + o_k[None, :]
+    p_q = q + o_c[:, None] * stride_qk + o_k[None, :]
+    b_k = tl.load(p_k, mask=m_kc, other=0.0)
+    b_b = tl.load(p_b, mask=m_kc, other=0.0)
+    b_q = tl.load(p_q, mask=m_kc, other=0.0)
+    b_a = tl.load(p_a, mask=m_kc, other=0.0)
+    b_dAqk = tl.load(p_dAqk, mask=m_dA, other=0.0)
+    b_dAab = tl.load(p_dAab, mask=m_dA, other=0.0)
+    b_dAqb = tl.load(p_dAqb, mask=m_dA, other=0.0)
+    b_dAak = tl.load(p_dAak, mask=m_dA, other=0.0)
 
     # inter chunk gradient calculation
-    o_k = i_k * BK + tl.arange(0, BK)
-    m_k = o_k < K
     # intra chunk gradient calculation
     for j in range(0, min(BC, T - i_t * BT)):
         # trick to index the block
@@ -192,32 +196,32 @@ def chunk_dplr_bwd_kernel_intra(
         b_db += tl.where(m_e, b_dA_ab_j * b_aj * tmp2, 0.)
 
     # post processing
-    p_dq = tl.make_block_ptr(dq, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_da = tl.make_block_ptr(da, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_db = tl.make_block_ptr(db, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_dgk = tl.make_block_ptr(dgk, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_dgk_offset = tl.make_block_ptr(dgk_offset, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_dqg = tl.make_block_ptr(dqg, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_dkg = tl.make_block_ptr(dkg, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_dag = tl.make_block_ptr(dag, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-    p_dbg = tl.make_block_ptr(dbg, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
+    p_dq = dq + o_c[:, None] * stride_qk + o_k[None, :]
+    p_dk = dk + o_c[:, None] * stride_qk + o_k[None, :]
+    p_da = da + o_c[:, None] * stride_qk + o_k[None, :]
+    p_db = db + o_c[:, None] * stride_qk + o_k[None, :]
+    p_dgk = dgk + o_c[:, None] * stride_qk + o_k[None, :]
+    p_dgk_offset = dgk_offset + o_c[:, None] * stride_qk + o_k[None, :]
+    p_dqg = dqg + o_c[:, None] * stride_qk + o_k[None, :]
+    p_dkg = dkg + o_c[:, None] * stride_qk + o_k[None, :]
+    p_dag = dag + o_c[:, None] * stride_qk + o_k[None, :]
+    p_dbg = dbg + o_c[:, None] * stride_qk + o_k[None, :]
     p_gn = gi + (min(i_t * BT + BT, T) - 1)*stride_qk + o_k
     p_gn = tl.max_contiguous(tl.multiple_of(p_gn, BK), BK)
     b_gn = tl.load(p_gn, mask=m_k, other=0)
-    b_da += tl.load(p_dag, boundary_check=(0, 1)) * exp2(b_ge)
-    b_dq += tl.load(p_dqg, boundary_check=(0, 1)) * exp2(b_gi) * scale
+    b_da += tl.load(p_dag, mask=m_kc, other=0.0) * exp2(b_ge)
+    b_dq += tl.load(p_dqg, mask=m_kc, other=0.0) * exp2(b_gi) * scale
     tmp = exp2(b_gn[None, :] - b_gi)
-    b_dk += tl.load(p_dkg, boundary_check=(0, 1)).to(tl.float32) * tmp
-    b_db += tl.load(p_dbg, boundary_check=(0, 1)).to(tl.float32) * tmp
-    tl.store(p_dq, (b_dq).to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_da, b_da.to(p_da.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0, 1))
+    b_dk += tl.load(p_dkg, mask=m_kc, other=0.0).to(tl.float32) * tmp
+    b_db += tl.load(p_dbg, mask=m_kc, other=0.0).to(tl.float32) * tmp
+    tl.store(p_dq, (b_dq).to(p_dq.dtype.element_ty), mask=m_kc)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_kc)
+    tl.store(p_da, b_da.to(p_da.dtype.element_ty), mask=m_kc)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_kc)
     b_dgk = (b_dq * b_q + b_da * b_a - b_dk * b_k - b_db * b_b).to(tl.float32)
     b_dgk_offset = b_da * b_a
-    tl.store(p_dgk, b_dgk.to(p_dgk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dgk_offset, b_dgk_offset.to(p_dgk_offset.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dgk, b_dgk.to(p_dgk.dtype.element_ty), mask=m_kc)
+    tl.store(p_dgk_offset, b_dgk_offset.to(p_dgk_offset.dtype.element_ty), mask=m_kc)
 
 
 @triton.heuristics({
@@ -266,11 +270,11 @@ def chunk_dplr_bwd_kernel_intra_tensorcore(
     IS_VARLEN: tl.constexpr,
     GATHER_SUPPORTED: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T_len = eos - bos
     else:
@@ -290,19 +294,23 @@ def chunk_dplr_bwd_kernel_intra_tensorcore(
     b_offset = tl.load(p_offset, mask=m_k, other=0.0).to(tl.float32)
 
     # Q, K, A, B, Gates: [BT, BK]
-    p_q = tl.make_block_ptr(q + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_a = tl.make_block_ptr(a + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_b = tl.make_block_ptr(b + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_gi = tl.make_block_ptr(gi + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_ge = tl.make_block_ptr(ge + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = tl.arange(0, BK) + i_k * BK
+    m_t = o_t < T_len
+    m_kk = m_t[:, None] & (o_k[None, :] < K)
+    p_q = q + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_a = a + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_b = b + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_gi = gi + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_ge = ge + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_a = tl.load(p_a, boundary_check=(0, 1))
-    b_b = tl.load(p_b, boundary_check=(0, 1))
-    b_gi_val = tl.load(p_gi, boundary_check=(0, 1)).to(tl.float32)
-    b_ge_val = tl.load(p_ge, boundary_check=(0, 1)).to(tl.float32)
+    b_q = tl.load(p_q, mask=m_kk, other=0.0)
+    b_k = tl.load(p_k, mask=m_kk, other=0.0)
+    b_a = tl.load(p_a, mask=m_kk, other=0.0)
+    b_b = tl.load(p_b, mask=m_kk, other=0.0)
+    b_gi_val = tl.load(p_gi, mask=m_kk, other=0.0).to(tl.float32)
+    b_ge_val = tl.load(p_ge, mask=m_kk, other=0.0).to(tl.float32)
 
     b_gi_shifted = b_gi_val - b_offset[None, :]
     b_ge_shifted = b_ge_val - b_offset[None, :]
@@ -315,15 +323,17 @@ def chunk_dplr_bwd_kernel_intra_tensorcore(
     b_ops = (b_b * inv_exp_gi_shifted).to(tl.float32)
     a_ops = (b_a * exp_ge_shifted).to(tl.float32)
 
-    p_dAqk = tl.make_block_ptr(dAqk + offset_base_attn, (T_len, BT), (H*BT, 1), (i_t*BT, 0), (BT, BT), (1, 0))
-    p_dAqb = tl.make_block_ptr(dAqb + offset_base_attn, (T_len, BT), (H*BT, 1), (i_t*BT, 0), (BT, BT), (1, 0))
-    p_dAak = tl.make_block_ptr(dAak + offset_base_attn, (T_len, BT), (H*BT, 1), (i_t*BT, 0), (BT, BT), (1, 0))
-    p_dAab = tl.make_block_ptr(dAab + offset_base_attn, (T_len, BT), (H*BT, 1), (i_t*BT, 0), (BT, BT), (1, 0))
+    o_A = tl.arange(0, BT)
+    m_dA = m_t[:, None] & (o_A[None, :] < BT)
+    p_dAqk = dAqk + offset_base_attn + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_dAqb = dAqb + offset_base_attn + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_dAak = dAak + offset_base_attn + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_dAab = dAab + offset_base_attn + o_t[:, None] * (H*BT) + o_A[None, :]
 
-    b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-    b_dAqb = tl.load(p_dAqb, boundary_check=(0, 1))
-    b_dAak = tl.load(p_dAak, boundary_check=(0, 1))
-    b_dAab = tl.load(p_dAab, boundary_check=(0, 1))
+    b_dAqk = tl.load(p_dAqk, mask=m_dA, other=0.0)
+    b_dAqb = tl.load(p_dAqb, mask=m_dA, other=0.0)
+    b_dAak = tl.load(p_dAak, mask=m_dA, other=0.0)
+    b_dAab = tl.load(p_dAab, mask=m_dA, other=0.0)
 
     offs_n = tl.arange(0, BT)
     offs_m = tl.arange(0, BT)
@@ -350,15 +360,15 @@ def chunk_dplr_bwd_kernel_intra_tensorcore(
     b_db_intra = tl.dot(b_dAqb_T, q_ops_h) + tl.dot(b_dAab_T, a_ops)
 
     # Inter-chunk gradients loading
-    p_dqg = tl.make_block_ptr(dqg + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_dkg = tl.make_block_ptr(dkg + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_dag = tl.make_block_ptr(dag + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_dbg = tl.make_block_ptr(dbg + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
+    p_dqg = dqg + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dkg = dkg + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dag = dag + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dbg = dbg + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
 
-    b_dqg = tl.load(p_dqg, boundary_check=(0, 1))
-    b_dag = tl.load(p_dag, boundary_check=(0, 1))
-    b_dkg = tl.load(p_dkg, boundary_check=(0, 1))
-    b_dbg = tl.load(p_dbg, boundary_check=(0, 1))
+    b_dqg = tl.load(p_dqg, mask=m_kk, other=0.0)
+    b_dag = tl.load(p_dag, mask=m_kk, other=0.0)
+    b_dkg = tl.load(p_dkg, mask=m_kk, other=0.0)
+    b_dbg = tl.load(p_dbg, mask=m_kk, other=0.0)
 
     last_idx = min((i_t+1) * BT, T_len) - 1
     p_g_last = gi + offset_base_k + last_idx * H * K + tl.arange(0, BK) + i_k * BK
@@ -373,19 +383,19 @@ def chunk_dplr_bwd_kernel_intra_tensorcore(
     b_dgk = (b_dq * b_q + b_da * b_a - b_dk * b_k - b_db * b_b)
     b_dgk_offset = b_da * b_a
 
-    p_dq = tl.make_block_ptr(dq + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_da = tl.make_block_ptr(da + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_db = tl.make_block_ptr(db + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_dgk = tl.make_block_ptr(dgk + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
-    p_dgk_offset = tl.make_block_ptr(dgk_offset + offset_base_k, (T_len, K), (H*K, 1), (i_t*BT, i_k*BK), (BT, BK), (1, 0))
+    p_dq = dq + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dk = dk + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_da = da + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_db = db + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dgk = dgk + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dgk_offset = dgk_offset + offset_base_k + o_t[:, None] * (H*K) + o_k[None, :]
 
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_da, b_da.to(p_da.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dgk, b_dgk.to(p_dgk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dgk_offset, b_dgk_offset.to(p_dgk_offset.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_kk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_kk)
+    tl.store(p_da, b_da.to(p_da.dtype.element_ty), mask=m_kk)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_kk)
+    tl.store(p_dgk, b_dgk.to(p_dgk.dtype.element_ty), mask=m_kk)
+    tl.store(p_dgk_offset, b_dgk_offset.to(p_dgk_offset.dtype.element_ty), mask=m_kk)
 
 
 @triton.heuristics({
@@ -416,11 +426,11 @@ def chunk_dplr_bwd_dgk_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_k, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_k, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -437,17 +447,20 @@ def chunk_dplr_bwd_dgk_kernel(
     p_dgk_last = dgk_last + tl.arange(0, BK) + i_k * BK
     m_k = tl.arange(0, BK) + i_k * BK < K
     b_dgk_last = tl.load(p_dgk_last, mask=m_k, other=0)
-    p_dgk_offset = tl.make_block_ptr(dgk_offset, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dgk = tl.make_block_ptr(dgk, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    b_dgk = tl.load(p_dgk, boundary_check=(0, 1))
-    b_dgk_offset = tl.load(p_dgk_offset, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = tl.arange(0, BK) + i_k * BK
+    m_kk = (o_t < T)[:, None] & (o_k[None, :] < K)
+    p_dgk_offset = dgk_offset + o_t[:, None] * stride_qk + o_k[None, :]
+    p_dgk = dgk + o_t[:, None] * stride_qk + o_k[None, :]
+    b_dgk = tl.load(p_dgk, mask=m_kk, other=0.0)
+    b_dgk_offset = tl.load(p_dgk_offset, mask=m_kk, other=0.0)
     # m_inv_cumsum = (tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :]).to(tl.float32)
     # b_dgk_cumsum = tl.dot(m_inv_cumsum, b_dgk, allow_tf32=False)
     b_dgk_cumsum = tl.cumsum(b_dgk, 0, reverse=True)
     b_dgk_cumsum += b_dgk_last[None, :]
     b_dgk_cumsum -= b_dgk_offset
-    p_dgk_output = tl.make_block_ptr(dgk_output, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    tl.store(p_dgk_output, b_dgk_cumsum.to(p_dgk_output.dtype.element_ty), boundary_check=(0, 1))
+    p_dgk_output = dgk_output + o_t[:, None] * stride_qk + o_k[None, :]
+    tl.store(p_dgk_output, b_dgk_cumsum.to(p_dgk_output.dtype.element_ty), mask=m_kk)
 
 
 def chunk_dplr_bwd_dqk_intra(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
@@ -56,10 +56,10 @@ def chunk_dplr_fwd_A_kernel_intra_sub_intra(
     IS_VARLEN: tl.constexpr,
     GATHER_SUPPORTED: tl.constexpr,
 ):
-    i_t, i_b, i_h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_b, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -69,31 +69,33 @@ def chunk_dplr_fwd_A_kernel_intra_sub_intra(
         return
 
     o_i = tl.arange(0, BC)
+    o_c = i_t * BT + o_i
     o_k = tl.arange(0, BK)
     m_k = o_k < K
+    m_kk = ((i_t * BT + tl.arange(0, BC)) < T)[:, None] & m_k[None, :]
     m_A = (i_t * BT + tl.arange(0, BC)) < T
     last_idx = min((i_t+1) * BT, T) - 1
     o_A = (bos + i_t * BT + tl.arange(0, BC)) * H*BT + i_h * BT
-    p_q = tl.make_block_ptr(q + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_a = tl.make_block_ptr(a + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_b = tl.make_block_ptr(b + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_gi = tl.make_block_ptr(gi + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_ge = tl.make_block_ptr(ge + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
+    p_q = q + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_k = k + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_a = a + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_b = b + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_gi = gi + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_ge = ge + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
     p_g_last = gi + (bos * H + i_h) * K + last_idx * H * K + tl.arange(0, BK)
     b_g_last = tl.load(p_g_last, mask=m_k, other=0)
-    p_qg = tl.make_block_ptr(qg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_kg = tl.make_block_ptr(kg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_ag = tl.make_block_ptr(ag + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
-    p_bg = tl.make_block_ptr(bg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BC, BK), (1, 0))
+    p_qg = qg + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_kg = kg + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_ag = ag + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
+    p_bg = bg + (bos * H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_kk, other=0.0)
     b_q = b_q * scale
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_a = tl.load(p_a, boundary_check=(0, 1))
-    b_b = tl.load(p_b, boundary_check=(0, 1))
-    b_gi = tl.load(p_gi, boundary_check=(0, 1)).to(tl.float32)
-    b_ge = tl.load(p_ge, boundary_check=(0, 1)).to(tl.float32)
+    b_k = tl.load(p_k, mask=m_kk, other=0.0)
+    b_a = tl.load(p_a, mask=m_kk, other=0.0)
+    b_b = tl.load(p_b, mask=m_kk, other=0.0)
+    b_gi = tl.load(p_gi, mask=m_kk, other=0.0).to(tl.float32)
+    b_ge = tl.load(p_ge, mask=m_kk, other=0.0).to(tl.float32)
 
     # deal with decay term.
     g_exp = exp2(b_gi)
@@ -102,10 +104,10 @@ def chunk_dplr_fwd_A_kernel_intra_sub_intra(
     b_kg = b_k * g_exp_inv
     b_bg = b_b * g_exp_inv
     b_ag = b_a * exp2(b_ge)
-    tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-    tl.store(p_bg, b_bg.to(p_bg.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-    tl.store(p_ag, b_ag.to(p_ag.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-    tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_kk)
+    tl.store(p_bg, b_bg.to(p_bg.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_kk)
+    tl.store(p_ag, b_ag.to(p_ag.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_kk)
+    tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_kk)
     # tl.debug_barrier()
 
     b_q = b_q.to(b_k.dtype)
@@ -182,10 +184,10 @@ def chunk_dplr_fwd_A_kernel_intra_tensorcore(
     IS_VARLEN: tl.constexpr,
     GATHER_SUPPORTED: tl.constexpr,
 ):
-    i_t, i_b, i_h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_b, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T_len = eos - bos
     else:
@@ -199,19 +201,23 @@ def chunk_dplr_fwd_A_kernel_intra_tensorcore(
     offset_base = (bos * H + i_h) * K
 
     # Load the current chunk of Q, K, A, B and their gates
-    p_q = tl.make_block_ptr(q + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_a = tl.make_block_ptr(a + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_b = tl.make_block_ptr(b + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_gi = tl.make_block_ptr(gi + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_ge = tl.make_block_ptr(ge + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_b = tl.arange(0, BK)
+    m_t = o_t < T_len
+    m_kb = m_t[:, None] & (o_b[None, :] < K)
+    p_q = q + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_k = k + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_a = a + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_b = b + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_gi = gi + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_ge = ge + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_a = tl.load(p_a, boundary_check=(0, 1))
-    b_b = tl.load(p_b, boundary_check=(0, 1))
-    b_gi_val = tl.load(p_gi, boundary_check=(0, 1)).to(tl.float32)
-    b_ge_val = tl.load(p_ge, boundary_check=(0, 1)).to(tl.float32)
+    b_q = tl.load(p_q, mask=m_kb, other=0.0)
+    b_k = tl.load(p_k, mask=m_kb, other=0.0)
+    b_a = tl.load(p_a, mask=m_kb, other=0.0)
+    b_b = tl.load(p_b, mask=m_kb, other=0.0)
+    b_gi_val = tl.load(p_gi, mask=m_kb, other=0.0).to(tl.float32)
+    b_ge_val = tl.load(p_ge, mask=m_kb, other=0.0).to(tl.float32)
 
     # Calculate the index of the middle element of the valid part of the chunk
     valid_len = min(T_len - i_t * BT, BT)
@@ -254,20 +260,20 @@ def chunk_dplr_fwd_A_kernel_intra_tensorcore(
     exp_g_centered = exp2(b_g_centered)
 
     # Create pointers for writing
-    p_qg = tl.make_block_ptr(qg + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_kg = tl.make_block_ptr(kg + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_ag = tl.make_block_ptr(ag + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_bg = tl.make_block_ptr(bg + offset_base, (T_len, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    p_qg = qg + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_kg = kg + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_ag = ag + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
+    p_bg = bg + offset_base + o_t[:, None] * (H*K) + o_b[None, :]
 
     # Store gated Q and A
-    tl.store(p_qg, (q_ops * exp_offset[None, :]).to(p_qg.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_ag, (a_ops * exp_offset[None, :]).to(p_ag.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_qg, (q_ops * exp_offset[None, :]).to(p_qg.dtype.element_ty), mask=m_kb)
+    tl.store(p_ag, (a_ops * exp_offset[None, :]).to(p_ag.dtype.element_ty), mask=m_kb)
 
     # Store gated K and B
     b_kg_g = k_ops * exp_g_centered[None, :]
     b_bg_g = b_ops * exp_g_centered[None, :]
-    tl.store(p_kg, b_kg_g.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_bg, b_bg_g.to(p_bg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_kg, b_kg_g.to(p_kg.dtype.element_ty), mask=m_kb)
+    tl.store(p_bg, b_bg_g.to(p_bg.dtype.element_ty), mask=m_kb)
 
     # Transpose K and B for dot product
     k_ops_t = tl.trans(k_ops)
@@ -295,15 +301,17 @@ def chunk_dplr_fwd_A_kernel_intra_tensorcore(
     # Store the intra-chunk attention matrices
     offset_out_base = (bos * H + i_h) * BT
 
-    p_Aqk = tl.make_block_ptr(Aqk + offset_out_base, (T_len, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_Aqb = tl.make_block_ptr(Aqb + offset_out_base, (T_len, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_Aak = tl.make_block_ptr(Aak + offset_out_base, (T_len, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_Aab = tl.make_block_ptr(Aab + offset_out_base, (T_len, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_A = tl.arange(0, BT)
+    m_AO = m_t[:, None] & (o_A[None, :] < BT)
+    p_Aqk = Aqk + offset_out_base + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_Aqb = Aqb + offset_out_base + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_Aak = Aak + offset_out_base + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_Aab = Aab + offset_out_base + o_t[:, None] * (H*BT) + o_A[None, :]
 
-    tl.store(p_Aqk, b_A_qk.to(p_Aqk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Aqb, b_A_qb.to(p_Aqb.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Aak, b_A_ak.to(p_Aak.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Aab, b_A_ab.to(p_Aab.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Aqk, b_A_qk.to(p_Aqk.dtype.element_ty), mask=m_AO)
+    tl.store(p_Aqb, b_A_qb.to(p_Aqb.dtype.element_ty), mask=m_AO)
+    tl.store(p_Aak, b_A_ak.to(p_Aak.dtype.element_ty), mask=m_AO)
+    tl.store(p_Aab, b_A_ab.to(p_Aab.dtype.element_ty), mask=m_AO)
 
 
 def chunk_dplr_fwd_intra(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_bwd.py
@@ -68,34 +68,42 @@ def chunk_dplr_bwd_kernel_dhu(
         NT = tl.cdiv(T, BT)
         boh = i_n * NT
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     # [BK, BV]
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_FINAL_STATE_GRADIENT:
-        p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_dh += tl.load(p_dht, boundary_check=(0, 1))
+        p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dht, mask=m_h, other=0.0)
 
     mask_k = tl.arange(0, BK) < K
     for i_t in range(NT - 1, -1, -1):
-        p_dh = tl.make_block_ptr(dh + ((boh+i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+        p_dh = dh + ((boh+i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), mask=m_h)
         b_dh_tmp = tl.zeros([BK, BV], dtype=tl.float32)
         for i_c in range(tl.cdiv(BT, BC) - 1, -1, -1):
-            p_qg = tl.make_block_ptr(qg+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_c * BC), (BK, BC), (0, 1))
-            p_bg = tl.make_block_ptr(bg+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_c * BC, i_k * BK), (BC, BK), (1, 0))
-            p_w = tl.make_block_ptr(w+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_c * BC), (BK, BC), (0, 1))
-            p_dv = tl.make_block_ptr(dv+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_c * BC, i_v * BV), (BC, BV), (1, 0))
-            p_do = tl.make_block_ptr(do+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_c * BC, i_v * BV), (BC, BV), (1, 0))
-            p_dv2 = tl.make_block_ptr(dv2+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_c * BC, i_v * BV), (BC, BV), (1, 0))
+            o_c = i_t * BT + i_c * BC + tl.arange(0, BC)
+            m_c = o_c < T
+            m_kc = (o_k[:, None] < K) & m_c[None, :]
+            m_bgc = m_c[:, None] & (o_k[None, :] < K)
+            m_vc = m_c[:, None] & (o_v[None, :] < V)
+            p_qg = qg+(bos*H+i_h)*K + o_k[:, None] + o_c[None, :] * (H*K)
+            p_bg = bg+(bos*H+i_h)*K + o_c[:, None] * (H*K) + o_k[None, :]
+            p_w = w+(bos*H+i_h)*K + o_k[:, None] + o_c[None, :] * (H*K)
+            p_dv = dv+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
+            p_do = do+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
+            p_dv2 = dv2+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
             # [BK, BT]
-            b_qg = tl.load(p_qg, boundary_check=(0, 1))
+            b_qg = tl.load(p_qg, mask=m_kc, other=0.0)
             # [BT, BK]
-            b_bg = tl.load(p_bg, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_bg = tl.load(p_bg, mask=m_bgc, other=0.0)
+            b_w = tl.load(p_w, mask=m_kc, other=0.0)
             # [BT, V]
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+            b_do = tl.load(p_do, mask=m_vc, other=0.0)
+            b_dv = tl.load(p_dv, mask=m_vc, other=0.0)
             b_dv2 = b_dv + tl.dot(b_bg, b_dh.to(b_bg.dtype))
-            tl.store(p_dv2, b_dv2.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dv2, b_dv2.to(p_dv.dtype.element_ty), mask=m_vc)
             # [BK, BV]
             b_dh_tmp += tl.dot(b_qg, b_do.to(b_qg.dtype))
             b_dh_tmp += tl.dot(b_w, b_dv2.to(b_qg.dtype))
@@ -105,8 +113,8 @@ def chunk_dplr_bwd_kernel_dhu(
         b_dh += b_dh_tmp
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_h)
 
 
 def chunk_dplr_bwd_dhu(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
@@ -68,35 +68,42 @@ def chunk_dplr_fwd_kernel_h(
         NT = tl.cdiv(T, BT)
         boh = i_n * NT
     o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
 
     # [BK, BV]
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h0, mask=m_h, other=0.0).to(tl.float32)
 
     for i_t in range(NT):
-        p_h = tl.make_block_ptr(h + ((boh + i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        p_h = h + ((boh + i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_h)
 
         b_hc = tl.zeros([BK, BV], dtype=tl.float32)
         # since we need to make all DK in the SRAM. we face serve SRAM memory burden. By subchunking we allievate such burden
         for i_c in range(tl.cdiv(min(BT, T - i_t * BT), BC)):
-            p_kg = tl.make_block_ptr(kg+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_c * BC), (BK, BC), (0, 1))
-            p_bg = tl.make_block_ptr(bg+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_c * BC), (BK, BC), (0, 1))
-            p_w = tl.make_block_ptr(w+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_c * BC, i_k * BK), (BC, BK), (1, 0))
-            p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT + i_c * BC, i_v * BV), (BC, BV), (1, 0))
-            p_u = tl.make_block_ptr(u+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT + i_c * BC, i_v * BV), (BC, BV), (1, 0))
-            p_v_new = tl.make_block_ptr(v_new+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT+i_c*BC, i_v * BV), (BC, BV), (1, 0))
+            o_c = i_t * BT + i_c * BC + tl.arange(0, BC)
+            m_c = o_c < T
+            m_kc = (o_k[:, None] < K) & m_c[None, :]
+            m_wc = m_c[:, None] & (o_k[None, :] < K)
+            m_vc = m_c[:, None] & (o_v[None, :] < V)
+            p_kg = kg+(bos*H+i_h)*K + o_k[:, None] + o_c[None, :] * (H*K)
+            p_bg = bg+(bos*H+i_h)*K + o_k[:, None] + o_c[None, :] * (H*K)
+            p_w = w+(bos*H+i_h)*K + o_c[:, None] * (H*K) + o_k[None, :]
+            p_v = v+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
+            p_u = u+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
+            p_v_new = v_new+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
             # [BK, BC]
-            b_kg = tl.load(p_kg, boundary_check=(0, 1))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_bg = tl.load(p_bg, boundary_check=(0, 1))
-            b_v2 = tl.dot(b_w, b_h.to(b_w.dtype)) + tl.load(p_u, boundary_check=(0, 1))
+            b_kg = tl.load(p_kg, mask=m_kc, other=0.0)
+            b_v = tl.load(p_v, mask=m_vc, other=0.0)
+            b_w = tl.load(p_w, mask=m_wc, other=0.0)
+            b_bg = tl.load(p_bg, mask=m_kc, other=0.0)
+            b_v2 = tl.dot(b_w, b_h.to(b_w.dtype)) + tl.load(p_u, mask=m_vc, other=0.0)
             b_hc += tl.dot(b_kg, b_v)
             b_hc += tl.dot(b_bg.to(b_hc.dtype), b_v2)
-            tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), mask=m_vc)
 
         last_idx = min((i_t + 1) * BT, T) - 1
         b_g_last = tl.load(gk + (bos + last_idx) * H*K + i_h * K + o_k, mask=o_k < K).to(tl.float32)
@@ -104,8 +111,8 @@ def chunk_dplr_fwd_kernel_h(
         b_h += b_hc
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_h)
 
 
 def chunk_dplr_fwd_h(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
@@ -49,10 +49,10 @@ def chunk_dplr_bwd_kernel_dAu(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -61,33 +61,40 @@ def chunk_dplr_bwd_kernel_dAu(
     b_dA_qk = tl.zeros([BT, BT], dtype=tl.float32)
     b_dA_qb = tl.zeros([BT, BT], dtype=tl.float32)
 
-    p_A_qb = tl.make_block_ptr(A_qb + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_A_qb = A_qb + (bos * H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
 
-    b_A_qb = tl.load(p_A_qb, boundary_check=(0, 1))
+    b_A_qb = tl.load(p_A_qb, mask=m_A, other=0.0)
     # causal mask
     b_A_qb = tl.where(tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :], b_A_qb, 0.).to(b_A_qb.dtype)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_do = tl.make_block_ptr(do + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_v_new = tl.make_block_ptr(v_new + (bos*H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_dv_new = tl.make_block_ptr(dv_new + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
-        b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        m_vt = (o_v[:, None] < V) & m_t[None, :]
+        p_do = do + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v = v + (bos*H + i_h) * V + o_v[:, None] + o_t[None, :] * (H*V)
+        p_v_new = v_new + (bos*H + i_h) * V + o_v[:, None] + o_t[None, :] * (H*V)
+        p_dv_new = dv_new + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_vt, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0)
+        b_v_new = tl.load(p_v_new, mask=m_vt, other=0.0)
         b_dA_qk += tl.dot(b_do, b_v)
         b_dA_qb += tl.dot(b_do, b_v_new)
         b_dv_new = tl.dot(tl.trans(b_A_qb), b_do)
         # for recurrent
-        tl.store(p_dv_new, b_dv_new.to(p_dv_new.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv_new, b_dv_new.to(p_dv_new.dtype.element_ty), mask=m_v)
 
-    p_dA_qk = tl.make_block_ptr(dA_qk + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_dA_qb = tl.make_block_ptr(dA_qb + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_dA_qk = dA_qk + (bos * H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_dA_qb = dA_qb + (bos * H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
     m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
     b_dA_qk = tl.where(m_s, b_dA_qk * scale, 0.)
-    tl.store(p_dA_qk, b_dA_qk.to(p_dA_qk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dA_qk, b_dA_qk.to(p_dA_qk.dtype.element_ty), mask=m_A)
     b_dA_qb = tl.where(m_s, b_dA_qb * scale, 0.)
-    tl.store(p_dA_qb, b_dA_qb.to(p_dA_qb.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dA_qb, b_dA_qb.to(p_dA_qb.dtype.element_ty), mask=m_A)
 
 
 @triton.heuristics({
@@ -130,12 +137,12 @@ def chunk_dplr_bwd_o_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -165,6 +172,9 @@ def chunk_dplr_bwd_o_kernel(
     stride_qk = H*K
     stride_vo = H*V
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_t = o_t < T
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     b_dw = tl.zeros([BT, BK], dtype=tl.float32)
@@ -172,18 +182,21 @@ def chunk_dplr_bwd_o_kernel(
     b_dgk_last = tl.zeros([BK], dtype=tl.float32)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v_new = tl.make_block_ptr(v_new, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        m_hv = (o_v[:, None] < V) & (o_k[None, :] < K)
+        p_v = v + o_t[:, None] * stride_vo + o_v[None, :]
+        p_v_new = v_new + o_t[:, None] * stride_vo + o_v[None, :]
+        p_do = do + o_t[:, None] * stride_vo + o_v[None, :]
+        p_h = h + o_v[:, None] + o_k[None, :] * V
+        p_dh = dh + o_v[:, None] + o_k[None, :] * V
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
+        b_v_new = tl.load(p_v_new, mask=m_v, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_hv, other=0.0)
+        b_dh = tl.load(p_dh, mask=m_hv, other=0.0)
         b_dgk_last += tl.sum((b_h * b_dh).to(tl.float32), axis=0)
 
         # [BT, BV] @ [BV, BK] -> [BT, BK]
@@ -191,30 +204,31 @@ def chunk_dplr_bwd_o_kernel(
         # [BT, BV] @ [BV, BK] -> [BT, BK]
         b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
         b_db += tl.dot(b_v_new, b_dh.to(b_v_new.dtype))
-        p_dv = tl.make_block_ptr(dv, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_dv = tl.load(p_dv, boundary_check=(0, 1))
+        p_dv = dv + o_t[:, None] * stride_vo + o_v[None, :]
+        b_dv = tl.load(p_dv, mask=m_v, other=0.0)
         b_dw += tl.dot(b_dv.to(b_v.dtype), b_h.to(b_v.dtype))
 
     m_k = (i_k*BK+tl.arange(0, BK)) < K
     last_idx = min(i_t * BT + BT, T) - 1
     b_gk_last = tl.load(gk + last_idx * stride_qk + i_k*BK + tl.arange(0, BK), mask=m_k, other=float('-inf'))
     b_dgk_last *= exp2(b_gk_last)
-    p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_b = tl.make_block_ptr(b, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_b = tl.load(p_b, boundary_check=(0, 1))
+    m_kk = m_t[:, None] & m_k[None, :]
+    p_k = k + o_t[:, None] * stride_qk + o_k[None, :]
+    p_b = b + o_t[:, None] * stride_qk + o_k[None, :]
+    b_k = tl.load(p_k, mask=m_kk, other=0.0)
+    b_b = tl.load(p_b, mask=m_kk, other=0.0)
     b_dgk_last += tl.sum(b_k * b_dk, axis=0)
     b_dgk_last += tl.sum(b_b * b_db, axis=0)
     tl.store(dgk_last + tl.arange(0, BK) + i_k * BK, b_dgk_last, mask=m_k)
 
-    p_dw = tl.make_block_ptr(dw, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_db = tl.make_block_ptr(db, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    tl.store(p_dw, b_dw.to(p_dw.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    p_dw = dw + o_t[:, None] * stride_qk + o_k[None, :]
+    p_dk = dk + o_t[:, None] * stride_qk + o_k[None, :]
+    p_db = db + o_t[:, None] * stride_qk + o_k[None, :]
+    p_dq = dq + o_t[:, None] * stride_qk + o_k[None, :]
+    tl.store(p_dw, b_dw.to(p_dw.dtype.element_ty), mask=m_kk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_kk)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_kk)
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_kk)
 
 
 @triton.heuristics({
@@ -249,11 +263,11 @@ def chunk_dplr_bwd_kernel_dv(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -275,20 +289,29 @@ def chunk_dplr_bwd_kernel_dv(
     stride_vo = H*V
     stride_A = H*BT
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
     for i_k in range(tl.cdiv(K, BK)):
-        p_dh = tl.make_block_ptr(dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_kg = tl.make_block_ptr(kg, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
-        b_kg = tl.load(p_kg, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_dh = (o_k[:, None] < K) & (o_v[None, :] < V)
+        m_kg = m_t[:, None] & (o_k[None, :] < K)
+        p_dh = dh + o_k[:, None] * V + o_v[None, :]
+        p_kg = kg + o_t[:, None] * stride_qk + o_k[None, :]
+        b_dh = tl.load(p_dh, mask=m_dh, other=0.0)
+        b_kg = tl.load(p_kg, mask=m_kg, other=0.0)
         b_dv += tl.dot(b_kg, b_dh.to(b_kg.dtype))
 
-    p_Aqk = tl.make_block_ptr(A_qk, (BT, T), (1, stride_A), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], tl.load(p_Aqk, boundary_check=(0, 1)), 0)
-    p_do = tl.make_block_ptr(do, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dv = tl.make_block_ptr(dv, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    m_A = (o_A[:, None] < BT) & m_t[None, :]
+    m_v = m_t[:, None] & (o_v[None, :] < V)
+    p_Aqk = A_qk + o_A[:, None] + o_t[None, :] * stride_A
+    b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], tl.load(p_Aqk, mask=m_A, other=0.0), 0)
+    p_do = do + o_t[:, None] * stride_vo + o_v[None, :]
+    p_dv = dv + o_t[:, None] * stride_vo + o_v[None, :]
+    b_do = tl.load(p_do, mask=m_v, other=0.0)
     b_dv += tl.dot(b_A.to(b_do.dtype), b_do)
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
 
 def chunk_dplr_bwd_dv(

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
@@ -51,12 +51,12 @@ def chunk_dplr_fwd_kernel_o(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -65,29 +65,38 @@ def chunk_dplr_fwd_kernel_o(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_qg = tl.make_block_ptr(qg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_qg = tl.load(p_qg, boundary_check=(0, 1))
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_qg = m_t[:, None] & (o_k[None, :] < K)
+        m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_qg = qg + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_h = h + (i_tg * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        b_qg = tl.load(p_qg, mask=m_qg, other=0.0)
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
         b_o += tl.dot(b_qg, b_h)
 
-    p_Aqk = tl.make_block_ptr(A_qk + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_Aqb = tl.make_block_ptr(A_qb + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_v_new = tl.make_block_ptr(v_new + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    o_A = tl.arange(0, BT)
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    m_v = m_t[:, None] & (o_v[None, :] < V)
+    p_Aqk = A_qk + (bos * H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_Aqb = A_qb + (bos * H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+    p_v_new = v_new + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+    p_o = o + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
 
     m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
-    b_Aqk = tl.load(p_Aqk, boundary_check=(0, 1))
-    b_Aqb = tl.load(p_Aqb, boundary_check=(0, 1))
+    b_Aqk = tl.load(p_Aqk, mask=m_A, other=0.0)
+    b_Aqb = tl.load(p_Aqb, mask=m_A, other=0.0)
     b_Aqk = tl.where(m_s, b_Aqk, 0)
     b_Aqb = tl.where(m_s, b_Aqb, 0)
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_v, other=0.0)
+    b_v_new = tl.load(p_v_new, mask=m_v, other=0.0)
     b_o = b_o + tl.dot(b_Aqk.to(b_v.dtype), b_v) + tl.dot(b_Aqb.to(b_v_new.dtype), b_v_new)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
 
 
 def chunk_dplr_fwd_o(

--- a/fla/ops/generalized_delta_rule/dplr/wy_fast_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/wy_fast_bwd.py
@@ -52,55 +52,64 @@ def prepare_wy_repr_bwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_Aak_t = tl.make_block_ptr(A_ak + (bos*H + i_h) * BT,  (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_Aab_inv_t = tl.make_block_ptr(A_ab_inv + (bos*H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_dAak = tl.make_block_ptr(dAak + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_dAab = tl.make_block_ptr(dAab + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    m_dA = m_t[:, None] & (o_A[None, :] < BT)
+    p_Aak_t = A_ak + (bos*H + i_h) * BT + o_A[:, None] + o_t[None, :] * (H*BT)
+    p_Aab_inv_t = A_ab_inv + (bos*H + i_h) * BT + o_A[:, None] + o_t[None, :] * (H*BT)
+    p_dAak = dAak + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_dAab = dAab + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
 
-    b_A_ab_inv_t = tl.load(p_Aab_inv_t, boundary_check=(0, 1))
-    b_A_ak_t = tl.load(p_Aak_t, boundary_check=(0, 1))
+    b_A_ab_inv_t = tl.load(p_Aab_inv_t, mask=m_AT, other=0.0)
+    b_A_ak_t = tl.load(p_Aak_t, mask=m_AT, other=0.0)
     b_A_ak_t = tl.where(tl.arange(0, BT)[:, None] < tl.arange(0, BT)[None, :], b_A_ak_t, 0)
     b_A_ab_inv_t = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], b_A_ab_inv_t, 0)
     b_A_tmp_t = tl.dot(b_A_ak_t, b_A_ab_inv_t).to(v.dtype.element_ty)
     b_dA_tmp = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv0 = tl.make_block_ptr(dv0 + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_du = tl.load(p_du, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv = dv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv0 = dv0 + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_du = du + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
+        b_du = tl.load(p_du, mask=m_v, other=0.0)
         b_dA_tmp += tl.dot(b_du.to(b_v.dtype), tl.trans(b_v))
-        b_dv0 = tl.load(p_dv0, boundary_check=(0, 1))
+        b_dv0 = tl.load(p_dv0, mask=m_v, other=0.0)
         b_dv = b_dv0 + tl.dot(b_A_tmp_t, b_du)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
     m_i = tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :]
     b_dA_tmp = tl.where(m_i, b_dA_tmp, 0)
     b_dA_ak = tl.dot(b_A_ab_inv_t, b_dA_tmp)
     b_dA_ak = tl.where(m_i, b_dA_ak, 0)
-    tl.store(p_dAak, b_dA_ak, boundary_check=(0, 1))
+    tl.store(p_dAak, b_dA_ak, mask=m_dA)
     b_dA_ab_inv = tl.dot(b_dA_tmp, b_A_ak_t)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_ag = tl.make_block_ptr(ag + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dag = tl.make_block_ptr(dag + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_ag = tl.load(p_ag, boundary_check=(0, 1))
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_ag = ag + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dag = dag + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dw = dw + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_ag = tl.load(p_ag, mask=m_k, other=0.0)
+        b_dw = tl.load(p_dw, mask=m_k, other=0.0)
         b_dA_ab_inv += tl.dot(b_dw, tl.trans(b_ag))
         b_dag = tl.dot(b_A_ab_inv_t.to(b_dw.dtype), b_dw)
-        tl.store(p_dag, b_dag.to(p_dag.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dag, b_dag.to(p_dag.dtype.element_ty), mask=m_k)
 
     # if we know dL/dA^(-1), for dL/dA, we can use the following formula:
     # dL/dA = -(A^(-1))^T @ (dL/dA^(-1)) @ (A^(-1))^T
@@ -113,7 +122,7 @@ def prepare_wy_repr_bwd_kernel(
     b_dA_ab_inv = tl.dot(b_A_ab_inv_t, b_dA_ab_inv)
     b_dA_ab_inv = tl.dot(b_dA_ab_inv, b_A_ab_inv_t)
     b_dA_ab_inv = tl.where(m_i, b_dA_ab_inv, 0)
-    tl.store(p_dAab, b_dA_ab_inv, boundary_check=(0, 1))
+    tl.store(p_dAab, b_dA_ab_inv, mask=m_dA)
 
 
 def chunk_dplr_bwd_wy(

--- a/fla/ops/generalized_delta_rule/dplr/wy_fast_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/wy_fast_fwd.py
@@ -37,17 +37,21 @@ def prepare_wy_repr_fwd_kernel_chunk32(
     BC: tl.constexpr,  # placeholder, do not delete
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
-    p_Aab = tl.make_block_ptr(A_ab + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_Aab_inv = tl.make_block_ptr(A_ab_inv + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_A_ab = tl.load(p_Aab, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_Aab = A_ab + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_Aab_inv = A_ab_inv + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    b_A_ab = tl.load(p_Aab, mask=m_A, other=0.0)
     b_A_ab = tl.where(tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :], b_A_ab, 0)
     for i in range(1, BT):
         mask = tl.arange(0, BT) == i
@@ -55,7 +59,7 @@ def prepare_wy_repr_fwd_kernel_chunk32(
         b_a = b_a + tl.sum(b_a[:, None] * b_A_ab, 0) * (tl.arange(0, BT) < i)
         b_A_ab = tl.where(mask[:, None], b_a, b_A_ab)
     b_A_ab += tl.arange(0, BT)[:, None] == tl.arange(0, BT)[None, :]
-    tl.store(p_Aab_inv, b_A_ab.to(p_Aab_inv.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Aab_inv, b_A_ab.to(p_Aab_inv.dtype.element_ty), mask=m_A)
 
 
 @triton.heuristics({
@@ -83,26 +87,31 @@ def prepare_wy_repr_fwd_kernel_chunk64(
     IS_VARLEN: tl.constexpr,
     GATHER_SUPPORTED: tl.constexpr = IS_GATHER_SUPPORTED,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_A1 = tl.make_block_ptr(A_ab + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BC, BC), (1, 0))
-    p_A2 = tl.make_block_ptr(A_ab + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT + BC, BC), (BC, BC), (1, 0))
-    p_A3 = tl.make_block_ptr(A_ab + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT + BC, 0), (BC, BC), (1, 0))
-    p_A_inv1 = tl.make_block_ptr(A_ab_inv + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BC, BC), (1, 0))
-    p_A_inv2 = tl.make_block_ptr(A_ab_inv + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT + BC, BC), (BC, BC), (1, 0))
-    p_A_inv3 = tl.make_block_ptr(A_ab_inv + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT + BC, 0), (BC, BC), (1, 0))
-    p_A_inv4 = tl.make_block_ptr(A_ab_inv + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, BC), (BC, BC), (1, 0))
+    o_c = tl.arange(0, BC)
+    o_t1 = i_t * BT + o_c
+    o_t2 = i_t * BT + BC + o_c
+    m_t1 = o_t1 < T
+    m_t2 = o_t2 < T
+    p_A1 = A_ab + (bos*H + i_h) * BT + o_t1[:, None] * (H*BT) + o_c[None, :]
+    p_A2 = A_ab + (bos*H + i_h) * BT + o_t2[:, None] * (H*BT) + (BC + o_c)[None, :]
+    p_A3 = A_ab + (bos*H + i_h) * BT + o_t2[:, None] * (H*BT) + o_c[None, :]
+    p_A_inv1 = A_ab_inv + (bos*H + i_h) * BT + o_t1[:, None] * (H*BT) + o_c[None, :]
+    p_A_inv2 = A_ab_inv + (bos*H + i_h) * BT + o_t2[:, None] * (H*BT) + (BC + o_c)[None, :]
+    p_A_inv3 = A_ab_inv + (bos*H + i_h) * BT + o_t2[:, None] * (H*BT) + o_c[None, :]
+    p_A_inv4 = A_ab_inv + (bos*H + i_h) * BT + o_t1[:, None] * (H*BT) + (BC + o_c)[None, :]
 
-    b_A = tl.load(p_A1, boundary_check=(0, 1))
-    b_A2 = tl.load(p_A2, boundary_check=(0, 1))
-    b_A3 = tl.load(p_A3, boundary_check=(0, 1))
+    b_A = tl.load(p_A1, mask=m_t1[:, None] & (o_c[None, :] < BT), other=0.0)
+    b_A2 = tl.load(p_A2, mask=m_t2[:, None] & ((BC + o_c)[None, :] < BT), other=0.0)
+    b_A3 = tl.load(p_A3, mask=m_t2[:, None] & (o_c[None, :] < BT), other=0.0)
     b_A = tl.where(tl.arange(0, BC)[:, None] > tl.arange(0, BC)[None, :], b_A, 0)
     b_A2 = tl.where(tl.arange(0, BC)[:, None] > tl.arange(0, BC)[None, :], b_A2, 0)
 
@@ -130,11 +139,15 @@ def prepare_wy_repr_fwd_kernel_chunk64(
     b_A2 += tl.arange(0, BC)[:, None] == tl.arange(0, BC)[None, :]
     b_A3 = tl.dot(tl.dot(b_A2, b_A3), b_A)
     # tl.debug_barrier()
-    tl.store(p_A_inv1, b_A.to(p_A_inv1.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-    tl.store(p_A_inv2, b_A2.to(p_A_inv2.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-    tl.store(p_A_inv3, b_A3.to(p_A_inv3.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_A_inv1, b_A.to(p_A_inv1.dtype.element_ty, fp_downcast_rounding="rtne"),
+             mask=m_t1[:, None] & (o_c[None, :] < BT))
+    tl.store(p_A_inv2, b_A2.to(p_A_inv2.dtype.element_ty, fp_downcast_rounding="rtne"),
+             mask=m_t2[:, None] & ((BC + o_c)[None, :] < BT))
+    tl.store(p_A_inv3, b_A3.to(p_A_inv3.dtype.element_ty, fp_downcast_rounding="rtne"),
+             mask=m_t2[:, None] & (o_c[None, :] < BT))
     # causal mask
-    tl.store(p_A_inv4, tl.zeros([BC, BC], dtype=tl.float32).to(p_A_inv4.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A_inv4, tl.zeros([BC, BC], dtype=tl.float32).to(
+        p_A_inv4.dtype.element_ty), mask=m_t1[:, None] & ((BC + o_c)[None, :] < BT))
 
 
 @triton.heuristics({
@@ -168,21 +181,24 @@ def wu_fwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
     o_s = tl.arange(0, BT)
 
-    p_A_ab_inv = tl.make_block_ptr(A_ab_inv + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_A_ak = tl.make_block_ptr(A_ak + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_t = i_t * BT + o_s
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_s[None, :] < BT)
+    p_A_ab_inv = A_ab_inv + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_s[None, :]
+    p_A_ak = A_ak + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_s[None, :]
 
-    b_Aab_inv = tl.load(p_A_ab_inv, boundary_check=(0, 1))
-    b_Aak = tl.load(p_A_ak, boundary_check=(0, 1))
+    b_Aab_inv = tl.load(p_A_ab_inv, mask=m_A, other=0.0)
+    b_Aak = tl.load(p_A_ak, mask=m_A, other=0.0)
     b_Aab_inv = tl.where(o_s[:, None] >= o_s[None, :], b_Aab_inv, 0)
     b_Aak = tl.where(o_s[:, None] > o_s[None, :], b_Aak, 0)
     # let's use tf32 here
@@ -192,18 +208,22 @@ def wu_fwd_kernel(
     b_Aab_inv = b_Aab_inv.to(ag.dtype.element_ty, fp_downcast_rounding="rtne")
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_ag = tl.make_block_ptr(ag + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_w = tl.make_block_ptr(w + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_ag = tl.load(p_ag, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_ag = ag + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_w = w + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_ag = tl.load(p_ag, mask=m_k, other=0.0)
         b_w = tl.dot(b_Aab_inv, b_ag)  # both bf16 or fp16
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_k)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_u = u + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_u = tl.dot(b_Aak, b_v)  # both bf16 or fp16
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_v)
 
 
 def wu_fwd(

--- a/fla/ops/generalized_delta_rule/iplr/chunk.py
+++ b/fla/ops/generalized_delta_rule/iplr/chunk.py
@@ -72,38 +72,46 @@ def chunk_generalized_iplr_delta_rule_fwd_kernel_h(
         NT = tl.cdiv(T, BT)
         boh = i_n * NT
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     # [BK, BV]
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h0 = tl.make_block_ptr(h0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+        p_h0 = h0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h0, mask=m_h, other=0.0).to(tl.float32)
 
     for i_t in range(NT):
-        p_h = tl.make_block_ptr(h + ((boh + i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        p_h = h + ((boh + i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_h)
         b_hc = tl.zeros([BK, BV], dtype=tl.float32)
         # since we need to make all DK in the SRAM. we face serve SRAM memory burden. By subchunking we allievate such burden
         for i_c in range(tl.cdiv(min(BT, T - i_t * BT), BC)):
-            p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_c * BC), (BK, BC), (0, 1))
-            p_b = tl.make_block_ptr(b+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_c * BC), (BK, BC), (0, 1))
-            p_d = tl.make_block_ptr(d+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_c * BC, i_k * BK), (BC, BK), (1, 0))
-            p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT + i_c * BC, i_v * BV), (BC, BV), (1, 0))
-            p_u = tl.make_block_ptr(u+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT + i_c * BC, i_v * BV), (BC, BV), (1, 0))
-            p_v_new = tl.make_block_ptr(v_new+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT+i_c*BC, i_v * BV), (BC, BV), (1, 0))
+            o_c = i_t * BT + i_c * BC + tl.arange(0, BC)
+            m_c = o_c < T
+            m_kc = (o_k[:, None] < K) & m_c[None, :]
+            m_dc = m_c[:, None] & (o_k[None, :] < K)
+            m_vc = m_c[:, None] & (o_v[None, :] < V)
+            p_k = k+(bos*H+i_h)*K + o_k[:, None] + o_c[None, :] * (H*K)
+            p_b = b+(bos*H+i_h)*K + o_k[:, None] + o_c[None, :] * (H*K)
+            p_d = d+(bos*H+i_h)*K + o_c[:, None] * (H*K) + o_k[None, :]
+            p_v = v+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
+            p_u = u+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
+            p_v_new = v_new+(bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
             # [BK, BC]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
-            b_d = tl.load(p_d, boundary_check=(0, 1))
-            b_b = tl.load(p_b, boundary_check=(0, 1))
-            b_v2 = tl.dot(b_d, b_h.to(b_d.dtype)) + tl.load(p_u, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=m_kc, other=0.0)
+            b_v = tl.load(p_v, mask=m_vc, other=0.0)
+            b_d = tl.load(p_d, mask=m_dc, other=0.0)
+            b_b = tl.load(p_b, mask=m_kc, other=0.0)
+            b_v2 = tl.dot(b_d, b_h.to(b_d.dtype)) + tl.load(p_u, mask=m_vc, other=0.0)
             b_hc += tl.dot(b_k, b_v)
             b_hc += tl.dot(b_b, b_v2.to(b_k.dtype))
-            tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), mask=m_vc)
         b_h += b_hc
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_h)
 
 
 @triton.heuristics({
@@ -140,12 +148,12 @@ def chunk_generalized_iplr_delta_rule_fwd_kernel_o(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -169,18 +177,25 @@ def chunk_generalized_iplr_delta_rule_fwd_kernel_o(
     b_Aqk = tl.zeros([BT, BT], dtype=tl.float32)
     b_Aqb = tl.zeros([BT, BT], dtype=tl.float32)
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k, (K, T), (1, stride_qk), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_b = tl.make_block_ptr(b, (K, T), (1, stride_qk), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_q = m_t[:, None] & (o_k[None, :] < K)
+        m_k = (o_k[:, None] < K) & m_t[None, :]
+        m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
+        p_q = q + o_t[:, None] * stride_qk + o_k[None, :]
+        p_k = k + o_k[:, None] + o_t[None, :] * stride_qk
+        p_h = h + o_k[:, None] * V + o_v[None, :]
+        p_b = b + o_k[:, None] + o_t[None, :] * stride_qk
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_b = tl.load(p_b, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_b = tl.load(p_b, mask=m_k, other=0.0)
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
         # [BT, BK] @ [BK, BV] -> [BT, BV]
         b_o += tl.dot(b_q, b_h)
         # [BT, BK] @ [BK, BT] -> [BT, BT]
@@ -193,13 +208,14 @@ def chunk_generalized_iplr_delta_rule_fwd_kernel_o(
     b_Aqk = tl.where(m_A, b_Aqk, 0)
     b_Aqb = tl.where(m_A, b_Aqb, 0)
 
-    p_v = tl.make_block_ptr(v, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_u = tl.make_block_ptr(u, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_u = tl.load(p_u, boundary_check=(0, 1))
+    m_v = m_t[:, None] & (o_v[None, :] < V)
+    p_v = v + o_t[:, None] * stride_vo + o_v[None, :]
+    p_u = u + o_t[:, None] * stride_vo + o_v[None, :]
+    p_o = o + o_t[:, None] * stride_vo + o_v[None, :]
+    b_v = tl.load(p_v, mask=m_v, other=0.0)
+    b_u = tl.load(p_u, mask=m_v, other=0.0)
     b_o = (b_o + tl.dot(b_Aqk.to(b_v.dtype), b_v) + tl.dot(b_Aqb.to(b_u.dtype), b_u)) * scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
 
 
 def chunk_generalized_iplr_delta_rule_fwd_o(

--- a/fla/ops/generalized_delta_rule/iplr/wy_fast.py
+++ b/fla/ops/generalized_delta_rule/iplr/wy_fast.py
@@ -41,21 +41,26 @@ def prepare_wy_repr_fwd_kernel_chunk32(
     BC: tl.constexpr,  # dummy placeholder
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_a = tl.make_block_ptr(a + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_b = tl.make_block_ptr(b + (bos * H + i_h) * K, (K, T), (1, K*H), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        b_a = tl.load(p_a, boundary_check=(0, 1))
-        b_b = tl.load(p_b, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_a = m_t[:, None] & (o_k[None, :] < K)
+        m_b = (o_k[:, None] < K) & m_t[None, :]
+        p_a = a + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_b = b + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (K*H)
+        b_a = tl.load(p_a, mask=m_a, other=0.0)
+        b_b = tl.load(p_b, mask=m_b, other=0.0)
         b_A += tl.dot(b_a, b_b)
 
     b_A = tl.where(tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :], b_A, 0)
@@ -66,8 +71,9 @@ def prepare_wy_repr_fwd_kernel_chunk32(
         b_A = tl.where(mask[:, None], b_a, b_A)
     b_A += tl.arange(0, BT)[:, None] == tl.arange(0, BT)[None, :]
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
 
 
 @triton.heuristics({
@@ -96,10 +102,10 @@ def prepare_wy_repr_fwd_kernel_chunk64(
     BC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -109,15 +115,25 @@ def prepare_wy_repr_fwd_kernel_chunk64(
     b_A2 = tl.zeros([BC, BC], dtype=tl.float32)
     b_A3 = tl.zeros([BC, BC], dtype=tl.float32)
 
+    o_c = tl.arange(0, BC)
+    o_t1 = i_t * BT + o_c
+    o_t2 = i_t * BT + BC + o_c
+    m_t1 = o_t1 < T
+    m_t2 = o_t2 < T
     for i_k in range(tl.cdiv(K, BK)):
-        p_a1 = tl.make_block_ptr(a + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BC, BK), (1, 0))
-        p_a2 = tl.make_block_ptr(a + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + BC, i_k * BK), (BC, BK), (1, 0))
-        p_b1 = tl.make_block_ptr(b + (bos * H + i_h) * K, (K, T), (1, K*H), (i_k * BK, i_t * BT), (BK, BC), (0, 1))
-        p_b2 = tl.make_block_ptr(b + (bos * H + i_h) * K, (K, T), (1, K*H), (i_k * BK, i_t * BT + BC), (BK, BC), (0, 1))
-        b_a1 = tl.load(p_a1, boundary_check=(0, 1))
-        b_a2 = tl.load(p_a2, boundary_check=(0, 1))
-        b_b1 = tl.load(p_b1, boundary_check=(0, 1))
-        b_b2 = tl.load(p_b2, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_a1 = m_t1[:, None] & (o_k[None, :] < K)
+        m_a2 = m_t2[:, None] & (o_k[None, :] < K)
+        m_b1 = (o_k[:, None] < K) & m_t1[None, :]
+        m_b2 = (o_k[:, None] < K) & m_t2[None, :]
+        p_a1 = a + (bos * H + i_h) * K + o_t1[:, None] * (H*K) + o_k[None, :]
+        p_a2 = a + (bos * H + i_h) * K + o_t2[:, None] * (H*K) + o_k[None, :]
+        p_b1 = b + (bos * H + i_h) * K + o_k[:, None] + o_t1[None, :] * (K*H)
+        p_b2 = b + (bos * H + i_h) * K + o_k[:, None] + o_t2[None, :] * (K*H)
+        b_a1 = tl.load(p_a1, mask=m_a1, other=0.0)
+        b_a2 = tl.load(p_a2, mask=m_a2, other=0.0)
+        b_b1 = tl.load(p_b1, mask=m_b1, other=0.0)
+        b_b2 = tl.load(p_b2, mask=m_b2, other=0.0)
         b_A += tl.dot(b_a1, b_b1, allow_tf32=False)
         b_A2 += tl.dot(b_a2, b_b2, allow_tf32=False)
         b_A3 += tl.dot(b_a2, b_b1, allow_tf32=False)
@@ -140,15 +156,16 @@ def prepare_wy_repr_fwd_kernel_chunk64(
     b_A2 += tl.arange(0, BC)[:, None] == tl.arange(0, BC)[None, :]
     b_A3 = tl.dot(tl.dot(b_A2, b_A3, allow_tf32=False), b_A, allow_tf32=False)
 
-    p_A1 = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BC, BC), (1, 0))
-    p_A2 = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT + BC, BC), (BC, BC), (1, 0))
-    p_A3 = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT + BC, 0), (BC, BC), (1, 0))
-    p_A4 = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, BC), (BC, BC), (1, 0))
-    tl.store(p_A1, b_A.to(p_A1.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A2, b_A2.to(p_A2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_A3, b_A3.to(p_A3.dtype.element_ty), boundary_check=(0, 1))
+    p_A1 = A + (bos*H + i_h) * BT + o_t1[:, None] * (H*BT) + o_c[None, :]
+    p_A2 = A + (bos*H + i_h) * BT + o_t2[:, None] * (H*BT) + (BC + o_c)[None, :]
+    p_A3 = A + (bos*H + i_h) * BT + o_t2[:, None] * (H*BT) + o_c[None, :]
+    p_A4 = A + (bos*H + i_h) * BT + o_t1[:, None] * (H*BT) + (BC + o_c)[None, :]
+    tl.store(p_A1, b_A.to(p_A1.dtype.element_ty), mask=m_t1[:, None] & (o_c[None, :] < BT))
+    tl.store(p_A2, b_A2.to(p_A2.dtype.element_ty), mask=m_t2[:, None] & ((BC + o_c)[None, :] < BT))
+    tl.store(p_A3, b_A3.to(p_A3.dtype.element_ty), mask=m_t2[:, None] & (o_c[None, :] < BT))
     # causal mask
-    tl.store(p_A4, tl.zeros([BC, BC], dtype=tl.float32).to(p_A4.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A4, tl.zeros([BC, BC], dtype=tl.float32).to(
+        p_A4.dtype.element_ty), mask=m_t1[:, None] & ((BC + o_c)[None, :] < BT))
 
 
 @triton.heuristics({
@@ -181,40 +198,48 @@ def wu_fwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_A = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
 
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
     b_Aak = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_a = tl.make_block_ptr(a + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_w = tl.make_block_ptr(w + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_a = tl.load(p_a, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_a = a + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_w = w + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_a = tl.load(p_a, mask=m_k, other=0.0)
         b_w = tl.dot(b_A, b_a)
         b_Aak += tl.dot(b_a, tl.trans(b_k))
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_k)
 
     b_Aak = tl.where(tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :], b_Aak, 0)
     b_Aak = b_Aak.to(k.dtype.element_ty)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_u = u + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_v = tl.dot(b_Aak, b_v).to(v.dtype.element_ty)
         b_u = tl.dot(b_A, b_v)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), mask=m_v)
 
 
 def prepare_wy_repr_fwd(

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -67,11 +67,11 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_c, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_i, i_j = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -83,31 +83,39 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter(
         return
 
     b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    o_i = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+    m_i = o_i < T
+    m_j = o_j < T
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
+        m_qk = m_i[:, None] & m_k[None, :]
+        m_kj = m_k[:, None] & m_j[None, :]
 
-        p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_g = tl.make_block_ptr(g + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
-        p_gk = tl.make_block_ptr(g + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
+        p_q = q + (bos*H+i_h)*K + o_i[:, None] * (H*K) + o_k[None, :]
+        p_g = g + (bos*H+i_h)*K + o_i[:, None] * (H*K) + o_k[None, :]
+        p_k = k + (bos*H+i_h)*K + o_k[:, None] + o_j[None, :] * (H*K)
+        p_gk = g + (bos*H+i_h)*K + o_k[:, None] + o_j[None, :] * (H*K)
         p_gn = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
 
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         # [BC, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_g = tl.load(p_g, mask=m_qk, other=0.0)
         b_qg = b_q * exp2(b_g - b_gn[None, :]) * scale
         # [BK, BC]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kj, other=0.0)
+        b_gk = tl.load(p_gk, mask=m_kj, other=0.0)
         b_kg = b_k * exp2(b_gn[:, None] - b_gk)
         # [BC, BC] using tf32 to improve precision here.
         b_A += tl.dot(b_qg, b_kg)
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
-    tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
+    o_jA = i_j * BC + tl.arange(0, BC)
+    m_A = m_i[:, None] & (o_jA[None, :] < BT)
+    p_A = A + (bos*H + i_h)*BT + o_i[:, None] * (H*BT) + o_jA[None, :]
+    tl.store(p_A, b_A.to(A.dtype.element_ty), mask=m_A)
 
 
 @triton.heuristics({
@@ -139,11 +147,11 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -163,10 +171,12 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra(
     g += (bos * H + i_h) * K
     A += (bos * H + i_h) * BT
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_qk = m_A[:, None] & m_k[None, :]
+    p_q = q + o_c[:, None] * (H*K) + o_k[None, :]
+    p_g = g + o_c[:, None] * (H*K) + o_k[None, :]
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_g = tl.load(p_g, mask=m_qk, other=0.0)
 
     p_k = k + (i_t * BT + i_j * BC) * H*K + o_k
     p_gk = g + (i_t * BT + i_j * BC) * H*K + o_k
@@ -216,10 +226,10 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
 ):
     i_k, i_tc, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
-    i_t, i_i = i_tc // NC, i_tc % NC
+    i_t, i_i = (i_tc // NC).to(tl.int64), i_tc % NC
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -241,10 +251,12 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
     g += (bos * H + i_h) * K
     A += ((i_k * all + bos) * H + i_h) * BC
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_qk = m_A[:, None] & m_k[None, :]
+    p_q = q + o_c[:, None] * (H*K) + o_k[None, :]
+    p_g = g + o_c[:, None] * (H*K) + o_k[None, :]
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_g = tl.load(p_g, mask=m_qk, other=0.0)
 
     p_k = k + (i_t * BT + i_j * BC) * H*K + o_k
     p_gk = g + (i_t * BT + i_j * BC) * H*K + o_k
@@ -288,10 +300,10 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
     NK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_c, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -303,11 +315,16 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
         return
 
     b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    o_c = i_t * BT + i_c * BC + tl.arange(0, BC)
+    o_i = tl.arange(0, BC)
+    m_c = o_c < T
+    m_A = m_c[:, None] & (o_i[None, :] < BC)
+    m_A2 = m_c[:, None] & ((i_c * BC + o_i)[None, :] < BT)
     for i_k in range(0, NK):
-        p_A = tl.make_block_ptr(A + (i_k*all+bos)*H*BC+i_h*BC, (T, BC), (H*BC, 1), (i_t*BT + i_c*BC, 0), (BC, BC), (1, 0))
-        b_A += tl.load(p_A, boundary_check=(0, 1))
-    p_A2 = tl.make_block_ptr(A2 + (bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_c * BC, i_c * BC), (BC, BC), (1, 0))
-    tl.store(p_A2, b_A.to(A2.dtype.element_ty), boundary_check=(0, 1))
+        p_A = A + (i_k*all+bos)*H*BC+i_h*BC + o_c[:, None] * (H*BC) + o_i[None, :]
+        b_A += tl.load(p_A, mask=m_A, other=0.0)
+    p_A2 = A2 + (bos*H+i_h)*BT + o_c[:, None] * (H*BT) + (i_c * BC + o_i)[None, :]
+    tl.store(p_A2, b_A.to(A2.dtype.element_ty), mask=m_A2)
 
 
 @triton.heuristics({
@@ -346,12 +363,12 @@ def chunk_gla_fwd_kernel_o(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -370,37 +387,49 @@ def chunk_gla_fwd_kernel_o(
     A += (bos * HV + i_hv) * BT
 
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_i = tl.arange(0, BT)
+    m_t = o_t < T
+    m_v = o_v < V
+    m_tv = m_t[:, None] & m_v[None, :]
+    m_A = m_t[:, None] & (o_i[None, :] < BT)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_qk = m_t[:, None] & m_k[None, :]
+        p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+        p_g = g + o_t[:, None] * (HV*K) + o_k[None, :]
         if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = h + o_v[:, None] * K + o_k[None, :]
+            m_h = m_v[:, None] & m_k[None, :]
         else:
-            p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_h = h + o_k[:, None] * V + o_v[None, :]
+            m_h = m_k[:, None] & m_v[None, :]
 
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
         # [BT, BK]
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        b_g = tl.load(p_g, mask=m_qk, other=0.0).to(tl.float32)
         # [BT, BK]
         b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
         if i_k >= 0:
             if STATE_V_FIRST:
                 b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
             else:
                 b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
     b_o *= scale
-    p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_A = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_v = v + o_t[:, None] * (HV*V) + o_v[None, :]
+    p_o = o + o_t[:, None] * (HV*V) + o_v[None, :]
+    p_A = A + o_t[:, None] * (HV*BT) + o_i[None, :]
     # [BT, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
     # [BT, BT]
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
     b_A = tl.where(m_s, b_A, 0.).to(b_v.dtype)
     b_o += tl.dot(b_A, b_v)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tv)
 
 
 @triton.heuristics({
@@ -434,11 +463,11 @@ def chunk_gla_bwd_kernel_intra(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_k, i_i = i_kc // NC, i_kc % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -449,9 +478,12 @@ def chunk_gla_bwd_kernel_intra(
     o_k = i_k * BK + tl.arange(0, BK)
     m_k = o_k < K
 
-    p_g = tl.make_block_ptr(g + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_c = o_c < T
+    m_ck = m_c[:, None] & m_k[None, :]
+    p_g = g + (bos*H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
     # [BC, BK]
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_g = tl.load(p_g, mask=m_ck, other=0.0)
 
     b_dq = tl.zeros([BC, BK], dtype=tl.float32)
     if i_i > 0:
@@ -459,15 +491,19 @@ def chunk_gla_bwd_kernel_intra(
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(0, i_i):
-            p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA+(bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t*BT+i_i*BC, i_j * BC), (BC, BC), (1, 0))
+            o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+            o_jA = i_j * BC + tl.arange(0, BC)
+            m_jk = (o_j[:, None] < T) & m_k[None, :]
+            m_da = m_c[:, None] & (o_jA[None, :] < BT)
+            p_k = k+(bos*H+i_h)*K + o_j[:, None] * (H*K) + o_k[None, :]
+            p_gk = g+(bos*H+i_h)*K + o_j[:, None] * (H*K) + o_k[None, :]
+            p_dA = dA+(bos*H+i_h)*BT + o_c[:, None] * (H*BT) + o_jA[None, :]
             # [BC, BK]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=m_jk, other=0.0)
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0)
             b_kg = b_k * exp2(b_gn[None, :] - b_gk)
             # [BC, BC]
-            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            b_dA = tl.load(p_dA, mask=m_da, other=0.0)
 
             b_dq += tl.dot(b_dA, b_kg)
         b_dq *= exp2(b_g - b_gn[None, :])
@@ -476,7 +512,7 @@ def chunk_gla_bwd_kernel_intra(
     o_dA = bos*H*BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_h * BT + i_i * BC
     p_kj = k + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gkj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_dq = tl.make_block_ptr(dq + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_dq = dq + (bos*H + i_h) * K + o_c[:, None] * (H*K) + o_k[None, :]
 
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         # [BC,]
@@ -491,7 +527,7 @@ def chunk_gla_bwd_kernel_intra(
         b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.)
         p_kj += H*K
         p_gkj += H*K
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_ck)
 
     tl.debug_barrier()
     # [BC, BK]
@@ -504,18 +540,20 @@ def chunk_gla_bwd_kernel_intra(
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(i_i + 1, NC):
-            p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_gq = tl.make_block_ptr(g + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA + (bos*H+i_h)*BT, (BT, T), (1, H*BT), (i_i*BC, i_t*BT + i_j*BC), (BC, BC), (0, 1))
-
             o_j = i_t * BT + i_j * BC + o_i
+            o_iA = i_i * BC + tl.arange(0, BC)
             m_j = o_j < T
+            m_jk = m_j[:, None] & m_k[None, :]
+            m_da = (o_iA[:, None] < BT) & m_j[None, :]
+            p_q = q + (bos*H+i_h)*K + o_j[:, None] * (H*K) + o_k[None, :]
+            p_gq = g + (bos*H+i_h)*K + o_j[:, None] * (H*K) + o_k[None, :]
+            p_dA = dA + (bos*H+i_h)*BT + o_iA[:, None] + o_j[None, :] * (H*BT)
             # [BC, BK]
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_gq = tl.load(p_gq, boundary_check=(0, 1))
+            b_q = tl.load(p_q, mask=m_jk, other=0.0)
+            b_gq = tl.load(p_gq, mask=m_jk, other=0.0)
             b_qg = b_q * tl.where(m_j[:, None], exp2(b_gq - b_gn[None, :]), 0)
             # [BC, BC]
-            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            b_dA = tl.load(p_dA, mask=m_da, other=0.0)
             # [BC, BK]
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dk += tl.dot(b_dA, b_qg)
@@ -523,7 +561,7 @@ def chunk_gla_bwd_kernel_intra(
     o_dA = bos*H*BT + (i_t * BT + i_i * BC) * H*BT + i_h * BT + i_i * BC + tl.arange(0, BC)
     p_qj = q + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gqj = g + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_dk = tl.make_block_ptr(dk + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_dk = dk + (bos*H+i_h)*K + o_c[:, None] * (H*K) + o_k[None, :]
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         # [BC,]
         b_dA = tl.load(dA + o_dA + j * H*BT)
@@ -535,7 +573,7 @@ def chunk_gla_bwd_kernel_intra(
         b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.)
         p_qj += H*K
         p_gqj += H*K
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_ck)
 
 
 @triton.heuristics({
@@ -565,28 +603,36 @@ def chunk_gla_bwd_kernel_dA(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
     T = eos - bos
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_i = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_i[None, :] < BT)
     for i_v in range(tl.cdiv(V, BV)):
-        p_do = tl.make_block_ptr(do + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        m_tv = m_t[:, None] & m_v[None, :]
+        m_vt = m_v[:, None] & m_t[None, :]
+        p_do = do + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v = v + (bos*H + i_h) * V + o_v[:, None] + o_t[None, :] * (H*V)
+        b_v = tl.load(p_v, mask=m_vt, other=0.0)
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
 
         b_dA += tl.dot(b_do, b_v)
 
-    p_dA = tl.make_block_ptr(dA + (bos * H + i_h) * BT, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_dA = dA + (bos * H + i_h) * BT + o_t[:, None] * (H*BT) + o_i[None, :]
     m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
     b_dA = tl.where(m_s, b_dA * scale, 0.)
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_A)
 
 
 @triton.heuristics({
@@ -624,11 +670,11 @@ def chunk_gla_bwd_kernel_dv(
     IS_VARLEN: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -637,11 +683,18 @@ def chunk_gla_bwd_kernel_dv(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
-    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_do = tl.make_block_ptr(do + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_i = tl.arange(0, BT)
+    m_t = o_t < T
+    m_v = o_v < V
+    m_A = (o_i[:, None] < BT) & m_t[None, :]
+    m_tv = m_t[:, None] & m_v[None, :]
+    p_A = A + (bos * H + i_h) * BT + o_i[:, None] + o_t[None, :] * (H*BT)
+    p_do = do + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+    p_dv = dv + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
+    b_do = tl.load(p_do, mask=m_tv, other=0.0)
 
     b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], b_A, 0.)
     # (SY 09/17) important to disallow tf32 here to maintain a good precision.
@@ -650,19 +703,21 @@ def chunk_gla_bwd_kernel_dv(
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
+        m_tk = m_t[:, None] & m_k[None, :]
+        m_kvd = m_k[:, None] & m_v[None, :]
 
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_gk = tl.make_block_ptr(g + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_k = k + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_gk = g + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
         p_gn = g + (bos + min(i_t * BT + BT, T) - 1)*H*K + i_h * K + o_k
         if STATE_V_FIRST:
             # dh stored as [V, K]; read a logical [BK, BV] tile via on-the-fly transpose
-            p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (K, V), (1, K), (i_k * BK, i_v * BV), (BK, BV), (0, 1))
+            p_dh = dh + (i_tg * H + i_h) * K*V + o_k[:, None] + o_v[None, :] * K
         else:
-            p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            p_dh = dh + (i_tg * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
 
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
+        b_gk = tl.load(p_gk, mask=m_tk, other=0.0)
+        b_dh = tl.load(p_dh, mask=m_kvd, other=0.0)
 
         b_gn = exp2(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
         b_k = (b_k * b_gn).to(b_k.dtype)
@@ -670,7 +725,7 @@ def chunk_gla_bwd_kernel_dv(
         # (SY 09/17) it is ok to have bf16 interchunk gradient contribution here
         b_dv += tl.dot(b_k, b_dh.to(b_k.dtype))
 
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
 
 
 @triton.heuristics({
@@ -715,11 +770,11 @@ def chunk_gla_bwd_kernel_inter(
     IS_VARLEN: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -743,8 +798,11 @@ def chunk_gla_bwd_kernel_inter(
     dk2 += (bos * H + i_h) * K
     dg += (bos * H + i_h) * K
 
-    p_gk = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    b_gk = tl.load(p_gk, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_tk = m_t[:, None] & m_k[None, :]
+    p_gk = g + o_t[:, None] * (H*K) + o_k[None, :]
+    b_gk = tl.load(p_gk, mask=m_tk, other=0.0)
     p_gn = g + (min(T, i_t * BT + BT) - 1) * H*K + o_k
     b_gn = tl.load(p_gn, mask=m_k, other=0)
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
@@ -752,21 +810,25 @@ def chunk_gla_bwd_kernel_inter(
     b_dgk = tl.zeros([BK], dtype=tl.float32)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        m_tv = m_t[:, None] & m_v[None, :]
+        m_vk = m_v[:, None] & m_k[None, :]
+        p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+        p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
         if STATE_V_FIRST:
             # h / dh stored as [V, K] -- the [BV, BK] tile is now a contiguous read
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            p_h = h + o_v[:, None] * K + o_k[None, :]
+            p_dh = dh + o_v[:, None] * K + o_k[None, :]
         else:
-            p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            p_h = h + o_v[:, None] + o_k[None, :] * V
+            p_dh = dh + o_v[:, None] + o_k[None, :] * V
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_vk, other=0.0)
+        b_dh = tl.load(p_dh, mask=m_vk, other=0.0)
 
         # [BK]
         b_dgk += tl.sum(b_h * b_dh, axis=0)
@@ -778,27 +840,27 @@ def chunk_gla_bwd_kernel_inter(
     b_dq *= scale
     b_dq = b_dq * exp2(b_gk)
     b_dk = b_dk * exp2(b_gn[None, :] - b_gk)
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dq = dq + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dk = dk + o_t[:, None] * (H*K) + o_k[None, :]
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
     b_dgk += tl.sum(b_dk * b_k, axis=0)
-    b_dq += tl.load(p_dq, boundary_check=(0, 1))
-    b_dk += tl.load(p_dk, boundary_check=(0, 1))
+    b_dq += tl.load(p_dq, mask=m_tk, other=0.0)
+    b_dk += tl.load(p_dk, mask=m_tk, other=0.0)
     b_dg = b_q * b_dq - b_k * b_dk
     # tl.debug_barrier()
     b_dg = b_dg - tl.cumsum(b_dg, axis=0) + tl.sum(b_dg, axis=0)[None, :] + b_dgk[None, :]
     # Buggy due to strange triton compiler issue.
     # m_s = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], 1., 0.)
     # b_dg = tl.dot(m_s, b_dg, allow_tf32=False) + b_dgk[None, :]
-    p_dq = tl.make_block_ptr(dq2, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk2, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq2 + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dk = dk2 + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dg = dg + o_t[:, None] * (H*K) + o_k[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_tk)
 
 
 def chunk_gla_fwd_intra_gk(

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -56,12 +56,12 @@ def chunk_gsa_fwd_k_kernel_inter(
     NG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -75,34 +75,45 @@ def chunk_gsa_fwd_k_kernel_inter(
 
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_v = o_v < V
+    m_tv = m_t[:, None] & m_v[None, :]
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_qk = m_t[:, None] & m_k[None, :]
+        m_kt = m_k[:, None] & m_t[None, :]
+        m_kv = m_k[:, None] & m_v[None, :]
+        p_q = q + (bos * HQ + i_hq) * K + o_t[:, None] * (HQ*K) + o_k[None, :]
+        p_k = k + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_h = h + (i_tg * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
 
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kt, other=0.0)
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_kv, other=0.0)
         # [BT, BV]
         b_o += tl.dot(b_q, b_h)
         # [BT, BT]
         b_A += tl.dot(b_q, b_k)
-    p_g = tl.make_block_ptr(g + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_A = tl.make_block_ptr(A + (bos * HQ + i_hq) * BT, (T, BT), (HQ*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    m_A = m_t[:, None] & (o_i[None, :] < BT)
+    p_g = g + (bos * H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+    p_o = o + (bos * HQ + i_hq) * V + o_t[:, None] * (HQ*V) + o_v[None, :]
+    p_A = A + (bos * HQ + i_hq) * BT + o_t[:, None] * (HQ*BT) + o_i[None, :]
     # [BT, BV]
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_g = tl.load(p_g, mask=m_tv, other=0.0)
     b_o = b_o * exp2(b_g)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tv)
 
     # [BT, BT]
     b_A = tl.where(m_s, b_A, 0.)
     if i_v == 0:
-        tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_A)
 
 
 @triton.heuristics({
@@ -130,9 +141,9 @@ def chunk_gsa_fwd_k_kernel_intra(
     i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
-    i_t, i_i = i_c // NC, i_c % NC
+    i_t, i_i = (i_c // NC).to(tl.int64), i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -145,25 +156,32 @@ def chunk_gsa_fwd_k_kernel_intra(
     if i_t * BT + i_i * BC >= T:
         return
 
-    p_g = tl.make_block_ptr(g + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_c = o_c < T
+    m_cv = m_c[:, None] & m_v[None, :]
+    p_g = g + (bos * H + i_h) * V + o_c[:, None] * (H*V) + o_v[None, :]
     p_gn = g + (bos + min(i_t * BT + i_i * BC, T)) * H*V + i_h * V + o_v
     # [BV,]
     b_gn = tl.load(p_gn, mask=m_v, other=0)
     # [BC, BV]
     b_o = tl.zeros([BC, BV], dtype=tl.float32)
     for i_j in range(0, i_i):
-        p_A = tl.make_block_ptr(A + (bos*HQ+i_hq) * BT, (T, BT), (HQ*BT, 1), (i_t*BT+i_i*BC, i_j * BC), (BC, BC), (1, 0))
-        p_v = tl.make_block_ptr(v + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
-        p_gv = tl.make_block_ptr(g + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_jA = i_j * BC + tl.arange(0, BC)
+        m_jv = (o_j[:, None] < T) & m_v[None, :]
+        m_A = m_c[:, None] & (o_jA[None, :] < BT)
+        p_A = A + (bos*HQ+i_hq) * BT + o_c[:, None] * (HQ*BT) + o_jA[None, :]
+        p_v = v + (bos*H+i_h) * V + o_j[:, None] * (H*V) + o_v[None, :]
+        p_gv = g + (bos*H+i_h) * V + o_j[:, None] * (H*V) + o_v[None, :]
         # [BC, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_jv, other=0.0)
+        b_gv = tl.load(p_gv, mask=m_jv, other=0.0)
         b_vg = (b_v * exp2(b_gn[None, :] - b_gv)).to(b_v.dtype)
         # [BC, BC]
-        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_A = tl.load(p_A, mask=m_A, other=0.0)
         b_o += tl.dot(b_A, b_vg)
     # [BC, BV]
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_g = tl.load(p_g, mask=m_cv, other=0.0)
     b_o *= exp2(b_g - b_gn[None, :])
 
     o_A = (bos + i_t * BT + i_i * BC + tl.arange(0, BC)) * HQ*BT + i_hq * BT + i_i * BC
@@ -180,9 +198,9 @@ def chunk_gsa_fwd_k_kernel_intra(
         b_vg = b_v[None, :] * exp2(b_g - b_gv[None, :])
         # avoid 0 * inf = inf
         b_o += tl.where(o_i[:, None] >= j, b_A[:, None] * b_vg, 0.)
-    p_o = tl.make_block_ptr(o + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
-    b_o += tl.load(p_o, boundary_check=(0, 1))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o = o + (bos*HQ + i_hq) * V + o_c[:, None] * (HQ*V) + o_v[None, :]
+    b_o += tl.load(p_o, mask=m_cv, other=0.0)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_cv)
 
 
 @triton.heuristics({
@@ -220,9 +238,9 @@ def chunk_gsa_bwd_k_kernel_dA(
     i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
-    i_t, i_i, i_j = i_c // (NC * NC), (i_c % (NC * NC)) // NC, (i_c % (NC * NC)) % NC
+    i_t, i_i, i_j = (i_c // (NC * NC)).to(tl.int64), (i_c % (NC * NC)) // NC, (i_c % (NC * NC)) % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -236,36 +254,43 @@ def chunk_gsa_bwd_k_kernel_dA(
     if i_t * BT + i_i * BC >= T:
         return
 
-    p_dA = tl.make_block_ptr(dA+((i_v*all+bos)*HQ+i_hq)*BT, (T, BT), (HQ*BT, 1), (i_t*BT+i_i*BC, i_j*BC), (BC, BC), (1, 0))
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_jA = i_j * BC + tl.arange(0, BC)
+    m_c = o_c < T
+    m_A = m_c[:, None] & (o_jA[None, :] < BT)
+    m_cv = m_c[:, None] & m_v[None, :]
+    p_dA = dA+((i_v*all+bos)*HQ+i_hq)*BT + o_c[:, None] * (HQ*BT) + o_jA[None, :]
 
     # [BC, BC]
     b_dA = tl.zeros([BC, BC], dtype=tl.float32)
     if i_i > i_j:
-        p_v = tl.make_block_ptr(v + (bos*H+i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t*BT + i_j*BC), (BV, BC), (0, 1))
-        p_gv = tl.make_block_ptr(g + (bos*H+i_h) * V, (V, T), (1, H*V), (i_v * BV, i_t*BT + i_j*BC), (BV, BC), (0, 1))
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        m_vj = m_v[:, None] & (o_j[None, :] < T)
+        p_v = v + (bos*H+i_h) * V + o_v[:, None] + o_j[None, :] * (H*V)
+        p_gv = g + (bos*H+i_h) * V + o_v[:, None] + o_j[None, :] * (H*V)
         p_gn = g + (bos + i_t*BT + i_i*BC) * H*V + i_h * V + o_v
-        p_g = tl.make_block_ptr(g + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos*HQ+i_hq) * V, (T, V), (HQ*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
+        p_g = g + (bos*H+i_h) * V + o_c[:, None] * (H*V) + o_v[None, :]
+        p_do = do + (bos*HQ+i_hq) * V + o_c[:, None] * (HQ*V) + o_v[None, :]
         # [BV,]
         b_gn = tl.load(p_gn, mask=m_v, other=0.)
         # [BC, BV]
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_g = tl.load(p_g, mask=m_cv, other=0.0)
+        b_do = tl.load(p_do, mask=m_cv, other=0.0)
         b_do = (b_do * exp2(b_g - b_gn[None, :])).to(b_do.dtype)
         # [BV, BC]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_gv = tl.load(p_gv, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_vj, other=0.0)
+        b_gv = tl.load(p_gv, mask=m_vj, other=0.0)
         b_vg = (b_v * exp2(b_gn[:, None] - b_gv)).to(b_v.dtype)
         # [BC, BC]
         b_dA = tl.dot(b_do, b_vg) * scale
     elif i_i == i_j:
-        p_g = tl.make_block_ptr(g + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
+        p_g = g + (bos*H + i_h) * V + o_c[:, None] * (H*V) + o_v[None, :]
+        p_do = do + (bos*HQ + i_hq) * V + o_c[:, None] * (HQ*V) + o_v[None, :]
         p_v = v + (bos + i_t*BT + i_j*BC) * H*V + i_h * V + o_v
         p_gv = g + (bos + i_t*BT + i_j*BC) * H*V + i_h * V + o_v
         # [BC, BV]
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)) * scale
+        b_g = tl.load(p_g, mask=m_cv, other=0.0)
+        b_do = tl.load(p_do, mask=m_cv, other=0.0) * scale
         m_v = o_v < V
 
         o_i = tl.arange(0, BC)
@@ -282,7 +307,7 @@ def chunk_gsa_bwd_k_kernel_dA(
             p_v += H*V
             p_gv += H*V
         b_dA = tl.where(m_dA, b_dA, 0.)
-    tl.store(p_dA, b_dA.to(dA.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dA, b_dA.to(dA.dtype.element_ty), mask=m_A)
 
 
 @triton.heuristics({
@@ -328,12 +353,12 @@ def chunk_gsa_bwd_k_kernel_dqkvg(
     NG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -348,46 +373,55 @@ def chunk_gsa_bwd_k_kernel_dqkvg(
     o_t = min(i_t * BT + BT, T)
     m_s = o_i[:, None] >= o_i[None, :]
 
-    p_q = tl.make_block_ptr(q + (bos*HQ+i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos*H+i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_A = tl.make_block_ptr(A + ((i_k*all+bos)*HQ+i_hq)*BT, (T, BT), (HQ*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_q = o_q < T
+    m_k = o_k < K
+    m_qk = m_q[:, None] & m_k[None, :]
+    m_A = m_q[:, None] & (o_i[None, :] < BT)
+    p_q = q + (bos*HQ+i_hq) * K + o_q[:, None] * (HQ*K) + o_k[None, :]
+    p_k = k + (bos*H+i_h) * K + o_q[:, None] * (H*K) + o_k[None, :]
+    p_A = A + ((i_k*all+bos)*HQ+i_hq)*BT + o_q[:, None] * (HQ*BT) + o_i[None, :]
 
     # [BT, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_k = tl.load(p_k, mask=m_qk, other=0.0)
     # [BT, BT]
     b_A = tl.dot((b_q * scale).to(b_q.dtype), tl.trans(b_k))
     b_A = tl.where(m_s, b_A, 0.)
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_A)
 
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
         o_v = i_v * BV + tl.arange(0, BV)
-        p_v = tl.make_block_ptr(v + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_g = tl.make_block_ptr(g + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_gn = g + (bos + o_t - 1) * H*V + i_h * V + o_v
-        p_do = tl.make_block_ptr(do + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + ((i_k*all+bos)*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dg = tl.make_block_ptr(dg + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dgv = tl.make_block_ptr(dgv+((i_k*all+bos)*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dh = tl.make_block_ptr(dh + (i_tg * HQ + i_hq) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
         m_v = o_v < V
+        m_qv = m_q[:, None] & m_v[None, :]
+        m_vk = m_v[:, None] & m_k[None, :]
+        m_kv = m_k[:, None] & m_v[None, :]
+        p_v = v + (bos*H+i_h)*V + o_q[:, None] * (H*V) + o_v[None, :]
+        p_g = g + (bos*H+i_h)*V + o_q[:, None] * (H*V) + o_v[None, :]
+        p_gn = g + (bos + o_t - 1) * H*V + i_h * V + o_v
+        p_do = do + (bos*HQ+i_hq)*V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_dv = dv + ((i_k*all+bos)*HQ+i_hq)*V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_dg = dg + (bos*HQ+i_hq)*V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_dgv = dgv+((i_k*all+bos)*HQ+i_hq)*V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_h = h + (i_tg * H + i_h) * K*V + o_v[:, None] + o_k[None, :] * V
+        p_dh = dh + (i_tg * HQ + i_hq) * K*V + o_k[:, None] * V + o_v[None, :]
 
         # [BV,]
         b_gn = tl.load(p_gn, mask=m_v, other=0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_qv, other=0.0)
+        b_g = tl.load(p_g, mask=m_qv, other=0.0)
         b_gv = exp2(b_gn[None, :] - b_g)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_vk, other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_qv, other=0.0)
         b_do = (b_do * exp2(b_g)).to(b_do.dtype)
         # [BK, BV]
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, mask=m_kv, other=0.0)
         # [BV]
         b_dg = tl.sum(tl.trans(b_h) * b_dh, 0) * exp2(b_gn)
 
@@ -401,23 +435,23 @@ def chunk_gsa_bwd_k_kernel_dqkvg(
         b_dg += tl.sum(b_dv * b_v, 0)
 
         if i_k == 0:
-            b_dgv = tl.load(p_dg, boundary_check=(0, 1)) + b_dg[None, :]
+            b_dgv = tl.load(p_dg, mask=m_qv, other=0.0) + b_dg[None, :]
         else:
             b_dgv = tl.zeros([BT, BV], dtype=tl.float32) + b_dg[None, :]
 
-        tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    p_dA = tl.make_block_ptr(dA + (bos*HQ + i_hq) * BT, (T, BT), (HQ*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_dq = tl.make_block_ptr(dq + (bos*HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (bos*HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), mask=m_qv)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_qv)
+    p_dA = dA + (bos*HQ + i_hq) * BT + o_q[:, None] * (HQ*BT) + o_i[None, :]
+    p_dq = dq + (bos*HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_k[None, :]
+    p_dk = dk + (bos*HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_k[None, :]
     # [BT, BT]
-    b_dA = tl.load(p_dA, boundary_check=(0, 1))
+    b_dA = tl.load(p_dA, mask=m_A, other=0.0)
     # [BT, BK]
     b_dq += tl.dot(b_dA, b_k)
     b_dk += tl.dot(tl.trans(b_dA).to(b_k.dtype), b_q)
 
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_qk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_qk)
 
 
 @triton.heuristics({
@@ -448,9 +482,9 @@ def chunk_gsa_bwd_k_kernel_intra_dvg(
     i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // NG
-    i_t, i_i = i_c // NC, i_c % NC
+    i_t, i_i = (i_c // NC).to(tl.int64), i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -463,24 +497,30 @@ def chunk_gsa_bwd_k_kernel_intra_dvg(
     if i_t * BT + i_i * BC >= T:
         return
 
-    p_gv = tl.make_block_ptr(g + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT + i_i * BC, i_v * BV), (BC, BV), (1, 0))
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_c = o_c < T
+    m_cv = m_c[:, None] & m_v[None, :]
+    p_gv = g + (bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
     p_gn = g + (bos + min(i_t * BT + i_i * BC + BC, T)-1)*H*V + i_h*V + o_v
     # [BV,]
     b_gn = tl.load(p_gn, mask=m_v, other=0)
     # [BC, BV]
-    b_gv = tl.load(p_gv, boundary_check=(0, 1))
+    b_gv = tl.load(p_gv, mask=m_cv, other=0.0)
     b_dv = tl.zeros([BC, BV], dtype=tl.float32)
     for i_j in range(i_i + 1, NC):
-        p_g = tl.make_block_ptr(g + (bos*H+i_h) * V, (T, V), (H*V, 1), (i_t * BT + i_j * BC, i_v * BV), (BC, BV), (1, 0))
-        p_A = tl.make_block_ptr(A + (bos*HQ+i_hq) * BT, (BT, T), (1, HQ*BT), (i_i*BC, i_t*BT + i_j*BC), (BC, BC), (0, 1))
-        p_do = tl.make_block_ptr(do + (bos*HQ+i_hq) * V, (T, V), (HQ*V, 1), (i_t*BT + i_j*BC, i_v*BV), (BC, BV), (1, 0))
-
+        o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+        o_iA = i_i * BC + tl.arange(0, BC)
         m_j = (i_t * BT + i_j * BC + o_i) < T
+        m_jv = m_j[:, None] & m_v[None, :]
+        m_A = (o_iA[:, None] < BT) & m_j[None, :]
+        p_g = g + (bos*H+i_h) * V + o_j[:, None] * (H*V) + o_v[None, :]
+        p_A = A + (bos*HQ+i_hq) * BT + o_iA[:, None] + o_j[None, :] * (HQ*BT)
+        p_do = do + (bos*HQ+i_hq) * V + o_j[:, None] * (HQ*V) + o_v[None, :]
         # [BC, BV]
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1)) * tl.where(m_j[:, None], exp2(b_g - b_gn[None, :]), 0)
+        b_g = tl.load(p_g, mask=m_jv, other=0.0)
+        b_do = tl.load(p_do, mask=m_jv, other=0.0) * tl.where(m_j[:, None], exp2(b_g - b_gn[None, :]), 0)
         # [BC, BC]
-        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_A = tl.load(p_A, mask=m_A, other=0.0)
         # [BC, BV]
         b_dv += tl.dot(b_A, b_do.to(b_A.dtype))
     b_dv *= exp2(b_gn[None, :] - b_gv)
@@ -501,19 +541,19 @@ def chunk_gsa_bwd_k_kernel_intra_dvg(
         p_g += H * V
         p_A += HQ * BT
         p_do += HQ * V
-    p_o = tl.make_block_ptr(o + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_do = tl.make_block_ptr(do + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
-    p_dg = tl.make_block_ptr(dg + (bos*HQ+i_hq)*V, (T, V), (HQ*V, 1), (i_t*BT + i_i*BC, i_v*BV), (BC, BV), (1, 0))
+    p_o = o + (bos*HQ+i_hq)*V + o_c[:, None] * (HQ*V) + o_v[None, :]
+    p_v = v + (bos*H+i_h)*V + o_c[:, None] * (H*V) + o_v[None, :]
+    p_do = do + (bos*HQ+i_hq)*V + o_c[:, None] * (HQ*V) + o_v[None, :]
+    p_dv = dv + (bos*HQ+i_hq)*V + o_c[:, None] * (HQ*V) + o_v[None, :]
+    p_dg = dg + (bos*HQ+i_hq)*V + o_c[:, None] * (HQ*V) + o_v[None, :]
 
-    b_o = tl.load(p_o, boundary_check=(0, 1)).to(tl.float32)
-    b_v = tl.load(p_v, boundary_check=(0, 1)).to(tl.float32)
-    b_do = tl.load(p_do, boundary_check=(0, 1)).to(tl.float32)
-    b_dv = b_dv + tl.load(p_dv, boundary_check=(0, 1)).to(tl.float32)
+    b_o = tl.load(p_o, mask=m_cv, other=0.0).to(tl.float32)
+    b_v = tl.load(p_v, mask=m_cv, other=0.0).to(tl.float32)
+    b_do = tl.load(p_do, mask=m_cv, other=0.0).to(tl.float32)
+    b_dv = b_dv + tl.load(p_dv, mask=m_cv, other=0.0).to(tl.float32)
     b_dg = b_o * b_do - b_v * b_dv
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_cv)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_cv)
 
 
 def chunk_gsa_fwd_v(

--- a/fla/ops/hgrn/chunk.py
+++ b/fla/ops/hgrn/chunk.py
@@ -108,16 +108,18 @@ def chunk_hgrn_fwd_kernel_o(
     mask = o_d < D
 
     for i_t in range(1, tl.cdiv(T, BT)):
-        p_gc = tl.make_block_ptr(gc + i_b * s_b, (T, D), (s_t, s_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-        p_o = tl.make_block_ptr(o + i_b * s_b, (T, D), (s_t, s_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
+        o_t = (i_t * BT).to(tl.int64) + tl.arange(0, BT)
+        m_g = (o_t[:, None] < T) & mask[None, :]
+        p_gc = gc + i_b * s_b + o_t[:, None] * s_t + o_d[None, :] * s_d
+        p_o = o + i_b * s_b + o_t[:, None] * s_t + o_d[None, :] * s_d
 
         # [BD,]
         b_h0 = tl.load(o + i_b * T * D + i_t * BT * D - D + o_d, mask=mask, other=0).to(tl.float32)
         # [BT, BD]
-        b_gc = tl.load(p_gc, boundary_check=(0, 1)).to(tl.float32)
-        b_o = tl.load(p_o, boundary_check=(0, 1)).to(tl.float32)
+        b_gc = tl.load(p_gc, mask=m_g, other=0.0).to(tl.float32)
+        b_o = tl.load(p_o, mask=m_g, other=0.0).to(tl.float32)
         b_o = b_o + exp(b_gc) * b_h0[None, :]
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_g)
 
 
 @triton.autotune(
@@ -195,25 +197,29 @@ def chunk_hgrn_bwd_kernel_o(
     mask = o_d < D
 
     for i_t in range(tl.cdiv(T, BT) - 1, -1, -1):
-        p_g = tl.make_block_ptr(g + i_b * s_b, (T, D), (s_t, s_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-        p_gc = tl.make_block_ptr(gc + i_b * s_b, (T, D), (s_t, s_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-        p_o = tl.make_block_ptr(o + i_b * s_b, (T, D), (s_t, s_d), (i_t * BT - 1, i_d * BD), (BT, BD), (1, 0))
-        p_dx = tl.make_block_ptr(dx + i_b * s_b, (T, D), (s_t, s_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-        p_dg = tl.make_block_ptr(dg + i_b * s_b, (T, D), (s_t, s_d), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
+        o_t = (i_t * BT).to(tl.int64) + tl.arange(0, BT)
+        o_to = (i_t * BT - 1).to(tl.int64) + tl.arange(0, BT)
+        m_g = (o_t[:, None] < T) & mask[None, :]
+        m_go = ((o_to >= 0) & (o_to < T))[:, None] & mask[None, :]
+        p_g = g + i_b * s_b + o_t[:, None] * s_t + o_d[None, :] * s_d
+        p_gc = gc + i_b * s_b + o_t[:, None] * s_t + o_d[None, :] * s_d
+        p_o = o + i_b * s_b + o_to[:, None] * s_t + o_d[None, :] * s_d
+        p_dx = dx + i_b * s_b + o_t[:, None] * s_t + o_d[None, :] * s_d
+        p_dg = dg + i_b * s_b + o_t[:, None] * s_t + o_d[None, :] * s_d
 
         # [BD,]
         mask_t = mask & ((i_t + 1) * BT < T)
         b_ht = tl.load(dx + i_b * T * D + (i_t + 1) * BT * D + o_d, mask=mask_t, other=0).to(tl.float32)
         # [BT, BD]
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-        b_gc = tl.load(p_gc, boundary_check=(0, 1)).to(tl.float32)
-        b_o = tl.load(p_o, boundary_check=(0, 1)).to(tl.float32)
-        b_dx = tl.load(p_dx, boundary_check=(0, 1)).to(tl.float32)
+        b_g = tl.load(p_g, mask=m_g, other=0.0).to(tl.float32)
+        b_gc = tl.load(p_gc, mask=m_g, other=0.0).to(tl.float32)
+        b_o = tl.load(p_o, mask=m_go, other=0.0).to(tl.float32)
+        b_dx = tl.load(p_dx, mask=m_g, other=0.0).to(tl.float32)
 
         b_dx = b_dx + exp(b_gc) * b_ht[None, :]
         b_dg = b_o * b_dx * exp(b_g)
-        tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), mask=m_g)
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_g)
 
 
 class ChunkHGRNFunction(torch.autograd.Function):

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -61,11 +61,11 @@ def chunk_kda_bwd_kernel_dAv(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -79,32 +79,39 @@ def chunk_kda_bwd_kernel_dAv(
     dv += (bos * HV + i_hv) * V
     dA += (bos * HV + i_hv) * BT
 
-    p_A = tl.make_block_ptr(A + (bos * HV + i_hv) * BT, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
+    o_A = tl.arange(0, BT)
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    p_A = A + (bos * HV + i_hv) * BT + o_A[:, None] + o_t[None, :] * (HV*BT)
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
+
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (V, T), (1, HV*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        m_vT = m_v[:, None] & m_t[None, :]
+        m_tv = m_t[:, None] & m_v[None, :]
+        p_v = v + o_v[:, None] + o_t[None, :] * (HV*V)
+        p_do = do + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_dv = dv + o_t[:, None] * (HV*V) + o_v[None, :]
         # [BV, BT]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_vT, other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
         # [BT, BT]
         b_dA += tl.dot(b_do, b_v)
         # [BT, BV]
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    m_dA = m_t[:, None] & (o_A[None, :] < BT)
+    p_dA = dA + o_t[:, None] * (HV*BT) + o_A[None, :]
     b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.)
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_dA)
 
 
 @triton.heuristics({
@@ -155,13 +162,13 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         NT = tl.cdiv(T, BT)
@@ -192,11 +199,13 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     db += bos * HV + i_hv
     dA += (bos * HV + i_hv) * BT
 
-    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
+    p_beta = beta + o_t * HV
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
 
-    p_A = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    p_A = A + o_A[:, None] + o_t[None, :] * (HV * BT)
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     b_db = tl.zeros([BT], dtype=tl.float32)
@@ -204,11 +213,12 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
+        m_tk = m_t[:, None] & m_k[None, :]
 
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        p_g = g + o_t[:, None] * (HV*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
+        b_g = tl.load(p_g, mask=m_tk, other=0.0).to(tl.float32)
 
         p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * HV*K + o_k
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
@@ -219,23 +229,26 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         b_dgk = tl.zeros([BK], dtype=tl.float32)
 
         for i_v in range(tl.cdiv(V, BV)):
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_do = tl.make_block_ptr(do, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            o_v = i_v * BV + tl.arange(0, BV)
+            m_tv = m_t[:, None] & (o_v[None, :] < V)
+            m_h = (o_v[:, None] < V) & m_k[None, :]
+            p_v_new = v_new + o_t[:, None] * (HV*V) + o_v[None, :]
+            p_do = do + o_t[:, None] * (HV*V) + o_v[None, :]
             if STATE_V_FIRST:
-                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_h = h + o_v[:, None] * K + o_k[None, :]
+                p_dh = dh + o_v[:, None] * K + o_k[None, :]
             else:
-                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_h = h + o_v[:, None] + o_k[None, :] * V
+                p_dh = dh + o_v[:, None] + o_k[None, :] * V
+            p_dv = dv + o_t[:, None] * (HV*V) + o_v[None, :]
             # [BT, BV]
-            b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
+            b_v_new = tl.load(p_v_new, mask=m_tv, other=0.0)
+            b_do = tl.load(p_do, mask=m_tv, other=0.0)
             # [BV, BK]
-            b_h = tl.load(p_h, boundary_check=(0, 1))
-            b_dh = tl.load(p_dh, boundary_check=(0, 1))
+            b_h = tl.load(p_h, mask=m_h, other=0.0)
+            b_dh = tl.load(p_dh, mask=m_h, other=0.0)
             # [BT, BV]
-            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+            b_dv = tl.load(p_dv, mask=m_tv, other=0.0)
 
             b_dgk += tl.sum(b_h * b_dh, axis=0)
             b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
@@ -243,10 +256,10 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
             b_dw += tl.dot(b_dv.to(b_v_new.dtype), b_h.to(b_v_new.dtype))
             tl.debug_barrier()  # DO NOT REMOVE THIS LINE!
             if i_k == 0:
-                p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-                p_dv2 = tl.make_block_ptr(dv2, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_v = v + o_t[:, None] * (HV*V) + o_v[None, :]
+                p_dv2 = dv2 + o_t[:, None] * (HV*V) + o_v[None, :]
 
-                b_v = tl.load(p_v, boundary_check=(0, 1))
+                b_v = tl.load(p_v, mask=m_tv, other=0.0)
 
                 b_dA += tl.dot(b_dv, tl.trans(b_v))
 
@@ -254,7 +267,7 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
                 b_dv2 = b_dvb * b_beta[:, None]
                 b_db += tl.sum(b_dvb * b_v, 1)
 
-                tl.store(p_dv2, b_dv2.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
+                tl.store(p_dv2, b_dv2.to(p_dv2.dtype.element_ty), mask=m_tv)
 
         b_gk_exp = exp2(b_g)
         b_gb = b_gk_exp * b_beta[:, None]
@@ -270,19 +283,19 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         b_dkgb = tl.dot(b_A, b_dw)
         b_db += tl.sum(b_dkgb * b_kg, 1)
 
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_tk, other=0.0)
         b_kdk = b_k * b_dk
         b_dgk += tl.sum(b_kdk, axis=0)
         b_dg = b_q * b_dq - b_kdk + m_last[:, None] * b_dgk + b_kg * b_dkgb * b_beta[:, None]
         b_dk = b_dk + b_dkgb * b_gb
 
-        p_dq = tl.make_block_ptr(dq, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+        p_dq = dq + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dk = dk + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dg = dg + o_t[:, None] * (HV*K) + o_k[None, :]
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_tk)
 
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA * b_beta[None, :], 0)
@@ -290,10 +303,11 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
     b_dA = tl.where(m_A, -b_dA, 0)
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    m_dA = m_t[:, None] & (o_A[None, :] < BT)
+    p_dA = dA + o_t[:, None] * (HV * BT) + o_A[None, :]
+    p_db = db + o_t * HV
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_dA)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_t)
 
 
 @dispatch('kda')

--- a/fla/ops/kda/chunk_intra.py
+++ b/fla/ops/kda/chunk_intra.py
@@ -74,12 +74,12 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     5. Computes merged Akk_inv
     6. Writes Akk_inv to Akk
     """
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -104,6 +104,15 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     m_tc1 = (i_tc1 + o_i) < T
     m_tc2 = (i_tc2 + o_i) < T
     m_tc3 = (i_tc3 + o_i) < T
+    o_c0 = i_tc0 + o_i
+    o_c1 = i_tc1 + o_i
+    o_c2 = i_tc2 + o_i
+    o_c3 = i_tc3 + o_i
+    m_tc0 = o_c0 < T
+    m_A0 = m_tc0[:, None] & (o_i[None, :] < BT)
+    m_A1 = m_tc1[:, None] & (o_i[None, :] < BT)
+    m_A2 = m_tc2[:, None] & (o_i[None, :] < BT)
+    m_A3 = m_tc3[:, None] & (o_i[None, :] < BT)
 
     b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
     b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
@@ -127,19 +136,21 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_k0 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-        p_g0 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-        b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
-        b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+        m_ck0 = m_tc0[:, None] & m_k[None, :]
+        p_k0 = k + o_c0[:, None] * (H*K) + o_k[None, :]
+        p_g0 = g + o_c0[:, None] * (HV*K) + o_k[None, :]
+        b_k0 = tl.load(p_k0, mask=m_ck0, other=0.0).to(tl.float32)
+        b_g0 = tl.load(p_g0, mask=m_ck0, other=0.0).to(tl.float32)
 
         if i_tc1 < T:
-            p_q1 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_k1 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_g1 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            m_ck1 = m_tc1[:, None] & m_k[None, :]
+            p_q1 = q + o_c1[:, None] * (H*K) + o_k[None, :]
+            p_k1 = k + o_c1[:, None] * (H*K) + o_k[None, :]
+            p_g1 = g + o_c1[:, None] * (HV*K) + o_k[None, :]
             # [BC, BK]
-            b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
-            b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
-            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+            b_q1 = tl.load(p_q1, mask=m_ck1, other=0.0).to(tl.float32)
+            b_k1 = tl.load(p_k1, mask=m_ck1, other=0.0).to(tl.float32)
+            b_g1 = tl.load(p_g1, mask=m_ck1, other=0.0).to(tl.float32)
             # [BK]
             b_gn1 = tl.load(g + i_tc1 * HV*K + o_k, mask=m_k, other=0).to(tl.float32)
             # [BC, BK]
@@ -151,13 +162,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
             b_Akk10 += tl.dot(b_k1 * b_gqn, b_kgt)
 
             if NC >= 3 and i_tc2 < T:
-                p_q2 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                p_k2 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-                p_g2 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                m_ck2 = m_tc2[:, None] & m_k[None, :]
+                p_q2 = q + o_c2[:, None] * (H*K) + o_k[None, :]
+                p_k2 = k + o_c2[:, None] * (H*K) + o_k[None, :]
+                p_g2 = g + o_c2[:, None] * (HV*K) + o_k[None, :]
                 # [BC, BK]
-                b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
-                b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
-                b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+                b_q2 = tl.load(p_q2, mask=m_ck2, other=0.0).to(tl.float32)
+                b_k2 = tl.load(p_k2, mask=m_ck2, other=0.0).to(tl.float32)
+                b_g2 = tl.load(p_g2, mask=m_ck2, other=0.0).to(tl.float32)
                 # [BK]
                 b_gn2 = tl.load(g + i_tc2 * HV*K + o_k, mask=m_k, other=0).to(tl.float32)
                 # [BC, BK]
@@ -175,13 +187,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
                 b_Akk21 += tl.dot(b_kg2, b_kgt)
 
                 if NC >= 4 and i_tc3 < T:
-                    p_q3 = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    p_k3 = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
-                    p_g3 = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                    m_ck3 = m_tc3[:, None] & m_k[None, :]
+                    p_q3 = q + o_c3[:, None] * (H*K) + o_k[None, :]
+                    p_k3 = k + o_c3[:, None] * (H*K) + o_k[None, :]
+                    p_g3 = g + o_c3[:, None] * (HV*K) + o_k[None, :]
                     # [BC, BK]
-                    b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
-                    b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
-                    b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+                    b_q3 = tl.load(p_q3, mask=m_ck3, other=0.0).to(tl.float32)
+                    b_k3 = tl.load(p_k3, mask=m_ck3, other=0.0).to(tl.float32)
+                    b_g3 = tl.load(p_g3, mask=m_ck3, other=0.0).to(tl.float32)
                     # [BK]
                     b_gn3 = tl.load(g + i_tc3 * HV*K + o_k, mask=m_k, other=0).to(tl.float32)
                     # [BC, BK]
@@ -208,46 +221,46 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     # save off-diagonal Aqk blocks and prepare Akk
     ################################################################################
     if i_tc1 < T:
-        p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk10 = Aqk + o_c1[:, None] * (HV*BT) + o_i[None, :]
+        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), mask=m_A1)
 
-        p_b1 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,))
-        b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+        p_b1 = beta + bos * HV + i_hv + o_c1 * HV
+        b_b1 = tl.load(p_b1, mask=m_tc1, other=0.0).to(tl.float32)
         b_Akk10 = b_Akk10 * b_b1[:, None]
     if NC >= 3 and i_tc2 < T:
-        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk20 = Aqk + o_c2[:, None] * (HV*BT) + o_i[None, :]
+        p_Aqk21 = Aqk + o_c2[:, None] * (HV*BT) + (o_i + BC)[None, :]
+        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), mask=m_A2)
+        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), mask=m_A2)
 
-        p_b2 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,))
-        b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+        p_b2 = beta + bos * HV + i_hv + o_c2 * HV
+        b_b2 = tl.load(p_b2, mask=m_tc2, other=0.0).to(tl.float32)
         b_Akk20 = b_Akk20 * b_b2[:, None]
         b_Akk21 = b_Akk21 * b_b2[:, None]
     if NC >= 4 and i_tc3 < T:
-        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
-        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        p_Aqk30 = Aqk + o_c3[:, None] * (HV*BT) + o_i[None, :]
+        p_Aqk31 = Aqk + o_c3[:, None] * (HV*BT) + (o_i + BC)[None, :]
+        p_Aqk32 = Aqk + o_c3[:, None] * (HV*BT) + (o_i + 2*BC)[None, :]
+        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), mask=m_A3)
 
-        p_b3 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,))
-        b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+        p_b3 = beta + bos * HV + i_hv + o_c3 * HV
+        b_b3 = tl.load(p_b3, mask=m_tc3, other=0.0).to(tl.float32)
         b_Akk30 = b_Akk30 * b_b3[:, None]
         b_Akk31 = b_Akk31 * b_b3[:, None]
         b_Akk32 = b_Akk32 * b_b3[:, None]
 
-    p_Akk00 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
+    p_Akk00 = Akkd + o_c0[:, None] * (HV*BC) + o_i[None, :]
+    p_Akk11 = Akkd + o_c1[:, None] * (HV*BC) + o_i[None, :]
+    b_Ai00 = tl.load(p_Akk00, mask=m_A0, other=0.0).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, mask=m_A1, other=0.0).to(tl.float32)
     if NC >= 3:
-        p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
-        b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+        p_Akk22 = Akkd + o_c2[:, None] * (HV*BC) + o_i[None, :]
+        b_Ai22 = tl.load(p_Akk22, mask=m_A2, other=0.0).to(tl.float32)
     if NC >= 4:
-        p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (HV*BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
-        b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+        p_Akk33 = Akkd + o_c3[:, None] * (HV*BC) + o_i[None, :]
+        b_Ai33 = tl.load(p_Akk33, mask=m_A3, other=0.0).to(tl.float32)
 
     ################################################################################
     # forward substitution on diagonals
@@ -341,29 +354,29 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     # store full Akk_inv to Akk
     ################################################################################
 
-    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+    p_Akk00 = Akk + o_c0[:, None] * (HV*BT) + o_i[None, :]
+    p_Akk10 = Akk + o_c1[:, None] * (HV*BT) + o_i[None, :]
+    p_Akk11 = Akk + o_c1[:, None] * (HV*BT) + (o_i + BC)[None, :]
 
-    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), mask=m_A0)
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), mask=m_A1)
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), mask=m_A1)
     if NC >= 3:
-        p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-        p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
-        p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc2, 2*BC), (BC, BC), (1, 0))
-        tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        p_Akk20 = Akk + o_c2[:, None] * (HV*BT) + o_i[None, :]
+        p_Akk21 = Akk + o_c2[:, None] * (HV*BT) + (o_i + BC)[None, :]
+        p_Akk22 = Akk + o_c2[:, None] * (HV*BT) + (o_i + 2*BC)[None, :]
+        tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), mask=m_A2)
+        tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), mask=m_A2)
+        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), mask=m_A2)
     if NC >= 4:
-        p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-        p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
-        p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 2*BC), (BC, BC), (1, 0))
-        p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (HV*BT, 1), (i_tc3, 3*BC), (BC, BC), (1, 0))
-        tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        p_Akk30 = Akk + o_c3[:, None] * (HV*BT) + o_i[None, :]
+        p_Akk31 = Akk + o_c3[:, None] * (HV*BT) + (o_i + BC)[None, :]
+        p_Akk32 = Akk + o_c3[:, None] * (HV*BT) + (o_i + 2*BC)[None, :]
+        p_Akk33 = Akk + o_c3[:, None] * (HV*BT) + (o_i + 3*BC)[None, :]
+        tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), mask=m_A3)
 
 
 @triton.heuristics({
@@ -408,14 +421,14 @@ def chunk_kda_bwd_kernel_intra(
     SAFE_GATE: tl.constexpr,
     USE_GATHER: tl.constexpr,
 ):
-    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     i_k, i_i = i_kc // NC, i_kc % NC
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -443,11 +456,17 @@ def chunk_kda_bwd_kernel_intra(
     dg2 += (bos * HV + i_hv) * K
     db += (i_k * all + bos) * HV + i_hv
 
-    p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    o_i = tl.arange(0, BC)
+    o_c = i_ti + o_i
+    m_c = o_c < T
+    m_ck = m_c[:, None] & m_k[None, :]
+    m_dAf = m_c[:, None] & (o_i[None, :] < BT)
+    m_dAt = (o_i[:, None] < BT) & m_c[None, :]
+    p_g = g + o_c[:, None] * (HV*K) + o_k[None, :]
+    b_g = tl.load(p_g, mask=m_ck, other=0.0).to(tl.float32)
 
-    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    p_b = beta + o_c * HV
+    b_b = tl.load(p_b, mask=m_c, other=0.0)
 
     b_dq2 = tl.zeros([BC, BK], dtype=tl.float32)
     b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
@@ -456,17 +475,19 @@ def chunk_kda_bwd_kernel_intra(
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
         for i_j in range(0, i_i):
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
-            p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV*BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+            o_j = i_t * BT + i_j * BC + o_i
+            m_jk = (o_j < T)[:, None] & m_k[None, :]
+            p_k = k + o_j[:, None] * (H*K) + o_k[None, :]
+            p_gk = g + o_j[:, None] * (HV*K) + o_k[None, :]
+            p_dAqk = dAqk + o_c[:, None] * (HV*BT) + (i_j * BC + o_i)[None, :]
+            p_dAkk = dAkk + o_c[:, None] * (HV*BT) + (i_j * BC + o_i)[None, :]
             # [BC, BK]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=m_jk, other=0.0)
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0)
             b_kg = b_k * exp2(b_gn - b_gk)
             # [BC, BC]
-            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
+            b_dAqk = tl.load(p_dAqk, mask=m_dAf, other=0.0)
+            b_dAkk = tl.load(p_dAkk, mask=m_dAf, other=0.0)
             # [BC, BK]
             b_dq2 += tl.dot(b_dAqk, b_kg)
             b_dk2 += tl.dot(b_dAkk, b_kg)
@@ -480,10 +501,10 @@ def chunk_kda_bwd_kernel_intra(
     p_kj = k + i_ti * H*K + o_k
     p_gkj = g + i_ti * HV*K + o_k
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    p_q = q + o_c[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_c[:, None] * (H*K) + o_k[None, :]
+    b_q = tl.load(p_q, mask=m_ck, other=0.0)
+    b_k = tl.load(p_k, mask=m_ck, other=0.0)
 
     if SAFE_GATE:
         if USE_GATHER:
@@ -492,10 +513,10 @@ def chunk_kda_bwd_kernel_intra(
             p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV*K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0)[None, :]
 
-        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        b_dAqk_diag_qk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_qk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+        p_dAqk = dAqk + o_c[:, None] * (HV*BT) + (i_i * BC + o_i)[None, :]
+        p_dAkk = dAkk + o_c[:, None] * (HV*BT) + (i_i * BC + o_i)[None, :]
+        b_dAqk_diag_qk = tl.load(p_dAqk, mask=m_dAf, other=0.0).to(tl.float32)
+        b_dAkk_diag_qk = tl.load(p_dAkk, mask=m_dAf, other=0.0).to(tl.float32)
 
         m_i_diag_qk = (o_i[:, None] >= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
         m_j_diag_qk = (i_ti + o_i[:, None]) < T
@@ -530,14 +551,14 @@ def chunk_kda_bwd_kernel_intra(
     b_db = tl.sum(b_dk2 * b_k, 1)
     b_dk2 *= b_b[:, None]
 
-    p_dq = tl.make_block_ptr(dq, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dq2 = tl.make_block_ptr(dq2, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_ti,), (BC,), (0,))
+    p_dq = dq + o_c[:, None] * (HV*K) + o_k[None, :]
+    p_dq2 = dq2 + o_c[:, None] * (HV*K) + o_k[None, :]
+    p_db = db + o_c * HV
 
     b_dg2 = b_q * b_dq2
-    b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
-    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    b_dq2 = b_dq2 + tl.load(p_dq, mask=m_ck, other=0.0)
+    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), mask=m_ck)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_c)
 
     tl.debug_barrier()
     b_dkt = tl.zeros([BC, BK], dtype=tl.float32)
@@ -548,24 +569,26 @@ def chunk_kda_bwd_kernel_intra(
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
         for i_j in range(i_i + 1, NC):
-            p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k*BK), (BC, BK), (1, 0))
-            p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_t * BT + i_j * BC, i_k*BK), (BC, BK), (1, 0))
-            p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT + i_j * BC,), (BC,), (0,))
-            p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV*BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-            p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV*BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-            # [BC]
-            b_b = tl.load(p_b, boundary_check=(0,))
-            # [BC, BK]
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_kb = tl.load(p_k, boundary_check=(0, 1)) * b_b[:, None]
-            b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
-            # [BC, BC]
-            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
-
             o_j = i_t * BT + i_j * BC + o_i
             m_j = o_j < T
+            m_jk = m_j[:, None] & m_k[None, :]
+            m_dAj = (o_i[:, None] < BT) & m_j[None, :]
+            p_q = q + o_j[:, None] * (H*K) + o_k[None, :]
+            p_k = k + o_j[:, None] * (H*K) + o_k[None, :]
+            p_gk = g + o_j[:, None] * (HV*K) + o_k[None, :]
+            p_b = beta + o_j * HV
+            p_dAqk = dAqk + (i_i * BC + o_i)[:, None] + o_j[None, :] * (HV*BT)
+            p_dAkk = dAkk + (i_i * BC + o_i)[:, None] + o_j[None, :] * (HV*BT)
+            # [BC]
+            b_b = tl.load(p_b, mask=m_j, other=0.0)
+            # [BC, BK]
+            b_q = tl.load(p_q, mask=m_jk, other=0.0)
+            b_kb = tl.load(p_k, mask=m_jk, other=0.0) * b_b[:, None]
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0).to(tl.float32)
+            # [BC, BC]
+            b_dAqk = tl.load(p_dAqk, mask=m_dAj, other=0.0)
+            b_dAkk = tl.load(p_dAkk, mask=m_dAj, other=0.0)
+
             # [BC, BK]
             b_gkn = exp2(b_gk - b_gn)
             b_qg = b_q * tl.where(m_j[:, None], b_gkn, 0)
@@ -587,15 +610,15 @@ def chunk_kda_bwd_kernel_intra(
         else:
             p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV*K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
-        b_b = tl.load(p_b, boundary_check=(0,))
+        p_q = q + o_c[:, None] * (H*K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_ck, other=0.0)
+        p_b = beta + o_c * HV
+        b_b = tl.load(p_b, mask=m_c, other=0.0)
 
-        p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV*BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        b_dAqk_diag_kk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_kk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+        p_dAqk = dAqk + (i_i * BC + o_i)[:, None] + o_c[None, :] * (HV*BT)
+        p_dAkk = dAkk + (i_i * BC + o_i)[:, None] + o_c[None, :] * (HV*BT)
+        b_dAqk_diag_kk = tl.load(p_dAqk, mask=m_dAt, other=0.0).to(tl.float32)
+        b_dAkk_diag_kk = tl.load(p_dAkk, mask=m_dAt, other=0.0).to(tl.float32)
 
         m_i_diag_kk = (o_i[:, None] <= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
         m_j_diag_kk = (i_ti + o_i[:, None]) < T
@@ -631,17 +654,17 @@ def chunk_kda_bwd_kernel_intra(
             p_kj += H*K
             p_gkj += HV*K
             p_bj += HV
-    p_dk = tl.make_block_ptr(dk, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dk2 = tl.make_block_ptr(dk2, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg2 = tl.make_block_ptr(dg2, (T, K), (HV*K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk = dk + o_c[:, None] * (HV*K) + o_k[None, :]
+    p_dk2 = dk2 + o_c[:, None] * (HV*K) + o_k[None, :]
+    p_dg = dg + o_c[:, None] * (HV*K) + o_k[None, :]
+    p_dg2 = dg2 + o_c[:, None] * (HV*K) + o_k[None, :]
 
-    b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, boundary_check=(0, 1))
-    b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
+    b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, mask=m_ck, other=0.0)
+    b_dk2 += tl.load(p_dk, mask=m_ck, other=0.0)
     b_dk2 += b_dkt
 
-    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), mask=m_ck)
+    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), mask=m_ck)
 
 
 @triton.heuristics({
@@ -677,12 +700,12 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     IS_VARLEN: tl.constexpr,
     USE_GATHER: tl.constexpr,
 ):
-    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -702,16 +725,19 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     Aqk = Aqk + (bos * HV + i_hv) * BT
     Akk = Akk + (bos * HV + i_hv) * BC
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_ti, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T, K), (HV*K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_ck = m_c[:, None] & m_k[None, :]
+    p_q = q + o_c[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_c[:, None] * (H*K) + o_k[None, :]
+    p_g = g + o_c[:, None] * (HV*K) + o_k[None, :]
 
-    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
+    p_beta = beta + o_c * HV
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
+    b_q = tl.load(p_q, mask=m_ck, other=0.0)
+    b_k = tl.load(p_k, mask=m_ck, other=0.0)
+    b_g = tl.load(p_g, mask=m_ck, other=0.0)
+    b_beta = tl.load(p_beta, mask=m_c, other=0.0)
 
     if USE_GATHER:
         b_gn = gather(b_g, tl.full([1, BK], min(BC//2, T - i_ti - 1), dtype=tl.int16), axis=0)
@@ -741,10 +767,12 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
     b_Akk = tl.where(m_Akk, b_Akk, 0.0)
 
-    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (HV*BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-    p_Akk = tl.make_block_ptr(Akk, (T, BC), (HV*BC, 1), (i_ti, 0), (BC, BC), (1, 0))
-    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    m_Aqk_st = m_c[:, None] & (o_i[None, :] < BT)
+    m_Akk_st = m_c[:, None] & (o_i[None, :] < BC)
+    p_Aqk = Aqk + o_c[:, None] * (HV*BT) + (i_i * BC + o_i)[None, :]
+    p_Akk = Akk + o_c[:, None] * (HV*BC) + o_i[None, :]
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), mask=m_Aqk_st)
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), mask=m_Akk_st)
 
     tl.debug_barrier()
 
@@ -759,7 +787,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
         b_a += tl.sum(b_a[:, None] * b_Ai, 0)
         b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
     b_Ai += m_I
-    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), mask=m_Akk_st)
 
 
 @dispatch('kda')

--- a/fla/ops/kda/chunk_intra_token_parallel.py
+++ b/fla/ops/kda/chunk_intra_token_parallel.py
@@ -105,15 +105,15 @@ def chunk_kda_fwd_kernel_intra_token_parallel(
     b_k = tl.load(k + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
 
     # g: [B, T, HV, K], beta: [B, T, HV]
-    p_g = tl.make_block_ptr(g + i_t * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-    p_beta = tl.make_block_ptr(beta + i_t * HV, (HV,), (1,), (i_hg * BH,), (BH,), (0,))
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-    b_k = b_k * tl.load(p_beta, boundary_check=(0,)).to(tl.float32)[:, None]
+    p_g = g + i_t * HV * K + o_hv[:, None] * K + o_k[None, :]
+    p_beta = beta + i_t * HV + o_hv
+    b_g = tl.load(p_g, mask=m_hk, other=0.0).to(tl.float32)
+    b_k = b_k * tl.load(p_beta, mask=m_hv, other=0.0).to(tl.float32)[:, None]
 
     for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
         b_kj = tl.load(k + j * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
-        p_gj = tl.make_block_ptr(g + j * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
-        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+        p_gj = g + j * HV * K + o_hv[:, None] * K + o_k[None, :]
+        b_gj = tl.load(p_gj, mask=m_hk, other=0.0).to(tl.float32)
 
         b_kgj = tl.where(m_k[None, :], b_kj * exp2(b_g - b_gj), 0.0)
         b_Aqk = tl.sum(b_q * b_kgj, axis=1) * scale

--- a/fla/ops/kda/gate.py
+++ b/fla/ops/kda/gate.py
@@ -103,28 +103,32 @@ def kda_gate_fwd_kernel(
     HAS_BETA: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
 ):
-    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
     b_A = tl.load(A_log + i_h).to(tl.float32)
 
-    p_g = tl.make_block_ptr(g + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_yg = tl.make_block_ptr(yg + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_g = m_t[:, None] & (o_d[None, :] < D)
+    p_g = g + i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
+    p_yg = yg + i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
     # [BT, BD]
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_g = tl.load(p_g, mask=m_g, other=0.0).to(tl.float32)
     if HAS_BIAS:
-        p_b = tl.make_block_ptr(dt_bias, (H * D,), (1,), (i_h * D,), (BD,), (0,))
-        b_g = b_g + tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+        o_b = i_h * D + tl.arange(0, BD)
+        b_g = b_g + tl.load(dt_bias + o_b, mask=o_b < H * D, other=0.0).to(tl.float32)
     if not USE_LOWER_BOUND:
         b_yg = -exp(b_A) * softplus(b_g)
     else:
         b_yg = lower_bound * tl.sigmoid(exp(b_A) * b_g)
-    tl.store(p_yg, b_yg.to(p_yg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_yg, b_yg.to(p_yg.dtype.element_ty), mask=m_g)
 
     if HAS_BETA:
-        p_b = tl.make_block_ptr(beta + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_yb = tl.make_block_ptr(yb + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        b_yb = tl.sigmoid(tl.load(p_b, boundary_check=(0,)).to(tl.float32))
-        tl.store(p_yb, b_yb.to(p_yb.dtype.element_ty), boundary_check=(0,))
+        p_b = beta + i_h + o_t * H
+        p_yb = yb + i_h + o_t * H
+        b_yb = tl.sigmoid(tl.load(p_b, mask=m_t, other=0.0).to(tl.float32))
+        tl.store(p_yb, b_yb.to(p_yb.dtype.element_ty), mask=m_t)
 
 
 @triton.heuristics({
@@ -162,21 +166,25 @@ def kda_gate_bwd_kernel(
     HAS_BETA: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
 ):
-    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
     b_A = tl.load(A_log + i_h).to(tl.float32)
 
-    p_g = tl.make_block_ptr(g + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_dg = tl.make_block_ptr(dg + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_dyg = tl.make_block_ptr(dyg + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_g = m_t[:, None] & (o_d[None, :] < D)
+    p_g = g + i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
+    p_dg = dg + i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
+    p_dyg = dyg + i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
 
     # [BT, BD]
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-    b_dyg = tl.load(p_dyg, boundary_check=(0, 1)).to(tl.float32)
+    b_g = tl.load(p_g, mask=m_g, other=0.0).to(tl.float32)
+    b_dyg = tl.load(p_dyg, mask=m_g, other=0.0).to(tl.float32)
 
     if HAS_BIAS:
-        p_b = tl.make_block_ptr(dt_bias, (H * D,), (1,), (i_h * D,), (BD,), (0,))
-        b_g = b_g + tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+        o_b = i_h * D + tl.arange(0, BD)
+        b_g = b_g + tl.load(dt_bias + o_b, mask=o_b < H * D, other=0.0).to(tl.float32)
 
     # [BT, BD]
     if not USE_LOWER_BOUND:
@@ -195,17 +203,17 @@ def kda_gate_bwd_kernel(
         b_dg = b_d_inner_term * b_A
         b_dA = tl.sum(tl.sum(b_dg * b_g, 1), 0)
 
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_g)
     tl.store(dA + i_t * H + i_h, b_dA)
 
     if HAS_BETA:
-        p_b = tl.make_block_ptr(beta + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_db = tl.make_block_ptr(dbeta + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_dyb = tl.make_block_ptr(dyb + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_b = beta + i_h + o_t * H
+        p_db = dbeta + i_h + o_t * H
+        p_dyb = dyb + i_h + o_t * H
 
-        b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
-        b_db = tl.load(p_dyb, boundary_check=(0,)).to(tl.float32) * b_b * (1.0 - b_b)
-        tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+        b_b = tl.load(p_b, mask=m_t, other=0.0).to(tl.float32)
+        b_db = tl.load(p_dyb, mask=m_t, other=0.0).to(tl.float32) * b_b * (1.0 - b_b)
+        tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_t)
 
 
 @dispatch('kda')
@@ -384,24 +392,26 @@ def kda_gate_chunk_cumsum_vector_kernel(
     IS_VARLEN: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
 ):
-    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_s = i_s * BS + tl.arange(0, BS)
+    m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
+    p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+    p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
     # [BT, BS]
-    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_s = tl.load(p_s, mask=m_s, other=0.0).to(tl.float32)
 
     # Apply dt_bias if exists
     if HAS_BIAS:
-        p_b = tl.make_block_ptr(dt_bias + i_h * S, (S,), (1,), (i_s * BS,), (BS,), (0,))
-        b_bias = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+        b_bias = tl.load(dt_bias + i_h * S + o_s, mask=o_s < S, other=0.0).to(tl.float32)
         b_s = b_s + b_bias[None, :]
 
     b_A = tl.load(A_log + i_h).to(tl.float32)
@@ -419,7 +429,7 @@ def kda_gate_chunk_cumsum_vector_kernel(
 
     if HAS_SCALE:
         b_o *= scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_s)
 
 
 @input_guard

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -56,11 +56,11 @@ def recompute_w_u_fwd_kda_kernel(
     STORE_KG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -79,46 +79,53 @@ def recompute_w_u_fwd_kda_kernel(
     if STORE_KG:
         kg += (bos * HV + i_hv) * K
 
-    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_b = beta + o_t * HV
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
 
-    p_A = tl.make_block_ptr(A, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    o_A = tl.arange(0, BT)
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + o_t[:, None] * (HV*BT) + o_A[None, :]
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_u = tl.make_block_ptr(u, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_u = u + o_t[:, None] * (HV*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), mask=m_v)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_w = tl.make_block_ptr(w, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_tk = m_t[:, None] & m_k[None, :]
+        p_w = w + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
         b_kb = b_k * b_b[:, None]
 
-        p_gk = tl.make_block_ptr(gk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+        p_gk = gk + o_t[:, None] * (HV*K) + o_k[None, :]
+        b_gk = tl.load(p_gk, mask=m_tk, other=0.0).to(tl.float32)
         b_kb *= exp2(b_gk)
         if STORE_QG:
-            p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            p_qg = tl.make_block_ptr(qg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+            p_qg = qg + o_t[:, None] * (HV*K) + o_k[None, :]
+            b_q = tl.load(p_q, mask=m_tk, other=0.0)
             b_qg = b_q * exp2(b_gk)
-            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), mask=m_tk)
         if STORE_KG:
             last_idx = min(i_t * BT + BT, T) - 1
-            o_k = i_k * BK + tl.arange(0, BK)
-            m_k = o_k < K
             b_gn = tl.load(gk + last_idx * HV*K + o_k, mask=m_k, other=0.).to(tl.float32)
             b_kg = b_k * tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], exp2(b_gn[None, :] - b_gk), 0)
-            p_kg = tl.make_block_ptr(kg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+            p_kg = kg + o_t[:, None] * (HV*K) + o_k[None, :]
+            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), mask=m_tk)
 
         b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_tk)
 
 
 @triton.heuristics({
@@ -161,11 +168,11 @@ def prepare_wy_repr_bwd_kda_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -186,54 +193,60 @@ def prepare_wy_repr_bwd_kda_kernel(
     dg += (bos * HV + i_hv) * K
     dg2 += (bos * HV + i_hv) * K
 
-    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A, (BT, T), (1, HV*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_b = beta + o_t * HV
+    p_db = db + o_t * HV
+    o_A = tl.arange(0, BT)
+    m_AT = (o_A[:, None] < BT) & m_t[None, :]
+    p_A = A + o_A[:, None] + o_t[None, :] * (HV*BT)
 
-    b_b = tl.load(p_b, boundary_check=(0,))
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
     b_db = tl.zeros([BT], dtype=tl.float32)
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_AT, other=0.0)
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk2 = tl.make_block_ptr(dk2, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg2 = tl.make_block_ptr(dg2, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dk2 = dk2 + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dw = dw + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dg = dg + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dg2 = dg2 + o_t[:, None] * (HV*K) + o_k[None, :]
 
         # [BT, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        p_gk = tl.make_block_ptr(gk, (T, K), (HV*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_gk_exp = exp2(tl.load(p_gk, boundary_check=(0, 1)))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        p_gk = gk + o_t[:, None] * (HV*K) + o_k[None, :]
+        b_gk_exp = exp2(tl.load(p_gk, mask=m_k, other=0.0))
         b_kbg = b_k * b_b[:, None] * b_gk_exp
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
+        b_dw = tl.load(p_dw, mask=m_k, other=0.0)
 
         b_dA += tl.dot(b_dw, tl.trans(b_kbg).to(b_dw.dtype))
         b_dkbg = tl.dot(b_A, b_dw)
-        b_dk = b_dkbg * b_gk_exp * b_b[:, None] + tl.load(p_dk, boundary_check=(0, 1))
+        b_dk = b_dkbg * b_gk_exp * b_b[:, None] + tl.load(p_dk, mask=m_k, other=0.0)
         b_db += tl.sum(b_dkbg * b_k * b_gk_exp, 1)
-        b_dg = b_kbg * b_dkbg + tl.load(p_dg, boundary_check=(0, 1))
+        b_dg = b_kbg * b_dkbg + tl.load(p_dg, mask=m_k, other=0.0)
 
-        tl.store(p_dk2, b_dk.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg2, b_dg.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk2, b_dk.to(p_dk2.dtype.element_ty), mask=m_k)
+        tl.store(p_dg2, b_dg.to(p_dg2.dtype.element_ty), mask=m_k)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du, (T, V), (HV*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_dv = dv + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_du = du + o_t[:, None] * (HV*V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
-        b_du = tl.load(p_du, boundary_check=(0, 1))
+        b_du = tl.load(p_du, mask=m_v, other=0.0)
         b_dA += tl.dot(b_du, tl.trans(b_vb))
         b_dvb = tl.dot(b_A, b_du)
         b_dv = b_dvb * b_b[:, None]
         b_db += tl.sum(b_dvb * b_v, 1)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_dA = tl.where(m_A, b_dA, 0)
     b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
@@ -241,9 +254,10 @@ def prepare_wy_repr_bwd_kda_kernel(
 
     b_dA = tl.where(m_A, -b_dA, 0)
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (HV*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+    m_dA = m_t[:, None] & (o_A[None, :] < BT)
+    p_dA = dA + o_t[:, None] * (HV*BT) + o_A[None, :]
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_dA)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=m_t)
 
 
 @dispatch('kda')

--- a/fla/ops/log_linear_attn/chunk.py
+++ b/fla/ops/log_linear_attn/chunk.py
@@ -67,8 +67,9 @@ def chunkwise_fwd_kernel(
     USE_INITIAL_STATE: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
 ):
-    p_llut = tl.make_block_ptr(llut, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
-    b_llut = tl.load(p_llut, boundary_check=(0, 1))
+    o_i = tl.arange(0, BT)
+    p_llut = llut + o_i[:, None] * BT + o_i[None, :]
+    b_llut = tl.load(p_llut, mask=(o_i[:, None] < BT) & (o_i[None, :] < BT), other=0.0)
     # parallel over sequences and heads
     i_k = tl.program_id(0)
     i_nh = tl.program_id(1)
@@ -83,7 +84,9 @@ def chunkwise_fwd_kernel(
     else:
         bos, eos = (i_n * T).to(tl.int64), (i_n * T + T).to(tl.int64)
 
-    o_i = tl.arange(0, BT)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_v = tl.arange(0, V)
+    m_kv = (o_kk[:, None] < K) & (o_v[None, :] < V)
 
     # For hierarchical masking
     num_intra_levels = (tl.log2(float(BT))).to(tl.int32) + 1
@@ -126,125 +129,41 @@ def chunkwise_fwd_kernel(
         first_chunk_index = offset // BT
 
         if KV_0_CREATED and (first_chunk_index & 1 > 0):
-            p_kv_0 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 0) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_0 = tl.load(p_kv_0, boundary_check=(0, 1))
+            p_kv_0 = h0 + ((i_n * L_IN + 0) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_0 = tl.load(p_kv_0, mask=m_kv, other=0.0)
         if KV_1_CREATED and (first_chunk_index & 2 > 0):
-            p_kv_1 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 1) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_1 = tl.load(p_kv_1, boundary_check=(0, 1))
+            p_kv_1 = h0 + ((i_n * L_IN + 1) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_1 = tl.load(p_kv_1, mask=m_kv, other=0.0)
         if KV_2_CREATED and (first_chunk_index & 4 > 0):
-            p_kv_2 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 2) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_2 = tl.load(p_kv_2, boundary_check=(0, 1))
+            p_kv_2 = h0 + ((i_n * L_IN + 2) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_2 = tl.load(p_kv_2, mask=m_kv, other=0.0)
         if KV_3_CREATED and (first_chunk_index & 8 > 0):
-            p_kv_3 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 3) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_3 = tl.load(p_kv_3, boundary_check=(0, 1))
+            p_kv_3 = h0 + ((i_n * L_IN + 3) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_3 = tl.load(p_kv_3, mask=m_kv, other=0.0)
         if KV_4_CREATED and (first_chunk_index & 16 > 0):
-            p_kv_4 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 4) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_4 = tl.load(p_kv_4, boundary_check=(0, 1))
+            p_kv_4 = h0 + ((i_n * L_IN + 4) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_4 = tl.load(p_kv_4, mask=m_kv, other=0.0)
         if KV_5_CREATED and (first_chunk_index & 32 > 0):
-            p_kv_5 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 5) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_5 = tl.load(p_kv_5, boundary_check=(0, 1))
+            p_kv_5 = h0 + ((i_n * L_IN + 5) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_5 = tl.load(p_kv_5, mask=m_kv, other=0.0)
         if KV_6_CREATED and (first_chunk_index & 64 > 0):
-            p_kv_6 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 6) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_6 = tl.load(p_kv_6, boundary_check=(0, 1))
+            p_kv_6 = h0 + ((i_n * L_IN + 6) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_6 = tl.load(p_kv_6, mask=m_kv, other=0.0)
         if KV_7_CREATED and (first_chunk_index & 128 > 0):
-            p_kv_7 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 7) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_7 = tl.load(p_kv_7, boundary_check=(0, 1))
+            p_kv_7 = h0 + ((i_n * L_IN + 7) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_7 = tl.load(p_kv_7, mask=m_kv, other=0.0)
         if KV_8_CREATED and (first_chunk_index & 256 > 0):
-            p_kv_8 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 8) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_8 = tl.load(p_kv_8, boundary_check=(0, 1))
+            p_kv_8 = h0 + ((i_n * L_IN + 8) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_8 = tl.load(p_kv_8, mask=m_kv, other=0.0)
         if KV_9_CREATED and (first_chunk_index & 512 > 0):
-            p_kv_9 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 9) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_9 = tl.load(p_kv_9, boundary_check=(0, 1))
+            p_kv_9 = h0 + ((i_n * L_IN + 9) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_9 = tl.load(p_kv_9, mask=m_kv, other=0.0)
         if KV_10_CREATED and (first_chunk_index & 1024 > 0):
-            p_kv_10 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 10) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_10 = tl.load(p_kv_10, boundary_check=(0, 1))
+            p_kv_10 = h0 + ((i_n * L_IN + 10) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_10 = tl.load(p_kv_10, mask=m_kv, other=0.0)
         if KV_11_CREATED and (first_chunk_index & 2048 > 0):
-            p_kv_11 = tl.make_block_ptr(
-                h0 + ((i_n * L_IN + 11) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            kv_11 = tl.load(p_kv_11, boundary_check=(0, 1))
+            p_kv_11 = h0 + ((i_n * L_IN + 11) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            kv_11 = tl.load(p_kv_11, mask=m_kv, other=0.0)
 
     NT = tl.cdiv(T, BT)
     output_offset = -1 * (offset % BT)
@@ -252,39 +171,29 @@ def chunkwise_fwd_kernel(
         b_h_ptrs = level_scales + ((bos + i_t * BT + i_idx) * H + i_h) * L + b_llut
         b_h = tl.load(b_h_ptrs, mask=i_idx >= j_idx)
 
-        p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_q = tl.make_block_ptr(
-            q + bos * K, (T, K), (K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
-        )
-        p_k = tl.make_block_ptr(
-            k + bos * K, (K, T), (1, K), (i_k * BK, i_t * BT), (BK, BT), (0, 1),
-        )
-        p_v = tl.make_block_ptr(
-            v + (bos * H + i_h) * V,
-            (T, V),
-            (H * V, 1),
-            (i_t * BT, 0),
-            (BT, V),
-            (1, 0),
-        )
-        p_o = tl.make_block_ptr(
-            o + ((bos * H + i_h) * (K // BK) + i_k) * V,
-            (T, V),
-            (H * (K // BK) * V, 1),
-            (i_t * BT + output_offset, 0),
-            (BT, V),
-            (1, 0),
-        )
+        o_t = (i_t * BT).to(tl.int64) + o_i
+        o_to = o_t + output_offset
+        m_t = o_t < T
+        m_to = (o_to >= 0) & (o_to < T)
+        m_qk = m_t[:, None] & (o_kk[None, :] < K)
+        m_kt = (o_kk[:, None] < K) & m_t[None, :]
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        m_ov = m_to[:, None] & (o_v[None, :] < V)
+        p_g = g + bos * H + i_h + o_t * H
+        p_q = q + bos * K + o_t[:, None] * K + o_kk[None, :]
+        p_k = k + bos * K + o_kk[:, None] + o_t[None, :] * K
+        p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        p_o = o + ((bos * H + i_h) * (K // BK) + i_k) * V + o_to[:, None] * (H * (K // BK) * V) + o_v[None, :]
 
-        b_g = tl.load(p_g, boundary_check=(0,))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_k = tl.load(p_k, mask=m_kt, other=0.0)
 
         m_t = i_t * BT + o_i < T
         b_s = tl.where((i_idx >= j_idx) & m_t[:, None] & m_t[None, :], tl.exp(b_g[:, None] - b_g[None, :]), 0)
         b_s = (tl.dot(b_q, b_k) * b_s).to(b_q.dtype) * b_h
 
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         b_o = tl.zeros((BT, V), dtype=tl.float32)
         if MIN_LEVEL == 0:
             b_o += tl.dot(b_s, b_v)
@@ -295,150 +204,66 @@ def chunkwise_fwd_kernel(
 
         if MIN_LEVEL <= 0 and MAX_LEVEL >= 0:
             if chunk_index & 1:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_0.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 1 and MAX_LEVEL >= 1:
             if chunk_index & 2:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 1),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 1
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 1) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_1.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 2 and MAX_LEVEL >= 2:
             if chunk_index & 4:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 2),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 2
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 2) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_2.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 3 and MAX_LEVEL >= 3:
             if chunk_index & 8:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 3),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 3
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 3) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_3.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 4 and MAX_LEVEL >= 4:
             if chunk_index & 16:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 4),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 4
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 4) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_4.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 5 and MAX_LEVEL >= 5:
             if chunk_index & 32:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 5),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 5
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 5) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_5.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 6 and MAX_LEVEL >= 6:
             if chunk_index & 64:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 6),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 6
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 6) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_6.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 7 and MAX_LEVEL >= 7:
             if chunk_index & 128:  # 8192 - 16384
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 7),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 7
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 7) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_7.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 8 and MAX_LEVEL >= 8:
             if chunk_index & 256:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 8),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 8
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 8) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_8.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 9 and MAX_LEVEL >= 9:
             if chunk_index & 512:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 9),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 9
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 9) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_9.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 10 and MAX_LEVEL >= 10:
             if chunk_index & 1024:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 10),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 10
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 10) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_10.to(b_q.dtype)) * tl.exp(b_g)[:, None]
         if MIN_LEVEL <= 11 and MAX_LEVEL >= 11:
             if chunk_index & 2048:
-                p_l = tl.make_block_ptr(
-                    level_scales + (bos * H + i_h) * L,
-                    (T, L),
-                    (H * L, 1),
-                    (i_t * BT, num_intra_levels + 11),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l = tl.load(p_l, boundary_check=(0, 1))
+                p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + num_intra_levels + 11
+                b_l = tl.load(p_l, mask=m_t[:, None] & ((num_intra_levels + 11) < L), other=0.0)
                 b_o += tl.dot((b_l * b_q), kv_11.to(b_q.dtype)) * tl.exp(b_g)[:, None]
 
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_ov)
 
         if i_t < NT - 1 or T % BT == 0:
             # Only apply the state update if the last chunk is a full chunk.
@@ -547,125 +372,41 @@ def chunkwise_fwd_kernel(
 
     if STORE_FINAL_STATE:
         if (MIN_LEVEL <= 0 and MAX_LEVEL >= 0) and (chunk_index & 1 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 0) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_0, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 0) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_0, mask=m_kv)
         if (MIN_LEVEL <= 1 and MAX_LEVEL >= 1) and (chunk_index & 2 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 1) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_1, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 1) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_1, mask=m_kv)
         if (MIN_LEVEL <= 2 and MAX_LEVEL >= 2) and (chunk_index & 4 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 2) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_2, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 2) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_2, mask=m_kv)
         if (MIN_LEVEL <= 3 and MAX_LEVEL >= 3) and (chunk_index & 8 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 3) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_3, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 3) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_3, mask=m_kv)
         if (MIN_LEVEL <= 4 and MAX_LEVEL >= 4) and (chunk_index & 16 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 4) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_4, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 4) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_4, mask=m_kv)
         if (MIN_LEVEL <= 5 and MAX_LEVEL >= 5) and (chunk_index & 32 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 5) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_5, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 5) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_5, mask=m_kv)
         if (MIN_LEVEL <= 6 and MAX_LEVEL >= 6) and (chunk_index & 64 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 6) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_6, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 6) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_6, mask=m_kv)
         if (MIN_LEVEL <= 7 and MAX_LEVEL >= 7) and (chunk_index & 128 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 7) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_7, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 7) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_7, mask=m_kv)
         if (MIN_LEVEL <= 8 and MAX_LEVEL >= 8) and (chunk_index & 256 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 8) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_8, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 8) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_8, mask=m_kv)
         if (MIN_LEVEL <= 9 and MAX_LEVEL >= 9) and (chunk_index & 512 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 9) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_9, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 9) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_9, mask=m_kv)
         if (MIN_LEVEL <= 10 and MAX_LEVEL >= 10) and (chunk_index & 1024 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 10) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_10, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 10) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_10, mask=m_kv)
         if (MIN_LEVEL <= 11 and MAX_LEVEL >= 11) and (chunk_index & 2048 > 0):
-            p_kv = tl.make_block_ptr(
-                ht + ((i_n * L_OUT + 11) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
-            tl.store(p_kv, kv_11, boundary_check=(0, 1))
+            p_kv = ht + ((i_n * L_OUT + 11) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+            tl.store(p_kv, kv_11, mask=m_kv)
 
         tl.store(new_offsets + i_n, (offset // BT) * BT + T)
 
@@ -718,105 +459,56 @@ def copy_input_kernel(
 
     NT = tl.cdiv(T, BT)
 
+    o_k = tl.arange(0, K)
+    o_v = tl.arange(0, V)
+    o_i = tl.arange(0, BT)
     for i_t in range(NT):
-        p_g = tl.make_block_ptr(
-            g + bos * H + i_h, (T,), (H,), (i_t * BT + input_offset,), (BT,), (0,),
-        )
-        p_q = tl.make_block_ptr(
-            q + bos * K, (T, K), (K, 1), (i_t * BT + input_offset, 0), (BT, K), (1, 0),
-        )
-        p_k = tl.make_block_ptr(
-            k + bos * K, (T, K), (K, 1), (i_t * BT + input_offset, 0), (BT, K), (1, 0),
-        )
-        p_v = tl.make_block_ptr(
-            v + (bos * H + i_h) * V,
-            (T, V),
-            (H * V, 1),
-            (i_t * BT + input_offset, 0),
-            (BT, V),
-            (1, 0),
-        )
-        p_g_new = tl.make_block_ptr(
-            g_new + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,),
-        )
-        p_q_new = tl.make_block_ptr(
-            q_new + bos * K, (T, K), (K, 1), (i_t * BT, 0), (BT, K), (1, 0),
-        )
-        p_k_new = tl.make_block_ptr(
-            k_new + bos * K, (T, K), (K, 1), (i_t * BT, 0), (BT, K), (1, 0),
-        )
-        p_v_new = tl.make_block_ptr(
-            v_new + (bos * H + i_h) * V,
-            (T, V),
-            (H * V, 1),
-            (i_t * BT, 0),
-            (BT, V),
-            (1, 0),
-        )
+        o_t = (i_t * BT + input_offset).to(tl.int64) + o_i
+        o_tn = (i_t * BT).to(tl.int64) + o_i
+        m_t = (o_t >= 0) & (o_t < T)
+        m_tn = o_tn < T
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        m_tnk = m_tn[:, None] & (o_k[None, :] < K)
+        m_tnv = m_tn[:, None] & (o_v[None, :] < V)
+        p_g = g + bos * H + i_h + o_t * H
+        p_q = q + bos * K + o_t[:, None] * K + o_k[None, :]
+        p_k = k + bos * K + o_t[:, None] * K + o_k[None, :]
+        p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        p_g_new = g_new + bos * H + i_h + o_tn * H
+        p_q_new = q_new + bos * K + o_tn[:, None] * K + o_k[None, :]
+        p_k_new = k_new + bos * K + o_tn[:, None] * K + o_k[None, :]
+        p_v_new = v_new + (bos * H + i_h) * V + o_tn[:, None] * (H * V) + o_v[None, :]
 
-        b_g = tl.load(p_g, boundary_check=(0,))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_g = tl.load(p_g, mask=m_t, other=0.0)
+        b_q = tl.load(p_q, mask=m_tk, other=0.0)
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
 
         if i_t == 0:
-            p_g_prev = tl.make_block_ptr(
-                g_prev + i_n * BT * H + i_h, (BT,), (H,), (0,), (BT,), (0,),
-            )
-            p_q_prev = tl.make_block_ptr(
-                q_prev + i_n * BT * K, (BT, K), (K, 1), (0, 0), (BT, K), (1, 0),
-            )
-            p_k_prev = tl.make_block_ptr(
-                k_prev + i_n * BT * K, (BT, K), (K, 1), (0, 0), (BT, K), (1, 0),
-            )
-            p_v_prev = tl.make_block_ptr(
-                v_prev + (i_n * BT * H + i_h) * V,
-                (BT, V),
-                (H * V, 1),
-                (0, 0),
-                (BT, V),
-                (1, 0),
-            )
+            p_g_prev = g_prev + i_n * BT * H + i_h + o_i * H
+            p_q_prev = q_prev + i_n * BT * K + o_i[:, None] * K + o_k[None, :]
+            p_k_prev = k_prev + i_n * BT * K + o_i[:, None] * K + o_k[None, :]
+            p_v_prev = v_prev + (i_n * BT * H + i_h) * V + o_i[:, None] * (H * V) + o_v[None, :]
 
-            b_g += tl.load(p_g_prev, boundary_check=(0,))
-            b_q += tl.load(p_q_prev, boundary_check=(0, 1))
-            b_k += tl.load(p_k_prev, boundary_check=(0, 1))
-            b_v += tl.load(p_v_prev, boundary_check=(0, 1))
+            b_g += tl.load(p_g_prev, mask=o_i < BT, other=0.0)
+            b_q += tl.load(p_q_prev, mask=(o_i[:, None] < BT) & (o_k[None, :] < K), other=0.0)
+            b_k += tl.load(p_k_prev, mask=(o_i[:, None] < BT) & (o_k[None, :] < K), other=0.0)
+            b_v += tl.load(p_v_prev, mask=(o_i[:, None] < BT) & (o_v[None, :] < V), other=0.0)
 
-        tl.store(p_g_new, b_g, boundary_check=(0,))
-        tl.store(p_q_new, b_q, boundary_check=(0, 1))
-        tl.store(p_k_new, b_k, boundary_check=(0, 1))
-        tl.store(p_v_new, b_v, boundary_check=(0, 1))
+        tl.store(p_g_new, b_g, mask=m_tn)
+        tl.store(p_q_new, b_q, mask=m_tnk)
+        tl.store(p_k_new, b_k, mask=m_tnk)
+        tl.store(p_v_new, b_v, mask=m_tnv)
 
         for i in range(L):
-            p_l = tl.make_block_ptr(
-                level_scales + (bos * H + i_h) * L,
-                (T, L),
-                (H * L, 1),
-                (i_t * BT + input_offset, i),
-                (BT, 1),
-                (1, 0),
-            )
-            p_l_new = tl.make_block_ptr(
-                level_scales_new + (bos * H + i_h) * L,
-                (T, L),
-                (H * L, 1),
-                (i_t * BT, i),
-                (BT, 1),
-                (1, 0),
-            )
-            b_l = tl.load(p_l, boundary_check=(0,))
+            p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + i
+            p_l_new = level_scales_new + (bos * H + i_h) * L + o_tn[:, None] * (H * L) + i
+            b_l = tl.load(p_l, mask=m_t[:, None], other=0.0)
             if i_t == 0:
-                p_l_prev = tl.make_block_ptr(
-                    level_scales_prev + (i_n * BT * H + i_h) * L,
-                    (BT, L),
-                    (H * L, 1),
-                    (0, i),
-                    (BT, 1),
-                    (1, 0),
-                )
-                b_l += tl.load(p_l_prev, boundary_check=(0,))
-            tl.store(p_l_new, b_l, boundary_check=(0,))
+                p_l_prev = level_scales_prev + (i_n * BT * H + i_h) * L + o_i[:, None] * (H * L) + i
+                b_l += tl.load(p_l_prev, mask=o_i[:, None] < BT, other=0.0)
+            tl.store(p_l_new, b_l, mask=m_tn[:, None])
 
 
 @triton.heuristics(
@@ -861,57 +553,33 @@ def copy_last_chunk_kernel(
 
     seq_offset = (T // BT) * BT
 
-    p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (seq_offset,), (BT,), (0,))
-    p_q = tl.make_block_ptr(
-        q + bos * K, (T, K), (K, 1), (seq_offset, 0), (BT, K), (1, 0),
-    )
-    p_k = tl.make_block_ptr(
-        k + bos * K, (T, K), (K, 1), (seq_offset, 0), (BT, K), (1, 0),
-    )
-    p_v = tl.make_block_ptr(
-        v + (bos * H + i_h) * V,
-        (T, V),
-        (H * V, 1),
-        (seq_offset, 0),
-        (BT, V),
-        (1, 0),
-    )
-    p_g_prev = tl.make_block_ptr(
-        g_prev + i_n * BT * H + i_h, (BT,), (H,), (0,), (BT,), (0,),
-    )
-    p_q_prev = tl.make_block_ptr(
-        q_prev + i_n * BT * K, (BT, K), (K, 1), (0, 0), (BT, K), (1, 0),
-    )
-    p_k_prev = tl.make_block_ptr(
-        k_prev + i_n * BT * K, (BT, K), (K, 1), (0, 0), (BT, K), (1, 0),
-    )
-    p_v_prev = tl.make_block_ptr(
-        v_prev + (i_n * BT * H + i_h) * V, (BT, V), (H * V, 1), (0, 0), (BT, V), (1, 0),
-    )
+    o_k = tl.arange(0, K)
+    o_v = tl.arange(0, V)
+    o_i = tl.arange(0, BT)
+    o_t = seq_offset.to(tl.int64) + o_i
+    m_t = o_t < T
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    m_ik = (o_i[:, None] < BT) & (o_k[None, :] < K)
+    m_iv = (o_i[:, None] < BT) & (o_v[None, :] < V)
+    p_g = g + bos * H + i_h + o_t * H
+    p_q = q + bos * K + o_t[:, None] * K + o_k[None, :]
+    p_k = k + bos * K + o_t[:, None] * K + o_k[None, :]
+    p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+    p_g_prev = g_prev + i_n * BT * H + i_h + o_i * H
+    p_q_prev = q_prev + i_n * BT * K + o_i[:, None] * K + o_k[None, :]
+    p_k_prev = k_prev + i_n * BT * K + o_i[:, None] * K + o_k[None, :]
+    p_v_prev = v_prev + (i_n * BT * H + i_h) * V + o_i[:, None] * (H * V) + o_v[None, :]
 
-    tl.store(p_g_prev, tl.load(p_g, boundary_check=(0,)), boundary_check=(0,))
-    tl.store(p_q_prev, tl.load(p_q, boundary_check=(0, 1)), boundary_check=(0, 1))
-    tl.store(p_k_prev, tl.load(p_k, boundary_check=(0, 1)), boundary_check=(0, 1))
-    tl.store(p_v_prev, tl.load(p_v, boundary_check=(0, 1)), boundary_check=(0, 1))
+    tl.store(p_g_prev, tl.load(p_g, mask=m_t, other=0.0), mask=o_i < BT)
+    tl.store(p_q_prev, tl.load(p_q, mask=m_tk, other=0.0), mask=m_ik)
+    tl.store(p_k_prev, tl.load(p_k, mask=m_tk, other=0.0), mask=m_ik)
+    tl.store(p_v_prev, tl.load(p_v, mask=m_tv, other=0.0), mask=m_iv)
 
     for i in range(L):
-        p_l = tl.make_block_ptr(
-            level_scales + (bos * H + i_h) * L,
-            (T, L),
-            (H * L, 1),
-            (seq_offset, i),
-            (BT, 1),
-            (1, 0),
-        )
-        p_l_prev = tl.make_block_ptr(
-            level_scales_prev + (i_n * BT * H + i_h) * L,
-            (BT, L),
-            (H * L, 1),
-            (0, i),
-            (BT, 1),
-            (1, 0),
-        )
-        tl.store(p_l_prev, tl.load(p_l, boundary_check=(0,)), boundary_check=(0,))
+        p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + i
+        p_l_prev = level_scales_prev + (i_n * BT * H + i_h) * L + o_i[:, None] * (H * L) + i
+        tl.store(p_l_prev, tl.load(p_l, mask=m_t[:, None], other=0.0), mask=o_i[:, None] < BT)
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
@@ -965,68 +633,44 @@ def chunkwise_bwd_kernel_dhg(
 
     num_intra_levels = (tl.log2(float(BT))).to(tl.int32) + 1
 
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_v = tl.arange(0, V)
+    o_i = tl.arange(0, BT)
+    m_kv = (o_kk[:, None] < K) & (o_v[None, :] < V)
     for i_t in range(tl.cdiv(T, BT) - 1, -1, -1):
-        p_dh = tl.make_block_ptr(
-            dh + ((i_n * NT + i_t) * H + i_h) * K * V,
-            (K, V),
-            (V, 1),
-            (i_k * BK, 0),
-            (BK, V),
-            (1, 0),
-        )
-        b_dh_old = tl.load(p_dh, boundary_check=(0, 1))
+        o_t = (i_t * BT).to(tl.int64) + o_i
+        m_t = o_t < T
+        m_kt = (o_kk[:, None] < K) & m_t[None, :]
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_dh = dh + ((i_n * NT + i_t) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
+        b_dh_old = tl.load(p_dh, mask=m_kv, other=0.0)
 
         if (i_t & (1 << ell)) == 0:  # store the chunk
             tl.store(
-                p_dh, b_dh.to(p_dh.dtype.element_ty) + b_dh_old, boundary_check=(0, 1),
+                p_dh, b_dh.to(p_dh.dtype.element_ty) + b_dh_old, mask=m_kv,
             )
             # if you are about the transition to compute, reset to zeros
             if i_t > 0 and ((i_t - 1) & (1 << ell)) > 0:
                 b_dh = tl.zeros([BK, V], dtype=tl.float32)
         if i_t & (1 << ell):
-            p_h = tl.make_block_ptr(
-                h_l + ((i_n * NT + i_t) * H + i_h) * K * V,
-                (K, V),
-                (V, 1),
-                (i_k * BK, 0),
-                (BK, V),
-                (1, 0),
-            )
+            p_h = h_l + ((i_n * NT + i_t) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
 
-            b_h = tl.load(p_h, boundary_check=(0, 1))
+            b_h = tl.load(p_h, mask=m_kv, other=0.0)
             p_dg_last = dg_last + i_n * NT * H + i_t * H + i_h
             tl.atomic_add(p_dg_last, tl.sum(b_h * (b_dh + b_dh_old)))
         last_idx = min((i_t + 1) * BT, T) - 1
         b_g_last = tl.exp(tl.load(g + bos * H + last_idx * H + i_h))
         b_dh *= b_g_last
         if i_t & (1 << ell):  # compute this chunk
-            p_g = tl.make_block_ptr(
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,),
-            )
-            p_q = tl.make_block_ptr(
-                q + bos * K, (K, T), (1, K), (i_k * BK, i_t * BT), (BK, BT), (0, 1),
-            )
-            p_do = tl.make_block_ptr(
-                do + (bos * H + i_h) * V,
-                (T, V),
-                (H * V, 1),
-                (i_t * BT, 0),
-                (BT, V),
-                (1, 0),
-            )
-            p_l = tl.make_block_ptr(
-                l + (bos * H + i_h) * L + num_intra_levels + ell,
-                (T,),
-                (H * L,),
-                (i_t * BT,),
-                (BT,),
-                (0,),
-            )
-            b_l = tl.load(p_l, boundary_check=(0,))
-            b_g = tl.load(p_g, boundary_check=(0,))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
+            p_g = g + bos * H + i_h + o_t * H
+            p_q = q + bos * K + o_kk[:, None] + o_t[None, :] * K
+            p_do = do + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_l = l + (bos * H + i_h) * L + num_intra_levels + ell + o_t * (H * L)
+            b_l = tl.load(p_l, mask=m_t, other=0.0)
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
+            b_q = tl.load(p_q, mask=m_kt, other=0.0)
             b_q = (b_q * (tl.exp(b_g) * b_l)[None, :]).to(b_q.dtype)
-            b_do = tl.load(p_do, boundary_check=(0, 1))
+            b_do = tl.load(p_do, mask=m_tv, other=0.0)
 
             b_s = tl.dot(b_q, b_do).to(b_q.dtype)
             b_dh += b_s
@@ -1083,77 +727,46 @@ def chunkwise_bwd_kernel_hdqgl(
 
     num_intra_levels = (tl.log2(float(BT))).to(tl.int32) + 1
 
+    o_k = tl.arange(0, K)
+    o_v = tl.arange(0, V)
+    o_i = tl.arange(0, BT)
+    m_vk = (o_v[:, None] < V) & (o_k[None, :] < K)
     for i_t in range(tl.cdiv(T, BT)):
-        p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        o_t = (i_t * BT).to(tl.int64) + o_i
+        m_t = o_t < T
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_g = g + bos * H + i_h + o_t * H
         if i_t & (1 << ell):  # compute and store derivatives
-            p_do = tl.make_block_ptr(
-                do + (bos * H + i_h) * V,
-                (T, V),
-                (H * V, 1),
-                (i_t * BT, 0),
-                (BT, V),
-                (1, 0),
-            )
-            p_q = tl.make_block_ptr(
-                q + bos * K, (T, K), (K, 1), (i_t * BT, 0), (BT, K), (1, 0),
-            )
-            p_l = tl.make_block_ptr(
-                l + (bos * H + i_h) * L + num_intra_levels + ell,
-                (T,),
-                (H * L,),
-                (i_t * BT,),
-                (BT,),
-                (0,),
-            )
-            p_dq = tl.make_block_ptr(
-                dq + (bos * H + i_h) * K,
-                (T, K),
-                (H * K, 1),
-                (i_t * BT, 0),
-                (BT, K),
-                (1, 0),
-            )
-            p_dg = tl.make_block_ptr(
-                dg + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,),
-            )
-            p_dl = tl.make_block_ptr(
-                dl + (bos * H + i_h) * L + num_intra_levels + ell,
-                (T,),
-                (H * L,),
-                (i_t * BT,),
-                (BT,),
-                (0,),
-            )
-            p_h = tl.make_block_ptr(
-                h_l + ((i_n * NT + i_t) * H + i_h) * K * V,
-                (V, K),
-                (1, V),
-                (0, 0),
-                (V, K),
-                (0, 1),
-            )
+            p_do = do + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_q = q + bos * K + o_t[:, None] * K + o_k[None, :]
+            p_l = l + (bos * H + i_h) * L + num_intra_levels + ell + o_t * (H * L)
+            p_dq = dq + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+            p_dg = dg + bos * H + i_h + o_t * H
+            p_dl = dl + (bos * H + i_h) * L + num_intra_levels + ell + o_t * (H * L)
+            p_h = h_l + ((i_n * NT + i_t) * H + i_h) * K * V + o_v[:, None] + o_k[None, :] * V
 
-            b_do = tl.load(p_do, boundary_check=(0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_g = tl.load(p_g, boundary_check=(0,))
-            b_l = tl.load(p_l, boundary_check=(0,))
+            b_do = tl.load(p_do, mask=m_tv, other=0.0)
+            b_q = tl.load(p_q, mask=m_tk, other=0.0)
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
+            b_l = tl.load(p_l, mask=m_t, other=0.0)
 
             b_dlq = tl.exp(b_g)[:, None] * tl.dot(b_do, b_h.to(b_do.dtype))
 
             b_dl = tl.sum(b_dlq * b_q, axis=1)
             b_dg = b_l * b_dl
 
-            tl.store(p_h, b_h, boundary_check=(0, 1))
-            b_dq_old = tl.load(p_dq, boundary_check=(0, 1))
+            tl.store(p_h, b_h, mask=m_vk)
+            b_dq_old = tl.load(p_dq, mask=m_tk, other=0.0)
             tl.store(
                 p_dq,
                 (b_l[:, None] * b_dlq).to(p_dq.dtype.element_ty) + b_dq_old,
-                boundary_check=(0, 1),
+                mask=m_tk,
             )
-            tl.store(p_dl, b_dl.to(p_dl.dtype.element_ty), boundary_check=(0,))
-            b_dg_old = tl.load(p_dg, boundary_check=(0,))
+            tl.store(p_dl, b_dl.to(p_dl.dtype.element_ty), mask=m_t)
+            b_dg_old = tl.load(p_dg, mask=m_t, other=0.0)
             tl.store(
-                p_dg, b_dg.to(p_dg.dtype.element_ty) + b_dg_old, boundary_check=(0,),
+                p_dg, b_dg.to(p_dg.dtype.element_ty) + b_dg_old, mask=m_t,
             )
             if ((i_t + 1) & (1 << ell)) == 0:
                 b_h = tl.zeros([V, K], dtype=tl.float32)
@@ -1162,20 +775,11 @@ def chunkwise_bwd_kernel_hdqgl(
         b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
         b_h *= tl.exp(b_g_last)
         if (i_t & (1 << ell)) == 0:  # update the state
-            p_k = tl.make_block_ptr(
-                k + bos * K, (T, K), (K, 1), (i_t * BT, 0), (BT, K), (1, 0),
-            )
-            p_v = tl.make_block_ptr(
-                v + (bos * H + i_h) * V,
-                (V, T),
-                (1, H * V),
-                (0, i_t * BT),
-                (V, BT),
-                (0, 1),
-            )
-            b_g = tl.load(p_g, boundary_check=(0,))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_k = k + bos * K + o_t[:, None] * K + o_k[None, :]
+            p_v = v + (bos * H + i_h) * V + o_v[:, None] + o_t[None, :] * (H * V)
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
+            b_k = tl.load(p_k, mask=m_tk, other=0.0)
+            b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_t[None, :], other=0.0)
             b_k = (b_k * tl.exp(b_g_last - b_g)[:, None]).to(b_k.dtype)
             b_h += tl.dot(b_v, b_k)
 
@@ -1210,7 +814,7 @@ def chunkwise_bwd_kernel_dkg(
     NT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_nh = tl.program_id(0), tl.program_id(1)
+    i_t, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
 
     if IS_VARLEN:
@@ -1226,33 +830,22 @@ def chunkwise_bwd_kernel_dkg(
     o_t = i_t * BT + o_i
     m_t = o_t < T
 
-    p_dh = tl.make_block_ptr(
-        dh + ((i_n * NT + i_t) * H + i_h) * K * V,
-        (V, K),
-        (1, V),
-        (0, 0),
-        (V, K),
-        (0, 1),
-    )
-    p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_k = tl.make_block_ptr(k + bos * K, (T, K), (K, 1), (i_t * BT, 0), (BT, K), (1, 0))
-    p_v = tl.make_block_ptr(
-        v + (bos * H + i_h) * V,
-        (T, V),
-        (H * V, 1),
-        (i_t * BT, 0),
-        (BT, V),
-        (1, 0),
-    )
-    p_dk = tl.make_block_ptr(
-        dk + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BT, K), (1, 0),
-    )
-    p_dg = tl.make_block_ptr(dg + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    o_k = tl.arange(0, K)
+    o_v = tl.arange(0, V)
+    m_vk = (o_v[:, None] < V) & (o_k[None, :] < K)
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    p_dh = dh + ((i_n * NT + i_t) * H + i_h) * K * V + o_v[:, None] + o_k[None, :] * V
+    p_g = g + bos * H + i_h + o_t * H
+    p_k = k + bos * K + o_t[:, None] * K + o_k[None, :]
+    p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+    p_dk = dk + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+    p_dg = dg + bos * H + i_h + o_t * H
 
-    b_dh = tl.load(p_dh, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0,))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_dh = tl.load(p_dh, mask=m_vk, other=0.0)
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
     last_idx = min((i_t + 1) * BT, T) - 1
     b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
     p_dg_last = dg_last + i_n * NT * H + i_t * H + i_h
@@ -1260,14 +853,14 @@ def chunkwise_bwd_kernel_dkg(
 
     b_dg_last *= tl.exp(b_g_last)
     b_dk = tl.where(m_t, exp(b_g_last - b_g), 0)[:, None] * tl.dot(b_v, b_dh).to(b_v.dtype)
-    b_dg = tl.load(p_dg, boundary_check=(0,))
+    b_dg = tl.load(p_dg, mask=m_t, other=0.0)
     b_dg -= tl.sum(b_k * b_dk, axis=1)
     b_dg_last += tl.sum(b_dk * b_k)
 
     b_dg = tl.where(o_i < BT - 1, b_dg, b_dg + b_dg_last)
 
-    tl.store(p_dg, b_dg, boundary_check=(0,))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dg, b_dg, mask=m_t)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
@@ -1297,7 +890,7 @@ def chunkwise_bwd_kernel_dv(
     NT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_nh = tl.program_id(0), tl.program_id(1)
+    i_t, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
 
     if IS_VARLEN:
@@ -1312,28 +905,24 @@ def chunkwise_bwd_kernel_dv(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
 
-    p_dh = tl.make_block_ptr(
-        dh + ((i_n * NT + i_t) * H + i_h) * K * V,
-        (K, V),
-        (V, 1),
-        (0, 0),
-        (K, V),
-        (1, 0),
-    )
-    p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_k = tl.make_block_ptr(k + bos * K, (T, K), (K, 1), (i_t * BT, 0), (BT, K), (1, 0))
-    p_dv = tl.make_block_ptr(
-        dv + (bos * H + i_h) * V, (T, V), (H * V, 1), (i_t * BT, 0), (BT, V), (1, 0),
-    )
+    o_k = tl.arange(0, K)
+    o_v = tl.arange(0, V)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    p_dh = dh + ((i_n * NT + i_t) * H + i_h) * K * V + o_k[:, None] * V + o_v[None, :]
+    p_g = g + bos * H + i_h + o_t * H
+    p_k = k + bos * K + o_t[:, None] * K + o_k[None, :]
+    p_dv = dv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
 
     last_idx = min((i_t + 1) * BT, T) - 1
     b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
 
-    b_dh = tl.load(p_dh, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0,))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_dh = tl.load(p_dh, mask=m_kv, other=0.0)
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
     b_dv = tl.where(m_t, exp(-b_g + b_g_last), 0)[:, None] * tl.dot(b_k, b_dh).to(b_k.dtype)
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
@@ -1371,9 +960,10 @@ def chunkwise_bwd_kernel_diag(
     BT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    p_llut = tl.make_block_ptr(llut, (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
-    b_llut = tl.load(p_llut, boundary_check=(0, 1))
-    i_t, i_nh = tl.program_id(0), tl.program_id(1)
+    o_i = tl.arange(0, BT)
+    p_llut = llut + o_i[:, None] * BT + o_i[None, :]
+    b_llut = tl.load(p_llut, mask=(o_i[:, None] < BT) & (o_i[None, :] < BT), other=0.0)
+    i_t, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
 
     if IS_VARLEN:
@@ -1385,42 +975,39 @@ def chunkwise_bwd_kernel_diag(
     else:
         bos, eos = (i_n * T).to(tl.int64), (i_n * T + T).to(tl.int64)
 
-    o_i = tl.arange(0, BT)
+    o_k = tl.arange(0, K)
+    o_v = tl.arange(0, V)
+    o_t = i_t * BT + o_i
+    m_t = o_t < T
+    m_kt = (o_k[:, None] < K) & m_t[None, :]
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    m_vt = (o_v[:, None] < V) & m_t[None, :]
     i_idx = o_i[:, None]  # BT x 1
     j_idx = o_i[None, :]  # 1 x BT
 
     b_h_ptrs = l + ((bos + i_t * BT + i_idx) * H + i_h) * L + b_llut
     b_h = tl.load(b_h_ptrs, mask=i_idx >= j_idx)
 
-    p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_q = tl.make_block_ptr(q + bos * K, (K, T), (1, K), (0, i_t * BT), (K, BT), (0, 1))
-    p_k = tl.make_block_ptr(k + bos * K, (T, K), (K, 1), (i_t * BT, 0), (BT, K), (1, 0))
-    p_v = tl.make_block_ptr(
-        v + (bos * H + i_h) * V, (V, T), (1, H * V), (0, i_t * BT), (V, BT), (0, 1),
-    )
-    p_do = tl.make_block_ptr(
-        do + (bos * H + i_h) * V, (T, V), (H * V, 1), (i_t * BT, 0), (BT, V), (1, 0),
-    )
-    p_dg = tl.make_block_ptr(dg + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dq = tl.make_block_ptr(
-        dq + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BT, K), (1, 0),
-    )
-    p_dk = tl.make_block_ptr(
-        dk + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BT, K), (1, 0),
-    )
-    p_dv = tl.make_block_ptr(
-        dv + (bos * H + i_h) * V, (T, V), (H * V, 1), (i_t * BT, 0), (BT, V), (1, 0),
-    )
+    p_g = g + bos * H + i_h + o_t * H
+    p_q = q + bos * K + o_k[:, None] + o_t[None, :] * K
+    p_k = k + bos * K + o_t[:, None] * K + o_k[None, :]
+    p_v = v + (bos * H + i_h) * V + o_v[:, None] + o_t[None, :] * (H * V)
+    p_do = do + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+    p_dg = dg + bos * H + i_h + o_t * H
+    p_dq = dq + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+    p_dk = dk + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :]
+    p_dv = dv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
 
-    b_g = tl.load(p_g, boundary_check=(0,))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
-    b_dq = tl.load(p_dq, boundary_check=(0, 1))
-    b_dk = tl.load(p_dk, boundary_check=(0, 1))
-    b_dv = tl.load(p_dv, boundary_check=(0, 1))
-    b_dg = tl.load(p_dg, boundary_check=(0,))
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_q = tl.load(p_q, mask=m_kt, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
+    b_v = tl.load(p_v, mask=m_vt, other=0.0)
+    b_do = tl.load(p_do, mask=m_tv, other=0.0)
+    b_dq = tl.load(p_dq, mask=m_tk, other=0.0)
+    b_dk = tl.load(p_dk, mask=m_tk, other=0.0)
+    b_dv = tl.load(p_dv, mask=m_tv, other=0.0)
+    b_dg = tl.load(p_dg, mask=m_t, other=0.0)
 
     b_s = (tl.dot(b_k, b_q)).to(b_q.dtype)
     # Apply causal and padding masks
@@ -1435,19 +1022,19 @@ def chunkwise_bwd_kernel_diag(
     b_dq += tl.dot(b_ds, b_k)
     b_dk += tl.trans(tl.dot(b_q, b_ds))
 
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
 
     num_intra_levels = (tl.log2(float(BT))).to(tl.int32) + 1
 
     for i in range(num_intra_levels):
-        p_mask = tl.make_block_ptr(mask + i * (BT * BT), (BT, BT), (BT, 1), (0, 0), (BT, BT), (1, 0))
-        b_mask = tl.load(p_mask, boundary_check=(0, 1))
+        p_mask = mask + i * (BT * BT) + o_i[:, None] * BT + o_i[None, :]
+        b_mask = tl.load(p_mask, mask=(o_i[:, None] < BT) & (o_i[None, :] < BT), other=0.0)
         dl_i = tl.sum(tl.where(b_mask == 1, b_dl, 0), axis=1)
-        p_dl_i = tl.make_block_ptr(dl + (bos * H + i_h) * L + i, (T,), (H * L,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_dl_i, dl_i, boundary_check=(0,))
+        p_dl_i = dl + (bos * H + i_h) * L + i + o_t * (H * L)
+        tl.store(p_dl_i, dl_i, mask=m_t)
 
 
 def construct_binary_level_mask(level, T):

--- a/fla/ops/mesa_net/chunk_cg_solver_bwd.py
+++ b/fla/ops/mesa_net/chunk_cg_solver_bwd.py
@@ -52,12 +52,12 @@ def chunk_fwd_mesa_cg_dim64_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -79,20 +79,24 @@ def chunk_fwd_mesa_cg_dim64_kernel(
     beta += bos * H + i_h
     lamb += i_h * K
 
-    p_q = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_h = tl.make_block_ptr(h, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_tk = m_t[:, None] & m_k[None, :]
+    m_kk = m_k[:, None] & m_k[None, :]
+    p_q = dq + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_h = h + o_k[:, None] * K + o_k[None, :]
 
-    b_h = tl.load(p_h, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
+    b_h = tl.load(p_h, mask=m_kk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
+    b_q = tl.load(p_q, mask=m_tk, other=0.0).to(tl.float32)
 
-    p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
-    p_lamb = tl.make_block_ptr(lamb, (K,), (1,), (0,), (BK,), (0,))
-    b_lamb = tl.load(p_lamb, boundary_check=(0,)).to(tl.float32)
+    p_g = g + o_t * H
+    b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
+    p_beta = beta + o_t * H
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0).to(tl.float32)
+    p_lamb = lamb + o_k
+    b_lamb = tl.load(p_lamb, mask=m_k, other=0.0).to(tl.float32)
 
     b_m = exp2(b_g[:, None] - b_g[None, :]) * b_beta[None, :]
     b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), b_m, 0)
@@ -115,8 +119,8 @@ def chunk_fwd_mesa_cg_dim64_kernel(
         b_p = b_r + (b_delta_new / (b_delta_old + 1e-5))[:, None] * b_p
         b_delta_old = b_delta_new
 
-    p_q_final = tl.make_block_ptr(dq_final, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_q_final, b_x.to(p_q_final.dtype.element_ty), boundary_check=(0, 1))
+    p_q_final = dq_final + o_t[:, None] * (H*K) + o_k[None, :]
+    tl.store(p_q_final, b_x.to(p_q_final.dtype.element_ty), mask=m_tk)
 
 
 def chunk_mesa_cg_bwd(

--- a/fla/ops/mesa_net/chunk_cg_solver_fwd.py
+++ b/fla/ops/mesa_net/chunk_cg_solver_fwd.py
@@ -55,12 +55,12 @@ def chunk_fwd_mesa_cg_dim64_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -85,21 +85,25 @@ def chunk_fwd_mesa_cg_dim64_kernel(
     v += (bos * H + i_h) * K
     h_kv += (i_tg * H + i_h).to(tl.int64) * K * K
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_h = tl.make_block_ptr(h, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_tk = m_t[:, None] & m_k[None, :]
+    m_kk = m_k[:, None] & m_k[None, :]
+    p_q = q + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_h = h + o_k[:, None] * K + o_k[None, :]
 
-    b_h = tl.load(p_h, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
+    b_h = tl.load(p_h, mask=m_kk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
+    b_q = tl.load(p_q, mask=m_tk, other=0.0).to(tl.float32)
 
-    p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
-    p_lamb = tl.make_block_ptr(lamb, (K,), (1,), (0,), (BK,), (0,))
+    p_g = g + o_t * H
+    b_g = tl.load(p_g, mask=m_t, other=0.0).to(tl.float32)
+    p_beta = beta + o_t * H
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0).to(tl.float32)
+    p_lamb = lamb + o_k
 
-    b_lamb = tl.load(p_lamb, boundary_check=(0,)).to(tl.float32)
+    b_lamb = tl.load(p_lamb, mask=m_k, other=0.0).to(tl.float32)
 
     b_m = exp2(b_g[:, None] - b_g[None, :]) * b_beta[None, :]
     b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), b_m, 0)
@@ -122,16 +126,16 @@ def chunk_fwd_mesa_cg_dim64_kernel(
         b_p = b_r + (b_delta_new / (b_delta_old + 1e-5))[:, None] * b_p
         b_delta_old = b_delta_new
 
-    p_q_final = tl.make_block_ptr(q_final, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_q_final, b_x.to(p_q_final.dtype.element_ty), boundary_check=(0, 1))
+    p_q_final = q_final + o_t[:, None] * (H*K) + o_k[None, :]
+    tl.store(p_q_final, b_x.to(p_q_final.dtype.element_ty), mask=m_tk)
 
-    p_h_kv = tl.make_block_ptr(h_kv, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
-    b_h_kv = tl.load(p_h_kv, boundary_check=(0, 1))
-    p_v = tl.make_block_ptr(v, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    p_h_kv = h_kv + o_k[:, None] * K + o_k[None, :]
+    b_h_kv = tl.load(p_h_kv, mask=m_kk, other=0.0)
+    p_v = v + o_t[:, None] * (H*K) + o_k[None, :]
+    b_v = tl.load(p_v, mask=m_tk, other=0.0)
     b_o = chunk_update_once(b_x, b_k, b_v, b_m, b_g_exp_q, b_h_kv, None)
-    p_o = tl.make_block_ptr(o, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o = o + o_t[:, None] * (H*K) + o_k[None, :]
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tk)
 
 
 def chunk_mesa_cg_fwd(

--- a/fla/ops/mesa_net/chunk_h_fwd.py
+++ b/fla/ops/mesa_net/chunk_h_fwd.py
@@ -68,36 +68,43 @@ def chunk_mesa_net_fwd_kernel_h(
         NS = tl.cdiv(T, BS)
         boh = i_n * NS
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     # [BK, BV]
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     b_h_kv = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        p_h0 = tl.make_block_ptr(h_init + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
-        p_h_kv0 = tl.make_block_ptr(h_kv_init + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h_kv = tl.load(p_h_kv0, boundary_check=(0, 1)).to(tl.float32)
+        p_h0 = h_init + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h0, mask=m_kv, other=0.0).to(tl.float32)
+        p_h_kv0 = h_kv_init + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_h_kv = tl.load(p_h_kv0, mask=m_kv, other=0.0).to(tl.float32)
 
     for i_t in range(NT):
         i_s = i_t // (BS // BT)
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_k2 = tl.make_block_ptr(k + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_beta = tl.make_block_ptr(beta + (bos*H + i_h), (T,), (H,), (i_t * BT,), (BT, ), (0,))
-        b_beta = tl.load(p_beta, boundary_check=(0,))
+        o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_tk = m_t[:, None] & (o_k[None, :] < K)
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k2 = k + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_beta = beta + (bos*H + i_h) + o_t * H
+        b_beta = tl.load(p_beta, mask=m_t, other=0.0)
 
         o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K*V
-        p_h = tl.make_block_ptr(h + o_h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_h_kv = tl.make_block_ptr(h_kv + o_h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+        p_h = h + o_h + o_k[:, None] * V + o_v[None, :]
+        p_h_kv = h_kv + o_h + o_k[:, None] * V + o_v[None, :]
 
         if i_t % (BS // BT) == 0:
-            tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
-            tl.store(p_h_kv, b_h_kv.to(p_h_kv.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_kv)
+            tl.store(p_h_kv, b_h_kv.to(p_h_kv.dtype.element_ty), mask=m_kv)
 
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
+        b_k2 = tl.load(p_k2, mask=m_tv, other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
         last_idx = min((i_t + 1) * BT, T) - 1
 
         # scalar decay
@@ -111,10 +118,10 @@ def chunk_mesa_net_fwd_kernel_h(
         b_h_kv += safe_dot(tl.trans(b_k_decay), b_v.to(b_k2.dtype))
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(h_final + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        p_h_kv_final = tl.make_block_ptr(h_kv_final + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_h_kv_final, b_h_kv.to(p_h_kv_final.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = h_final + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_kv)
+        p_h_kv_final = h_kv_final + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_h_kv_final, b_h_kv.to(p_h_kv_final.dtype.element_ty), mask=m_kv)
 
 
 def chunk_mesa_fwd_h(

--- a/fla/ops/mesa_net/chunk_h_kk_intra_bwd.py
+++ b/fla/ops/mesa_net/chunk_h_kk_intra_bwd.py
@@ -42,12 +42,12 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -79,25 +79,31 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     b_dg_last = tl.zeros([1], dtype=tl.float32)
     b_dg = tl.zeros([BT], dtype=tl.float32)
 
-    p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_g = tl.load(p_g, boundary_check=(0,))
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_k = o_k < K
+    m_tk = m_t[:, None] & m_k[None, :]
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    m_h = (o_v[:, None] < V) & m_k[None, :]
+    p_g = g + o_t * H
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
     b_g_last = tl.load(g + (min(i_t * BT + BT, T) - 1) * H)
     b_gk = tl.where(m_t, exp2(b_g_last - b_g), 0)
 
-    p_q_star = tl.make_block_ptr(q_star, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_q_star = tl.load(p_q_star, boundary_check=(0, 1))
-    p_dq = tl.make_block_ptr(dq, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_dq = tl.load(p_dq, boundary_check=(0, 1))
+    p_q_star = q_star + o_t[:, None] * (H*V) + o_v[None, :]
+    b_q_star = tl.load(p_q_star, mask=m_tv, other=0.0)
+    p_dq = dq + o_t[:, None] * (H*V) + o_v[None, :]
+    b_dq = tl.load(p_dq, mask=m_tv, other=0.0)
     b_dlamb = -tl.sum(b_q_star * b_dq, axis=0)
-    p_dlamb = tl.make_block_ptr(dlamb, (K,), (1,), (0,), (BK,), (0,))
-    tl.store(p_dlamb, b_dlamb.to(p_dlamb.dtype.element_ty), boundary_check=(0,))
+    p_dlamb = dlamb + o_k
+    tl.store(p_dlamb, b_dlamb.to(p_dlamb.dtype.element_ty), mask=m_k)
 
-    p_h = tl.make_block_ptr(h, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
-    p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
-    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    b_beta = tl.load(p_beta, boundary_check=(0,))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_v = tl.load(p_k, boundary_check=(0, 1))
+    p_h = h + o_v[:, None] + o_k[None, :] * V
+    p_dh = dh + o_v[:, None] + o_k[None, :] * V
+    p_beta = beta + o_t * H
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    b_v = tl.load(p_k, mask=m_tk, other=0.0)
     b_k = (b_v * b_beta[:, None]).to(b_v.dtype)
 
     b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp2(b_g[:, None] - b_g[None, :]), 0)
@@ -111,9 +117,9 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     b_ds = b_ds * b_m
     b_dk += tl.dot(tl.trans(b_ds.to(b_q_star.dtype)), b_q_star)
 
-    b_h = tl.load(p_h, boundary_check=(0, 1))
+    b_h = tl.load(p_h, mask=m_h, other=0.0)
     b_dg += tl.sum(tl.dot(b_dq, tl.trans(b_h)) * exp2(b_g)[:, None] * b_q_star, axis=1)
-    b_dh = tl.load(p_dh, boundary_check=(0, 1))
+    b_dh = tl.load(p_dh, mask=m_h, other=0.0)
     b_dk2 = tl.dot(b_v, b_dh.to(b_v.dtype)) * b_gk[:, None]
     b_dg -= tl.sum(b_dk2 * b_k, axis=1)
     b_dg_last += tl.sum(b_dk2 * b_k)
@@ -122,19 +128,19 @@ def chunk_mesa_net_h_kk_bwd_intra_kernel(
     b_dh = b_dh * b_h
     b_dg_last += tl.sum(b_dh) * exp2(b_g_last)
 
-    p_dk_beta = tl.make_block_ptr(dk_beta, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_dk -= tl.load(p_dk_beta, boundary_check=(0, 1))
+    p_dk_beta = dk_beta + o_t[:, None] * (H*K) + o_k[None, :]
+    b_dk -= tl.load(p_dk_beta, mask=m_tk, other=0.0)
     b_dbeta = tl.sum(b_dk * b_v, axis=1)
     b_dk = b_dk * b_beta[:, None] + b_dv
     b_dk = -b_dk
 
     b_dg = tl.where(o_t < min(i_t * BT + BT, T) - 1, b_dg, b_dg + b_dg_last)
-    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    p_dg = tl.make_block_ptr(dg, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dg, -b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
-    p_dbeta = tl.make_block_ptr(dbeta, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dbeta, -b_dbeta.to(p_dbeta.dtype.element_ty), boundary_check=(0,))
+    p_dk = dk + o_t[:, None] * (H*K) + o_k[None, :]
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
+    p_dg = dg + o_t * H
+    tl.store(p_dg, -b_dg.to(p_dg.dtype.element_ty), mask=m_t)
+    p_dbeta = dbeta + o_t * H
+    tl.store(p_dbeta, -b_dbeta.to(p_dbeta.dtype.element_ty), mask=m_t)
 
 
 def chunk_mesa_net_h_kk_bwd_intra_fn(

--- a/fla/ops/mesa_net/chunk_h_kv_intra_bwd.py
+++ b/fla/ops/mesa_net/chunk_h_kv_intra_bwd.py
@@ -55,11 +55,11 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -92,23 +92,28 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel(
     b_dg_last = tl.zeros([1], dtype=tl.float32)
     b_dg = tl.zeros([BT], dtype=tl.float32)
 
-    p_q = tl.make_block_ptr(q_star, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_beta = tl.make_block_ptr(beta, (T, ), (H, ), (i_t * BT,), (BT,), (0,))
-    p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_h = tl.make_block_ptr(h_kv, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
-    p_dh = tl.make_block_ptr(dh_kv, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+    p_q = q_star + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+    p_g = g + o_t * H
+    p_beta = beta + o_t * H
+    p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
+    p_h = h_kv + o_v[:, None] + o_k[None, :] * V
+    p_dh = dh_kv + o_v[:, None] + o_k[None, :] * V
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0,))
-    b_beta = tl.load(p_beta, boundary_check=(0, ))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
-    b_h = tl.load(p_h, boundary_check=(0, 1))
-    b_dh = tl.load(p_dh, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_do = tl.load(p_do, mask=m_tv, other=0.0)
+    b_h = tl.load(p_h, mask=m_h, other=0.0)
+    b_dh = tl.load(p_dh, mask=m_h, other=0.0)
     b_g_last = tl.load(g + (min(i_t * BT + BT, T) - 1) * H)
 
     # calculation
@@ -139,14 +144,14 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel(
     b_dk += tl.dot(tl.trans(b_ds.to(b_q.dtype)), b_q)
 
     b_dg = tl.where(o_t < min(i_t * BT + BT, T) - 1, b_dg, b_dg + b_dg_last)
-    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk_beta, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+    p_dq = dq + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dk = dk_beta + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dv = dv + o_t[:, None] * (H*V) + o_v[None, :]
+    p_dg = dg + o_t * H
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
 
 
 def chunk_mesa_net_h_kv_bwd_intra_fn(

--- a/fla/ops/mesa_net/chunk_h_kv_intra_bwd_separate.py
+++ b/fla/ops/mesa_net/chunk_h_kv_intra_bwd_separate.py
@@ -53,11 +53,11 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dkv(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -88,23 +88,28 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dkv(
     b_dg_last = tl.zeros([1], dtype=tl.float32)
     b_dg = tl.zeros([BT], dtype=tl.float32)
 
-    p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_beta = tl.make_block_ptr(beta, (T, ), (H, ), (i_t * BT,), (BT,), (0,))
-    p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_h = tl.make_block_ptr(h_kv, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
-    p_dh = tl.make_block_ptr(dh_kv, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
-    p_q = tl.make_block_ptr(q_star, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+    p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_beta = beta + o_t * H
+    p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
+    p_h = h_kv + o_v[:, None] + o_k[None, :] * V
+    p_dh = dh_kv + o_v[:, None] + o_k[None, :] * V
+    p_q = q_star + o_t[:, None] * (H*K) + o_k[None, :]
+    p_g = g + o_t * H
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_beta = tl.load(p_beta, boundary_check=(0, ))
-    b_g = tl.load(p_g, boundary_check=(0,))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
-    b_h = tl.load(p_h, boundary_check=(0, 1))
-    b_dh = tl.load(p_dh, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_do = tl.load(p_do, mask=m_tv, other=0.0)
+    b_h = tl.load(p_h, mask=m_h, other=0.0)
+    b_dh = tl.load(p_dh, mask=m_h, other=0.0)
     b_g_last = tl.load(g + (min(i_t * BT + BT, T) - 1) * H)
 
     # calculation
@@ -127,12 +132,12 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dkv(
     b_dv += tl.dot(b_k, tl.trans(b_dh).to(b_k.dtype)) * b_g_exp_k[:, None] + tl.dot(tl.trans(b_s.to(b_do.dtype)), b_do)
     b_dk += tl.dot(tl.trans(b_ds.to(b_q.dtype)), b_q)
     b_dg = tl.where(o_t < min(i_t * BT + BT, T) - 1, b_dg, b_dg + b_dg_last)
-    p_dk = tl.make_block_ptr(dk_beta, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+    p_dk = dk_beta + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dv = dv + o_t[:, None] * (H*V) + o_v[None, :]
+    p_dg = dg + o_t * H
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
 
 
 @triton.heuristics({
@@ -171,11 +176,11 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dq(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -201,24 +206,29 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dq(
 
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
 
-    p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_beta = tl.make_block_ptr(beta, (T, ), (H, ), (i_t * BT,), (BT,), (0,))
-    p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_h = tl.make_block_ptr(h_kv, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
-    p_q = tl.make_block_ptr(q_star, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dg_prev = tl.make_block_ptr(dg_prev, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dg = tl.make_block_ptr(dg, (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_tk = m_t[:, None] & (o_k[None, :] < K)
+    m_tv = m_t[:, None] & (o_v[None, :] < V)
+    m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+    p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+    p_k = k + o_t[:, None] * (H*K) + o_k[None, :]
+    p_beta = beta + o_t * H
+    p_do = do + o_t[:, None] * (H*V) + o_v[None, :]
+    p_h = h_kv + o_v[:, None] + o_k[None, :] * V
+    p_q = q_star + o_t[:, None] * (H*K) + o_k[None, :]
+    p_g = g + o_t * H
+    p_dg_prev = dg_prev + o_t * H
+    p_dg = dg + o_t * H
+    p_dq = dq + o_t[:, None] * (H*K) + o_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_beta = tl.load(p_beta, boundary_check=(0, ))
-    b_g = tl.load(p_g, boundary_check=(0,))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
-    b_h = tl.load(p_h, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_do = tl.load(p_do, mask=m_tv, other=0.0)
+    b_h = tl.load(p_h, mask=m_h, other=0.0)
 
     b_m = tl.where((o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :]), exp2(b_g[:, None] - b_g[None, :]), 0)
     b_k = (b_k * b_beta[:, None]).to(b_k.dtype)
@@ -226,11 +236,11 @@ def chunk_mesa_net_h_kv_bwd_intra_kernel_dq(
     b_ds = tl.dot(b_do, tl.trans(b_v)) * b_m
     b_g_exp_q = exp2(b_g)
     b_dq = tl.dot(b_do, b_h.to(b_do.dtype)) * b_g_exp_q[:, None]
-    b_dg = tl.sum(b_dq * b_q, axis=1) + tl.load(p_dg_prev, boundary_check=(0,))
+    b_dg = tl.sum(b_dq * b_q, axis=1) + tl.load(p_dg_prev, mask=m_t, other=0.0)
     b_dq += tl.dot(b_ds.to(b_k.dtype), b_k)
 
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
 
 
 def chunk_mesa_net_h_kv_bwd_intra_separate_fn(

--- a/fla/ops/nsa/compression.py
+++ b/fla/ops/nsa/compression.py
@@ -51,11 +51,11 @@ def parallel_nsa_compression_fwd_kernel(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_v, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int64)
         bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int64), tl.load(cu_seqlens_q + i_n + 1).to(tl.int64)
         bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int64), tl.load(cu_seqlens_k + i_n + 1).to(tl.int64)
         TQ = (eos_q - bos_q).to(tl.int32)
@@ -67,17 +67,22 @@ def parallel_nsa_compression_fwd_kernel(
         TC = tl.cdiv(TK, BS)
         boc = i_b * TC
 
-    p_q = tl.make_block_ptr(q + (bos_q + i_t) * HQ*K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    o_g = i_h * G + tl.arange(0, G)
+    o_d = tl.arange(0, BK)
+    m_q = (o_g[:, None] < HQ) & (o_d[None, :] < K)
+    p_q = q + (bos_q + i_t) * HQ*K + o_g[:, None] * K + o_d[None, :]
     Q_OFFSET = TK - TQ
     # the Q block is kept in the shared memory throughout the whole kernel
     # [G, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
 
     # number of complete compression blocks visible to the query (q tokens are the last TQ of the sequence)
     NC = (i_t + Q_OFFSET + 1) // BS
 
-    p_o = tl.make_block_ptr(o + (bos_q + i_t) * HQ*V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_o = (o_g[:, None] < HQ) & (o_v[None, :] < V)
+    p_o = o + (bos_q + i_t) * HQ*V + o_g[:, None] * V + o_v[None, :]
     # [G, BV]
     b_o = tl.zeros([G, BV], dtype=tl.float32)
     # max scores for the current block
@@ -88,12 +93,12 @@ def parallel_nsa_compression_fwd_kernel(
     for i_c in range(0, NC, BC):
         o_c = i_c + tl.arange(0, BC)
 
-        p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H*K), (0, i_c), (BK, BC), (0, 1))
-        p_v = tl.make_block_ptr(v + (boc * H + i_h) * V, (TC, V), (H*V, 1), (i_c, i_v * BV), (BC, BV), (1, 0))
+        p_k = k + (boc * H + i_h) * K + o_d[:, None] + o_c[None, :] * (H*K)
+        p_v = v + (boc * H + i_h) * V + o_c[:, None] * (H*V) + o_v[None, :]
         # [BK, BC]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & (o_c[None, :] < TC), other=0.0)
         # [BC, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=(o_c[:, None] < TC) & (o_v[None, :] < V), other=0.0)
         # [G, BC]
         b_s = tl.dot(b_q, b_k)
         # causal mask: only the NC complete blocks are visible
@@ -114,7 +119,7 @@ def parallel_nsa_compression_fwd_kernel(
         b_o = b_o / b_acc[:, None]
         b_lse = b_m + log(b_acc)
 
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_o)
     if i_v == 0:
         tl.store(lse + (bos_q + i_t) * HQ + i_h * G + tl.arange(0, G), b_lse.to(lse.dtype.element_ty))
 
@@ -156,12 +161,12 @@ def parallel_nsa_compression_bwd_kernel_dq(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_v, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         boc = tl.load(chunk_offsets + i_n).to(tl.int32)
@@ -175,14 +180,19 @@ def parallel_nsa_compression_bwd_kernel_dq(
     delta += (bos + i_t) * HQ
     dq += (i_v * all + bos + i_t) * HQ*K
 
-    p_q = tl.make_block_ptr(q, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    o_g = i_h * G + tl.arange(0, G)
+    o_d = tl.arange(0, BK)
+    m_q = (o_g[:, None] < HQ) & (o_d[None, :] < K)
+    p_q = q + o_g[:, None] * K + o_d[None, :]
+    p_dq = dq + o_g[:, None] * K + o_d[None, :]
 
     # [G, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
 
-    p_do = tl.make_block_ptr(do, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_o = (o_g[:, None] < HQ) & (o_v[None, :] < V)
+    p_do = do + o_g[:, None] * V + o_v[None, :]
     p_lse = lse + i_h * G + tl.arange(0, G)
     p_delta = delta + i_h * G + tl.arange(0, G)
 
@@ -193,7 +203,7 @@ def parallel_nsa_compression_bwd_kernel_dq(
     NC = (i_t + 1) // BS
 
     # [G, BV]
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    b_do = tl.load(p_do, mask=m_o, other=0.0)
     # [G]
     b_lse = tl.load(p_lse)
     b_delta = tl.load(p_delta)
@@ -202,12 +212,12 @@ def parallel_nsa_compression_bwd_kernel_dq(
     b_dq = tl.zeros([G, BK], dtype=tl.float32)
     for i_c in range(0, NC, BC):
         o_c = i_c + tl.arange(0, BC)
-        p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H*K), (0, i_c), (BK, BC), (0, 1))
-        p_v = tl.make_block_ptr(v + (boc * H + i_h) * V, (V, TC), (1, H*V), (i_v * BV, i_c), (BV, BC), (0, 1))
+        p_k = k + (boc * H + i_h) * K + o_d[:, None] + o_c[None, :] * (H*K)
+        p_v = v + (boc * H + i_h) * V + o_v[:, None] + o_c[None, :] * (H*V)
         # [BK, BC]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & (o_c[None, :] < TC), other=0.0)
         # [BV, BC]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=(o_v[:, None] < V) & (o_c[None, :] < TC), other=0.0)
 
         # [G, BC]
         b_s = tl.dot(b_q, b_k)
@@ -220,7 +230,7 @@ def parallel_nsa_compression_bwd_kernel_dq(
         # [G, BC] @ [BC, BK] -> [G, BK]
         b_dq += tl.dot(b_ds.to(b_k.dtype), tl.trans(b_k))
     b_dq *= scale
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q)
 
 
 @triton.heuristics({
@@ -262,13 +272,13 @@ def parallel_nsa_compression_bwd_kernel_dkv(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     all = B * TC
 
     if IS_VARLEN:
-        i_n, i_c = tl.load(chunk_indices + i_c * 2).to(tl.int32), tl.load(chunk_indices + i_c * 2 + 1).to(tl.int32)
+        i_n, i_c = tl.load(chunk_indices + i_c * 2).to(tl.int32), tl.load(chunk_indices + i_c * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         # the number of compression representations in total
@@ -278,31 +288,35 @@ def parallel_nsa_compression_bwd_kernel_dkv(
         bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
         boc = i_b * tl.cdiv(T, BS)
 
-    p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (TC, K), (H*K, 1), (i_c * BC, 0), (BC, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (boc * H + i_h) * V, (TC, V), (H*V, 1), (i_c * BC, i_v * BV), (BC, BV), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (i_v * all*H + boc * H + i_h) * K, (TC, K), (H*K, 1), (i_c * BC, 0), (BC, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (boc * H + i_h) * V, (TC, V), (H*V, 1), (i_c * BC, i_v * BV), (BC, BV), (1, 0))
+    o_c = i_c * BC + tl.arange(0, BC)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = (o_c[:, None] < TC) & (o_d[None, :] < K)
+    m_v = (o_c[:, None] < TC) & (o_v[None, :] < V)
+    p_k = k + (boc * H + i_h) * K + o_c[:, None] * (H*K) + o_d[None, :]
+    p_v = v + (boc * H + i_h) * V + o_c[:, None] * (H*V) + o_v[None, :]
+    p_dk = dk + (i_v * all*H + boc * H + i_h) * K + o_c[:, None] * (H*K) + o_d[None, :]
+    p_dv = dv + (boc * H + i_h) * V + o_c[:, None] * (H*V) + o_v[None, :]
 
     # [BC, BK]
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_k = tl.load(p_k, mask=m_k, other=0.0)
     b_dk = tl.zeros([BC, BK], dtype=tl.float32)
     # [BC, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_v, other=0.0)
     b_dv = tl.zeros([BC, BV], dtype=tl.float32)
 
     for i in range(i_c * BC * BS, T):
-        o_c = i_c * BC + tl.arange(0, BC)
-
-        p_q = tl.make_block_ptr(q + (bos + i) * HQ*K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+        o_g = i_h * G + tl.arange(0, G)
+        p_q = q + (bos + i) * HQ*K + o_g[:, None] * K + o_d[None, :]
         # [G, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=(o_g[:, None] < HQ) & (o_d[None, :] < K), other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
 
-        p_do = tl.make_block_ptr(do + (bos + i) * HQ*V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+        p_do = do + (bos + i) * HQ*V + o_g[:, None] * V + o_v[None, :]
         p_lse = lse + (bos + i) * HQ + i_h * G + tl.arange(0, G)
         p_delta = delta + (bos + i) * HQ + i_h * G + tl.arange(0, G)
         # [G, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=(o_g[:, None] < HQ) & (o_v[None, :] < V), other=0.0)
         # [G]
         b_lse = tl.load(p_lse)
         b_delta = tl.load(p_delta)
@@ -319,8 +333,8 @@ def parallel_nsa_compression_bwd_kernel_dkv(
         # [BC, G] @ [G, BK] -> [BC, BK]
         b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
 
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
 
 def parallel_nsa_compression_fwd(

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -63,11 +63,11 @@ def parallel_nsa_kernel_topk(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int64)
         bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int64), tl.load(cu_seqlens_q + i_n + 1).to(tl.int64)
         bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int64), tl.load(cu_seqlens_k + i_n + 1).to(tl.int64)
         TQ = (eos_q - bos_q).to(tl.int32)
@@ -79,12 +79,15 @@ def parallel_nsa_kernel_topk(
         TC = tl.cdiv(TK, BS)
         boc = i_b * TC
     # boc is the start of the current sequence at [B, TC] dimensions
-    p_q = tl.make_block_ptr(q + (bos_q + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    o_g = i_h * G + tl.arange(0, G)
+    o_d = tl.arange(0, BK)
+    m_q = (o_g[:, None] < HQ) & (o_d[None, :] < K)
+    p_q = q + (bos_q + i_t) * HQ * K + o_g[:, None] * K + o_d[None, :]
     Q_OFFSET = TK - TQ
 
     # the Q block is kept in the shared memory throughout the whole kernel
     # [G, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
 
     # number of complete compression blocks visible to the query (q tokens are the last TQ of the sequence)
@@ -102,9 +105,9 @@ def parallel_nsa_kernel_topk(
         for i_c in range(0, NC, BC):
             o_c = i_c + tl.arange(0, BC)
 
-            p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H*K), (0, i_c), (BK, BC), (0, 1))
+            p_k = k + (boc * H + i_h) * K + o_d[:, None] + o_c[None, :] * (H*K)
             # [BK, BC]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=(o_d[:, None] < K) & (o_c[None, :] < TC), other=0.0)
 
             # [G, BC]
             b_s = tl.dot(b_q, b_k)
@@ -135,9 +138,9 @@ def parallel_nsa_kernel_topk(
     IC = (i_t + Q_OFFSET) // BS  # Idx of the current query block
     for i_c in range(0, IC + 1, BC):  # +1, because the current block might be also included
         o_c = i_c + tl.arange(0, BC)
-        p_k = tl.make_block_ptr(k + (boc * H + i_h) * K, (K, TC), (1, H*K), (0, i_c), (BK, BC), (0, 1))
+        p_k = k + (boc * H + i_h) * K + o_d[:, None] + o_c[None, :] * (H*K)
         # [BK, BC]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & (o_c[None, :] < TC), other=0.0)
         # [G, BC]
         b_s = tl.dot(b_q, b_k)
         b_s = tl.where(o_c < IC, b_s, float('-inf'))
@@ -163,7 +166,7 @@ def parallel_nsa_kernel_topk(
     m_top = tl.arange(0, BC // S) == 0
     b_top = tl.sum(m_top[:, None] * tl.reshape(o_i, [BC // S, S]), 0)
 
-    p_b = tl.make_block_ptr(block_indices + (bos_q + i_t) * H*S, (H*S,), (1,), (i_h * S,), (S,), (0,))
+    p_b = block_indices + (bos_q + i_t) * H*S + i_h * S + tl.arange(0, S)
     tl.store(p_b, b_top.to(p_b.dtype.element_ty))
 
 
@@ -207,13 +210,13 @@ def parallel_nsa_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_BLOCK_COUNTS: tl.constexpr,
 ):
-    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_v, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     # k/v: [B, TK, H, *], q: [B, TQ, HQ, K], block_indices: [B, TQ, H, S], lse: [B, TQ, HQ]; G = HQ // H
 
     if IS_VARLEN:
         # token_indices_q maps a flattened query to its (sequence index, in-sequence position)
-        i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices_q + i_t * 2).to(tl.int32), tl.load(token_indices_q + i_t * 2 + 1).to(tl.int64)
         bos_q, eos_q = tl.load(cu_seqlens_q + i_n).to(tl.int64), tl.load(cu_seqlens_q + i_n + 1).to(tl.int64)
         bos_k, eos_k = tl.load(cu_seqlens_k + i_n).to(tl.int64), tl.load(cu_seqlens_k + i_n + 1).to(tl.int64)
         TQ = (eos_q - bos_q).to(tl.int32)
@@ -235,13 +238,18 @@ def parallel_nsa_fwd_kernel(
     else:
         NS = S
 
-    p_q = tl.make_block_ptr(q + (bos_q + i_t) * HQ * K, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    o_g = i_h * G + tl.arange(0, G)
+    o_d = tl.arange(0, BK)
+    m_q = (o_g[:, None] < HQ) & (o_d[None, :] < K)
+    p_q = q + (bos_q + i_t) * HQ * K + o_g[:, None] * K + o_d[None, :]
     # the Q block is kept in shared memory throughout the kernel
     # [G, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
 
-    p_o = tl.make_block_ptr(o + (bos_q + i_t) * HQ * V, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_o = (o_g[:, None] < HQ) & (o_v[None, :] < V)
+    p_o = o + (bos_q + i_t) * HQ * V + o_g[:, None] * V + o_v[None, :]
     p_lse = lse + (bos_q + i_t) * HQ + i_h * G + tl.arange(0, G)
 
     # [G, BV]
@@ -250,14 +258,16 @@ def parallel_nsa_fwd_kernel(
     b_m = tl.full([G], float('-inf'), dtype=tl.float32)
     b_acc = tl.zeros([G], dtype=tl.float32)
     for i in range(NS):
-        i_s = tl.load(block_indices + i).to(tl.int32) * BS  # start token index of the i-th selected KV block
+        i_s = tl.load(block_indices + i).to(tl.int64) * BS  # start token index of the i-th selected KV block
         if i_s <= Q_OFFSET + i_t and i_s >= 0:
-            p_k = tl.make_block_ptr(k, (K, TK), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-            p_v = tl.make_block_ptr(v, (TK, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
+            o_s = i_s + tl.arange(0, BS)
+            m_s = o_s < TK
+            p_k = k + o_d[:, None] + o_s[None, :] * (H*K)
+            p_v = v + o_s[:, None] * (H*V) + o_v[None, :]
             # [BK, BS]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_s[None, :], other=0.0)
             # [BS, BV]
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            b_v = tl.load(p_v, mask=m_s[:, None] & (o_v[None, :] < V), other=0.0)
             # [G, BS]
             b_s = tl.dot(b_q, b_k)
             # causal mask against the absolute query position Q_OFFSET + i_t
@@ -275,7 +285,7 @@ def parallel_nsa_fwd_kernel(
 
     b_o = b_o / b_acc[:, None]
     b_m += log(b_acc)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_o)
     if i_v == 0:
         tl.store(p_lse, b_m.to(p_lse.dtype.element_ty))
 
@@ -321,12 +331,12 @@ def parallel_nsa_bwd_kernel_dq(
     IS_VARLEN: tl.constexpr,
     USE_BLOCK_COUNTS: tl.constexpr,
 ):
-    i_t, i_v, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_v, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(token_indices + i_t * 2).to(tl.int32), tl.load(token_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -347,19 +357,24 @@ def parallel_nsa_bwd_kernel_dq(
     k += (bos * H + i_h) * K
     v += (bos * H + i_h) * V
 
-    p_q = tl.make_block_ptr(q, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq, (HQ, K), (K, 1), (i_h * G, 0), (G, BK), (1, 0))
+    o_g = i_h * G + tl.arange(0, G)
+    o_d = tl.arange(0, BK)
+    m_q = (o_g[:, None] < HQ) & (o_d[None, :] < K)
+    p_q = q + o_g[:, None] * K + o_d[None, :]
+    p_dq = dq + o_g[:, None] * K + o_d[None, :]
 
     # [G, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
 
-    p_do = tl.make_block_ptr(do, (HQ, V), (V, 1), (i_h * G, i_v * BV), (G, BV), (1, 0))
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_o = (o_g[:, None] < HQ) & (o_v[None, :] < V)
+    p_do = do + o_g[:, None] * V + o_v[None, :]
     p_lse = lse + i_h * G + tl.arange(0, G)
     p_delta = delta + i_h * G + tl.arange(0, G)
 
     # [G, BV]
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    b_do = tl.load(p_do, mask=m_o, other=0.0)
     # [G]
     b_lse = tl.load(p_lse)
     b_delta = tl.load(p_delta)
@@ -367,14 +382,16 @@ def parallel_nsa_bwd_kernel_dq(
     # [G, BK]
     b_dq = tl.zeros([G, BK], dtype=tl.float32)
     for i in range(NS):
-        i_s = tl.load(block_indices + i).to(tl.int32) * BS
+        i_s = tl.load(block_indices + i).to(tl.int64) * BS
         if i_s <= i_t and i_s >= 0:
-            p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-            p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
+            o_s = i_s + tl.arange(0, BS)
+            m_s = o_s < T
+            p_k = k + o_d[:, None] + o_s[None, :] * (H*K)
+            p_v = v + o_v[:, None] + o_s[None, :] * (H*V)
             # [BK, BS]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_s[None, :], other=0.0)
             # [BV, BS]
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_s[None, :], other=0.0)
 
             # [G, BS]
             b_s = tl.dot(b_q, b_k)
@@ -388,7 +405,7 @@ def parallel_nsa_bwd_kernel_dq(
             b_dq += tl.dot(b_ds.to(b_k.dtype), tl.trans(b_k))
     b_dq *= scale
 
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q)
 
 
 def _prune_dkv_bq(configs, nargs, **kwargs):

--- a/fla/ops/parallax/decode.py
+++ b/fla/ops/parallax/decode.py
@@ -42,7 +42,7 @@ def parallax_decode_kernel(
     sliding window and to ``[cache_start, Skv)`` when set. One program owns a
     ``BT``-row query block; see ``naive_parallax`` for the output formula.
     """
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G                               # kv head shared by this q head (GQA)
     RCP_LN2: tl.constexpr = 1.4426950216
@@ -69,14 +69,15 @@ def parallax_decode_kernel(
         leftmost = kv_lo
     KV_START_BLOCK = leftmost // BS
 
-    p_q = tl.make_block_ptr(q + (i_b * Sq * HQ + i_hq) * K, (Sq, K), (HQ * K, 1), (q_off, 0), (BT, BK), (1, 0))
-    p_r = tl.make_block_ptr(r + (i_b * Sq * HQ + i_hq) * K, (Sq, K), (HQ * K, 1), (q_off, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (i_b * Skv * H + i_h) * K, (Skv, K), (H * K, 1), (KV_START_BLOCK * BS, 0), (BS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (i_b * Skv * H + i_h) * K, (Skv, K), (H * K, 1), (KV_START_BLOCK * BS, 0), (BS, BK), (1, 0))
-    p_o = tl.make_block_ptr(o + (i_b * Sq * HQ + i_hq) * K, (Sq, K), (HQ * K, 1), (q_off, 0), (BT, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_qk = row_mask & m_k[None, :]
+    p_q = q + (i_b * Sq * HQ + i_hq) * K + rows[:, None] * (HQ * K) + o_k[None, :]
+    p_r = r + (i_b * Sq * HQ + i_hq) * K + rows[:, None] * (HQ * K) + o_k[None, :]
+    p_o = o + (i_b * Sq * HQ + i_hq) * K + rows[:, None] * (HQ * K) + o_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-    b_r = tl.load(p_r, boundary_check=(0, 1), padding_option="zero")
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_r = tl.load(p_r, mask=m_qk, other=0.0)
     m_acc = tl.zeros((BT, 1), dtype=tl.float32) - float("inf")
     d1_acc = tl.zeros((BT, 1), dtype=tl.float32)
     d2_acc = tl.zeros((BT, 1), dtype=tl.float32)
@@ -86,8 +87,12 @@ def parallax_decode_kernel(
 
     for col_block_id in range(KV_START_BLOCK, KV_END_BLOCK):
         col = (col_block_id * BS + tl.arange(0, BS))[None, :]   # [1, BS] key positions
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")   # [BS, BK]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")   # [BS, BK]
+        o_kv = col_block_id.to(tl.int64) * BS + tl.arange(0, BS)
+        m_kv = (o_kv[:, None] < Skv) & m_k[None, :]
+        p_k = k + (i_b * Skv * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (i_b * Skv * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)   # [BS, BK]
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)   # [BS, BK]
         # [BT, BS]: causal, in-cache, past left-padding; optionally inside the window.
         mask = (abs_q >= col) & row_mask & (col < Skv) & (col >= kv_lo)
         if WINDOW_SIZE_LEFT >= 0:
@@ -108,8 +113,6 @@ def parallax_decode_kernel(
         barv_acc = tl.dot(w.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=barv_acc)
         Rv_acc = tl.dot(wr.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=Rv_acc)
         m_acc = m_new
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     # Rows that see no valid key (e.g. left-padded query positions) have d1 == 0;
     # emit a finite zero instead of inf/NaN so padding can't poison valid rows.
@@ -118,7 +121,7 @@ def parallax_decode_kernel(
     b_bart = d2_acc * inv_d1                                   # d2 / d1
     b_o = b_barv + b_bart * b_barv - Rv_acc * inv_d1           # O1/d1 * (1 + d2/d1) - O2/d1
 
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_qk)
 
 
 def parallax_decode(
@@ -229,11 +232,13 @@ def parallax_decode_one_step_kernel(
         kv_lo = tl.maximum(kv_lo, Skv - WINDOW_SIZE_LEFT)
     kv_lo = tl.maximum(kv_lo, 0)
 
-    p_q = tl.make_block_ptr(q + i_bh * K, (K,), (1,), (0,), (BK,), (0,))
-    p_r = tl.make_block_ptr(r + i_bh * K, (K,), (1,), (0,), (BK,), (0,))
-    p_o = tl.make_block_ptr(o + i_bh * K, (K,), (1,), (0,), (BK,), (0,))
-    b_q = tl.load(p_q, boundary_check=(0,), padding_option="zero").to(tl.float32)   # [BK] query vector
-    b_r = tl.load(p_r, boundary_check=(0,), padding_option="zero").to(tl.float32)   # [BK] secondary query
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    p_q = q + i_bh * K + o_k
+    p_r = r + i_bh * K + o_k
+    p_o = o + i_bh * K + o_k
+    b_q = tl.load(p_q, mask=m_k, other=0.0).to(tl.float32)   # [BK] query vector
+    b_r = tl.load(p_r, mask=m_k, other=0.0).to(tl.float32)   # [BK] secondary query
     scale_log2 = scale * RCP_LN2
 
     # Running online-softmax state for the single query: pivot m, denominators
@@ -245,13 +250,15 @@ def parallax_decode_one_step_kernel(
     o2 = tl.zeros((BK,), dtype=tl.float32)
 
     start_block = kv_lo // BS
-    p_k = tl.make_block_ptr(k + (i_b * Skv * H + i_h) * K, (Skv, K), (H * K, 1), (start_block * BS, 0), (BS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (i_b * Skv * H + i_h) * K, (Skv, K), (H * K, 1), (start_block * BS, 0), (BS, BK), (1, 0))
     for i_s in range(start_block * BS, tl.cdiv(Skv, BS) * BS, BS):
         col = i_s + tl.arange(0, BS)
+        o_kv = i_s.to(tl.int64) + tl.arange(0, BS)
+        m_kv = (o_kv[:, None] < Skv) & m_k[None, :]
+        p_k = k + (i_b * Skv * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (i_b * Skv * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
         mask = (col >= kv_lo) & (col < Skv)                          # [BS] valid keys
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")   # [BS, BK]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")   # [BS, BK]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)   # [BS, BK]
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)   # [BS, BK]
         s1 = tl.sum(b_q[None, :] * b_k, axis=1) * scale_log2          # [BS] = scale * (q . k), base-2
         s2 = tl.sum(b_r[None, :] * b_k, axis=1)                        # [BS] = r . k (unscaled)
         s1 = tl.where(mask, s1, -float("inf"))
@@ -265,12 +272,10 @@ def parallax_decode_one_step_kernel(
         o1 = o1 * alpha + tl.sum(p1[:, None] * b_v, axis=0)           # [BK]
         o2 = o2 * alpha + tl.sum(p2[:, None] * b_v, axis=0)
         m = m_new
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     inv_d1 = tl.where(d1 > 0.0, 1.0 / d1, 0.0)                        # 0 when no valid key (avoid NaN)
     out = o1 * inv_d1 * (1.0 + d2 * inv_d1) - o2 * inv_d1             # [BK] O1/d1*(1 + d2/d1) - O2/d1
-    tl.store(p_o, out.to(p_o.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_o, out.to(p_o.dtype.element_ty), mask=m_k)
 
 
 def parallax_decode_one_step(

--- a/fla/ops/parallax/parallel.py
+++ b/fla/ops/parallax/parallel.py
@@ -52,12 +52,12 @@ def parallel_parallax_fwd_kernel(
     BS: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -85,18 +85,19 @@ def parallel_parallax_fwd_kernel(
     SAFE_MIDDLE_START = tl.maximum(FIRST_COL_BLOCK, SAFE_LEFT_START)
     RIGHT_BORDER_START = tl.maximum(FIRST_COL_BLOCK, NUM_SAFE_BLOCKS)
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_r = tl.make_block_ptr(r + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H * K, 1), (FIRST_COL_BLOCK * BS, 0), (BS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * K, (T, K), (H * K, 1), (FIRST_COL_BLOCK * BS, 0), (BS, BK), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_barv = tl.make_block_ptr(barv + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_d1 = tl.make_block_ptr(d1 + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_bart = tl.make_block_ptr(bart + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_m = tl.make_block_ptr(m + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_qk = row_mask & m_k[None, :]
+    p_q = q + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_r = r + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_o = o + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_barv = barv + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_d1 = d1 + bos * HQ + i_hq + row_indices[:, None] * HQ
+    p_bart = bart + bos * HQ + i_hq + row_indices[:, None] * HQ
+    p_m = m + bos * HQ + i_hq + row_indices[:, None] * HQ
 
-    b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-    b_r = tl.load(p_r, boundary_check=(0, 1), padding_option="zero")
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_r = tl.load(p_r, mask=m_qk, other=0.0)
     m_acc = tl.zeros((BT, 1), dtype=tl.float32) - float("inf")
     d1_acc = tl.zeros((BT, 1), dtype=tl.float32)
     d2_acc = tl.zeros((BT, 1), dtype=tl.float32)
@@ -106,9 +107,12 @@ def parallel_parallax_fwd_kernel(
 
     # Phase 0: left-border blocks (SWA only). Window mask only.
     for col_block_id in range(FIRST_COL_BLOCK, LEFT_BORDER_END):
-        col_indices = col_block_id * BS + tl.arange(0, BS)
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        col_indices = col_block_id.to(tl.int64) * BS + tl.arange(0, BS)
+        m_kv = (col_indices[:, None] < T) & m_k[None, :]
+        p_k = k + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         mask = (
             (col_indices[None, :] >= row_indices[:, None] - WINDOW_SIZE_LEFT + 1)
             & row_mask
@@ -129,13 +133,15 @@ def parallel_parallax_fwd_kernel(
         barv_acc = tl.dot(w.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=barv_acc)
         Rv_acc = tl.dot(wr.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=Rv_acc)
         m_acc = m_new
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     # Phase A: safe blocks (no mask).
     for _safe in range(SAFE_MIDDLE_START, NUM_SAFE_BLOCKS):
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        o_kv = _safe.to(tl.int64) * BS + tl.arange(0, BS)
+        m_kv = (o_kv[:, None] < T) & m_k[None, :]
+        p_k = k + (bos * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (bos * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         qk = tl.dot(b_q, tl.trans(b_k), out_dtype=tl.float32) * scale_log2
         m_new = tl.maximum(m_acc, tl.max(qk, axis=1, keep_dims=True))
         safe_m = tl.where(m_new == -float("inf"), 0.0, m_new)
@@ -150,14 +156,15 @@ def parallel_parallax_fwd_kernel(
         barv_acc = tl.dot(w.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=barv_acc)
         Rv_acc = tl.dot(wr.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=Rv_acc)
         m_acc = m_new
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     # Phase B: right-border blocks (causal + boundary + window mask).
     for col_block_id in range(RIGHT_BORDER_START, NUM_TOTAL_BLOCKS):
-        col_indices = col_block_id * BS + tl.arange(0, BS)
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        col_indices = col_block_id.to(tl.int64) * BS + tl.arange(0, BS)
+        m_kv = (col_indices[:, None] < T) & m_k[None, :]
+        p_k = k + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         if WINDOW_SIZE_LEFT >= 0:
             mask = (
                 (row_indices[:, None] >= col_indices[None, :])
@@ -186,19 +193,17 @@ def parallel_parallax_fwd_kernel(
         barv_acc = tl.dot(w.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=barv_acc)
         Rv_acc = tl.dot(wr.to(b_v.dtype), b_v, out_dtype=tl.float32, acc=Rv_acc)
         m_acc = m_new
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     inv_d1 = tl.where(row_mask, 1.0 / d1_acc, 0.0)
     b_barv = barv_acc * inv_d1
     b_bart = d2_acc * inv_d1
     b_o = b_barv + b_bart * b_barv - Rv_acc * inv_d1
 
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_barv, b_barv.to(p_barv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_d1, d1_acc, boundary_check=(0, 1))
-    tl.store(p_bart, b_bart, boundary_check=(0, 1))
-    tl.store(p_m, m_acc, boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_qk)
+    tl.store(p_barv, b_barv.to(p_barv.dtype.element_ty), mask=m_qk)
+    tl.store(p_d1, d1_acc, mask=row_mask)
+    tl.store(p_bart, b_bart, mask=row_mask)
+    tl.store(p_m, m_acc, mask=row_mask)
 
 
 @triton.heuristics({
@@ -220,32 +225,36 @@ def parallel_parallax_bwd_kernel_preprocess(
     BT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
         bos = (i_b * T).to(tl.int64)
 
     row_offset = i_t * BT
-    p_grad_o = tl.make_block_ptr(grad_o + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_barv = tl.make_block_ptr(barv + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_t = tl.make_block_ptr(delta_t + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_b = tl.make_block_ptr(delta_b + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
+    o_t = row_offset + tl.arange(0, BT)
+    o_k = tl.arange(0, BK)
+    m_tk = (o_t[:, None] < T) & (o_k[None, :] < K)
+    m_t = o_t[:, None] < T
+    p_grad_o = grad_o + (bos * HQ + i_hq) * K + o_t[:, None] * (HQ * K) + o_k[None, :]
+    p_o = o + (bos * HQ + i_hq) * K + o_t[:, None] * (HQ * K) + o_k[None, :]
+    p_barv = barv + (bos * HQ + i_hq) * K + o_t[:, None] * (HQ * K) + o_k[None, :]
+    p_t = delta_t + bos * HQ + i_hq + o_t[:, None] * HQ
+    p_b = delta_b + bos * HQ + i_hq + o_t[:, None] * HQ
 
-    b_grad_o = tl.load(p_grad_o, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
-    b_o = tl.load(p_o, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
-    b_barv = tl.load(p_barv, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+    b_grad_o = tl.load(p_grad_o, mask=m_tk, other=0.0).to(tl.float32)
+    b_o = tl.load(p_o, mask=m_tk, other=0.0).to(tl.float32)
+    b_barv = tl.load(p_barv, mask=m_tk, other=0.0).to(tl.float32)
 
     b_t = tl.sum(b_grad_o * b_o, axis=1, keep_dims=True)
     b_b = tl.sum(b_grad_o * b_barv, axis=1, keep_dims=True)
 
-    tl.store(p_t, b_t, boundary_check=(0, 1))
-    tl.store(p_b, b_b, boundary_check=(0, 1))
+    tl.store(p_t, b_t, mask=m_t)
+    tl.store(p_b, b_b, mask=m_t)
 
 
 @triton.heuristics({
@@ -279,12 +288,12 @@ def parallel_parallax_bwd_kernel_dqr(
     BS: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -311,27 +320,28 @@ def parallel_parallax_bwd_kernel_dqr(
     SAFE_MIDDLE_START = tl.maximum(FIRST_COL_BLOCK, SAFE_LEFT_START)
     RIGHT_BORDER_START = tl.maximum(FIRST_COL_BLOCK, NUM_SAFE_BLOCKS)
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_r = tl.make_block_ptr(r + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H * K, 1), (FIRST_COL_BLOCK * BS, 0), (BS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * K, (T, K), (H * K, 1), (FIRST_COL_BLOCK * BS, 0), (BS, BK), (1, 0))
-    p_d1 = tl.make_block_ptr(d1 + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_bart = tl.make_block_ptr(bart + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_m = tl.make_block_ptr(m + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_t = tl.make_block_ptr(delta_t + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_b = tl.make_block_ptr(delta_b + bos * HQ + i_hq, (T, 1), (HQ, 1), (row_offset, 0), (BT, 1), (1, 0))
-    p_grad_o = tl.make_block_ptr(grad_o + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_grad_q = tl.make_block_ptr(grad_q + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
-    p_grad_r = tl.make_block_ptr(grad_r + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (row_offset, 0), (BT, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_qk = row_mask & m_k[None, :]
+    p_q = q + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_r = r + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_d1 = d1 + bos * HQ + i_hq + row_indices[:, None] * HQ
+    p_bart = bart + bos * HQ + i_hq + row_indices[:, None] * HQ
+    p_m = m + bos * HQ + i_hq + row_indices[:, None] * HQ
+    p_t = delta_t + bos * HQ + i_hq + row_indices[:, None] * HQ
+    p_b = delta_b + bos * HQ + i_hq + row_indices[:, None] * HQ
+    p_grad_o = grad_o + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_grad_q = grad_q + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_grad_r = grad_r + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-    b_r = tl.load(p_r, boundary_check=(0, 1), padding_option="zero")
-    b_d1 = tl.load(p_d1, boundary_check=(0, 1), padding_option="zero")
-    b_bart = tl.load(p_bart, boundary_check=(0, 1), padding_option="zero")
-    b_m = tl.load(p_m, boundary_check=(0, 1), padding_option="zero")
-    b_t = tl.load(p_t, boundary_check=(0, 1), padding_option="zero")
-    b_b = tl.load(p_b, boundary_check=(0, 1), padding_option="zero")
-    grad_o_tile = tl.load(p_grad_o, boundary_check=(0, 1), padding_option="zero")
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_r = tl.load(p_r, mask=m_qk, other=0.0)
+    b_d1 = tl.load(p_d1, mask=row_mask, other=0.0)
+    b_bart = tl.load(p_bart, mask=row_mask, other=0.0)
+    b_m = tl.load(p_m, mask=row_mask, other=0.0)
+    b_t = tl.load(p_t, mask=row_mask, other=0.0)
+    b_b = tl.load(p_b, mask=row_mask, other=0.0)
+    grad_o_tile = tl.load(p_grad_o, mask=m_qk, other=0.0)
     grad_q_acc = tl.zeros((BT, BK), dtype=tl.float32)
     grad_r_acc = tl.zeros((BT, BK), dtype=tl.float32)
     scale_log2 = scale * RCP_LN2
@@ -340,9 +350,12 @@ def parallel_parallax_bwd_kernel_dqr(
 
     # Phase 0: left-border blocks (SWA only).
     for col_block_id in range(FIRST_COL_BLOCK, LEFT_BORDER_END):
-        col_indices = col_block_id * BS + tl.arange(0, BS)
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        col_indices = col_block_id.to(tl.int64) * BS + tl.arange(0, BS)
+        m_kv = (col_indices[:, None] < T) & m_k[None, :]
+        p_k = k + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         mask = (
             (col_indices[None, :] >= row_indices[:, None] - WINDOW_SIZE_LEFT + 1)
             & row_mask
@@ -360,13 +373,15 @@ def parallel_parallax_bwd_kernel_dqr(
         gu = -p * delta
         grad_q_acc = tl.dot(gl.to(b_k.dtype), b_k, out_dtype=tl.float32, acc=grad_q_acc)
         grad_r_acc = tl.dot(gu.to(b_k.dtype), b_k, out_dtype=tl.float32, acc=grad_r_acc)
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     # Phase A: safe blocks (no mask).
     for _ in range(SAFE_MIDDLE_START, NUM_SAFE_BLOCKS):
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        o_kv = _.to(tl.int64) * BS + tl.arange(0, BS)
+        m_kv = (o_kv[:, None] < T) & m_k[None, :]
+        p_k = k + (bos * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (bos * H + i_h) * K + o_kv[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         qk = tl.dot(b_q, tl.trans(b_k), out_dtype=tl.float32) * scale_log2
         w = exp2(qk - b_m)
         a = tl.dot(grad_o_tile, tl.trans(b_v), out_dtype=tl.float32)
@@ -378,14 +393,15 @@ def parallel_parallax_bwd_kernel_dqr(
         gu = -p * delta
         grad_q_acc = tl.dot(gl.to(b_k.dtype), b_k, out_dtype=tl.float32, acc=grad_q_acc)
         grad_r_acc = tl.dot(gu.to(b_k.dtype), b_k, out_dtype=tl.float32, acc=grad_r_acc)
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     # Phase B: right-border blocks (causal + boundary + window mask).
     for col_block_id in range(RIGHT_BORDER_START, NUM_TOTAL_BLOCKS):
-        col_indices = col_block_id * BS + tl.arange(0, BS)
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        col_indices = col_block_id.to(tl.int64) * BS + tl.arange(0, BS)
+        m_kv = (col_indices[:, None] < T) & m_k[None, :]
+        p_k = k + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        p_v = v + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+        b_k = tl.load(p_k, mask=m_kv, other=0.0)
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         if WINDOW_SIZE_LEFT >= 0:
             mask = (
                 (row_indices[:, None] >= col_indices[None, :])
@@ -411,13 +427,11 @@ def parallel_parallax_bwd_kernel_dqr(
         gu = -p * delta
         grad_q_acc = tl.dot(gl.to(b_k.dtype), b_k, out_dtype=tl.float32, acc=grad_q_acc)
         grad_r_acc = tl.dot(gu.to(b_k.dtype), b_k, out_dtype=tl.float32, acc=grad_r_acc)
-        p_k = tl.advance(p_k, (BS, 0))
-        p_v = tl.advance(p_v, (BS, 0))
 
     grad_q_acc = scale * grad_q_acc
 
-    tl.store(p_grad_q, grad_q_acc.to(p_grad_q.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_grad_r, grad_r_acc.to(p_grad_r.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_grad_q, grad_q_acc.to(p_grad_q.dtype.element_ty), mask=m_qk)
+    tl.store(p_grad_r, grad_r_acc.to(p_grad_r.dtype.element_ty), mask=m_qk)
 
 
 @triton.heuristics({
@@ -451,12 +465,12 @@ def parallel_parallax_bwd_kernel_dkv(
     BS: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -467,7 +481,6 @@ def parallel_parallax_bwd_kernel_dkv(
     col_indices = col_offset + tl.arange(0, BS)
 
     start_row_block = col_offset // BT
-    start_row_offset = start_row_block * BT
 
     num_row_blocks_qbound = tl.cdiv(T, BT)
     if WINDOW_SIZE_LEFT >= 0:
@@ -478,21 +491,16 @@ def parallel_parallax_bwd_kernel_dkv(
         num_row_blocks = num_row_blocks_qbound
         WINDOW_SAFE_END = num_row_blocks
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (start_row_offset, 0), (BT, BK), (1, 0))
-    p_r = tl.make_block_ptr(r + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (start_row_offset, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H * K, 1), (col_offset, 0), (BS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * K, (T, K), (H * K, 1), (col_offset, 0), (BS, BK), (1, 0))
-    p_d1 = tl.make_block_ptr(d1 + bos * HQ + i_hq, (T, 1), (HQ, 1), (start_row_offset, 0), (BT, 1), (1, 0))
-    p_bart = tl.make_block_ptr(bart + bos * HQ + i_hq, (T, 1), (HQ, 1), (start_row_offset, 0), (BT, 1), (1, 0))
-    p_m = tl.make_block_ptr(m + bos * HQ + i_hq, (T, 1), (HQ, 1), (start_row_offset, 0), (BT, 1), (1, 0))
-    p_t = tl.make_block_ptr(delta_t + bos * HQ + i_hq, (T, 1), (HQ, 1), (start_row_offset, 0), (BT, 1), (1, 0))
-    p_b = tl.make_block_ptr(delta_b + bos * HQ + i_hq, (T, 1), (HQ, 1), (start_row_offset, 0), (BT, 1), (1, 0))
-    p_grad_o = tl.make_block_ptr(grad_o + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (start_row_offset, 0), (BT, BK), (1, 0))
-    p_grad_k = tl.make_block_ptr(grad_k + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (col_offset, 0), (BS, BK), (1, 0))
-    p_grad_v = tl.make_block_ptr(grad_v + (bos * HQ + i_hq) * K, (T, K), (HQ * K, 1), (col_offset, 0), (BS, BK), (1, 0))
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_ck = (col_indices[:, None] < T) & m_k[None, :]
+    p_k = k + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+    p_v = v + (bos * H + i_h) * K + col_indices[:, None] * (H * K) + o_k[None, :]
+    p_grad_k = grad_k + (bos * HQ + i_hq) * K + col_indices[:, None] * (HQ * K) + o_k[None, :]
+    p_grad_v = grad_v + (bos * HQ + i_hq) * K + col_indices[:, None] * (HQ * K) + o_k[None, :]
 
-    b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-    b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+    b_k = tl.load(p_k, mask=m_ck, other=0.0)
+    b_v = tl.load(p_v, mask=m_ck, other=0.0)
     grad_k_acc = tl.zeros((BS, BK), dtype=tl.float32)
     grad_v_acc = tl.zeros((BS, BK), dtype=tl.float32)
     scale_log2 = scale * RCP_LN2
@@ -504,17 +512,26 @@ def parallel_parallax_bwd_kernel_dkv(
     # Phase A: causal-border row blocks.
     causal_end = tl.minimum(first_safe_row_block, num_row_blocks)
     for row_block_id in range(start_row_block, causal_end):
-        row_offset = row_block_id * BT
+        row_offset = row_block_id.to(tl.int64) * BT
         row_indices = row_offset + tl.arange(0, BT)
         row_mask = row_indices[:, None] < T
-        b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-        b_r = tl.load(p_r, boundary_check=(0, 1), padding_option="zero")
-        b_d1 = tl.load(p_d1, boundary_check=(0, 1), padding_option="zero")
-        b_bart = tl.load(p_bart, boundary_check=(0, 1), padding_option="zero")
-        b_m = tl.load(p_m, boundary_check=(0, 1), padding_option="zero")
-        b_t = tl.load(p_t, boundary_check=(0, 1), padding_option="zero")
-        b_b = tl.load(p_b, boundary_check=(0, 1), padding_option="zero")
-        grad_o_tile = tl.load(p_grad_o, boundary_check=(0, 1), padding_option="zero")
+        m_qk = row_mask & m_k[None, :]
+        p_q = q + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        p_r = r + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        p_d1 = d1 + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_bart = bart + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_m = m + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_t = delta_t + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_b = delta_b + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_grad_o = grad_o + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_r = tl.load(p_r, mask=m_qk, other=0.0)
+        b_d1 = tl.load(p_d1, mask=row_mask, other=0.0)
+        b_bart = tl.load(p_bart, mask=row_mask, other=0.0)
+        b_m = tl.load(p_m, mask=row_mask, other=0.0)
+        b_t = tl.load(p_t, mask=row_mask, other=0.0)
+        b_b = tl.load(p_b, mask=row_mask, other=0.0)
+        grad_o_tile = tl.load(p_grad_o, mask=m_qk, other=0.0)
 
         qk = tl.dot(b_q, tl.trans(b_k), out_dtype=tl.float32) * scale_log2
         rk = tl.dot(b_r, tl.trans(b_k), out_dtype=tl.float32)
@@ -545,29 +562,29 @@ def parallel_parallax_bwd_kernel_dkv(
         weights = p * (1 + bart_minus_rk)
         grad_v_acc = tl.dot(tl.trans(weights).to(grad_o_tile.dtype), grad_o_tile, out_dtype=tl.float32, acc=grad_v_acc)
 
-        p_q = tl.advance(p_q, (BT, 0))
-        p_r = tl.advance(p_r, (BT, 0))
-        p_d1 = tl.advance(p_d1, (BT, 0))
-        p_bart = tl.advance(p_bart, (BT, 0))
-        p_m = tl.advance(p_m, (BT, 0))
-        p_t = tl.advance(p_t, (BT, 0))
-        p_b = tl.advance(p_b, (BT, 0))
-        p_grad_o = tl.advance(p_grad_o, (BT, 0))
-
     # Phase B: safe row blocks (no causal/col/window mask).
     safe_b_start = tl.maximum(first_safe_row_block, start_row_block)
     for row_block_id in range(safe_b_start, SAFE_MIDDLE_END):
-        row_offset = row_block_id * BT
+        row_offset = row_block_id.to(tl.int64) * BT
         row_indices = row_offset + tl.arange(0, BT)
         row_mask = row_indices[:, None] < T
-        b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-        b_r = tl.load(p_r, boundary_check=(0, 1), padding_option="zero")
-        b_d1 = tl.load(p_d1, boundary_check=(0, 1), padding_option="zero")
-        b_bart = tl.load(p_bart, boundary_check=(0, 1), padding_option="zero")
-        b_m = tl.load(p_m, boundary_check=(0, 1), padding_option="zero")
-        b_t = tl.load(p_t, boundary_check=(0, 1), padding_option="zero")
-        b_b = tl.load(p_b, boundary_check=(0, 1), padding_option="zero")
-        grad_o_tile = tl.load(p_grad_o, boundary_check=(0, 1), padding_option="zero")
+        m_qk = row_mask & m_k[None, :]
+        p_q = q + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        p_r = r + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        p_d1 = d1 + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_bart = bart + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_m = m + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_t = delta_t + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_b = delta_b + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_grad_o = grad_o + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_r = tl.load(p_r, mask=m_qk, other=0.0)
+        b_d1 = tl.load(p_d1, mask=row_mask, other=0.0)
+        b_bart = tl.load(p_bart, mask=row_mask, other=0.0)
+        b_m = tl.load(p_m, mask=row_mask, other=0.0)
+        b_t = tl.load(p_t, mask=row_mask, other=0.0)
+        b_b = tl.load(p_b, mask=row_mask, other=0.0)
+        grad_o_tile = tl.load(p_grad_o, mask=m_qk, other=0.0)
 
         qk = tl.dot(b_q, tl.trans(b_k), out_dtype=tl.float32) * scale_log2
         rk = tl.dot(b_r, tl.trans(b_k), out_dtype=tl.float32)
@@ -584,29 +601,29 @@ def parallel_parallax_bwd_kernel_dkv(
         weights = p * (1 + bart_minus_rk)
         grad_v_acc = tl.dot(tl.trans(weights).to(grad_o_tile.dtype), grad_o_tile, out_dtype=tl.float32, acc=grad_v_acc)
 
-        p_q = tl.advance(p_q, (BT, 0))
-        p_r = tl.advance(p_r, (BT, 0))
-        p_d1 = tl.advance(p_d1, (BT, 0))
-        p_bart = tl.advance(p_bart, (BT, 0))
-        p_m = tl.advance(p_m, (BT, 0))
-        p_t = tl.advance(p_t, (BT, 0))
-        p_b = tl.advance(p_b, (BT, 0))
-        p_grad_o = tl.advance(p_grad_o, (BT, 0))
-
     # Phase C: window-border row blocks (SWA only).
     window_border_start = tl.maximum(WINDOW_BORDER_START, start_row_block)
     for row_block_id in range(window_border_start, num_row_blocks):
-        row_offset = row_block_id * BT
+        row_offset = row_block_id.to(tl.int64) * BT
         row_indices = row_offset + tl.arange(0, BT)
         row_mask = row_indices[:, None] < T
-        b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-        b_r = tl.load(p_r, boundary_check=(0, 1), padding_option="zero")
-        b_d1 = tl.load(p_d1, boundary_check=(0, 1), padding_option="zero")
-        b_bart = tl.load(p_bart, boundary_check=(0, 1), padding_option="zero")
-        b_m = tl.load(p_m, boundary_check=(0, 1), padding_option="zero")
-        b_t = tl.load(p_t, boundary_check=(0, 1), padding_option="zero")
-        b_b = tl.load(p_b, boundary_check=(0, 1), padding_option="zero")
-        grad_o_tile = tl.load(p_grad_o, boundary_check=(0, 1), padding_option="zero")
+        m_qk = row_mask & m_k[None, :]
+        p_q = q + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        p_r = r + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        p_d1 = d1 + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_bart = bart + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_m = m + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_t = delta_t + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_b = delta_b + bos * HQ + i_hq + row_indices[:, None] * HQ
+        p_grad_o = grad_o + (bos * HQ + i_hq) * K + row_indices[:, None] * (HQ * K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_r = tl.load(p_r, mask=m_qk, other=0.0)
+        b_d1 = tl.load(p_d1, mask=row_mask, other=0.0)
+        b_bart = tl.load(p_bart, mask=row_mask, other=0.0)
+        b_m = tl.load(p_m, mask=row_mask, other=0.0)
+        b_t = tl.load(p_t, mask=row_mask, other=0.0)
+        b_b = tl.load(p_b, mask=row_mask, other=0.0)
+        grad_o_tile = tl.load(p_grad_o, mask=m_qk, other=0.0)
 
         qk = tl.dot(b_q, tl.trans(b_k), out_dtype=tl.float32) * scale_log2
         rk = tl.dot(b_r, tl.trans(b_k), out_dtype=tl.float32)
@@ -629,17 +646,8 @@ def parallel_parallax_bwd_kernel_dkv(
         weights = p * (1 + bart_minus_rk)
         grad_v_acc = tl.dot(tl.trans(weights).to(grad_o_tile.dtype), grad_o_tile, out_dtype=tl.float32, acc=grad_v_acc)
 
-        p_q = tl.advance(p_q, (BT, 0))
-        p_r = tl.advance(p_r, (BT, 0))
-        p_d1 = tl.advance(p_d1, (BT, 0))
-        p_bart = tl.advance(p_bart, (BT, 0))
-        p_m = tl.advance(p_m, (BT, 0))
-        p_t = tl.advance(p_t, (BT, 0))
-        p_b = tl.advance(p_b, (BT, 0))
-        p_grad_o = tl.advance(p_grad_o, (BT, 0))
-
-    tl.store(p_grad_k, grad_k_acc.to(p_grad_k.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_grad_v, grad_v_acc.to(p_grad_v.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_grad_k, grad_k_acc.to(p_grad_k.dtype.element_ty), mask=m_ck)
+    tl.store(p_grad_v, grad_v_acc.to(p_grad_v.dtype.element_ty), mask=m_ck)
 
 
 def parallel_parallax_fwd(q, r, k, v, scale, cu_seqlens=None, chunk_indices=None, window_size_left=-1):

--- a/fla/ops/path_attn/cumprod_householder_bwd.py
+++ b/fla/ops/path_attn/cumprod_householder_bwd.py
@@ -63,39 +63,44 @@ def chunk_cumprod_householder_bwd_kernel(
 
     stride_h = H * K * K
     NT_small = tl.cdiv(min(S, T-i_s*S), BT)
-    p_dhc_whole = tl.make_block_ptr(dhc_whole, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
+    o_d = tl.arange(0, BK)
+    m_d = o_d < K
+    p_dhc_whole = dhc_whole + o_d[:, None] * K + o_d[None, :]
     b_dhc = tl.zeros([BK, BK], dtype=tl.float32)
-    b_dhc += tl.load(p_dhc_whole, boundary_check=(0, 1))
+    b_dhc += tl.load(p_dhc_whole, mask=m_d[:, None] & m_d[None, :], other=0.0)
 
     # calculate dh
     for i_t_small in range(0, NT_small):
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_s*S + i_t_small*BT, 0), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (HQ*K, 1), (i_s*S + i_t_small*BT, 0), (BT, BK), (1, 0))
-        p_dk_new = tl.make_block_ptr(dk_new, (T, K), (HQ*K, 1), (i_s*S + i_t_small*BT, 0), (BT, BK), (1, 0))
-        p_hc = tl.make_block_ptr(hc_suffix + i_t_small * stride_h, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
+        o_k = (i_s*S + i_t_small*BT).to(tl.int64) + tl.arange(0, BT)
+        m_k = o_k < T
+        m_kk = m_k[:, None] & m_d[None, :]
+        p_k = k + o_k[:, None] * (H*K) + o_d[None, :]
+        p_dk = dk + o_k[:, None] * (HQ*K) + o_d[None, :]
+        p_dk_new = dk_new + o_k[:, None] * (HQ*K) + o_d[None, :]
+        p_hc = hc_suffix + i_t_small * stride_h + o_d[:, None] * K + o_d[None, :]
 
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_dk = tl.load(p_dk, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
+        b_dk = tl.load(p_dk, mask=m_kk, other=0.0)
 
-        p_w1 = tl.make_block_ptr(w1, (T, K), (H*K, 1), (i_s*S + i_t_small*BT, 0), (BT, BK), (1, 0))
-        p_w2 = tl.make_block_ptr(w2, (T, K), (H*K, 1), (i_s*S + i_t_small*BT, 0), (BT, BK), (1, 0))
+        p_w1 = w1 + o_k[:, None] * (H*K) + o_d[None, :]
+        p_w2 = w2 + o_k[:, None] * (H*K) + o_d[None, :]
 
-        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-        b_w2 = tl.load(p_w2, boundary_check=(0, 1))
-        b_hc = tl.load(p_hc, boundary_check=(0, 1))
+        b_w1 = tl.load(p_w1, mask=m_kk, other=0.0)
+        b_w2 = tl.load(p_w2, mask=m_kk, other=0.0)
+        b_hc = tl.load(p_hc, mask=m_d[:, None] & m_d[None, :], other=0.0)
 
         b_dk_new = b_dk - tl.dot(b_dk.to(b_hc.dtype), b_hc)
-        tl.store(p_dk_new, b_dk_new.to(dk_new.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk_new, b_dk_new.to(dk_new.dtype.element_ty), mask=m_kk)
 
         b_dh = b_dhc - tl.dot(tl.trans(b_hc), b_dhc.to(b_hc.dtype))
         b_dw2 = tl.dot(b_w1, b_dh.to(b_w1.dtype))
         b_dw1 = tl.dot(b_w2, tl.trans(b_dh.to(b_w2.dtype)))
 
-        p_dw1 = tl.make_block_ptr(dw1, (T, K), (HQ*K, 1), (i_s*S + i_t_small*BT, 0), (BT, BK), (1, 0))
-        p_dw2 = tl.make_block_ptr(dw2, (T, K), (HQ*K, 1), (i_s*S + i_t_small*BT, 0), (BT, BK), (1, 0))
+        p_dw1 = dw1 + o_k[:, None] * (HQ*K) + o_d[None, :]
+        p_dw2 = dw2 + o_k[:, None] * (HQ*K) + o_d[None, :]
 
-        tl.store(p_dw1, b_dw1.to(dw1.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dw2, b_dw2.to(dw2.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dw1, b_dw1.to(dw1.dtype.element_ty), mask=m_kk)
+        tl.store(p_dw2, b_dw2.to(dw2.dtype.element_ty), mask=m_kk)
 
         b_dhc = b_dhc - tl.dot(tl.dot(b_dhc.to(b_w2.dtype), tl.trans(b_w2)).to(b_w1.dtype), b_w1)
         b_dhc -= tl.dot(tl.trans(b_dk).to(b_k.dtype), b_k)

--- a/fla/ops/path_attn/cumprod_householder_fwd.py
+++ b/fla/ops/path_attn/cumprod_householder_fwd.py
@@ -66,24 +66,28 @@ def chunk_cumprod_householder_fwd_kernel(
     w1 += (bos * H + i_h) * K
     w2 += (bos * H + i_h) * K
 
+    o_d = tl.arange(0, BK)
+    m_d = o_d < K
     b_h = tl.zeros([BK, BK], dtype=tl.float32)
     for i_t_small in range(NT_small-1, -1, -1):
-        p_hc_suffix = tl.make_block_ptr(hc_suffix + i_t_small * stride_h, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
-        tl.store(p_hc_suffix, b_h.to(hc_suffix.dtype.element_ty), boundary_check=(0, 1))
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_s * S + i_t_small * BT, 0), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = (i_s * S + i_t_small * BT).to(tl.int64) + tl.arange(0, BT)
+        m_k = o_k < T
+        p_hc_suffix = hc_suffix + i_t_small * stride_h + o_d[:, None] * K + o_d[None, :]
+        tl.store(p_hc_suffix, b_h.to(hc_suffix.dtype.element_ty), mask=m_d[:, None] & m_d[None, :])
+        p_k = k + o_k[:, None] * (H*K) + o_d[None, :]
+        b_k = tl.load(p_k, mask=m_k[:, None] & m_d[None, :], other=0.0)
         b_k = (b_k - tl.dot(b_k, tl.trans(b_h.to(b_k.dtype))))
-        p_w1 = tl.make_block_ptr(w1, (K, T), (1, H*K), (0, i_s * S + i_t_small * BT), (BK, BT), (0, 1))
-        p_w2 = tl.make_block_ptr(w2, (T, K), (H*K, 1), (i_s * S + i_t_small * BT, 0), (BT, BK), (1, 0))
-        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-        b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+        p_w1 = w1 + o_d[:, None] + o_k[None, :] * (H*K)
+        p_w2 = w2 + o_k[:, None] * (H*K) + o_d[None, :]
+        b_w1 = tl.load(p_w1, mask=m_d[:, None] & m_k[None, :], other=0.0)
+        b_w2 = tl.load(p_w2, mask=m_k[:, None] & m_d[None, :], other=0.0)
         b_v_new = (b_w1 - tl.dot(b_h.to(b_w1.dtype), b_w1)).to(b_w2.dtype)
         b_h += tl.dot(b_v_new, b_w2)
-        p_k_new = tl.make_block_ptr(k_new, (T, K), (H*K, 1), (i_s * S + i_t_small * BT, 0), (BT, BK), (1, 0))
-        tl.store(p_k_new, b_k.to(k_new.dtype.element_ty), boundary_check=(0, 1))
+        p_k_new = k_new + o_k[:, None] * (H*K) + o_d[None, :]
+        tl.store(p_k_new, b_k.to(k_new.dtype.element_ty), mask=m_k[:, None] & m_d[None, :])
 
-    p_hc_whole = tl.make_block_ptr(hc_whole, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
-    tl.store(p_hc_whole, b_h.to(hc_whole.dtype.element_ty), boundary_check=(0, 1))
+    p_hc_whole = hc_whole + o_d[:, None] * K + o_d[None, :]
+    tl.store(p_hc_whole, b_h.to(hc_whole.dtype.element_ty), mask=m_d[:, None] & m_d[None, :])
 
 
 def chunk_cumprod_householder_fwd_fn(

--- a/fla/ops/path_attn/intra_chunk_preprocess_bwd.py
+++ b/fla/ops/path_attn/intra_chunk_preprocess_bwd.py
@@ -27,12 +27,12 @@ def intra_chunk_preprocess_bwd_kernel(
     K: tl.constexpr, BT: tl.constexpr, BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_nh = tl.program_id(0), tl.program_id(1)
+    i_t, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(offsets + i_n).to(tl.int64), tl.load(offsets + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -43,38 +43,43 @@ def intra_chunk_preprocess_bwd_kernel(
     b_dw = tl.zeros([BT, BK], dtype=tl.float32)
     b_dT = tl.zeros([BT, BT], dtype=tl.float32)
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (K*H, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_w = tl.make_block_ptr(w + (bos * H + i_h) * K, (T, K), (K*H, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_w2 = tl.make_block_ptr(w2 + (bos * H + i_h) * K, (T, K), (K*H, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_beta = tl.make_block_ptr(beta + (bos * H + i_h), (T, ), (H, ), (i_t * BT, ), (BT, ), (0, ))
-    p_T = tl.make_block_ptr(AT + (bos * H + i_h) * BT, (T, BT), (BT*H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_w = tl.load(p_w, boundary_check=(0, 1))
-    b_Twb = tl.load(p_w2, boundary_check=(0, 1))
-    b_beta = tl.load(p_beta, boundary_check=(0, ))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_T = tl.load(p_T, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_i = tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    m_t = o_t < T
+    m_k = m_t[:, None] & (o_d[None, :] < K)
+    m_T = m_t[:, None] & (o_i[None, :] < BT)
+    p_q = q + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    p_k = k + (bos * H + i_h) * K + o_t[:, None] * (K*H) + o_d[None, :]
+    p_w = w + (bos * H + i_h) * K + o_t[:, None] * (K*H) + o_d[None, :]
+    p_w2 = w2 + (bos * H + i_h) * K + o_t[:, None] * (K*H) + o_d[None, :]
+    p_beta = beta + (bos * H + i_h) + o_t * H
+    p_T = AT + (bos * H + i_h) * BT + o_t[:, None] * (BT*H) + o_i[None, :]
+    b_w = tl.load(p_w, mask=m_k, other=0.0)
+    b_Twb = tl.load(p_w2, mask=m_k, other=0.0)
+    b_beta = tl.load(p_beta, mask=m_t, other=0.0)
+    b_q = tl.load(p_q, mask=m_k, other=0.0)
+    b_k = tl.load(p_k, mask=m_k, other=0.0)
+    b_T = tl.load(p_T, mask=m_T, other=0.0)
     b_w_beta = (b_w * b_beta[:, None]).to(b_w.dtype)
 
-    o_i = tl.arange(0, BT)
     b_qw = tl.where(o_i[:, None] >= o_i[None, :], tl.dot(b_q, tl.trans(b_w)), 0).to(b_q.dtype)
     b_wbk = tl.where(o_i[:, None] > o_i[None, :], tl.dot(b_w_beta, tl.trans(b_k)), 0).to(b_k.dtype)
     b_Twbk = tl.dot(b_T, b_wbk).to(b_w.dtype)
 
-    p_dA_local = tl.make_block_ptr(dA_local + (bos * HQ + i_hq) * BT, (T, BT), (BT*HQ, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_dA_local = tl.load(p_dA_local, boundary_check=(0, 1))
+    p_dA_local = dA_local + (bos * HQ + i_hq) * BT + o_t[:, None] * (BT*HQ) + o_i[None, :]
+    b_dA_local = tl.load(p_dA_local, mask=m_T, other=0.0)
 
     # # Twb part qw part.
-    p_dq = tl.make_block_ptr(dq + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_dq = tl.load(p_dq, boundary_check=(0, 1))
+    p_dq = dq + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    b_dq = tl.load(p_dq, mask=m_k, other=0.0)
 
-    p_dw1 = tl.make_block_ptr(dw1 + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_dw += tl.load(p_dw1, boundary_check=(0, 1))
+    p_dw1 = dw1 + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    b_dw += tl.load(p_dw1, mask=m_k, other=0.0)
 
     b_dqw = -tl.dot(b_dA_local, tl.trans(b_Twbk)) - tl.dot(b_dq.to(b_Twb.dtype), tl.trans(b_Twb))
-    p_dw2 = tl.make_block_ptr(dw2 + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_dTwb = -tl.dot(tl.trans(b_qw), b_dq) + tl.load(p_dw2, boundary_check=(0, 1))
+    p_dw2 = dw2 + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    b_dTwb = -tl.dot(tl.trans(b_qw), b_dq) + tl.load(p_dw2, mask=m_k, other=0.0)
     b_dT += tl.dot(b_dTwb.to(b_w_beta.dtype), tl.trans(b_w_beta))
     b_dw_beta += tl.dot(tl.trans(b_T), b_dTwb.to(b_T.dtype))
 
@@ -82,12 +87,12 @@ def intra_chunk_preprocess_bwd_kernel(
     b_dq += tl.dot(b_dA_local.to(b_k.dtype), b_k)
     b_dq += tl.dot(b_dqw.to(b_w.dtype), b_w)
     b_dw += tl.dot(tl.trans(b_dqw.to(b_q.dtype)), b_q)
-    p_q_new = tl.make_block_ptr(dq_new + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_q_new, b_dq.to(dq_new.dtype.element_ty), boundary_check=(0, 1))
+    p_q_new = dq_new + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    tl.store(p_q_new, b_dq.to(dq_new.dtype.element_ty), mask=m_k)
 
     # Twbk part
-    p_dk = tl.make_block_ptr(dk + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_dk = tl.load(p_dk, boundary_check=(0, 1))
+    p_dk = dk + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    b_dk = tl.load(p_dk, mask=m_k, other=0.0)
     b_dTwbk = -tl.dot(tl.trans(b_qw), b_dA_local.to(b_qw.dtype)) - tl.dot(b_w, tl.trans(b_dk.to(b_w.dtype)))
     b_dw -= tl.dot(b_Twbk, b_dk.to(b_w.dtype))
     b_dT += tl.dot(b_dTwbk.to(b_wbk.dtype), tl.trans(b_wbk))
@@ -96,12 +101,12 @@ def intra_chunk_preprocess_bwd_kernel(
 
     b_dk += tl.dot(tl.trans(b_dwbk), b_w_beta)
     b_dk += tl.dot(tl.trans(b_dA_local), b_q)
-    p_dk_new = tl.make_block_ptr(dk_new + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_dk_new, b_dk.to(dk_new.dtype.element_ty), boundary_check=(0, 1))
+    p_dk_new = dk_new + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    tl.store(p_dk_new, b_dk.to(dk_new.dtype.element_ty), mask=m_k)
 
     # matrix inverse's gradient
-    p_T = tl.make_block_ptr(AT + (bos * H + i_h) * BT, (BT, T), (1, BT*H), (0, i_t * BT), (BT, BT), (0, 1))
-    b_Tt = tl.load(p_T, boundary_check=(0, 1))
+    p_T = AT + (bos * H + i_h) * BT + o_i[:, None] + o_t[None, :] * (BT*H)
+    b_Tt = tl.load(p_T, mask=(o_i[:, None] < BT) & m_t[None, :], other=0.0)
     b_dT = tl.where(tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :], b_dT, 0).to(b_w.dtype)
     b_dT = tl.dot(b_Tt, b_dT).to(b_w.dtype)
     b_dT = tl.dot(b_dT, b_Tt)
@@ -112,10 +117,10 @@ def intra_chunk_preprocess_bwd_kernel(
     b_dw += b_dw_beta * b_beta[:, None]
     b_dbeta = tl.sum(b_dw_beta * b_w, axis=1)
 
-    p_dw = tl.make_block_ptr(dw + (bos * HQ + i_hq) * K, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_dw, b_dw.to(dw.dtype.element_ty), boundary_check=(0, 1))
-    p_dbeta = tl.make_block_ptr(dbeta + (bos * HQ + i_hq), (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-    tl.store(p_dbeta, b_dbeta.to(dbeta.dtype.element_ty), boundary_check=(0, ))
+    p_dw = dw + (bos * HQ + i_hq) * K + o_t[:, None] * (K*HQ) + o_d[None, :]
+    tl.store(p_dw, b_dw.to(dw.dtype.element_ty), mask=m_k)
+    p_dbeta = dbeta + (bos * HQ + i_hq) + o_t * HQ
+    tl.store(p_dbeta, b_dbeta.to(dbeta.dtype.element_ty), mask=m_t)
 
 
 def intra_chunk_preprocess_bwd_fn(q, k, w, w2, beta,

--- a/fla/ops/path_attn/intra_chunk_preprocess_bwd_prepare.py
+++ b/fla/ops/path_attn/intra_chunk_preprocess_bwd_prepare.py
@@ -51,12 +51,12 @@ def chunk_transform_qk_bwd_kernel_prepare(
     USE_GATE: tl.constexpr,
     RETURN_H: tl.constexpr,
 ):
-    i_t, i_nh = tl.program_id(0), tl.program_id(1)
+    i_t, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(offsets + i_n).to(tl.int64), tl.load(offsets + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         boh = tl.load(chunk_offsets + i_n).to(tl.int32)
@@ -88,19 +88,26 @@ def chunk_transform_qk_bwd_kernel_prepare(
     L += (bos*HQ + i_hq)
     D += (bos*HQ + i_hq)
 
-    p_q = tl.make_block_ptr(q, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (0, i_t * BT), (BK, BT), (0, 1))
-    p_w = tl.make_block_ptr(w, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_beta = tl.make_block_ptr(beta, (T, ), (H, ), (i_t * BT, ), (BT, ), (0, ))
-
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_kt = tl.load(p_k, boundary_check=(0, 1))
-    b_w = tl.load(p_w, boundary_check=(0, 1))
-    b_beta = tl.load(p_beta, boundary_check=(0, ))
-    p_T = tl.make_block_ptr(AT, (T, BT), (BT*H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_T = tl.load(p_T, boundary_check=(0, 1)) * b_beta[None, :]
-
+    o_t = i_t * BT + tl.arange(0, BT)
     o_i = tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_r = o_t < T
+    m_k = m_r[:, None] & (o_d[None, :] < K)
+    m_v = m_r[:, None] & (o_v[None, :] < V)
+    m_T = m_r[:, None] & (o_i[None, :] < BT)
+    p_q = q + o_t[:, None] * (HQ*K) + o_d[None, :]
+    p_k = k + o_d[:, None] + o_t[None, :] * (H*K)
+    p_w = w + o_t[:, None] * (H*K) + o_d[None, :]
+    p_beta = beta + o_t * H
+
+    b_q = tl.load(p_q, mask=m_k, other=0.0)
+    b_kt = tl.load(p_k, mask=(o_d[:, None] < K) & m_r[None, :], other=0.0)
+    b_w = tl.load(p_w, mask=m_k, other=0.0)
+    b_beta = tl.load(p_beta, mask=m_r, other=0.0)
+    p_T = AT + o_t[:, None] * (BT*H) + o_i[None, :]
+    b_T = tl.load(p_T, mask=m_T, other=0.0) * b_beta[None, :]
+
     m_t = o_i[:, None] >= o_i[None, :]
     b_qw = tl.where(m_t, tl.dot(b_q, tl.trans(b_w.to(b_q.dtype))), 0).to(b_q.dtype)
     b_qwT = tl.dot(b_qw, b_T.to(b_q.dtype)).to(b_q.dtype)
@@ -108,46 +115,46 @@ def chunk_transform_qk_bwd_kernel_prepare(
     b_A = tl.where(m_t, tl.dot(b_q, b_kt) - tl.dot(b_qwT, b_wbk), 0)
 
     b_q = b_q.to(tl.float32) - tl.dot(b_qwT, b_w.to(b_qwT.dtype))
-    p_q_new = tl.make_block_ptr(q_new, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, K), (1, 0))
-    tl.store(p_q_new, b_q.to(p_q_new.dtype.element_ty), boundary_check=(0, 1))
+    p_q_new = q_new + o_t[:, None] * (K*HQ) + o_d[None, :]
+    tl.store(p_q_new, b_q.to(p_q_new.dtype.element_ty), mask=m_k)
 
     if i_hq % G == 0:
         b_Twb = tl.dot(b_T, b_w)  # tf32
-        p_h = tl.make_block_ptr(h, (T, K), (K * H, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-        tl.store(p_h, b_Twb.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        p_h = h + o_t[:, None] * (K * H) + o_d[None, :]
+        tl.store(p_h, b_Twb.to(p_h.dtype.element_ty), mask=m_k)
         b_T_wbk = tl.dot(b_T.to(b_wbk.dtype), b_wbk).to(b_kt.dtype)
-        p_k_new = tl.make_block_ptr(k_new, (K, T), (1, K*H), (0, i_t * BT), (BK, BT), (0, 1))
+        p_k_new = k_new + o_d[:, None] + o_t[None, :] * (K*H)
         tl.store(p_k_new, (b_kt - tl.dot(tl.trans(b_w.to(b_kt.dtype)), b_T_wbk)
-                           ).to(p_k_new.dtype.element_ty), boundary_check=(0, 1))
+                           ).to(p_k_new.dtype.element_ty), mask=(o_d[:, None] < K) & m_r[None, :])
 
     if USE_GATE:
-        p_g_cumsum = tl.make_block_ptr(g_cumsum, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-        b_g_cumsum = tl.load(p_g_cumsum, boundary_check=(0, ))
+        p_g_cumsum = g_cumsum + o_t * HQ
+        b_g_cumsum = tl.load(p_g_cumsum, mask=m_r, other=0.0)
         b_A = b_A + (b_g_cumsum[:, None] - b_g_cumsum[None, :])
         b_A = tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], b_A, float("-inf"))  # avoid nan
 
-    p_l = tl.make_block_ptr(L, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-    b_l = tl.load(p_l, boundary_check=(0, ))
-    p_delta = tl.make_block_ptr(D, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-    delta = tl.load(p_delta, boundary_check=(0, ))
+    p_l = L + o_t * HQ
+    b_l = tl.load(p_l, mask=m_r, other=0.0)
+    p_delta = D + o_t * HQ
+    delta = tl.load(p_delta, mask=m_r, other=0.0)
 
     b_A_softmax = tl.exp2(tl.where(o_i[:, None] >= o_i[None, :], b_A * sm_scale - b_l[:, None], float("-inf")))
-    p_do = tl.make_block_ptr(do, (T, V), (HQ*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    p_do = do + o_t[:, None] * (HQ*V) + o_v[None, :]
+    b_do = tl.load(p_do, mask=m_v, other=0.0)
     b_dv = tl.dot(tl.trans(b_A_softmax.to(b_do.dtype)), b_do)
-    p_dv = tl.make_block_ptr(dv, (T, V), (HQ*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    p_dv = dv + o_t[:, None] * (HQ*V) + o_v[None, :]
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
-    p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (0, i_t * BT), (BV, BT), (0, 1))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    p_v = v + o_v[:, None] + o_t[None, :] * (H*V)
+    b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_r[None, :], other=0.0)
     b_dp = tl.dot(b_do, b_v)
     b_dA = ((b_dp - delta[:, None]) * b_A_softmax * scale)
     if USE_GATE:
         b_dgq = tl.sum(b_dA, axis=1) - tl.sum(b_dA, axis=0)
-        p_dg = tl.make_block_ptr(dg_cumsum, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-        tl.store(p_dg, b_dgq.to(p_dg.dtype.element_ty), boundary_check=(0,))
-    p_dA = tl.make_block_ptr(dA_local, (T, BT), (BT*HQ, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+        p_dg = dg_cumsum + o_t * HQ
+        tl.store(p_dg, b_dgq.to(p_dg.dtype.element_ty), mask=m_r)
+    p_dA = dA_local + o_t[:, None] * (BT*HQ) + o_i[None, :]
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_T)
 
 
 def intra_chunk_preprocess_bwd_prepare_fn(q, k, v, w, beta, g_cumsum, A, L, D, do, scale, return_h=True, cu_seqlens=None,

--- a/fla/ops/path_attn/intra_chunk_preprocess_fwd.py
+++ b/fla/ops/path_attn/intra_chunk_preprocess_fwd.py
@@ -46,12 +46,12 @@ def intra_chunk_preprocess_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    i_t, i_nh = tl.program_id(0), tl.program_id(1)
+    i_t, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(offsets + i_n).to(tl.int64), tl.load(offsets + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -74,22 +74,28 @@ def intra_chunk_preprocess_fwd_kernel(
     L += (bos*HQ + i_hq)
     M += (bos*HQ + i_hq)
 
-    p_q = tl.make_block_ptr(q, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (0, i_t * BT), (BK, BT), (0, 1))
-    p_w = tl.make_block_ptr(w, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    p_beta = tl.make_block_ptr(beta, (T, ), (H, ), (i_t * BT, ), (BT, ), (0, ))
-    p_T = tl.make_block_ptr(A, (T, BT), (BT*H, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_i = tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_r = o_t < T
+    m_k = m_r[:, None] & (o_d[None, :] < K)
+    m_v = m_r[:, None] & (o_v[None, :] < V)
+    p_q = q + o_t[:, None] * (HQ*K) + o_d[None, :]
+    p_k = k + o_d[:, None] + o_t[None, :] * (H*K)
+    p_w = w + o_t[:, None] * (H*K) + o_d[None, :]
+    p_v = v + o_t[:, None] * (H*V) + o_v[None, :]
+    p_beta = beta + o_t * H
+    p_T = A + o_t[:, None] * (BT*H) + o_i[None, :]
 
-    b_beta = tl.load(p_beta, boundary_check=(0, ))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_kt = tl.load(p_k, boundary_check=(0, 1))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
-    b_w = tl.load(p_w, boundary_check=(0, 1))
-    b_T = tl.load(p_T, boundary_check=(0, 1))
+    b_beta = tl.load(p_beta, mask=m_r, other=0.0)
+    b_q = tl.load(p_q, mask=m_k, other=0.0)
+    b_kt = tl.load(p_k, mask=(o_d[:, None] < K) & m_r[None, :], other=0.0)
+    b_v = tl.load(p_v, mask=m_v, other=0.0)
+    b_w = tl.load(p_w, mask=m_k, other=0.0)
+    b_T = tl.load(p_T, mask=m_r[:, None] & (o_i[None, :] < BT), other=0.0)
     b_T = b_T * b_beta[None, :]
 
-    o_i = tl.arange(0, BT)
     m_t = o_i[:, None] >= o_i[None, :]
 
     b_qw = tl.where(m_t, tl.dot(b_q, tl.trans(b_w.to(b_q.dtype))), 0).to(b_q.dtype)
@@ -98,21 +104,21 @@ def intra_chunk_preprocess_fwd_kernel(
     b_A = tl.where(m_t, tl.dot(b_q, b_kt) - tl.dot(b_qwT.to(b_q.dtype), b_wbk), 0)
 
     b_q = b_q.to(tl.float32) - tl.dot(b_qwT, b_w.to(b_q.dtype))
-    p_q_new = tl.make_block_ptr(q_new, (T, K), (K*HQ, 1), (i_t * BT, 0), (BT, K), (1, 0))
-    tl.store(p_q_new, b_q.to(p_q_new.dtype.element_ty), boundary_check=(0, 1))
+    p_q_new = q_new + o_t[:, None] * (K*HQ) + o_d[None, :]
+    tl.store(p_q_new, b_q.to(p_q_new.dtype.element_ty), mask=m_k)
 
     if i_hq % G == 0:
         b_Twb = tl.dot(b_T, b_w)
-        p_w2 = tl.make_block_ptr(w2, (T, K), (K*H, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-        tl.store(p_w2, b_Twb.to(p_w2.dtype.element_ty), boundary_check=(0, 1))
+        p_w2 = w2 + o_t[:, None] * (K*H) + o_d[None, :]
+        tl.store(p_w2, b_Twb.to(p_w2.dtype.element_ty), mask=m_k)
         b_T_wbk = tl.dot(b_T.to(b_kt.dtype), b_wbk).to(b_kt.dtype)
-        p_k_new = tl.make_block_ptr(k_new, (K, T), (1, K*H), (0, i_t * BT), (BK, BT), (0, 1))
+        p_k_new = k_new + o_d[:, None] + o_t[None, :] * (K*H)
         tl.store(p_k_new, (b_kt - tl.dot(tl.trans(b_w.to(b_kt.dtype)), b_T_wbk)
-                           ).to(p_k_new.dtype.element_ty), boundary_check=(0, 1))
+                           ).to(p_k_new.dtype.element_ty), mask=(o_d[:, None] < K) & m_r[None, :])
 
     if USE_G:
-        p_g_cumsum = tl.make_block_ptr(g_cumsum, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-        b_g_cumsum = tl.load(p_g_cumsum, boundary_check=(0, ))
+        p_g_cumsum = g_cumsum + o_t * HQ
+        b_g_cumsum = tl.load(p_g_cumsum, mask=m_r, other=0.0)
         b_A = b_A + (b_g_cumsum[:, None] - b_g_cumsum[None, :])
         b_A = tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], b_A, float("-inf"))  # avoid nan
 
@@ -121,12 +127,12 @@ def intra_chunk_preprocess_fwd_kernel(
     b_qkT_softmax = tl.math.exp2(b_qkT_softmax - m_i[:, None])
     l_i = tl.sum(b_qkT_softmax, 1)
     b_o = tl.dot(b_qkT_softmax.to(b_v.dtype), b_v)
-    p_o = tl.make_block_ptr(o, (T, V), (V*HQ, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
-    p_l = tl.make_block_ptr(L, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-    p_m = tl.make_block_ptr(M, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-    tl.store(p_m, m_i.to(p_m.dtype.element_ty), boundary_check=(0,))
-    tl.store(p_l, l_i.to(p_l.dtype.element_ty), boundary_check=(0,))
+    p_o = o + o_t[:, None] * (V*HQ) + o_v[None, :]
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
+    p_l = L + o_t * HQ
+    p_m = M + o_t * HQ
+    tl.store(p_m, m_i.to(p_m.dtype.element_ty), mask=m_r)
+    tl.store(p_l, l_i.to(p_l.dtype.element_ty), mask=m_r)
 
 
 def intra_chunk_preprocess_fwd_fn(q, k, v, w, beta, g_cumsum, A, scale, BT, cu_seqlens,

--- a/fla/ops/path_attn/parallel_path_bwd_inter_dkv.py
+++ b/fla/ops/path_attn/parallel_path_bwd_inter_dkv.py
@@ -48,12 +48,12 @@ def parallel_path_bwd_dkv_kernel(
     USE_GATE: tl.constexpr,
     NUM_BLOCKS: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         boh_large = tl.load(split_offsets + i_n).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
@@ -82,15 +82,19 @@ def parallel_path_bwd_dkv_kernel(
     sm_scale = scale * 1.44269504
 
     # load query
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    o_k = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_k = o_k < T
+    p_k = k + o_k[:, None] * (H*K) + o_d[None, :]
+    b_k = tl.load(p_k, mask=m_k[:, None] & (o_d[None, :] < K), other=0.0)
+    p_v = v + o_k[:, None] * (H*V) + o_v[None, :]
+    b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
 
     if USE_GATE:
         b_g_cumsum_k = tl.zeros([BT], dtype=tl.float32)
-        p_g_cumsum_k = tl.make_block_ptr(g_cumsum, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-        b_g_cumsum_k += tl.load(p_g_cumsum_k, boundary_check=(0, ))
+        p_g_cumsum_k = g_cumsum + o_k * HQ
+        b_g_cumsum_k += tl.load(p_g_cumsum_k, mask=m_k, other=0.0)
         b_dg_cumsum_k = tl.zeros([BT], dtype=tl.float32)
     else:
         b_g_cumsum_k = None
@@ -105,23 +109,24 @@ def parallel_path_bwd_dkv_kernel(
     last_chunk_end = tl.ceil(T / BS).to(tl.int32) * BS - BS
 
     for offset in range(last_chunk_end, last_chunk_start+S-BS, -BS):
-        p_delta = tl.make_block_ptr(D, (T, ), (HQ, ), (offset, ), (BS, ), (0, ))
-        p_l = tl.make_block_ptr(L, (T, ), (HQ, ), (offset, ), (BS, ), (0, ))
-        b_delta = tl.load(p_delta, boundary_check=(0, ))
-        b_l = tl.load(p_l, boundary_check=(0, ))
+        o_q = (offset + tl.arange(0, BS)).to(tl.int64)
+        m_q = o_q < T
+        p_delta = D + o_q * HQ
+        p_l = L + o_q * HQ
+        b_delta = tl.load(p_delta, mask=m_q, other=0.0)
+        b_l = tl.load(p_l, mask=m_q, other=0.0)
 
-        p_q = tl.make_block_ptr(q + ((bos.to(tl.int64) * NUM_BLOCKS + idx_j) * HQ + i_hq) * K, (T, K),
-                                (HQ*K*NUM_BLOCKS, 1), (offset, 0), (BS, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + ((bos.to(tl.int64) * NUM_BLOCKS + idx_j) * HQ + i_hq) * K + o_q[:, None] * (HQ*K*NUM_BLOCKS) + o_d[None, :]
+        b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
         b_A = tl.dot(b_k, tl.trans(b_q).to(b_k.dtype))
         if USE_GATE:
-            p_g_cumsum_q = tl.make_block_ptr(g_cumsum, (T, ), (HQ, ), (offset, ), (BS, ), (0, ))
-            b_g_cumsum_q = tl.load(p_g_cumsum_q, boundary_check=(0, ))
+            p_g_cumsum_q = g_cumsum + o_q * HQ
+            b_g_cumsum_q = tl.load(p_g_cumsum_q, mask=m_q, other=0.0)
             b_A = b_A + b_g_cumsum_q[None, :] - b_g_cumsum_k[:, None]
-            b_A = tl.where((offset + tl.arange(0, BS) < T)[None, :], b_A, float("-inf"))  # avoid nan
+            b_A = tl.where(m_q[None, :], b_A, float("-inf"))  # avoid nan
         b_A_softmax = tl.math.exp2(b_A * sm_scale - b_l[None, :])
-        p_do = tl.make_block_ptr(do, (T, V), (HQ*V, 1), (offset, 0), (BS, BV), (1, 0))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        p_do = do + o_q[:, None] * (HQ*V) + o_v[None, :]
+        b_do = tl.load(p_do, mask=m_q[:, None] & (o_v[None, :] < V), other=0.0)
         b_dv += tl.dot(b_A_softmax.to(b_do.dtype), b_do)
         b_dp = tl.dot(b_v, tl.trans(b_do))
 
@@ -130,8 +135,8 @@ def parallel_path_bwd_dkv_kernel(
             b_dg_cumsum_k -= tl.sum(b_dA, axis=1)
         b_dk += tl.dot(b_dA.to(b_q.dtype), b_q)
 
-    p_dk = tl.make_block_ptr(dk, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_dk, b_dk.to(dk.dtype.element_ty), boundary_check=(0, 1))
+    p_dk = dk + o_k[:, None] * (HQ*K) + o_d[None, :]
+    tl.store(p_dk, b_dk.to(dk.dtype.element_ty), mask=m_k[:, None] & (o_d[None, :] < K))
     mask = i_t * BT + tl.arange(0, BT) < T
     tl.atomic_add(
         dv + (i_t * BT + tl.arange(0, BT))[:, None] * HQ * V + tl.arange(0, BV)[None, :],

--- a/fla/ops/path_attn/parallel_path_bwd_inter_dqh.py
+++ b/fla/ops/path_attn/parallel_path_bwd_inter_dqh.py
@@ -50,12 +50,12 @@ def parallel_path_bwd_dq_kernel(
     IS_VARLEN: tl.constexpr,
     USE_GATE: tl.constexpr,
 ):
-    i_t, i_nh = tl.program_id(0), tl.program_id(1)
+    i_t, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         boh_large = tl.load(split_offsets + i_n).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
@@ -64,6 +64,8 @@ def parallel_path_bwd_dq_kernel(
         boh_large = i_n * tl.cdiv(T, S)
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
+    o_d = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
 
     k += (bos * H + i_h) * K  # GQA when H!=HQ
     v += (bos * H + i_h) * V  # GQA when H!=HQ
@@ -83,17 +85,17 @@ def parallel_path_bwd_dq_kernel(
     sm_scale = scale * 1.44269504
 
     # load query
-    p_do = tl.make_block_ptr(do, (T, V), (HQ*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    p_do = do + o_t[:, None] * (HQ*V) + o_v[None, :]
+    b_do = tl.load(p_do, mask=m_t[:, None] & (o_v[None, :] < V), other=0.0)
 
-    p_l = tl.make_block_ptr(L, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-    p_d = tl.make_block_ptr(D, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-    b_l = tl.load(p_l, boundary_check=(0,))
-    b_delta = tl.load(p_d, boundary_check=(0,))
+    p_l = L + o_t * HQ
+    p_d = D + o_t * HQ
+    b_l = tl.load(p_l, mask=m_t, other=0.0)
+    b_delta = tl.load(p_d, mask=m_t, other=0.0)
 
     if USE_GATE:
-        p_g_cumsum_q = tl.make_block_ptr(g_cumsum, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        b_g_cumsum_q = tl.load(p_g_cumsum_q, boundary_check=(0,)).to(tl.float32)
+        p_g_cumsum_q = g_cumsum + o_t * HQ
+        b_g_cumsum_q = tl.load(p_g_cumsum_q, mask=m_t, other=0.0).to(tl.float32)
         b_dg_cumsum_q = tl.zeros([BT], dtype=tl.float32)
     else:
         b_g_cumsum_q = None
@@ -104,37 +106,39 @@ def parallel_path_bwd_dq_kernel(
 
     for offset_outer in range(0, curr_end, S):
         idx_j = offset_outer // S
-        p_q = tl.make_block_ptr(q + ((bos.to(tl.int64) * NUM_BLOCKS + idx_j + 1) * HQ + i_hq) * K, (T, K),
-                                (HQ*K*NUM_BLOCKS, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + ((bos.to(tl.int64) * NUM_BLOCKS + idx_j + 1) * HQ + i_hq) * \
+            K + o_t[:, None] * (HQ*K*NUM_BLOCKS) + o_d[None, :]
+        b_q = tl.load(p_q, mask=m_t[:, None] & (o_d[None, :] < K), other=0.0)
 
         b_dh = -tl.dot(tl.trans(b_q), b_dq.to(b_q.dtype))
         tl.atomic_add(dhc_whole + idx_j * stride_hq + tl.arange(0, K)
                       [:, None] * K + tl.arange(0, K)[None, :], b_dh, sem='relaxed')
-        p_h = tl.make_block_ptr(hc_whole + idx_j * stride_h, (K, K), (K, 1), (0, 0), (BK, BK), (1, 0))
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        p_h = hc_whole + idx_j * stride_h + o_d[:, None] * K + o_d[None, :]
+        b_h = tl.load(p_h, mask=(o_d[:, None] < K) & (o_d[None, :] < K), other=0.0)
         b_dq = b_dq - tl.dot(b_dq.to(b_h.dtype), tl.trans(b_h))
 
         for offset in range(offset_outer, min(offset_outer+S, i_t*BT), BS):
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (offset, 0), (BS, BK), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            o_k = (offset + tl.arange(0, BS)).to(tl.int64)
+            m_k = o_k < T
+            p_k = k + o_k[:, None] * (H * K) + o_d[None, :]
+            b_k = tl.load(p_k, mask=m_k[:, None] & (o_d[None, :] < K), other=0.0)
             b_A = tl.dot(b_q, tl.trans(b_k).to(b_q.dtype))
             if USE_GATE:
-                p_g_cumsum_k = tl.make_block_ptr(g_cumsum, (T,), (HQ,), (offset,), (BS,), (0,))
-                b_g_cumsum_k = tl.load(p_g_cumsum_k, boundary_check=(0,)).to(tl.float32)
+                p_g_cumsum_k = g_cumsum + o_k * HQ
+                b_g_cumsum_k = tl.load(p_g_cumsum_k, mask=m_k, other=0.0).to(tl.float32)
                 b_A = b_A + b_g_cumsum_q[:, None] - b_g_cumsum_k[None, :]
             b_A = exp2(b_A * sm_scale - b_l[:, None])
             b_A = tl.where(m_t[:, None], b_A, 0)
-            p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (offset, 0), (BS, BV), (1, 0))
-            b_v = tl.load(p_v, boundary_check=(0, 1))
+            p_v = v + o_k[:, None] * (H*V) + o_v[None, :]
+            b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
             b_dp = tl.dot(b_do, tl.trans(b_v).to(b_do.dtype))
             b_dA = (b_dp - b_delta[:, None]) * b_A * scale
             b_dq += tl.dot(b_dA.to(b_k.dtype), b_k)
             if USE_GATE:
                 b_dg_cumsum_q += tl.sum(b_dA, axis=1)
 
-    p_dq = tl.make_block_ptr(dq, (T, K), (K * HQ, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(dq.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq + o_t[:, None] * (K * HQ) + o_d[None, :]
+    tl.store(p_dq, b_dq.to(dq.dtype.element_ty), mask=m_t[:, None] & (o_d[None, :] < K))
     if USE_GATE:
         tl.atomic_add(dg_cumsum + o_t * HQ, b_dg_cumsum_q, mask=m_t, sem='relaxed')
 

--- a/fla/ops/path_attn/parallel_path_bwd_intra.py
+++ b/fla/ops/path_attn/parallel_path_bwd_intra.py
@@ -28,12 +28,12 @@ def parallel_path_bwd_intra_chunk_kernel(
     BT: tl.constexpr, S: tl.constexpr,
     IS_VARLEN: tl.constexpr, USE_GATE: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(offsets + i_n).to(tl.int64), tl.load(offsets + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -63,24 +63,29 @@ def parallel_path_bwd_intra_chunk_kernel(
     # constants
     sm_scale = scale * 1.44269504
 
-    p_do = tl.make_block_ptr(do, (T, V), (HQ*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_t = o_t < T
+    m_k = m_t[:, None] & (o_d[None, :] < K)
+    p_do = do + o_t[:, None] * (HQ*V) + o_v[None, :]
     # [BT, BV]
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    b_do = tl.load(p_do, mask=m_t[:, None] & (o_v[None, :] < V), other=0.0)
 
-    p_delta = tl.make_block_ptr(D, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-    b_delta = tl.load(p_delta, boundary_check=(0, ))
-    p_l = tl.make_block_ptr(L, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-    b_l = tl.load(p_l, boundary_check=(0, ))
+    p_delta = D + o_t * HQ
+    b_delta = tl.load(p_delta, mask=m_t, other=0.0)
+    p_l = L + o_t * HQ
+    b_l = tl.load(p_l, mask=m_t, other=0.0)
 
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
-    p_dq = tl.make_block_ptr(dq, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_dq += tl.load(p_dq, boundary_check=(0, 1))
-    p_q = tl.make_block_ptr(q, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    p_dq = dq + o_t[:, None] * (HQ*K) + o_d[None, :]
+    b_dq += tl.load(p_dq, mask=m_k, other=0.0)
+    p_q = q + o_t[:, None] * (HQ*K) + o_d[None, :]
+    b_q = tl.load(p_q, mask=m_k, other=0.0)
 
     if USE_GATE:
-        p_gq_cumsum = tl.make_block_ptr(g_cumsum, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0, ))
-        b_gq_cumsum = tl.load(p_gq_cumsum, boundary_check=(0, ))
+        p_gq_cumsum = g_cumsum + o_t * HQ
+        b_gq_cumsum = tl.load(p_gq_cumsum, mask=m_t, other=0.0)
         b_dgq = tl.zeros([BT], dtype=tl.float32)
     else:
         b_dgq = None
@@ -88,23 +93,27 @@ def parallel_path_bwd_intra_chunk_kernel(
     curr_start = (tl.floor(i_t * BT / S).to(tl.int32) * S).to(tl.int32)
 
     for offset in range(curr_start, i_t * BT, BT):
-        mask = offset + tl.arange(0, BT) < T
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (offset, 0), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = (offset + tl.arange(0, BT)).to(tl.int64)
+        mask = o_k < T
+        m_kk = mask[:, None] & (o_d[None, :] < K)
+        p_k = k + o_k[:, None] * (H*K) + o_d[None, :]
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
         b_q_tmp = tl.zeros([BT, BK], dtype=tl.float32)
         b_q_tmp += b_q
         for i_t_small in range(i_t * BT - BT, offset, -BT):
-            p_w1 = tl.make_block_ptr(w1, (T, K), (H*K, 1), (i_t_small, 0), (BT, BK), (1, 0))
-            b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-            p_w2 = tl.make_block_ptr(w2, (T, K), (H*K, 1), (i_t_small, 0), (BT, BK), (1, 0))
-            b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+            o_w = i_t_small + tl.arange(0, BT)
+            m_w = (o_w[:, None] < T) & (o_d[None, :] < K)
+            p_w1 = w1 + o_w[:, None] * (H*K) + o_d[None, :]
+            b_w1 = tl.load(p_w1, mask=m_w, other=0.0)
+            p_w2 = w2 + o_w[:, None] * (H*K) + o_d[None, :]
+            b_w2 = tl.load(p_w2, mask=m_w, other=0.0)
             b_A_tmp = tl.dot(b_q_tmp.to(b_w1.dtype), tl.trans(b_w1))
             b_q_tmp -= tl.dot(b_A_tmp.to(b_w1.dtype), b_w2)
         b_q2 = b_q_tmp.to(b_k.dtype)
         b_A = tl.dot(b_q2, tl.trans(b_k))
         if USE_GATE:
-            p_gk_cumsum = tl.make_block_ptr(g_cumsum, (T, ), (HQ, ), (offset, ), (BT, ), (0, ))
-            b_gk_cumsum = tl.load(p_gk_cumsum, boundary_check=(0, ))
+            p_gk_cumsum = g_cumsum + o_k * HQ
+            b_gk_cumsum = tl.load(p_gk_cumsum, mask=mask, other=0.0)
             b_A = b_A + b_gq_cumsum[:, None] - b_gk_cumsum[None, :]
             b_A = tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], b_A, float("-inf"))  # avoid nan
         b_A_softmax = tl.math.exp2(b_A * sm_scale - b_l[:, None])
@@ -115,8 +124,8 @@ def parallel_path_bwd_intra_chunk_kernel(
             mask=mask[:, None],
             sem='relaxed',
         )
-        p_v = tl.make_block_ptr(v, (T, V), (V*H, 1), (offset, 0), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        p_v = v + o_k[:, None] * (V*H) + o_v[None, :]
+        b_v = tl.load(p_v, mask=mask[:, None] & (o_v[None, :] < V), other=0.0)
         b_dp = tl.dot(b_do, tl.trans(b_v))
         b_dA = ((b_dp - b_delta[:, None]) * b_A_softmax * scale)
         if USE_GATE:
@@ -127,10 +136,10 @@ def parallel_path_bwd_intra_chunk_kernel(
         b_dk = tl.dot(tl.trans(b_dA), b_q2)
         tl.atomic_add(dk + (offset + tl.arange(0, BT))[:, None] * HQ*K + tl.arange(0,
                       BK)[None, :], b_dk, mask=mask[:, None], sem='relaxed')
-        p_w1 = tl.make_block_ptr(w1, (T, K), (H*K, 1), (offset, 0), (BT, BK), (1, 0))
-        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-        p_w2 = tl.make_block_ptr(w2, (T, K), (H*K, 1), (offset, 0), (BT, BK), (1, 0))
-        b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+        p_w1 = w1 + o_k[:, None] * (H*K) + o_d[None, :]
+        b_w1 = tl.load(p_w1, mask=m_kk, other=0.0)
+        p_w2 = w2 + o_k[:, None] * (H*K) + o_d[None, :]
+        b_w2 = tl.load(p_w2, mask=m_kk, other=0.0)
         b_dA2 = tl.dot(b_dq.to(b_w2.dtype), tl.trans(b_w2)).to(b_v.dtype)
         b_A2 = tl.dot(b_q2.to(b_w1.dtype), tl.trans(b_w1)).to(b_v.dtype)
         b_dw2 = -tl.dot(tl.trans(b_A2), b_dq.to(b_v.dtype))
@@ -142,8 +151,8 @@ def parallel_path_bwd_intra_chunk_kernel(
         b_dq -= tl.dot(b_dA2, b_w1.to(b_v.dtype))
         b_dq += tl.dot(b_dA.to(b_k.dtype), b_k)
 
-    p_dq_new = tl.make_block_ptr(dq_new, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_dq_new, b_dq.to(dq_new.dtype.element_ty), boundary_check=(0, 1))
+    p_dq_new = dq_new + o_t[:, None] * (HQ*K) + o_d[None, :]
+    tl.store(p_dq_new, b_dq.to(dq_new.dtype.element_ty), mask=m_k)
     mask = i_t * BT + tl.arange(0, BT) < T
     if USE_GATE:
         tl.atomic_add(dg_cumsum + (i_t * BT + tl.arange(0, BT)) * HQ, b_dgq, mask=mask, sem='relaxed')

--- a/fla/ops/path_attn/parallel_path_fwd.py
+++ b/fla/ops/path_attn/parallel_path_fwd.py
@@ -45,57 +45,64 @@ def parallel_path_fwd_kernel(
     USE_GATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
         i_n = i_b
         bos, eos = (i_n * T).to(tl.int64), (i_n * T + T).to(tl.int64)
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_q = o_q < T
+    m_o = m_q[:, None] & (o_v[None, :] < V)
+    p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
     b_q = tl.zeros([BT, BK], dtype=tl.float32)
-    b_q += tl.load(p_q, boundary_check=(0, 1))
+    b_q += tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
     sm_scale = scale * 1.44269504
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
-    p_o = tl.make_block_ptr(o + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, 0), (BT, BV), (1, 0))
-    b_o += tl.load(p_o, boundary_check=(0, 1))
+    p_o = o + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+    b_o += tl.load(p_o, mask=m_o, other=0.0)
 
-    p_L = tl.make_block_ptr(L + bos * HQ + i_hq, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0,))
-    p_M = tl.make_block_ptr(M + bos * HQ + i_hq, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0,))
-    b_l = tl.load(p_L, boundary_check=(0,))
-    b_m = tl.load(p_M, boundary_check=(0,))
+    p_L = L + bos * HQ + i_hq + o_q * HQ
+    p_M = M + bos * HQ + i_hq + o_q * HQ
+    b_l = tl.load(p_L, mask=m_q, other=0.0)
+    b_m = tl.load(p_M, mask=m_q, other=0.0)
 
     if USE_GATE:
-        p_g_cumsum_q = tl.make_block_ptr(g_cumsum + bos * HQ + i_hq, (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0,))
-        b_g_cumsum_q = tl.load(p_g_cumsum_q, boundary_check=(0,))
+        p_g_cumsum_q = g_cumsum + bos * HQ + i_hq + o_q * HQ
+        b_g_cumsum_q = tl.load(p_g_cumsum_q, mask=m_q, other=0.0)
     else:
         b_g_cumsum_q = None
 
     for offset in range((i_t + 1) * BT - 2 * BS, i_t*BT-BS, -BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, K*H), (0, offset), (BK, BS), (0, 1))  # GQA when H!=HQ
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (V*H, 1), (offset, 0), (BS, BV), (1, 0))  # GQA when H!=HQ
-        p_w1 = tl.make_block_ptr(w1 + (bos * H + i_h) * K, (K, T), (1, K*H), (0, offset), (BK, BS), (0, 1))
-        p_w2 = tl.make_block_ptr(w2 + (bos * H + i_h) * K, (T, K), (K*H, 1), (offset, 0), (BS, BK), (1, 0))
+        o_k = offset + tl.arange(0, BS)
+        m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (K*H)  # GQA when H!=HQ
+        p_v = v + (bos * H + i_h) * V + o_k[:, None] * (V*H) + o_v[None, :]  # GQA when H!=HQ
+        p_w1 = w1 + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (K*H)
+        p_w2 = w2 + (bos * H + i_h) * K + o_k[:, None] * (K*H) + o_d[None, :]
         # [BK, BS]
 
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
         # [BK, BK]
-        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-        b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+        b_w1 = tl.load(p_w1, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
+        b_w2 = tl.load(p_w2, mask=m_k[:, None] & (o_d[None, :] < K), other=0.0)
         # [BT, BS]
         m_s = i_t * BT + tl.arange(0, BT) >= (offset + BS)
         b_s = tl.dot(b_q.to(b_k.dtype), b_k)
 
         if USE_GATE:
-            p_g_cumsum_k = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq), (T, ), (HQ, ), (offset, ), (BS, ), (0,))
-            b_g_cumsum_k = tl.load(p_g_cumsum_k, boundary_check=(0,))
+            p_g_cumsum_k = g_cumsum + (bos * HQ + i_hq) + o_k * HQ
+            b_g_cumsum_k = tl.load(p_g_cumsum_k, mask=m_k, other=0.0)
             b_s = b_s + b_g_cumsum_q[:, None] - b_g_cumsum_k[None, :]
         b_s = tl.where(m_s[:, None], b_s * sm_scale, float("-inf"))
         b_m_new = tl.maximum(b_m, tl.max(b_s, 1))
@@ -112,21 +119,23 @@ def parallel_path_fwd_kernel(
     tl.debug_barrier()
 
     for offset in range(i_t * BT - BS, -BS, -BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, K*H), (0, offset), (BK, BS), (0, 1))  # GQA when H!=HQ
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (V*H, 1), (offset, 0), (BS, BV), (1, 0))  # GQA when H!=HQ
-        p_w1 = tl.make_block_ptr(w1 + (bos * H + i_h) * K, (K, T), (1, K*H), (0, offset), (BK, BS), (0, 1))
-        p_w2 = tl.make_block_ptr(w2 + (bos * H + i_h) * K, (T, K), (K*H, 1), (offset, 0), (BS, BK), (1, 0))
+        o_k = offset + tl.arange(0, BS)
+        m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (K*H)  # GQA when H!=HQ
+        p_v = v + (bos * H + i_h) * V + o_k[:, None] * (V*H) + o_v[None, :]  # GQA when H!=HQ
+        p_w1 = w1 + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (K*H)
+        p_w2 = w2 + (bos * H + i_h) * K + o_k[:, None] * (K*H) + o_d[None, :]
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-        b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
+        b_w1 = tl.load(p_w1, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
+        b_w2 = tl.load(p_w2, mask=m_k[:, None] & (o_d[None, :] < K), other=0.0)
         # [BT, BS]
         b_s = tl.dot(b_q.to(b_k.dtype), b_k)
         if USE_GATE:
-            p_g_cumsum_k = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq), (T, ), (HQ, ), (offset, ), (BS, ), (0,))
-            b_g_cumsum_k = tl.load(p_g_cumsum_k, boundary_check=(0,))
+            p_g_cumsum_k = g_cumsum + (bos * HQ + i_hq) + o_k * HQ
+            b_g_cumsum_k = tl.load(p_g_cumsum_k, mask=m_k, other=0.0)
             b_s = b_s + b_g_cumsum_q[:, None] - b_g_cumsum_k[None, :]
         b_s = b_s * sm_scale
         b_m_new = tl.maximum(b_m, tl.max(b_s, 1))
@@ -140,11 +149,11 @@ def parallel_path_fwd_kernel(
         b_q -= tl.dot(b_s2.to(b_w2.dtype), b_w2)
 
     b_o = b_o / b_l[:, None]
-    p_o_new = tl.make_block_ptr(o_new + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-    tl.store(p_o_new, b_o.to(p_o_new.dtype.element_ty), boundary_check=(0, 1))
+    p_o_new = o_new + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+    tl.store(p_o_new, b_o.to(p_o_new.dtype.element_ty), mask=m_o)
     b_l = tl.math.log2(b_l) + b_m
-    p_L_new = tl.make_block_ptr(L_new + (bos * HQ + i_hq), (T, ), (HQ, ), (i_t * BT, ), (BT, ), (0,))
-    tl.store(p_L_new, b_l.to(p_L_new.dtype.element_ty), boundary_check=(0,))
+    p_L_new = L_new + (bos * HQ + i_hq) + o_q * HQ
+    tl.store(p_L_new, b_l.to(p_L_new.dtype.element_ty), mask=m_q)
 
 
 def parallel_path_fwd_fn(

--- a/fla/ops/path_attn/prepare_k_cache.py
+++ b/fla/ops/path_attn/prepare_k_cache.py
@@ -25,11 +25,11 @@ def parallel_path_fwd_kernel_prepare_k_cache(
     BT: tl.constexpr, BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(offsets + i_n).to(tl.int64), tl.load(offsets + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -41,19 +41,24 @@ def parallel_path_fwd_kernel_prepare_k_cache(
     w1 += (bos * H + i_h) * K
     w2 += (bos * H + i_h) * K
     # constants
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    o_k = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    m_k = (o_k[:, None] < T) & (o_d[None, :] < K)
+    p_k = k + o_k[:, None] * (H*K) + o_d[None, :]
     b_k = tl.zeros([BT, BK], dtype=tl.float32)
-    b_k += tl.load(p_k, boundary_check=(0, 1))
+    b_k += tl.load(p_k, mask=m_k, other=0.0)
     for k_block_idx in range(i_t + 1, tl.cdiv(T, BT)):
-        p_w1 = tl.make_block_ptr(w1, (T, K), (H*K, 1), (k_block_idx * BT, 0), (BT, BK), (1, 0))
-        p_w2 = tl.make_block_ptr(w2, (T, K), (H*K, 1), (k_block_idx * BT, 0), (BT, BK), (1, 0))
-        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-        b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+        o_w = k_block_idx * BT + tl.arange(0, BT)
+        m_w = (o_w[:, None] < T) & (o_d[None, :] < K)
+        p_w1 = w1 + o_w[:, None] * (H*K) + o_d[None, :]
+        p_w2 = w2 + o_w[:, None] * (H*K) + o_d[None, :]
+        b_w1 = tl.load(p_w1, mask=m_w, other=0.0)
+        b_w2 = tl.load(p_w2, mask=m_w, other=0.0)
         b_A = tl.dot(b_k.to(b_w2.dtype), tl.trans(b_w2))
         b_k = b_k - tl.dot(b_A.to(b_w1.dtype), b_w1)
 
-    p_k_new = tl.make_block_ptr(k_new, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    tl.store(p_k_new, b_k.to(p_k_new.dtype.element_ty), boundary_check=(0, 1))
+    p_k_new = k_new + o_k[:, None] * (H*K) + o_d[None, :]
+    tl.store(p_k_new, b_k.to(p_k_new.dtype.element_ty), mask=m_k)
 
 
 def prepare_k_cache_fn(k, w1, w2, cu_seqlens, BS, use_cache=False, chunk_indices: torch.LongTensor | None = None):

--- a/fla/ops/path_attn/transform_q.py
+++ b/fla/ops/path_attn/transform_q.py
@@ -35,42 +35,47 @@ def transform_q_fwd_kernel(
     NUM_BLOCKS: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(indices + i_t * 2).to(tl.int32), tl.load(indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
         i_n = i_b
         bos, eos = (i_n * T).to(tl.int64), (i_n * T + T).to(tl.int64)
         # boh = i_n * tl.cdiv(T, BS)
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    m_q = (o_q[:, None] < T) & (o_d[None, :] < K)
+    p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
     b_q = tl.zeros([BT, BK], dtype=tl.float32)
-    b_q += tl.load(p_q, boundary_check=(0, 1))
+    b_q += tl.load(p_q, mask=m_q, other=0.0)
 
     if BS == BT:
         if (i_t * BT) % S == 0:
-            p_q_new = tl.make_block_ptr(q_new + ((bos.to(tl.int64) * NUM_BLOCKS + (i_t * BT // S)) * HQ + i_hq) * K,
-                                        (T, K), (HQ*K*NUM_BLOCKS, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-            tl.store(p_q_new, b_q.to(q_new.dtype.element_ty), boundary_check=(0, 1))
+            p_q_new = q_new + ((bos.to(tl.int64) * NUM_BLOCKS + (i_t * BT // S)) * HQ + i_hq) * \
+                K + o_q[:, None] * (HQ*K*NUM_BLOCKS) + o_d[None, :]
+            tl.store(p_q_new, b_q.to(q_new.dtype.element_ty), mask=m_q)
 
     for offset in range((i_t + 1) * BT - 2 * BS, S-BS, -BS):
-        p_w1 = tl.make_block_ptr(w1 + (bos * H + i_h) * K, (K, T), (1, K*H), (0, offset), (BK, BS), (0, 1))
-        p_w2 = tl.make_block_ptr(w2 + (bos * H + i_h) * K, (T, K), (K*H, 1), (offset, 0), (BS, BK), (1, 0))
-        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
-        b_w2 = tl.load(p_w2, boundary_check=(0, 1))
-        m_s = i_t * BT + tl.arange(0, BT) >= (offset + BS)
+        o_w = offset + tl.arange(0, BS)
+        m_w = o_w < T
+        p_w1 = w1 + (bos * H + i_h) * K + o_d[:, None] + o_w[None, :] * (K*H)
+        p_w2 = w2 + (bos * H + i_h) * K + o_w[:, None] * (K*H) + o_d[None, :]
+        b_w1 = tl.load(p_w1, mask=(o_d[:, None] < K) & m_w[None, :], other=0.0)
+        b_w2 = tl.load(p_w2, mask=m_w[:, None] & (o_d[None, :] < K), other=0.0)
+        m_s = o_q >= (offset + BS)
         b_s2 = tl.dot(b_q.to(b_w1.dtype), b_w1)
         b_s2 = tl.where(m_s[:, None], b_s2, 0)
         b_q -= tl.dot(b_s2.to(b_w2.dtype), b_w2)
 
         if offset % S == 0:
-            p_q_new = tl.make_block_ptr(q_new + ((bos.to(tl.int64) * NUM_BLOCKS + (offset // S)) * HQ + i_hq) * K,
-                                        (T, K), (HQ*K*NUM_BLOCKS, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-            tl.store(p_q_new, b_q.to(q_new.dtype.element_ty), boundary_check=(0, 1))
+            p_q_new = q_new + ((bos.to(tl.int64) * NUM_BLOCKS + (offset // S)) * HQ + i_hq) * \
+                K + o_q[:, None] * (HQ*K*NUM_BLOCKS) + o_d[None, :]
+            tl.store(p_q_new, b_q.to(q_new.dtype.element_ty), mask=m_q)
 
 
 def transform_q_fwd_fn(

--- a/fla/ops/rebased/parallel.py
+++ b/fla/ops/rebased/parallel.py
@@ -34,29 +34,38 @@ def parallel_rebased_fwd_kernel(
     BV: tl.constexpr,
 ):
     # i_c: chunk index. used for sequence parallelism
-    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     NV = tl.cdiv(V, BV)
     i_k = i_kv // (NV)
     i_v = i_kv % (NV)
 
-    p_q = tl.make_block_ptr(q + i_bh * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k*BK, 0), (BK, BTS), (0, 1))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (0, i_v*BV), (BTS, BV), (1, 0))
+    o_t = i_c * BTL + tl.arange(0, BTL)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_q = m_t[:, None] & (o_kk[None, :] < K)
+    m_o = m_t[:, None] & (o_vv[None, :] < V)
+    p_q = q + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
 
     # [BQ, BD] block Q, in the shared memory throughout the whole kernel
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
     b_o = tl.zeros([BTL, BV], dtype=tl.float32)
     b_z = tl.zeros([BTL], dtype=tl.float32)
 
     # Q block and K block have no overlap
     # no need for mask, thereby saving flops
-    for _ in range(0, i_c*BTL, BTS):
+    for i_s in range(0, i_c*BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_v = (o_s[:, None] < T) & (o_vv[None, :] < V)
+        p_k = k + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_v = v + i_bh * T*V + o_s[:, None] * V + o_vv[None, :]
         # [BK, BTS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
 
         # [BTS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         b_s = tl.dot(b_q, (b_k), allow_tf32=False)
         b_s = b_s * b_s
@@ -64,8 +73,6 @@ def parallel_rebased_fwd_kernel(
 
         # [BQ, BD]
         b_o = b_o + tl.dot(b_s.to(b_v.dtype), b_v, allow_tf32=False)
-        p_k = tl.advance(p_k, (0, BTS))
-        p_v = tl.advance(p_v, (BTS, 0))
 
     # # rescale interchunk output
     tl.debug_barrier()
@@ -74,14 +81,17 @@ def parallel_rebased_fwd_kernel(
     # tl.debug_barrier()
 
     o_k = tl.arange(0, BTS)
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (K, T), (1, K), (i_k*BK, i_c*BTL), (BK, BTS), (0, 1))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_c*BTL, i_v*BV), (BTS, BV), (1, 0))
     # Q block and K block have overlap. masks required
-    for _ in range(i_c*BTL, (i_c + 1) * BTL, BTS):
+    for i_s in range(i_c*BTL, (i_c + 1) * BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_v = (o_s[:, None] < T) & (o_vv[None, :] < V)
+        p_k = k + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_v = v + i_bh * T*V + o_s[:, None] * V + o_vv[None, :]
         # [BK, BTS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BTS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         m_s = o_q[:, None] >= o_k[None, :]
         b_s = tl.dot(b_q, b_k, allow_tf32=False)
@@ -90,13 +100,11 @@ def parallel_rebased_fwd_kernel(
         b_z += tl.sum(b_s, axis=1)
         # [BTL, BV]
         b_o += tl.dot(b_s.to(b_q.dtype), b_v, allow_tf32=False)
-        p_k = tl.advance(p_k, (0, BTS))
-        p_v = tl.advance(p_v, (BTS, 0))
         o_k += BTS
 
-    p_o = tl.make_block_ptr(o + (i_bh + B * H * i_k) * T*V, (T, V), (V, 1), (i_c*BTL, i_v*BV), (BTL, BV), (1, 0))
+    p_o = o + (i_bh + B * H * i_k) * T*V + o_t[:, None] * V + o_vv[None, :]
     p_z = z + (i_bh + B * H * i_k) * T + i_c*BTL + tl.arange(0, BTL)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_o)
     tl.store(p_z, b_z.to(p_z.dtype.element_ty), mask=((i_c*BTL + tl.arange(0, BTL)) < T))
 
 
@@ -124,22 +132,31 @@ def _parallel_rebased_bwd_dq(
     BK: tl.constexpr,
     BV: tl.constexpr,
 ):
-    p_do = tl.make_block_ptr(do + i_bh * T*V, (T, V), (V, 1), (i_c*BTL, i_v*BV), (BTL, BV), (1, 0))
-    p_q = tl.make_block_ptr(q + (i_bh) * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)
+    o_t = i_c * BTL + tl.arange(0, BTL)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_q = m_t[:, None] & (o_kk[None, :] < K)
+    m_o = m_t[:, None] & (o_vv[None, :] < V)
+    p_do = do + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+    p_q = q + (i_bh) * T*K + o_t[:, None] * K + o_kk[None, :]
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
+    b_do = tl.load(p_do, mask=m_o, other=0.0).to(b_q.dtype)
     b_q = (b_q * scale).to(b_q.dtype)
     b_dq = tl.zeros([BTL, BK], dtype=tl.float32)
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (0, i_k*BK), (BTS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (V, T), (1, V), (i_v*BV, 0), (BV, BTS), (0, 1))
     p_dz = dz + i_bh * T + i_c*BTL + tl.arange(0, BTL)
     b_dz = tl.load(p_dz, mask=(i_c*BTL + tl.arange(0, BTL)) < T)
 
-    for _ in range(0, i_c*BTL, BTS):
+    for i_s in range(0, i_c*BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_s[:, None] < T) & (o_kk[None, :] < K)
+        m_v = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_k = k + i_bh * T*K + o_s[:, None] * K + o_kk[None, :]
+        p_v = v + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         # [BTS, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BV, BTS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         b_ds = tl.dot(b_do, b_v, allow_tf32=False)
         if i_v == 0:
@@ -149,20 +166,21 @@ def _parallel_rebased_bwd_dq(
         b_s = tl.dot(b_q, tl.trans(b_k), allow_tf32=False)
         # [BQ, BD]
         b_dq += tl.dot((2 * b_ds * b_s).to(b_v.dtype), b_k, allow_tf32=False)
-        p_k = tl.advance(p_k, (BTS, 0))
-        p_v = tl.advance(p_v, (0, BTS))
 
     b_dq *= scale
     o_q = tl.arange(0, BTL)
     o_k = tl.arange(0, BTS)
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTS, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (V, T), (1, V), (i_v*BV, i_c*BTL), (BV, BTS), (0, 1))
     # Q block and K block have overlap. masks required
-    for _ in range(i_c*BTL, (i_c + 1) * BTL, BTS):
+    for i_s in range(i_c*BTL, (i_c + 1) * BTL, BTS):
+        o_s = i_s + tl.arange(0, BTS)
+        m_k = (o_s[:, None] < T) & (o_kk[None, :] < K)
+        m_v = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_k = k + i_bh * T*K + o_s[:, None] * K + o_kk[None, :]
+        p_v = v + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         # [BTS, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BV, BTS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         # [BTL, BTS]
         m_s = o_q[:, None] >= o_k[None, :]
         b_ds = tl.dot(b_do, b_v, allow_tf32=False)
@@ -176,11 +194,9 @@ def _parallel_rebased_bwd_dq(
         # [BTL, BK]
         b_dq += tl.dot((2 * b_ds * b_s).to(b_k.dtype),
                        b_k, allow_tf32=False)
-        p_k = tl.advance(p_k, (BTS, 0))
-        p_v = tl.advance(p_v, (0, BTS))
         o_k += BTS
-    p_dq = tl.make_block_ptr(dq + (i_bh + B * H * i_v) * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq + (i_bh + B * H * i_v) * T*K + o_t[:, None] * K + o_kk[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q)
     return
 
 
@@ -210,20 +226,29 @@ def _parallel_rebased_bwd_dkv(
     BV: tl.constexpr,
 ):
     # compute dk dv
-    p_k = tl.make_block_ptr(k + i_bh * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + i_bh * T*V, (T, V), (V, 1), (i_c*BTL, i_v*BV), (BTL, BV), (1, 0))
-    b_k, b_v = tl.load(p_k, boundary_check=(0, 1)), tl.load(p_v, boundary_check=(0, 1))
+    o_t = i_c * BTL + tl.arange(0, BTL)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_k = m_t[:, None] & (o_kk[None, :] < K)
+    m_v = m_t[:, None] & (o_vv[None, :] < V)
+    p_k = k + i_bh * T*K + o_t[:, None] * K + o_kk[None, :]
+    p_v = v + i_bh * T*V + o_t[:, None] * V + o_vv[None, :]
+    b_k, b_v = tl.load(p_k, mask=m_k, other=0.0), tl.load(p_v, mask=m_v, other=0.0)
     b_dk, b_dv = tl.zeros([BTL, BK], dtype=tl.float32), tl.zeros(
         [BTL, BV], dtype=tl.float32)
 
     for i in range((tl.cdiv(T, BTS) * BTS)-BTS, (i_c + 1) * BTL - BTS, -BTS):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (K, T), (1, K), (i_k*BK, i), (BK, BTS), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (V, T), (1, V), (i_v*BV, i), (BV, BTS), (0, 1))
+        o_s = i + tl.arange(0, BTS)
+        m_q = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_o = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_q = q + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_do = do + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         p_dz = dz + i_bh * T + i + tl.arange(0, BTS)
         # [BK, BTS]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
         # [BV, BTS]
-        b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)
+        b_do = tl.load(p_do, mask=m_o, other=0.0).to(b_q.dtype)
         b_dz = tl.load(p_dz, mask=(i + tl.arange(0, BTS)) < T)
         # [BTL, BTS]
         b_s = tl.dot(b_k.to(b_q.dtype), b_q, allow_tf32=False) * scale
@@ -239,11 +264,14 @@ def _parallel_rebased_bwd_dkv(
     tl.debug_barrier()
     o_q, o_k = tl.arange(0, BTS), tl.arange(0, BTL)
     for i in range(i_c*BTL, (i_c+1)*BTL, BTS):
-        p_q = tl.make_block_ptr(q + i_bh * T*K, (K, T), (1, K), (i_k*BK, i), (BK, BTS), (0, 1))
-        p_do = tl.make_block_ptr(do + i_bh * T*V, (V, T), (1, V), (i_v*BV, i), (BV, BTS), (0, 1))
+        o_s = i + tl.arange(0, BTS)
+        m_q = (o_kk[:, None] < K) & (o_s[None, :] < T)
+        m_o = (o_vv[:, None] < V) & (o_s[None, :] < T)
+        p_q = q + i_bh * T*K + o_kk[:, None] + o_s[None, :] * K
+        p_do = do + i_bh * T*V + o_vv[:, None] + o_s[None, :] * V
         p_dz = dz + i_bh * T + i + tl.arange(0, BTS)
-        b_q = tl.load(p_q, boundary_check=(0, 1))  # [BD, BQ]
-        b_do = tl.load(p_do, boundary_check=(0, 1)).to(b_q.dtype)
+        b_q = tl.load(p_q, mask=m_q, other=0.0)  # [BD, BQ]
+        b_do = tl.load(p_do, mask=m_o, other=0.0).to(b_q.dtype)
         b_dz = tl.load(p_dz, mask=(i + tl.arange(0, BTS)) < T)
         # [BK, BQ]
         m_s = o_k[:, None] <= o_q[None, :]
@@ -263,10 +291,10 @@ def _parallel_rebased_bwd_dkv(
         b_dk += tl.dot((2 * b_ds * b_s).to(b_q.dtype), tl.trans(b_q), allow_tf32=False)
         o_q += BTS
 
-    p_dk = tl.make_block_ptr(dk + (i_bh + B * H * i_v) * T*K, (T, K), (K, 1), (i_c*BTL, i_k*BK), (BTL, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (i_bh + B * H * i_k) * T*V, (T, V), (V, 1), (i_c*BTL, i_v*BV), (BTL, BV), (1, 0))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    p_dk = dk + (i_bh + B * H * i_v) * T*K + o_t[:, None] * K + o_kk[None, :]
+    p_dv = dv + (i_bh + B * H * i_k) * T*V + o_t[:, None] * V + o_vv[None, :]
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
     return
 
 
@@ -291,7 +319,7 @@ def parallel_rebased_bwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
 ):
-    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     NV = tl.cdiv(V, BV)
     i_k = i_kv // (NV)
     i_v = i_kv % (NV)

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -57,10 +57,10 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -70,19 +70,22 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     m_i = tl.where(o_i[:, None] >= o_i[None, :], 1., 0.).to(tl.float32)
     m_e = tl.where(o_i[:, None] > o_i[None, :], 1., 0.).to(tl.float32)
 
-    p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-    p_oi = tl.make_block_ptr(oi + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-    p_oe = tl.make_block_ptr(oe + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_s = i_s * BS + tl.arange(0, BS)
+    m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
+    p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+    p_oi = oi + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+    p_oe = oe + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
     # [BT, BS]
-    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_s = tl.load(p_s, mask=m_s, other=0.0).to(tl.float32)
     b_oi = tl.dot(m_i, b_s)
     b_oe = tl.dot(m_e, b_s)
     if HAS_SCALE:
         # Pre-scale by RCP_LN2 so downstream kernels can use exp2 directly.
         b_oi = b_oi * scale
         b_oe = b_oe * scale
-    tl.store(p_oi, b_oi.to(p_oi.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-    tl.store(p_oe, b_oe.to(p_oe.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+    tl.store(p_oi, b_oi.to(p_oi.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_s)
+    tl.store(p_oe, b_oe.to(p_oe.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_s)
 
 
 def chunk_rwkv6_fwd_cumsum(
@@ -148,11 +151,11 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_c, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_i, i_j = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -170,27 +173,33 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_inter(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_gq = tl.make_block_ptr(ge + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
-        p_gk = tl.make_block_ptr(gi + (bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT + i_j * BC), (BK, BC), (0, 1))
+        o_qi = i_t * BT + i_i * BC + tl.arange(0, BC)
+        o_kj = i_t * BT + i_j * BC + tl.arange(0, BC)
+        m_qk = m_i[:, None] & m_k[None, :]
+        m_kj = m_k[:, None] & (o_kj[None, :] < T)
+        p_q = q + (bos*H+i_h)*K + o_qi[:, None] * (H*K) + o_k[None, :]
+        p_gq = ge + (bos*H+i_h)*K + o_qi[:, None] * (H*K) + o_k[None, :]
+        p_k = k + (bos*H+i_h)*K + o_k[:, None] + o_kj[None, :] * (H*K)
+        p_gk = gi + (bos*H+i_h)*K + o_k[:, None] + o_kj[None, :] * (H*K)
         p_gn = gi + (bos + i_t * BT + i_i * BC - 1) * H*K + i_h * K + o_k
 
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         # [BC, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_gq = tl.where(m_i[:, None] & m_k, tl.load(p_gq, boundary_check=(0, 1)), float('-inf'))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
+        b_gq = tl.where(m_i[:, None] & m_k, tl.load(p_gq, mask=m_qk, other=0.0), float('-inf'))
         b_qg = b_q * exp2(b_gq - b_gn[None, :]) * scale
         # [BK, BC]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kj, other=0.0)
+        b_gk = tl.load(p_gk, mask=m_kj, other=0.0)
         b_kg = b_k * exp2(b_gn[:, None] - b_gk)
         # [BC, BC] using tf32 to improve precision here.
         b_A += tl.dot(b_qg, b_kg)
 
-    p_A = tl.make_block_ptr(A + (bos*H + i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0))
-    tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
+    o_Ai = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_Aj = i_j * BC + tl.arange(0, BC)
+    p_A = A + (bos*H + i_h)*BT + o_Ai[:, None] * (H*BT) + o_Aj[None, :]
+    tl.store(p_A, b_A.to(A.dtype.element_ty), mask=m_i[:, None] & (o_Aj[None, :] < BT))
 
 
 @triton.heuristics({
@@ -223,11 +232,11 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -241,17 +250,19 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra(
     m_k = o_k < K
     m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
     o_A = (bos + i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_h * BT + i_j * BC
-    p_q = tl.make_block_ptr(q + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(ge + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0))
+    o_q = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_q = m_A[:, None] & m_k[None, :]
+    p_q = q + (bos * H + i_h) * K + o_q[:, None] * (H*K) + o_k[None, :]
+    p_g = ge + (bos * H + i_h) * K + o_q[:, None] * (H*K) + o_k[None, :]
     p_qj = q + (bos + i_t * BT + i_j * BC) * H*K + i_h * K + o_k
     p_kj = k + (bos + i_t * BT + i_j * BC) * H*K + i_h * K + o_k
     p_gk = gi + (bos + i_t * BT + i_j * BC) * H*K + i_h * K + o_k
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
+    b_g = tl.load(p_g, mask=m_q, other=0.0)
 
-    p_u = tl.make_block_ptr(u + i_h * K, (K,), (1,), (0,), (BK,), (0,))
-    b_u = tl.load(p_u, boundary_check=(0,))
+    p_u = u + i_h * K + o_k
+    b_u = tl.load(p_u, mask=m_k, other=0.0)
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
         b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
@@ -299,12 +310,12 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_tc, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_tc, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_t, i_i = i_tc // NC, i_tc % NC
     i_j = i_i
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -321,17 +332,19 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_split(
     m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
 
     o_A = (i_k * all + bos + i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BC + i_h * BC
-    p_q = tl.make_block_ptr(q + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_g = tl.make_block_ptr(ge + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    o_q = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_q = m_A[:, None] & m_k[None, :]
+    p_q = q + (bos * H + i_h) * K + o_q[:, None] * (H*K) + o_k[None, :]
+    p_g = ge + (bos * H + i_h) * K + o_q[:, None] * (H*K) + o_k[None, :]
     p_qj = q + (bos + i_t * BT + i_j * BC) * H*K + i_h * K + o_k
     p_kj = k + (bos + i_t * BT + i_j * BC) * H*K + i_h * K + o_k
     p_gk = gi + (bos + i_t * BT + i_j * BC) * H*K + i_h * K + o_k
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
+    b_g = tl.load(p_g, mask=m_q, other=0.0)
 
-    p_u = tl.make_block_ptr(u + i_h * K, (K,), (1,), (i_k * BK), (BK,), (0,))
-    b_u = tl.load(p_u, boundary_check=(0,))
+    p_u = u + i_h * K + o_k
+    b_u = tl.load(p_u, mask=m_k, other=0.0)
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
         b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
@@ -372,10 +385,10 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge(
     NK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_t, i_c, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         all = T
         T = eos - bos
@@ -386,12 +399,16 @@ def chunk_rwkv6_fwd_A_kernel_intra_sub_intra_merge(
     if i_t * BT + i_c * BC >= T:
         return
 
+    o_r = i_t * BT + i_c * BC + tl.arange(0, BC)
+    o_c = tl.arange(0, BC)
+    m_r = o_r < T
     b_A = tl.zeros([BC, BC], dtype=tl.float32)
     for i_k in range(0, NK):
-        p_A = tl.make_block_ptr(A + (i_k*all+bos)*H*BC+i_h*BC, (T, BC), (H*BC, 1), (i_t*BT + i_c*BC, 0), (BC, BC), (1, 0))
-        b_A += tl.load(p_A, boundary_check=(0, 1))
-    p_A2 = tl.make_block_ptr(A2 + (bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t * BT + i_c * BC, i_c * BC), (BC, BC), (1, 0))
-    tl.store(p_A2, b_A.to(A2.dtype.element_ty), boundary_check=(0, 1))
+        p_A = A + (i_k*all+bos)*H*BC+i_h*BC + o_r[:, None] * (H*BC) + o_c[None, :]
+        b_A += tl.load(p_A, mask=m_r[:, None] & (o_c[None, :] < BC), other=0.0)
+    o_c2 = i_c * BC + tl.arange(0, BC)
+    p_A2 = A2 + (bos*H+i_h)*BT + o_r[:, None] * (H*BT) + o_c2[None, :]
+    tl.store(p_A2, b_A.to(A2.dtype.element_ty), mask=m_r[:, None] & (o_c2[None, :] < BT))
 
 
 @triton.heuristics({
@@ -448,35 +465,42 @@ def chunk_rwkv6_bwd_kernel_dh(
         NT = tl.cdiv(T, BT)
         boh = i_n * NT
 
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_kv = (o_k[:, None] < K) & (o_v[None, :] < V)
     # [BK, BV]
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_FINAL_STATE_GRADIENT:
-        p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_dh += tl.load(p_dht, boundary_check=(0, 1)).to(tl.float32)
+        p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dht, mask=m_kv, other=0.0).to(tl.float32)
 
     for i_t in range(NT - 1, -1, -1):
-        p_dh = tl.make_block_ptr(dh + ((boh+i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_kt = (o_k[:, None] < K) & m_t[None, :]
+        m_tv = m_t[:, None] & (o_v[None, :] < V)
+        p_dh = dh + ((boh+i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), mask=m_kv)
         last_idx = min(i_t * BT + BT, T) - 1
         # [BK, BT]
-        p_q = tl.make_block_ptr(q + (bos*HQ + i_hq) * K, (K, T), (1, HQ*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_do = tl.make_block_ptr(do + (bos*HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + (bos*HQ + i_hq) * K + o_k[:, None] + o_t[None, :] * (HQ*K)
+        p_do = do + (bos*HQ + i_hq) * V + o_t[:, None] * (HQ*V) + o_v[None, :]
+        b_q = tl.load(p_q, mask=m_kt, other=0.0)
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
 
-        p_gk = tl.make_block_ptr(ge + (bos*H + i_h) * K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+        p_gk = ge + (bos*H + i_h) * K + o_k[:, None] + o_t[None, :] * (H*K)
         p_gk_last = gi + (bos + last_idx) * H*K + i_h * K + i_k * BK + tl.arange(0, BK)
 
-        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_gk = tl.load(p_gk, mask=m_kt, other=0.0)
         b_q = (b_q * exp2(b_gk) * scale).to(b_q.dtype)
         b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.)
         b_dh *= exp2(b_gk_last)[:, None]
         b_dh += tl.dot(b_q, b_do)
 
     if STORE_INITIAL_STATE_GRADIENT:
-        p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_kv)
 
 
 @triton.heuristics({
@@ -510,11 +534,11 @@ def chunk_rwkv6_bwd_kernel_intra(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     i_t, i_i = i_c // NC, i_c % NC
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -524,25 +548,30 @@ def chunk_rwkv6_bwd_kernel_intra(
 
     o_k = i_k * BK + tl.arange(0, BK)
     m_k = o_k < K
+    o_r = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_rk = (o_r[:, None] < T) & m_k[None, :]
 
-    p_ge = tl.make_block_ptr(ge + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_ge = ge + (bos*H + i_h) * K + o_r[:, None] * (H*K) + o_k[None, :]
     # [BC, BK]
-    b_ge = tl.load(p_ge, boundary_check=(0, 1))
+    b_ge = tl.load(p_ge, mask=m_rk, other=0.0)
     b_dq = tl.zeros([BC, BK], dtype=tl.float32)
     if i_i > 0:
         p_gn = gi + (bos + i_t * BT + i_i * BC - 1) * H*K + i_h*K + o_k
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(0, i_i):
-            p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(gi+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT+i_j*BC, i_k * BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA+(bos*H+i_h)*BT, (T, BT), (H*BT, 1), (i_t*BT+i_i*BC, i_j * BC), (BC, BC), (1, 0))
+            o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+            m_jk = (o_j[:, None] < T) & m_k[None, :]
+            o_dAj = i_j * BC + tl.arange(0, BC)
+            p_k = k+(bos*H+i_h)*K + o_j[:, None] * (H*K) + o_k[None, :]
+            p_gk = gi+(bos*H+i_h)*K + o_j[:, None] * (H*K) + o_k[None, :]
+            p_dA = dA+(bos*H+i_h)*BT + o_r[:, None] * (H*BT) + o_dAj[None, :]
             # [BC, BK]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_k = tl.load(p_k, mask=m_jk, other=0.0)
+            b_gk = tl.load(p_gk, mask=m_jk, other=0.0)
             b_kg = b_k * exp2(b_gn[None, :] - b_gk)
             # [BC, BC]
-            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            b_dA = tl.load(p_dA, mask=(o_r[:, None] < T) & (o_dAj[None, :] < BT), other=0.0)
             # [BC, BK]
             b_dq += tl.dot(b_dA, b_kg)
         b_dq *= exp2(b_ge - b_gn[None, :])
@@ -552,7 +581,7 @@ def chunk_rwkv6_bwd_kernel_intra(
     o_dA = bos*H*BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H*BT + i_h * BT + i_i * BC
     p_kj = k + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gkj = gi + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_dq = tl.make_block_ptr(dq + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_dq = dq + (bos*H + i_h) * K + o_r[:, None] * (H*K) + o_k[None, :]
 
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         # [BC,]
@@ -567,15 +596,13 @@ def chunk_rwkv6_bwd_kernel_intra(
         b_dq += tl.where(m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_ge - b_gkj[None, :]), 0.)
         p_kj += H*K
         p_gkj += H*K
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_rk)
 
     tl.debug_barrier()
-    p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
-    p_gk = tl.make_block_ptr(gi + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_gk = gi + (bos*H + i_h) * K + o_r[:, None] * (H*K) + o_k[None, :]
 
     # [BC, BK]
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_gk = tl.load(p_gk, boundary_check=(0, 1))
+    b_gk = tl.load(p_gk, mask=m_rk, other=0.0)
     b_dk = tl.zeros([BC, BK], dtype=tl.float32)
 
     NC = min(NC, tl.cdiv(T - i_t * BT, BC))
@@ -585,16 +612,19 @@ def chunk_rwkv6_bwd_kernel_intra(
         # [BK,]
         b_gn = tl.load(p_gn, mask=m_k, other=0)
         for i_j in range(i_i + 1, NC):
-            m_j = (i_t * BT + i_j * BC + tl.arange(0, BC)) < T
-            p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k*BK), (BC, BK), (1, 0))
-            p_gq = tl.make_block_ptr(ge + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_j * BC, i_k*BK), (BC, BK), (1, 0))
-            p_dA = tl.make_block_ptr(dA + (bos*H+i_h)*BT, (BT, T), (1, H*BT), (i_i*BC, i_t*BT + i_j*BC), (BC, BC), (0, 1))
+            o_j2 = i_t * BT + i_j * BC + tl.arange(0, BC)
+            m_j = o_j2 < T
+            m_jk = m_j[:, None] & m_k[None, :]
+            o_dAi = i_i * BC + tl.arange(0, BC)
+            p_q = q + (bos*H+i_h)*K + o_j2[:, None] * (H*K) + o_k[None, :]
+            p_gq = ge + (bos*H+i_h)*K + o_j2[:, None] * (H*K) + o_k[None, :]
+            p_dA = dA + (bos*H+i_h)*BT + o_dAi[:, None] + o_j2[None, :] * (H*BT)
             # [BC, BK]
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_gq = tl.where(m_j[:, None] & m_k, tl.load(p_gq, boundary_check=(0, 1)), float('-inf'))
+            b_q = tl.load(p_q, mask=m_jk, other=0.0)
+            b_gq = tl.where(m_j[:, None] & m_k, tl.load(p_gq, mask=m_jk, other=0.0), float('-inf'))
             b_qg = b_q * exp2(b_gq - b_gn[None, :])
             # [BC, BC]
-            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            b_dA = tl.load(p_dA, mask=(o_dAi[:, None] < BT) & m_j[None, :], other=0.0)
             # [BC, BK]
             # (SY 09/17) important to not use bf16 here to have a good precision.
             b_dk += tl.dot(b_dA, b_qg)
@@ -602,7 +632,7 @@ def chunk_rwkv6_bwd_kernel_intra(
     o_dA = bos*H*BT + (i_t * BT + i_i * BC) * H*BT + i_h * BT + i_i * BC + tl.arange(0, BC)
     p_qj = q + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
     p_gqj = ge + (bos + i_t * BT + i_i * BC) * H*K + i_h * K + o_k
-    p_dk = tl.make_block_ptr(dk + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0))
+    p_dk = dk + (bos*H+i_h)*K + o_r[:, None] * (H*K) + o_k[None, :]
     for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
         # [BC,]
         b_dA = tl.load(dA + o_dA + j * H*BT)
@@ -614,7 +644,7 @@ def chunk_rwkv6_bwd_kernel_intra(
         b_dk += tl.where(m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_gk), 0.)
         p_qj += H*K
         p_gqj += H*K
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_rk)
 
 
 @triton.heuristics({
@@ -660,12 +690,12 @@ def chunk_rwkv6_bwd_kernel_inter(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -676,8 +706,10 @@ def chunk_rwkv6_bwd_kernel_inter(
     o_k = i_k * BK + tl.arange(0, BK)
     m_k = o_k < K
 
-    p_gk = tl.make_block_ptr(ge + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_gi = tl.make_block_ptr(gi + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_tk = (o_t[:, None] < T) & m_k[None, :]
+    p_gk = ge + (bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_gi = gi + (bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
     p_gn = gi + (bos + min(T, i_t * BT + BT)-1) * H*K + i_h * K + o_k
     b_gn = tl.load(p_gn, mask=m_k, other=0)
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
@@ -685,16 +717,19 @@ def chunk_rwkv6_bwd_kernel_inter(
     b_dgk = tl.zeros([BK], dtype=tl.float32)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos*H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h + (i_tg * H + i_h) * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dh = tl.make_block_ptr(dh + (i_tg * H + i_h) * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_tv = (o_t[:, None] < T) & (o_v[None, :] < V)
+        m_h = (o_v[:, None] < V) & m_k[None, :]
+        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_do = do + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_h = h + (i_tg * H + i_h) * K*V + o_v[:, None] + o_k[None, :] * V
+        p_dh = dh + (i_tg * H + i_h) * K*V + o_v[:, None] + o_k[None, :] * V
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_tv, other=0.0)
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
+        b_dh = tl.load(p_dh, mask=m_h, other=0.0)
         # [BK]
         b_dgk += tl.sum(b_h * b_dh, axis=0)
         # [BT, BK]
@@ -702,43 +737,43 @@ def chunk_rwkv6_bwd_kernel_inter(
         b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
     b_dgk *= exp2(b_gn)
     b_dq *= scale
-    b_gk = tl.load(p_gk, boundary_check=(0, 1))
-    b_gi = tl.load(p_gi, boundary_check=(0, 1))
+    b_gk = tl.load(p_gk, mask=m_tk, other=0.0)
+    b_gi = tl.load(p_gi, mask=m_tk, other=0.0)
     b_dq = b_dq * exp2(b_gk)
     b_dk = b_dk * exp2(b_gn[None, :] - b_gi)
 
     o_i = tl.arange(0, BT)
-    p_q = tl.make_block_ptr(q + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    p_q = q + (bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_k = k + (bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dq = dq + (bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dk = dk + (bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
     p_dA_dig = dA + ((bos + i_t * BT + o_i) * H + i_h) * BT + o_i
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_tk, other=0.0)
+    b_k = tl.load(p_k, mask=m_tk, other=0.0)
     b_dgk += tl.sum(b_dk * b_k, axis=0)
 
-    b_dq += tl.load(p_dq, boundary_check=(0, 1))
-    b_dk += tl.load(p_dk, boundary_check=(0, 1))
+    b_dq += tl.load(p_dq, mask=m_tk, other=0.0)
+    b_dk += tl.load(p_dk, mask=m_tk, other=0.0)
     b_dg = b_q * b_dq - b_k * b_dk
     b_dg = b_dg - tl.cumsum(b_dg, axis=0) + tl.sum(b_dg, axis=0)[None, :] + b_dgk[None, :] - b_q * b_dq
     # [BT,]
     b_dA_dig = tl.load(p_dA_dig, mask=(i_t * BT + o_i) < T, other=0)
 
-    p_u = tl.make_block_ptr(u + i_h * K, (K,), (1,), (i_k * BK,), (BK,), (0,))
-    b_u = tl.load(p_u, boundary_check=(0,))
+    p_u = u + i_h * K + o_k
+    b_u = tl.load(p_u, mask=m_k, other=0.0)
     # scale is already applied to b_dA_diag
     b_dq += (b_dA_dig[:, None] * b_u[None, :] * b_k)
     b_dk += (b_dA_dig[:, None] * b_u[None, :] * b_q)
     b_du = tl.sum(b_dA_dig[:, None] * b_q * b_k, axis=0)
-    p_du = tl.make_block_ptr(du + (i_tg * H + i_h) * K, (K,), (1,), (i_k * BK,), (BK,), (0,))
-    tl.store(p_du, b_du, boundary_check=(0,))
+    p_du = du + (i_tg * H + i_h) * K + o_k
+    tl.store(p_du, b_du, mask=m_k)
 
-    p_dq = tl.make_block_ptr(dq2 + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk2 + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq2 + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dk = dk2 + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+    p_dg = dg + (bos * H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_tk)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_tk)
 
 
 @dispatch('rwkv6')

--- a/fla/ops/rwkv6/fused_recurrent.py
+++ b/fla/ops/rwkv6/fused_recurrent.py
@@ -329,24 +329,31 @@ def fused_recurrent_rwkv6_bwd_kernel_dw(
 
     o_i = tl.arange(0, BT)
     m_i = tl.where(o_i[:, None] >= o_i[None, :], 1., 0.) if not REVERSE else tl.where(o_i[:, None] <= o_i[None, :], 1., 0.)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
 
     b_z = tl.zeros([BK], dtype=tl.float32)
 
     i_t = 0 if not REVERSE else NT - 1
     for _ in range(NT):
-        p_q = tl.make_block_ptr(q + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + 1, i_k * BK), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k + (bos*H + i_h) * K, (T-1, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dq = tl.make_block_ptr(dq + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT + 1, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk + (bos*H + i_h) * K, (T-1, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos*H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        o_q = i_t.to(tl.int64) * BT + 1 + o_i
+        o_kt = i_t.to(tl.int64) * BT + o_i
+        m_q = (o_q[:, None] < T) & m_k[None, :]
+        m_kt = (o_kt[:, None] < T - 1) & m_k[None, :]
+        m_wt = (o_kt[:, None] < T) & m_k[None, :]
+        p_q = q + (bos*H + i_h) * K + o_q[:, None] * (H*K) + o_k[None, :]
+        p_k = k + (bos*H + i_h) * K + o_kt[:, None] * (H*K) + o_k[None, :]
+        p_dq = dq + (bos*H + i_h) * K + o_q[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*H + i_h) * K + o_kt[:, None] * (H*K) + o_k[None, :]
+        p_dw = dw + (bos*H + i_h) * K + o_kt[:, None] * (H*K) + o_k[None, :]
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
-        b_dq = tl.load(p_dq, boundary_check=(0, 1)).to(tl.float32)
-        b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
-        b_dk = tl.load(p_dk, boundary_check=(0, 1)).to(tl.float32)
+        b_q = tl.load(p_q, mask=m_q, other=0.0).to(tl.float32)
+        b_dq = tl.load(p_dq, mask=m_q, other=0.0).to(tl.float32)
+        b_k = tl.load(p_k, mask=m_kt, other=0.0).to(tl.float32)
+        b_dk = tl.load(p_dk, mask=m_kt, other=0.0).to(tl.float32)
         b_dw = (b_q * b_dq * scale) - b_k * b_dk
         b_c = b_z[None, :] + tl.dot(m_i, b_dw, allow_tf32=False)
-        tl.store(p_dw, b_c.to(p_dw.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dw, b_c.to(p_dw.dtype.element_ty), mask=m_wt)
         if i_t >= 0:
             b_z += tl.sum(b_dw, 0)
 

--- a/fla/ops/simple_gla/parallel.py
+++ b/fla/ops/simple_gla/parallel.py
@@ -68,13 +68,13 @@ def parallel_simple_gla_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_k, i_v = i_kv // NV, i_kv % NV
     i_b, i_h = i_bh // H, i_bh % H
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -89,17 +89,21 @@ def parallel_simple_gla_fwd_kernel(
     if OUTPUT_ATTENTIONS:
         attn += i_k * B * H * T * T + (bos * H + i_h * T) * T
 
-    p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+    # [BT]
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_q = o_q < T
+    m_qk = m_q[:, None] & (o_kk[None, :] < K)
+    m_qv = m_q[:, None] & (o_vv[None, :] < V)
+    p_q = q + o_q[:, None] * (H*K) + o_kk[None, :]
 
     # the Q block is kept in the shared memory throughout the whole kernel
     # [BT, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
     b_q = (b_q * scale).to(b_q.dtype)
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
 
-    # [BT]
-    o_q = i_t * BT + tl.arange(0, BT)
-    m_q = o_q < T
     # Q block and K block have overlap.
     # masks required
     if USE_G:
@@ -110,15 +114,16 @@ def parallel_simple_gla_fwd_kernel(
         b_gq = None
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (i_k * BK, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
+        m_kk = (o_kk[:, None] < K) & m_k[None, :]
+        m_kv = m_k[:, None] & (o_vv[None, :] < V)
+        p_k = k + o_kk[:, None] + o_k[None, :] * (H*K)
+        p_v = v + o_k[:, None] * (H*V) + o_vv[None, :]
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         # [BT, BS]
         m_s = (o_q[:, None] >= o_k[None, :]) & (m_q[:, None] & m_k[None, :])
         b_s = tl.dot(b_q, b_k)
@@ -130,18 +135,19 @@ def parallel_simple_gla_fwd_kernel(
         if i_s >= 0:
             b_o += tl.dot(b_s.to(b_q.dtype), b_v)
         if OUTPUT_ATTENTIONS:
-            p_a = tl.make_block_ptr(attn, (T, T), (T, 1), (i_t * BT, i_s), (BT, BS), (1, 0))
-            tl.store(p_a, b_s.to(p_a.dtype.element_ty), boundary_check=(0, 1))
+            p_a = attn + o_q[:, None] * T + o_k[None, :]
+            tl.store(p_a, b_s.to(p_a.dtype.element_ty), mask=m_q[:, None] & m_k[None, :])
     for i_s in range(i_t * BT - BS, -BS, -BS):
-        p_k = tl.make_block_ptr(k, (K, T), (1, H*K), (i_k * BK, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
+        m_kk = (o_kk[:, None] < K) & m_k[None, :]
+        m_kv = m_k[:, None] & (o_vv[None, :] < V)
+        p_k = k + o_kk[:, None] + o_k[None, :] * (H*K)
+        p_v = v + o_k[:, None] * (H*V) + o_vv[None, :]
         # [BK, BS]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
         # [BS, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_kv, other=0.0)
         # [BT, BS]
         m_s = m_q[:, None] & m_k[None, :]
         b_s = tl.dot(b_q, b_k)
@@ -154,12 +160,12 @@ def parallel_simple_gla_fwd_kernel(
             b_gq += b_gn - b_gp
         b_s = tl.where(m_s, b_s, 0)
         if OUTPUT_ATTENTIONS:
-            p_a = tl.make_block_ptr(attn, (T, T), (T, 1), (i_t * BT, i_s), (BT, BS), (1, 0))
-            tl.store(p_a, b_s.to(p_a.dtype.element_ty), boundary_check=(0, 1))
+            p_a = attn + o_q[:, None] * T + o_k[None, :]
+            tl.store(p_a, b_s.to(p_a.dtype.element_ty), mask=m_q[:, None] & m_k[None, :])
         if i_s >= 0:
             b_o += tl.dot(b_s.to(b_v.dtype), b_v)
-    p_o = tl.make_block_ptr(o, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o = o + o_q[:, None] * (H*V) + o_vv[None, :]
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_qv)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -185,25 +191,30 @@ def parallel_simple_gla_bwd_kernel_dq(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+    # [BT]
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
+    m_q = o_q < T
+    m_qk = m_q[:, None] & (o_kk[None, :] < K)
+    m_qv = m_q[:, None] & (o_vv[None, :] < V)
+    p_do = do + o_q[:, None] * (H*V) + o_vv[None, :]
     # [BT, BV]
-    b_do = tl.load(p_do, boundary_check=(0, 1))
+    b_do = tl.load(p_do, mask=m_qv, other=0.0)
     # [BT, BK]
     b_dq = tl.zeros([BT, BK], dtype=tl.float32)
 
-    # [BT]
-    o_q = i_t * BT + tl.arange(0, BT)
-    m_q = o_q < T
     for i_s in range(0, i_t * BT, BS):
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_s, i_k * BK), (BS, BK), (1, 0))
-        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
-
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
+        m_kk = m_k[:, None] & (o_kk[None, :] < K)
+        m_vk = (o_vv[:, None] < V) & m_k[None, :]
+        p_k = k + o_k[:, None] * (H*K) + o_kk[None, :]
+        p_v = v + o_vv[:, None] + o_k[None, :] * (H*V)
         # [BS, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
         # [BV, BS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_vk, other=0.0)
         # [BT, BV] @ [BV, BS] = [BT, BS]
         b_ds = tl.dot(b_do, b_v)
         if USE_G:
@@ -223,15 +234,16 @@ def parallel_simple_gla_bwd_kernel_dq(
         b_dq *= exp2(b_gq)[:, None]
     # Q block and K block have overlap. masks required
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_s, i_k * BK), (BS, BK), (1, 0))
-        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
-
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
+        m_kk = m_k[:, None] & (o_kk[None, :] < K)
+        m_vk = (o_vv[:, None] < V) & m_k[None, :]
+        p_k = k + o_k[:, None] * (H*K) + o_kk[None, :]
+        p_v = v + o_vv[:, None] + o_k[None, :] * (H*V)
         # [BS, BK]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.load(p_k, mask=m_kk, other=0.0)
         # [BV, BS]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_vk, other=0.0)
         # [BT, BV] @ [BV, BS] = [BT, BS]
         b_ds = tl.dot(b_do, b_v)
         if USE_G:
@@ -243,14 +255,14 @@ def parallel_simple_gla_bwd_kernel_dq(
         b_dq += tl.dot(b_ds.to(b_k.dtype), b_k)
 
     b_dq *= scale
-    p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    p_dq = dq + o_q[:, None] * (H*K) + o_kk[None, :]
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_qk)
     if USE_G:
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_q = q + o_q[:, None] * (H*K) + o_kk[None, :]
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
         b_dg = tl.sum(b_dq * b_q, 1)
-        p_dg = tl.make_block_ptr(dg, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+        p_dg = dg + o_q * H
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_q)
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -278,29 +290,34 @@ def parallel_simple_gla_bwd_kernel_dkv(
     USE_G: tl.constexpr,
 ):
     o_k = i_t * BT + tl.arange(0, BT)
+    o_kk = i_k * BK + tl.arange(0, BK)
+    o_vv = i_v * BV + tl.arange(0, BV)
     m_k = o_k < T
+    m_kk = m_k[:, None] & (o_kk[None, :] < K)
+    m_kv = m_k[:, None] & (o_vv[None, :] < V)
     # [BT, BK]
-    p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    p_k = k + o_k[:, None] * (H*K) + o_kk[None, :]
+    b_k = tl.load(p_k, mask=m_kk, other=0.0)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
     # [BT, BV]
-    p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    p_v = v + o_k[:, None] * (H*V) + o_vv[None, :]
+    b_v = tl.load(p_v, mask=m_kv, other=0.0)
     b_dv = tl.zeros([BT, BV], dtype=tl.float32)
     if USE_G:
         b_gk = tl.load(g + o_k * H, mask=m_k, other=0)
     NTS = tl.cdiv(T, BS)
     # [BT, BK]
     for i_s in range(NTS * BS - BS, (i_t + 1) * BT - BS, -BS):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_s, i_k * BK), (BS, BK), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-
         o_q = i_s + tl.arange(0, BS)
         m_q = o_q < T
+        m_qk = m_q[:, None] & (o_kk[None, :] < K)
+        m_qv = m_q[:, None] & (o_vv[None, :] < V)
+        p_q = q + o_q[:, None] * (H*K) + o_kk[None, :]
+        p_do = do + o_q[:, None] * (H*V) + o_vv[None, :]
         # [BS, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
         # [BS, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_qv, other=0.0)
         # [BT, BS]
         b_ds = tl.dot(b_v, tl.trans(b_do))
         b_s = tl.dot(b_k, tl.trans(b_q))
@@ -328,15 +345,16 @@ def parallel_simple_gla_bwd_kernel_dkv(
             b_dv *= b_gpn
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_s, i_k * BK), (BS, BK), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-
         o_q = i_s + tl.arange(0, BS)
         m_q = o_q < T
+        m_qk = m_q[:, None] & (o_kk[None, :] < K)
+        m_qv = m_q[:, None] & (o_vv[None, :] < V)
+        p_q = q + o_q[:, None] * (H*K) + o_kk[None, :]
+        p_do = do + o_q[:, None] * (H*V) + o_vv[None, :]
         # [BS, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qk, other=0.0)
         # [BS, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_qv, other=0.0)
         # [BS]
         b_s = tl.dot(b_k, tl.trans(b_q))
         b_ds = tl.dot(b_v, tl.trans(b_do))
@@ -354,10 +372,10 @@ def parallel_simple_gla_bwd_kernel_dkv(
         b_dv += tl.dot(b_s.to(b_do.dtype), b_do)
     b_dk *= scale
     b_dv *= scale
-    p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+    p_dk = dk + o_k[:, None] * (H*K) + o_kk[None, :]
+    p_dv = dv + o_k[:, None] * (H*V) + o_vv[None, :]
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_kk)
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_kv)
     if USE_G:
         b_dg = tl.load(dg + o_k * H, mask=m_k, other=0)
         b_dg -= tl.sum(b_dk * b_k, 1)
@@ -404,7 +422,7 @@ def parallel_simple_gla_bwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
 ):
-    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_kv, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_k, i_v = i_kv // NV, i_kv % NV
     i_b, i_h = i_bh // H, i_bh % H
     dq += i_v * B * H * T * K
@@ -414,7 +432,7 @@ def parallel_simple_gla_bwd_kernel(
         dg += i_kv * B * H * T
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:

--- a/fla/ops/ttt/chunk.py
+++ b/fla/ops/ttt/chunk.py
@@ -74,28 +74,34 @@ def chunk_ttt_linear_fwd_kernel_h(
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     # [BV]
     b_hb = tl.zeros([BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     if USE_INITIAL_STATE:
-        p_h0 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h = tl.load(p_h0, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h0, mask=m_h, other=0.0).to(tl.float32)
     if USE_INITIAL_STATE_B:
-        p_hb0 = tl.make_block_ptr(hb0 + i_nh * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-        b_hb = tl.load(p_hb0, boundary_check=(0,), padding_option="zero").to(tl.float32)
+        p_hb0 = hb0 + i_nh * V + o_v
+        b_hb = tl.load(p_hb0, mask=o_v < V, other=0.0).to(tl.float32)
 
     offs = tl.arange(0, BV)
     b_w = tl.load(w + i_h * V + offs, mask=offs < V, other=0.)
     b_b = tl.load(b + i_h * V + offs, mask=offs < V, other=0.)
 
     for i_t in range(NT):
-        p_h = tl.make_block_ptr(h + ((boh + i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_hb = tl.make_block_ptr(hb + ((boh + i_t) * H + i_h) * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_hb, b_hb.to(p_hb.dtype.element_ty), boundary_check=(0,))
-        p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v_new = tl.make_block_ptr(v_new+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, i_v * BV), (BT, BV), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_v = (o_t[:, None] < T) & (o_v[None, :] < V)
+        m_k = (o_k[:, None] < K) & (o_t[None, :] < T)
+        p_h = h + ((boh + i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        p_hb = hb + ((boh + i_t) * H + i_h) * V + o_v
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_h)
+        tl.store(p_hb, b_hb.to(p_hb.dtype.element_ty), mask=o_v < V)
+        p_k = k+(bos*H+i_h)*K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_v = v+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v_new = v_new+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
         p_eta_last = eta+bos*H+i_h + (T-1)*H if i_t == NT-1 else eta+bos*H+i_h + (i_t*BT+BT-1)*H
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
 
         b_kh = tl.dot(tl.trans(b_k), b_h.to(b_k.dtype), allow_tf32=False).to(tl.float32) + b_hb[None, :]
         b_kh = tl.where((offs < V)[None, :], b_kh, 0.)
@@ -110,16 +116,16 @@ def chunk_ttt_linear_fwd_kernel_h(
         b_v = tl.where((offs < V)[None, :], b_v * b_w[None, :].to(b_k.dtype), 0.)
         b_v2 = rstd * (V * b_v - tl.sum(b_v, axis=1, keep_dims=True) - b_kh_hat.to(b_k.dtype)
                        * tl.sum(b_v * b_kh_hat.to(b_k.dtype), axis=1, keep_dims=True)) / V
-        tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), mask=m_v)
         b_eta_last = tl.load(p_eta_last)
         b_h = b_h - tl.dot(b_eta_last * b_k, b_v2.to(b_k.dtype), allow_tf32=False)
         b_hb = b_hb - tl.sum(b_eta_last * b_v2.to(b_k.dtype), axis=0)
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_hbt = tl.make_block_ptr(hbt + i_nh * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_hbt, b_hb.to(p_hbt.dtype.element_ty), boundary_check=(0,))
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        p_hbt = hbt + i_nh * V + o_v
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_h)
+        tl.store(p_hbt, b_hb.to(p_hbt.dtype.element_ty), mask=o_v < V)
 
 
 @triton.heuristics({
@@ -155,12 +161,12 @@ def chunk_ttt_linear_fwd_kernel_o(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -181,21 +187,29 @@ def chunk_ttt_linear_fwd_kernel_o(
     stride_vo = H*V
     stride_eta = H
 
-    p_q = tl.make_block_ptr(q, (T, K), (stride_qk, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (K, T), (1, stride_qk), (0, i_t * BT), (BK, BT), (0, 1))
-    p_eta = tl.make_block_ptr(eta, (T,), (stride_eta,), (i_t * BT,), (BT,), (0,))
-    p_h = tl.make_block_ptr(h, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
-    p_hb = tl.make_block_ptr(hb, (V,), (1,), (i_v * BV,), (BV,), (0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_q = m_t[:, None] & (o_k[None, :] < K)
+    m_k = (o_k[:, None] < K) & m_t[None, :]
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
+    m_v = m_t[:, None] & (o_v[None, :] < V)
+    p_q = q + o_t[:, None] * stride_qk + o_k[None, :]
+    p_k = k + o_k[:, None] + o_t[None, :] * stride_qk
+    p_eta = eta + o_t * stride_eta
+    p_h = h + o_k[:, None] * V + o_v[None, :]
+    p_hb = hb + o_v
     # [BT, BK]
-    b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
+    b_q = tl.load(p_q, mask=m_q, other=0.0)
     # [BK, BT]
-    b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
+    b_k = tl.load(p_k, mask=m_k, other=0.0)
     # [BT, 1]
-    b_eta = tl.load(p_eta, boundary_check=(0,), padding_option="zero")
+    b_eta = tl.load(p_eta, mask=m_t, other=0.0)
     # [BK, BV]
-    b_h = tl.load(p_h, boundary_check=(0, 1), padding_option="zero")
+    b_h = tl.load(p_h, mask=m_h, other=0.0)
     # [BV]
-    b_hb = tl.load(p_hb, boundary_check=(0,), padding_option="zero")
+    b_hb = tl.load(p_hb, mask=o_v < V, other=0.0)
     # [BT, BK] @ [BK, BV] -> [BT, BV]
     b_o = tl.dot(b_q, b_h, allow_tf32=False)
     # [BT, BK] @ [BK, BT] -> [BT, BT]
@@ -206,12 +220,12 @@ def chunk_ttt_linear_fwd_kernel_o(
     b_A = tl.where(m_A, b_A, 0)
     b_Ae = tl.where(m_A, b_eta[:, None], 0.0)
 
-    p_v = tl.make_block_ptr(v, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_o = tl.make_block_ptr(o, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+    p_v = v + o_t[:, None] * stride_vo + o_v[None, :]
+    p_o = o + o_t[:, None] * stride_vo + o_v[None, :]
+    b_v = tl.load(p_v, mask=m_v, other=0.0)
     b_o = (b_o - tl.dot(b_eta[:, None] * b_A.to(b_v.dtype), b_v, allow_tf32=False)) * scale
     b_o += b_hb[None, :] - tl.dot(b_Ae.to(b_v.dtype), b_v, allow_tf32=False)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
 
 
 @triton.heuristics({
@@ -272,29 +286,35 @@ def chunk_ttt_linear_bwd_kernel_h(
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     # [BV]
     b_hb = tl.zeros([BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     if USE_INITIAL_STATE:
-        p_h0 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_h = tl.load(p_h0, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h0, mask=m_h, other=0.0).to(tl.float32)
     if USE_INITIAL_STATE_B:
-        p_hb0 = tl.make_block_ptr(hb0 + i_nh * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-        b_hb = tl.load(p_hb0, boundary_check=(0,), padding_option="zero").to(tl.float32)
+        p_hb0 = hb0 + i_nh * V + o_v
+        b_hb = tl.load(p_hb0, mask=o_v < V, other=0.0).to(tl.float32)
 
     offs = tl.arange(0, BV)
     b_w = tl.load(w + i_h * V + offs, mask=offs < V, other=0.)
     b_b = tl.load(b + i_h * V + offs, mask=offs < V, other=0.)
 
     for i_t in range(NT):
-        p_h = tl.make_block_ptr(h + ((boh + i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
-        p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v_new = tl.make_block_ptr(v_new+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, i_v * BV), (BT, BV), (1, 0))
-        p_x = tl.make_block_ptr(x+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, i_v * BV), (BT, BV), (1, 0))
-        p_y = tl.make_block_ptr(y+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, i_v * BV), (BT, BV), (1, 0))
-        p_r = tl.make_block_ptr(r+bos*H+i_h, (T, 1), (H, 1), (i_t*BT, 0), (BT, 1), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_v = (o_t[:, None] < T) & (o_v[None, :] < V)
+        m_k = (o_k[:, None] < K) & (o_t[None, :] < T)
+        p_h = h + ((boh + i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_h)
+        p_k = k+(bos*H+i_h)*K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_v = v+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v_new = v_new+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_x = x+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_y = y+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_r = r+bos*H+i_h + o_t[:, None] * H
         p_eta_last = eta+bos*H+i_h + (T-1)*H if i_t == NT-1 else eta+bos*H+i_h + (i_t*BT+BT-1)*H
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
 
         b_kh = tl.dot(tl.trans(b_k), b_h.to(b_k.dtype), allow_tf32=False).to(tl.float32) + b_hb[None, :]
         b_kh = tl.where((offs < V)[None, :], b_kh, 0.)
@@ -309,10 +329,10 @@ def chunk_ttt_linear_bwd_kernel_h(
         b_v = tl.where((offs < V)[None, :], b_v * b_w[None, :].to(b_k.dtype), 0.)
         b_v2 = rstd * (V * b_v - tl.sum(b_v, axis=1, keep_dims=True) - b_kh_hat.to(b_k.dtype)
                        * tl.sum(b_v * b_kh_hat.to(b_k.dtype), axis=1, keep_dims=True)) / V
-        tl.store(p_x, b_kh_hat.to(p_x.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_y, b_v.to(p_y.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_r, rstd.to(p_r.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_x, b_kh_hat.to(p_x.dtype.element_ty), mask=m_v)
+        tl.store(p_y, b_v.to(p_y.dtype.element_ty), mask=m_v)
+        tl.store(p_r, rstd.to(p_r.dtype.element_ty), mask=o_t[:, None] < T)
+        tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), mask=m_v)
         b_eta_last = tl.load(p_eta_last)
         b_h = b_h - tl.dot(b_eta_last * b_k, b_v2.to(b_k.dtype), allow_tf32=False)
         b_hb = b_hb - tl.sum(b_eta_last * b_v2.to(b_k.dtype), axis=0)
@@ -348,10 +368,10 @@ def chunk_ttt_linear_bwd_kernel_dv_local(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
@@ -368,25 +388,32 @@ def chunk_ttt_linear_bwd_kernel_dv_local(
     stride_eta = H
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_q = tl.make_block_ptr(q, (K, T), (1, stride_qk), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        m_q = (o_k[:, None] < K) & m_t[None, :]
+        p_k = k + o_t[:, None] * stride_qk + o_k[None, :]
+        p_q = q + o_k[:, None] + o_t[None, :] * stride_qk
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_A += tl.dot(b_k, b_q)
 
-    p_eta = tl.make_block_ptr(eta, (T,), (stride_eta,), (i_t * BT,), (BT,), (0,))
-    b_eta = tl.load(p_eta, boundary_check=(0,))
+    p_eta = eta + o_t * stride_eta
+    b_eta = tl.load(p_eta, mask=m_t, other=0.0)
     mask = (tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :])
     b_A = - tl.where(mask, b_A * scale * b_eta[None, :], 0).to(do.dtype.element_ty)
     b_Ae = - tl.where(mask, b_eta[None, :], 0).to(do.dtype.element_ty)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_do = tl.make_block_ptr(do, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_do = do + o_t[:, None] * stride_vo + o_v[None, :]
+        p_dv = dv + o_t[:, None] * stride_vo + o_v[None, :]
+        b_do = tl.load(p_do, mask=m_v, other=0.0)
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do) + tl.dot(b_Ae.to(b_do.dtype), b_do)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
 
 
 @triton.heuristics({
@@ -461,12 +488,15 @@ def chunk_ttt_linear_bwd_kernel_norm(
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     # [BV]
     b_dhb = tl.zeros([BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     if USE_FINAL_STATE_GRADIENT:
-        p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        b_dh += tl.load(p_dht, boundary_check=(0, 1), padding_option="zero")
+        p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dht, mask=m_h, other=0.0)
     if USE_FINAL_STATE_GRADIENT_B:
-        p_dhbt = tl.make_block_ptr(dhbt + i_nh * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-        b_dhb += tl.load(p_dhbt, boundary_check=(0,), padding_option="zero")
+        p_dhbt = dhbt + i_nh * V + o_v
+        b_dhb += tl.load(p_dhbt, mask=o_v < V, other=0.0)
 
     # [BV]
     offs_v = tl.arange(0, BV)
@@ -475,44 +505,50 @@ def chunk_ttt_linear_bwd_kernel_norm(
     b_b = tl.load(b + i_h * V + offs_v, mask=offs_v < V, other=0.)
     b_dw = tl.zeros([BV], dtype=b_w.dtype)
     b_db = tl.zeros([BV], dtype=b_b.dtype)
-    p_dw = tl.make_block_ptr(dw + i_nh * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-    p_db = tl.make_block_ptr(db + i_nh * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
+    p_dw = dw + i_nh * V + o_v
+    p_db = db + i_nh * V + o_v
 
     for i_t in range(NT - 1, -1, -1):
-        p_h = tl.make_block_ptr(h + ((boh+i_t) * H + i_h) * K*V, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dh = tl.make_block_ptr(dh + ((boh+i_t) * H + i_h) * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        p_dhb = tl.make_block_ptr(dhb + ((boh+i_t) * H + i_h) * V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dhb, b_dhb.to(p_dhb.dtype.element_ty), boundary_check=(0,))
-        p_q = tl.make_block_ptr(q+(bos*H+i_h)*K, (K, T), (1, H*K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_v_new = tl.make_block_ptr(v_new+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_x = tl.make_block_ptr(x+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_y = tl.make_block_ptr(y+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv_new = tl.make_block_ptr(dv_new+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, i_v * BV), (BT, BV), (1, 0))
-        p_dk = tl.make_block_ptr(dk+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT, i_k * BK), (BT, BK), (1, 0))
-        p_do = tl.make_block_ptr(do+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, i_v * BV), (BT, BV), (1, 0))
-        p_r = tl.make_block_ptr(r+bos*H+i_h, (T, 1), (H, 1), (i_t*BT, 0), (BT, 1), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        m_q = (o_k[:, None] < K) & m_t[None, :]
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        m_hv = (o_v[:, None] < V) & (o_k[None, :] < K)
+        p_h = h + ((boh+i_t) * H + i_h) * K*V + o_v[:, None] + o_k[None, :] * V
+        p_dh = dh + ((boh+i_t) * H + i_h) * K*V + o_k[:, None] * V + o_v[None, :]
+        p_dhb = dhb + ((boh+i_t) * H + i_h) * V + o_v
+        tl.store(p_dh, b_dh.to(p_dh.dtype.element_ty), mask=m_h)
+        tl.store(p_dhb, b_dhb.to(p_dhb.dtype.element_ty), mask=o_v < V)
+        p_q = q+(bos*H+i_h)*K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_k = k+(bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_v = v+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v_new = v_new+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_x = x+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_y = y+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv_new = dv_new+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dv = dv+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dk = dk+(bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_do = do+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_r = r+bos*H+i_h + o_t[:, None] * H
         p_eta_last = eta+bos*H+i_h + (T-1)*H if i_t == NT-1 else eta+bos*H+i_h + (i_t*BT+BT-1)*H
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_dv_new = tl.load(p_dv_new, boundary_check=(0, 1), padding_option="zero").to(b_k.dtype)
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_dv_new = tl.load(p_dv_new, mask=m_v, other=0.0).to(b_k.dtype)
         b_eta_last = tl.load(p_eta_last)
         b_dv_new -= tl.dot(b_eta_last * b_k, b_dh.to(b_k.dtype))
         b_dv_new -= b_eta_last * b_dhb.to(b_k.dtype)[None, :]
 
-        b_v_new = tl.load(p_v_new, boundary_check=(0, 1), padding_option="zero")
-        b_x = tl.load(p_x, boundary_check=(0, 1), padding_option="zero").to(b_k.dtype)
-        b_y = tl.load(p_y, boundary_check=(0, 1), padding_option="zero").to(b_k.dtype)
-        b_rstd = tl.load(p_r, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_v_new = tl.load(p_v_new, mask=m_v, other=0.0)
+        b_x = tl.load(p_x, mask=m_v, other=0.0).to(b_k.dtype)
+        b_y = tl.load(p_y, mask=m_v, other=0.0).to(b_k.dtype)
+        b_rstd = tl.load(p_r, mask=m_t[:, None], other=0.0).to(tl.float32)
         b_dy = b_rstd * (b_dv_new * V - tl.sum(b_dv_new, axis=1, keep_dims=True) -
                          b_x * tl.sum(b_dv_new * b_x, axis=1, keep_dims=True)) / V
         b_dx = -b_rstd * (b_dv_new * tl.sum(b_x * b_y, axis=1, keep_dims=True) +
                           b_y * tl.sum(b_dv_new * b_x, axis=1, keep_dims=True)) / V
         b_drstd = tl.sum(b_dv_new.to(b_rstd.dtype) * b_v_new.to(b_rstd.dtype) / b_rstd, axis=1, keep_dims=True)
 
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_w = b_w.to(b_k.dtype)
         b_b = b_b.to(b_k.dtype)
         b_dv = -b_w * b_dy.to(b_k.dtype)
@@ -523,9 +559,9 @@ def chunk_ttt_linear_bwd_kernel_norm(
         b_dx = b_dx.to(b_k.dtype) + b_w * b_w * b_dy.to(b_k.dtype)
 
         # d_rstd, dx --> dkh --> dk, dh
-        b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-        b_h = tl.load(p_h, boundary_check=(0, 1), padding_option="zero")
-        b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
+        b_h = tl.load(p_h, mask=m_hv, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         b_dkh = b_rstd * (V * b_dx - tl.sum(b_dx, axis=1, keep_dims=True) -
                           b_x * tl.sum(b_x * b_dx, axis=1, keep_dims=True)) / V
@@ -537,17 +573,17 @@ def chunk_ttt_linear_bwd_kernel_norm(
         b_dh = tl.where((offs_v < V)[None, :], b_dh, 0.)
         b_dhb = tl.where((offs_v < V), b_dhb, 0.)
 
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dw, b_dw.to(p_dw.dtype.element_ty), boundary_check=(0,))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+    tl.store(p_dw, b_dw.to(p_dw.dtype.element_ty), mask=o_v < V)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=o_v < V)
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0 + i_nh * K*V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_h)
     if USE_INITIAL_STATE_B:
-        p_dhb0 = tl.make_block_ptr(dhb0+i_nh*V, (V,), (1,), (i_v * BV,), (BV,), (0,))
-        tl.store(p_dhb0, b_dhb.to(p_dhb0.dtype.element_ty), boundary_check=(0,))
+        p_dhb0 = dhb0+i_nh*V + o_v
+        tl.store(p_dhb0, b_dhb.to(p_dhb0.dtype.element_ty), mask=o_v < V)
 
 
 @triton.heuristics({
@@ -588,11 +624,11 @@ def chunk_bwd_kernel_dqke(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -622,27 +658,34 @@ def chunk_bwd_kernel_dqke(
     b_ds = tl.zeros([BT, BT], dtype=tl.float32)
     b_de = tl.zeros([BT], dtype=tl.float32)
 
-    p_k = tl.make_block_ptr(k, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_t = o_t < T
+    m_k = m_t[:, None] & (o_k[None, :] < K)
+    p_k = k + o_t[:, None] * stride_qk + o_k[None, :]
+    b_k = tl.load(p_k, mask=m_k, other=0.0)
     p_e_last = (e + (i_t*BT+BT-1)*stride_e) if (i_t*BT+BT) <= T else (e + (T-1)*stride_e)
     i_last = (BT-1) if (i_t*BT+BT) <= T else (T % BT-1)
     mask = (tl.arange(0, BT) == i_last)
     b_e_last = tl.load(p_e_last)
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T, V), (stride_vo, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        p_dhb = tl.make_block_ptr(dhb, (V,), (1,), (i_v * BV,), (BV,), (0,))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
+        p_v = v + o_t[:, None] * stride_vo + o_v[None, :]
+        p_do = do + o_t[:, None] * stride_vo + o_v[None, :]
+        p_h = h + o_v[:, None] + o_k[None, :] * V
+        p_dh = dh + o_v[:, None] + o_k[None, :] * V
+        p_dhb = dhb + o_v
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0)
         # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
+        b_dh = tl.load(p_dh, mask=m_h, other=0.0)
         # [BV]
-        b_dhb = tl.load(p_dhb, boundary_check=(0,))
+        b_dhb = tl.load(p_dhb, mask=o_v < V, other=0.0)
         # [BT, BV] @ [BV, BT] -> [BT, BT]
         b_ds += tl.dot(b_do, tl.trans(b_v))
         # [BT, BV] @ [BV, BK] -> [BT, BK]
@@ -653,14 +696,14 @@ def chunk_bwd_kernel_dqke(
         b_de -= mask * tl.sum(b_dhb * tl.sum(b_v, axis=0).to(b_k.dtype))
 
     o_i = tl.arange(0, BT)
-    p_q = tl.make_block_ptr(q, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_e = tl.make_block_ptr(e, (T,), (stride_e,), (i_t * BT,), (BT,), (0,))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_e = tl.load(p_e, boundary_check=(0,))
+    p_q = q + o_t[:, None] * stride_qk + o_k[None, :]
+    p_e = e + o_t * stride_e
+    b_q = tl.load(p_q, mask=m_k, other=0.0)
+    b_e = tl.load(p_e, mask=m_t, other=0.0)
 
-    p_dq = tl.make_block_ptr(dq, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_dk = tl.make_block_ptr(dk, (T, K), (stride_qk, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-    p_de = tl.make_block_ptr(de, (T,), (stride_e,), (i_t * BT,), (BT,), (0,))
+    p_dq = dq + o_t[:, None] * stride_qk + o_k[None, :]
+    p_dk = dk + o_t[:, None] * stride_qk + o_k[None, :]
+    p_de = de + o_t * stride_e
 
     b_ds = tl.where(o_i[:, None] >= o_i[None, :], b_ds, 0)
     b_ds = b_ds.to(b_k.dtype)
@@ -669,9 +712,9 @@ def chunk_bwd_kernel_dqke(
     b_de -= tl.sum(scale * tl.dot(b_ds, b_k) * b_q, axis=1)
     b_de -= tl.sum(b_ds, axis=1)
     b_dq *= scale
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_de, b_de.to(p_de.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_k)
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+    tl.store(p_de, b_de.to(p_de.dtype.element_ty), mask=m_t)
 
 
 def chunk_ttt_linear_fwd_h(

--- a/fla/ops/ttt/fused_chunk.py
+++ b/fla/ops/ttt/fused_chunk.py
@@ -78,24 +78,32 @@ def fused_chunk_ttt_linear_fwd_kernel(
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     # [BV]
     b_hb = tl.zeros([BV], dtype=tl.float32)
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     if USE_INITIAL_STATE:
-        p_h0 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (0, 0), (BK, BV), (1, 0))
-        b_h = tl.load(p_h0, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h0, mask=m_h, other=0.0).to(tl.float32)
     if USE_INITIAL_STATE_B:
-        p_hb0 = tl.make_block_ptr(hb0 + i_nh * V, (V,), (1,), (0,), (BV,), (0,))
-        b_hb = tl.load(p_hb0, boundary_check=(0,), padding_option="zero").to(tl.float32)
+        p_hb0 = hb0 + i_nh * V + o_v
+        b_hb = tl.load(p_hb0, mask=o_v < V, other=0.0).to(tl.float32)
 
     for i_t in range(NT):
-        p_q = tl.make_block_ptr(q+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT, 0), (BT, BK), (1, 0))
-        p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (K, T), (1, H*K), (0, i_t*BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_o = tl.make_block_ptr(o+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_e = tl.make_block_ptr(eta+(bos*H+i_h), (T,), (H,), (i_t*BT,), (BT,), (0,))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_q = m_t[:, None] & (o_k[None, :] < K)
+        m_k = (o_k[:, None] < K) & m_t[None, :]
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_q = q+(bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k = k+(bos*H+i_h)*K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_v = v+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_o = o+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_e = eta+(bos*H+i_h) + o_t * H
         p_e_last = eta+bos*H+i_h + (T-1)*H if i_t == NT-1 else eta+bos*H+i_h + (i_t*BT+BT-1)*H
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
 
         # [BT, BV]
         b_kh = tl.dot(tl.trans(b_k), b_h.to(b_k.dtype), allow_tf32=False).to(tl.float32) + b_hb[None, :]
@@ -113,9 +121,9 @@ def fused_chunk_ttt_linear_fwd_kernel(
                        * tl.sum(b_v * b_kh_hat.to(b_k.dtype), axis=1, keep_dims=True)) / V
 
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
         # [BT]
-        b_e = tl.load(p_e, boundary_check=(0,), padding_option="zero")
+        b_e = tl.load(p_e, mask=m_t, other=0.0)
         b_q = (b_q * scale).to(b_k.dtype)
 
         # [BT, BT]
@@ -131,13 +139,13 @@ def fused_chunk_ttt_linear_fwd_kernel(
         b_hb = b_hb - tl.sum(b_e_last * b_v2.to(b_k.dtype), axis=0)
         b_h = tl.where((v_i < V)[None, :], b_h, 0.)
         b_hb = tl.where((v_i < V), b_hb, 0.)
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht + i_nh * K*V, (K, V), (V, 1), (0, 0), (BK, BV), (1, 0))
-        p_hbt = tl.make_block_ptr(hbt + i_nh * V, (V,), (1,), (0,), (BV,), (0,))
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_hbt, b_hb.to(p_hbt.dtype.element_ty), boundary_check=(0,))
+        p_ht = ht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        p_hbt = hbt + i_nh * V + o_v
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_h)
+        tl.store(p_hbt, b_hb.to(p_hbt.dtype.element_ty), mask=o_v < V)
 
 
 @triton.heuristics({
@@ -197,30 +205,38 @@ def fused_chunk_ttt_linear_bwd_kernel_h(
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     # [BV]
     b_hb = tl.zeros([BV], dtype=tl.float32)
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     if USE_INITIAL_STATE:
-        p_h0 = tl.make_block_ptr(h0 + i_nh * K * V, (K, V), (V, 1), (0, 0), (BK, BV), (1, 0))
-        b_h = tl.load(p_h0, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h = tl.load(p_h0, mask=m_h, other=0.0).to(tl.float32)
     if USE_INITIAL_STATE_B:
-        p_hb0 = tl.make_block_ptr(hb0 + i_nh * V, (V,), (1,), (0,), (BV,), (0,))
-        b_hb = tl.load(p_hb0, boundary_check=(0,), padding_option="zero").to(tl.float32)
+        p_hb0 = hb0 + i_nh * V + o_v
+        b_hb = tl.load(p_hb0, mask=o_v < V, other=0.0).to(tl.float32)
 
     for i_t in range(NT):
-        p_h = tl.make_block_ptr(h+((boh+i_t)*H+i_h)*K*V, (K, V), (V, 1), (0, 0), (BK, BV), (1, 0))
-        p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (K, T), (1, H*K), (0, i_t*BT), (BK, BT), (0, 1))
-        p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_v2 = tl.make_block_ptr(v2+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_x = tl.make_block_ptr(x+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_y = tl.make_block_ptr(y+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_r = tl.make_block_ptr(r+bos*H+i_h, (T, 1), (H, 1), (i_t*BT, 0), (BT, 1), (1, 0))
-        p_e = tl.make_block_ptr(eta+(bos*H+i_h), (T,), (H,), (i_t*BT,), (BT,), (0,))
-        p_dq = tl.make_block_ptr(dq+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT, 0), (BT, BK), (1, 0))
-        p_do = tl.make_block_ptr(do+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_q = m_t[:, None] & (o_k[None, :] < K)
+        m_k = (o_k[:, None] < K) & m_t[None, :]
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_h = h+((boh+i_t)*H+i_h)*K*V + o_k[:, None] * V + o_v[None, :]
+        p_k = k+(bos*H+i_h)*K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_v = v+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v2 = v2+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_x = x+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_y = y+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_r = r+bos*H+i_h + o_t[:, None] * H
+        p_e = eta+(bos*H+i_h) + o_t * H
+        p_dq = dq+(bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_do = do+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
         p_e_last = eta+bos*H+i_h + (T-1)*H if i_t == NT-1 else eta+bos*H+i_h + (i_t*BT+BT-1)*H
-        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), mask=m_h)
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
         # [BT, BV]
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
 
         b_kh = tl.dot(tl.trans(b_k), b_h.to(b_k.dtype), allow_tf32=False).to(tl.float32) + b_hb[None, :]
         b_kh = tl.where((v_i < V)[None, :], b_kh, 0.)
@@ -235,13 +251,13 @@ def fused_chunk_ttt_linear_bwd_kernel_h(
         b_v = tl.where((v_i < V)[None, :], b_v * b_w[None, :].to(b_k.dtype), 0.)
         b_v2 = rstd * (V * b_v - tl.sum(b_v, axis=1, keep_dims=True) - b_kh_hat.to(b_k.dtype)
                        * tl.sum(b_v * b_kh_hat.to(b_k.dtype), axis=1, keep_dims=True)) / V
-        tl.store(p_x, b_kh_hat.to(p_x.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_y, b_v.to(p_y.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_r, rstd.to(p_r.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_v2, b_v2.to(p_v2.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_x, b_kh_hat.to(p_x.dtype.element_ty), mask=m_v)
+        tl.store(p_y, b_v.to(p_y.dtype.element_ty), mask=m_v)
+        tl.store(p_r, rstd.to(p_r.dtype.element_ty), mask=m_t[:, None])
+        tl.store(p_v2, b_v2.to(p_v2.dtype.element_ty), mask=m_v)
 
-        b_e = tl.load(p_e, boundary_check=(0,), padding_option="zero")
-        b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
+        b_e = tl.load(p_e, mask=m_t, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0)
 
         b_v2 = tl.where((v_i < V)[None, :], b_v2, 0.)
         b_ds = tl.dot(b_do, tl.trans(b_v2).to(b_do.dtype))
@@ -256,7 +272,7 @@ def fused_chunk_ttt_linear_bwd_kernel_h(
         b_hb = b_hb - tl.sum(b_e_last * b_v2.to(b_k.dtype), axis=0)
         b_h = tl.where((v_i < V)[None, :], b_h, 0.)
         b_hb = tl.where((v_i < V), b_hb, 0.)
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q)
 
 
 @triton.heuristics({
@@ -319,12 +335,15 @@ def fused_chunk_ttt_linear_bwd_kernel_dh(
     b_dh = tl.zeros([BK, BV], dtype=tl.float32)
     # [BV]
     b_dhb = tl.zeros([BV], dtype=tl.float32)
+    o_k = tl.arange(0, BK)
+    o_v = tl.arange(0, BV)
+    m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
     if USE_FINAL_STATE_GRADIENT:
-        p_dht = tl.make_block_ptr(dht + i_nh * K*V, (K, V), (V, 1), (0, 0), (BK, BV), (1, 0))
-        b_dh += tl.load(p_dht, boundary_check=(0, 1), padding_option="zero")
+        p_dht = dht + i_nh * K*V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dht, mask=m_h, other=0.0)
     if USE_FINAL_STATE_GRADIENT_B:
-        p_dhbt = tl.make_block_ptr(dhbt + i_nh * V, (V,), (1,), (0,), (BV,), (0,))
-        b_dhb += tl.load(p_dhbt, boundary_check=(0,), padding_option="zero")
+        p_dhbt = dhbt + i_nh * V + o_v
+        b_dhb += tl.load(p_dhbt, mask=o_v < V, other=0.0)
 
     # [BV]
     o_i = tl.arange(0, BT)
@@ -335,28 +354,34 @@ def fused_chunk_ttt_linear_bwd_kernel_dh(
     b_b = tl.load(b + i_h * V + v_i, mask=v_i < V, other=0.)
     b_dw = tl.zeros([BV], dtype=b_w.dtype)
     b_db = tl.zeros([BV], dtype=b_b.dtype)
-    p_dw = tl.make_block_ptr(dw + i_nh * V, (V,), (1,), (0,), (BV,), (0,))
-    p_db = tl.make_block_ptr(db + i_nh * V, (V,), (1,), (0,), (BV,), (0,))
+    p_dw = dw + i_nh * V + o_v
+    p_db = db + i_nh * V + o_v
 
     for i_t in range(NT - 1, -1, -1):
-        p_h = tl.make_block_ptr(h+((boh+i_t)*H+i_h)*K*V, (V, K), (1, V), (0, 0), (BV, BK), (0, 1))
-        p_q = tl.make_block_ptr(q+(bos*H+i_h)*K, (K, T), (1, H*K), (0, i_t*BT), (BK, BT), (0, 1))
-        p_k = tl.make_block_ptr(k+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT, 0), (BT, BK), (1, 0))
-        p_v = tl.make_block_ptr(v+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_v2 = tl.make_block_ptr(v2+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_x = tl.make_block_ptr(x+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_y = tl.make_block_ptr(y+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_r = tl.make_block_ptr(r+bos*H+i_h, (T, 1), (H, 1), (i_t*BT, 0), (BT, 1), (1, 0))
-        p_e = tl.make_block_ptr(eta+(bos*H+i_h), (T,), (H,), (i_t*BT,), (BT,), (0,))
-        p_dv = tl.make_block_ptr(dv+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_dk = tl.make_block_ptr(dk+(bos*H+i_h)*K, (T, K), (H*K, 1), (i_t*BT, 0), (BT, BK), (1, 0))
-        p_do = tl.make_block_ptr(do+(bos*H+i_h)*V, (T, V), (H*V, 1), (i_t*BT, 0), (BT, BV), (1, 0))
-        p_de = tl.make_block_ptr(de+(bos*H+i_h), (T,), (H,), (i_t*BT,), (BT,), (0,))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_q = (o_k[:, None] < K) & m_t[None, :]
+        m_k = m_t[:, None] & (o_k[None, :] < K)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        m_hv = (o_v[:, None] < V) & (o_k[None, :] < K)
+        p_h = h+((boh+i_t)*H+i_h)*K*V + o_v[:, None] + o_k[None, :] * V
+        p_q = q+(bos*H+i_h)*K + o_k[:, None] + o_t[None, :] * (H*K)
+        p_k = k+(bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_v = v+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v2 = v2+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_x = x+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_y = y+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_r = r+bos*H+i_h + o_t[:, None] * H
+        p_e = eta+(bos*H+i_h) + o_t * H
+        p_dv = dv+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_dk = dk+(bos*H+i_h)*K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_do = do+(bos*H+i_h)*V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_de = de+(bos*H+i_h) + o_t * H
         p_e_last = eta+bos*H+i_h + (T-1)*H if i_t == NT-1 else eta+bos*H+i_h + (i_t*BT+BT-1)*H
-        b_q = tl.load(p_q, boundary_check=(0, 1), padding_option="zero")
-        b_k = tl.load(p_k, boundary_check=(0, 1), padding_option="zero")
-        b_e = tl.load(p_e, boundary_check=(0,), padding_option="zero")
-        b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
+        b_q = tl.load(p_q, mask=m_q, other=0.0)
+        b_k = tl.load(p_k, mask=m_k, other=0.0)
+        b_e = tl.load(p_e, mask=m_t, other=0.0)
+        b_do = tl.load(p_do, mask=m_v, other=0.0)
         b_e_last = tl.load(p_e_last)
         b_A = tl.dot(b_k, b_q)
         b_A = - tl.where(m_A_t, b_A * scale * b_e[None, :], 0).to(do.dtype.element_ty)
@@ -365,17 +390,17 @@ def fused_chunk_ttt_linear_bwd_kernel_dh(
         b_dv_new -= tl.dot(b_e_last * b_k, b_dh.to(b_k.dtype))
         b_dv_new -= b_e_last * b_dhb.to(b_k.dtype)[None, :]
 
-        b_v2 = tl.load(p_v2, boundary_check=(0, 1), padding_option="zero").to(b_k.dtype)
-        b_x = tl.load(p_x, boundary_check=(0, 1), padding_option="zero").to(b_k.dtype)
-        b_y = tl.load(p_y, boundary_check=(0, 1), padding_option="zero").to(b_k.dtype)
-        b_rstd = tl.load(p_r, boundary_check=(0, 1), padding_option="zero").to(tl.float32)
+        b_v2 = tl.load(p_v2, mask=m_v, other=0.0).to(b_k.dtype)
+        b_x = tl.load(p_x, mask=m_v, other=0.0).to(b_k.dtype)
+        b_y = tl.load(p_y, mask=m_v, other=0.0).to(b_k.dtype)
+        b_rstd = tl.load(p_r, mask=m_t[:, None], other=0.0).to(tl.float32)
         b_dy = b_rstd * (b_dv_new * V - tl.sum(b_dv_new, axis=1, keep_dims=True) -
                          b_x * tl.sum(b_dv_new * b_x, axis=1, keep_dims=True)) / V
         b_dx = -b_rstd * (b_dv_new * tl.sum(b_x * b_y, axis=1, keep_dims=True) +
                           b_y * tl.sum(b_dv_new * b_x, axis=1, keep_dims=True)) / V
         b_drstd = tl.sum(b_dv_new.to(b_rstd.dtype) * b_v2.to(b_rstd.dtype) / b_rstd, axis=1, keep_dims=True)
 
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_w = b_w.to(b_k.dtype)
         b_b = b_b.to(b_k.dtype)
         b_dv = -b_w * b_dy.to(b_k.dtype)
@@ -385,7 +410,7 @@ def fused_chunk_ttt_linear_bwd_kernel_dh(
         b_db += tl.sum(b_w * b_dy.to(b_k.dtype), axis=0).to(b_db.dtype)
         b_dx = b_dx.to(b_k.dtype) + b_w * b_w * b_dy.to(b_k.dtype)
 
-        b_h = tl.load(p_h, boundary_check=(0, 1), padding_option="zero")
+        b_h = tl.load(p_h, mask=m_hv, other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
         b_dkh = b_rstd * (V * b_dx - tl.sum(b_dx, axis=1, keep_dims=True) -
                           b_x * tl.sum(b_x * b_dx, axis=1, keep_dims=True)) / V
@@ -409,18 +434,18 @@ def fused_chunk_ttt_linear_bwd_kernel_dh(
         b_dh = tl.where((v_i < V)[None, :], b_dh, 0.)
         b_dhb = tl.where((v_i < V), b_dhb, 0.)
 
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_de, b_de.to(p_de.dtype.element_ty), boundary_check=(0,))
-    tl.store(p_dw, b_dw.to(p_dw.dtype.element_ty), boundary_check=(0,))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
+        tl.store(p_de, b_de.to(p_de.dtype.element_ty), mask=m_t)
+    tl.store(p_dw, b_dw.to(p_dw.dtype.element_ty), mask=o_v < V)
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), mask=o_v < V)
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0+i_nh*K*V, (K, V), (V, 1), (0, 0), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0+i_nh*K*V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_h)
     if USE_INITIAL_STATE_B:
-        p_dhb0 = tl.make_block_ptr(dhb0+i_nh*V, (V,), (1,), (0,), (BV,), (0,))
-        tl.store(p_dhb0, b_dhb.to(p_dhb0.dtype.element_ty), boundary_check=(0,))
+        p_dhb0 = dhb0+i_nh*V + o_v
+        tl.store(p_dhb0, b_dhb.to(p_dhb0.dtype.element_ty), mask=o_v < V)
 
 
 def fused_chunk_ttt_linear_bwd_h(

--- a/fla/ops/utils/cumsum.py
+++ b/fla/ops/utils/cumsum.py
@@ -45,30 +45,32 @@ def chunk_local_cumsum_scalar_kernel(
     IS_VARLEN: tl.constexpr,
     HEAD_FIRST: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
     if HEAD_FIRST:
-        p_s = tl.make_block_ptr(s + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
-        p_o = tl.make_block_ptr(o + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        p_s = s + bos*H + i_h*T + o_t
+        p_o = o + bos*H + i_h*T + o_t
     else:
-        p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_s = s + bos*H + i_h + o_t * H
+        p_o = o + bos*H + i_h + o_t * H
     # [BT]
-    b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+    b_s = tl.load(p_s, mask=m_t, other=0.0).to(tl.float32)
     b_o = tl.cumsum(b_s, axis=0)
     if REVERSE:
         b_z = tl.sum(b_s, axis=0)
         b_o = -b_o + b_z[None] + b_s
     if HAS_SCALE:
         b_o *= scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_t)
 
 
 @triton.heuristics({
@@ -102,30 +104,33 @@ def chunk_local_cumsum_vector_kernel(
     IS_VARLEN: tl.constexpr,
     HEAD_FIRST: tl.constexpr,
 ):
-    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_s = i_s * BS + tl.arange(0, BS)
+    m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
     if HEAD_FIRST:
-        p_s = tl.make_block_ptr(s + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-        p_o = tl.make_block_ptr(o + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        p_s = s + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
+        p_o = o + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
     else:
-        p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-        p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+        p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
     # [BT, BS]
-    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_s = tl.load(p_s, mask=m_s, other=0.0).to(tl.float32)
     if REVERSE:
         b_o = tl.cumsum(b_s, axis=0, reverse=True)
     else:
         b_o = tl.cumsum(b_s, axis=0)
     if HAS_SCALE:
         b_o *= scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_s)
 
 
 @triton.heuristics({
@@ -169,13 +174,15 @@ def chunk_global_cumsum_scalar_kernel(
     NT = tl.cdiv(T, BT)
     for i_c in range(NT):
         i_t = NT - 1 - i_c if REVERSE else i_c
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
         if HEAD_FIRST:
-            p_s = tl.make_block_ptr(s + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
-            p_o = tl.make_block_ptr(o + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
+            p_s = s + bos*H + i_h*T + o_t
+            p_o = o + bos*H + i_h*T + o_t
         else:
-            p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-            p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+            p_s = s + bos*H + i_h + o_t * H
+            p_o = o + bos*H + i_h + o_t * H
+        b_s = tl.load(p_s, mask=m_t, other=0.0).to(tl.float32)
         b_o = tl.cumsum(b_s, axis=0)
         b_ss = tl.sum(b_s, 0)
         if REVERSE:
@@ -185,7 +192,7 @@ def chunk_global_cumsum_scalar_kernel(
             b_z += b_ss
         if HAS_SCALE:
             b_o *= scale
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_t)
 
 
 @triton.heuristics({
@@ -231,21 +238,24 @@ def chunk_global_cumsum_vector_kernel(
     NT = tl.cdiv(T, BT)
     for i_c in range(NT):
         i_t = NT - 1 - i_c if REVERSE else i_c
+        o_t = i_t * BT + tl.arange(0, BT)
+        o_s = i_s * BS + tl.arange(0, BS)
+        m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
         if HEAD_FIRST:
-            p_s = tl.make_block_ptr(s + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-            p_o = tl.make_block_ptr(o + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+            p_s = s + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
+            p_o = o + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
         else:
-            p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-            p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+            p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+            p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
         # [BT, BS]
-        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+        b_s = tl.load(p_s, mask=m_s, other=0.0).to(tl.float32)
         if REVERSE:
             b_c = b_z[None, :] + tl.cumsum(b_s, axis=0, reverse=True)
         else:
             b_c = b_z[None, :] + tl.cumsum(b_s, axis=0)
         if HAS_SCALE:
             b_c *= scale
-        tl.store(p_o, b_c.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_o, b_c.to(p_o.dtype.element_ty), mask=m_s)
         b_z += tl.sum(b_s, 0)
 
 

--- a/fla/ops/utils/logcumsumexp.py
+++ b/fla/ops/utils/logcumsumexp.py
@@ -36,11 +36,13 @@ def logcumsumexp_fwd_kernel(
     b_mp = tl.full([S], float('-inf'), dtype=tl.float32)
     b_zp = tl.zeros([S], dtype=tl.float32)
     for i_t in range(tl.cdiv(T, BT)):
-        p_s = tl.make_block_ptr(s + i_bh * T*S, (T, S), (S, 1), (i_t * BT, 0), (BT, S), (1, 0))
-        p_z = tl.make_block_ptr(z + i_bh * T*S, (T, S), (S, 1), (i_t * BT, 0), (BT, S), (1, 0))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        p_s = s + i_bh * T*S + o_t[:, None] * S + tl.arange(0, S)[None, :]
+        p_z = z + i_bh * T*S + o_t[:, None] * S + tl.arange(0, S)[None, :]
 
         # [BT, S]
-        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+        b_s = tl.load(p_s, mask=m_t[:, None], other=0.0).to(tl.float32)
         # [S,]
         b_mc = tl.max(b_s, 0)
         b_mc = tl.maximum(b_mp, b_mc)
@@ -55,4 +57,4 @@ def logcumsumexp_fwd_kernel(
         # [BT, BS]
         # small eps to prevent underflows
         b_z = log(tl.where(b_z != 0, b_z, 1e-20)) + b_mc
-        tl.store(p_z, b_z.to(p_z.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_z, b_z.to(p_z.dtype.element_ty), mask=m_t[:, None])

--- a/fla/ops/utils/pooling.py
+++ b/fla/ops/utils/pooling.py
@@ -38,11 +38,11 @@ def mean_pooling_fwd_kernel(
     BD: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_d, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_d, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -51,13 +51,16 @@ def mean_pooling_fwd_kernel(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
-    p_x = tl.make_block_ptr(x + (bos * H + i_h) * D, (T, D), (H*D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-    p_o = tl.make_block_ptr(o + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = i_d * BD + tl.arange(0, BD)
+    m_x = (o_t[:, None] < T) & (o_d[None, :] < D)
+    p_x = x + (bos * H + i_h) * D + o_t[:, None] * (H*D) + o_d[None, :]
+    p_o = o + (i_tg * H + i_h) * D + o_d
     # [BT, BD]
-    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    b_x = tl.load(p_x, mask=m_x, other=0.0).to(tl.float32)
     # [BD]
     b_o = tl.sum(b_x, axis=0) / min(BT, T - i_t * BT)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=o_d < D)
 
 
 @triton.heuristics({
@@ -85,11 +88,11 @@ def mean_pooling_bwd_kernel(
     BD: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_d, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_d, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_tg = i_t
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -98,13 +101,16 @@ def mean_pooling_bwd_kernel(
         i_tg = i_b * NT + i_t
         bos, eos = i_b * T, i_b * T + T
 
-    p_dx = tl.make_block_ptr(dx + (bos * H + i_h) * D, (T, D), (H*D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
-    p_do = tl.make_block_ptr(do + (i_tg * H + i_h) * D, (D,), (1,), (i_d * BD,), (BD,), (0,))
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = i_d * BD + tl.arange(0, BD)
+    m_x = (o_t[:, None] < T) & (o_d[None, :] < D)
+    p_dx = dx + (bos * H + i_h) * D + o_t[:, None] * (H*D) + o_d[None, :]
+    p_do = do + (i_tg * H + i_h) * D + o_d
     # [BD]
-    b_do = tl.load(p_do, boundary_check=(0,)).to(tl.float32)
+    b_do = tl.load(p_do, mask=o_d < D, other=0.0).to(tl.float32)
     # [BT, BD]
     b_dx = b_do / tl.full((BT,), min(BT, T - i_t * BT), dtype=tl.float32)[:, None]
-    tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dx, b_dx.to(p_dx.dtype.element_ty), mask=m_x)
 
 
 def mean_pooling_fwd(

--- a/fla/ops/utils/solve_tril.py
+++ b/fla/ops/utils/solve_tril.py
@@ -63,10 +63,12 @@ def solve_tril_16x16_kernel(
     Ai = Ai + (bos*H + i_h) * 16
 
     offset = (i_t * 16) % BT
+    o_t = (i_t * 16 + o_i).to(tl.int64)
+    m_t = o_t < T
     if not USE_TMA:
-        p_A = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * 16, offset), (16, 16), (1, 0))
+        p_A = A + o_t[:, None] * (H*BT) + (o_i + offset)[None, :]
         # [16, 16]
-        b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+        b_A = tl.load(p_A, mask=m_t[:, None], other=0.0).to(tl.float32)
         b_A = tl.where(m_A, b_A, 0)
     else:
         desc = make_tensor_descriptor(A, [T, BT], [H*BT, 1], [16, 16])
@@ -83,8 +85,8 @@ def solve_tril_16x16_kernel(
         b_A = tl.where((o_i == i)[:, None], b_a, b_A)
     b_A += m_I
     if not USE_TMA:
-        p_Ai = tl.make_block_ptr(Ai, (T, 16), (H*16, 1), (i_t * 16, 0), (16, 16), (1, 0))
-        tl.store(p_Ai, b_A.to(p_Ai.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+        p_Ai = Ai + o_t[:, None] * (H*16) + o_i[None, :]
+        tl.store(p_Ai, b_A.to(p_Ai.dtype.element_ty, fp_downcast_rounding="rtne"), mask=m_t[:, None])
     else:
         desc_o.store([i_t * 16, 0], b_A.to(desc_o.dtype, fp_downcast_rounding="rtne"))
 
@@ -130,11 +132,12 @@ def merge_16x16_to_32x32_inverse_kernel(
     A += (bos * H + i_h) * BT
     Ai += (bos * H + i_h) * BT
 
+    o_t = (i_t * BT + o_i).to(tl.int64)
     if not USE_TMA:
-        p_A_11 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
-        p_A_22 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
-        b_Ai_11 = tl.load(p_A_11, boundary_check=(0, 1)).to(tl.float32)
-        b_Ai_22 = tl.load(p_A_22, boundary_check=(0, 1)).to(tl.float32)
+        p_A_11 = A + o_t[:, None] * (H*BT) + o_i[None, :]
+        p_A_22 = A + (o_t[:, None] + 16) * (H*BT) + (o_i[None, :] + 16)
+        b_Ai_11 = tl.load(p_A_11, mask=(o_t[:, None] < T), other=0.0).to(tl.float32)
+        b_Ai_22 = tl.load(p_A_22, mask=(o_t[:, None] + 16 < T), other=0.0).to(tl.float32)
     else:
         desc = make_tensor_descriptor(A, [T, BT], [H*BT, 1], [16, 16])
         desc_o = make_tensor_descriptor(Ai, [T, BT], [H*BT, 1], [16, 16])
@@ -158,20 +161,20 @@ def merge_16x16_to_32x32_inverse_kernel(
     b_Ai_22 += m_I
 
     if not USE_TMA:
-        p_A_21 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
-        b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+        p_A_21 = A + (o_t[:, None] + 16) * (H*BT) + o_i[None, :]
+        b_A_21 = tl.load(p_A_21, mask=(o_t[:, None] + 16 < T), other=0.0).to(tl.float32)
     else:
         b_A_21 = desc.load([i_t * BT + 16, 0]).to(tl.float32)
 
     b_Ai_21 = -tl.dot(tl.dot(b_Ai_22, b_A_21, input_precision=DOT_PRECISION), b_Ai_11, input_precision=DOT_PRECISION)
 
     if not USE_TMA:
-        p_Ai_11 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
-        p_Ai_21 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
-        p_Ai_22 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
-        tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+        p_Ai_11 = Ai + o_t[:, None] * (H*BT) + o_i[None, :]
+        p_Ai_21 = Ai + (o_t[:, None] + 16) * (H*BT) + o_i[None, :]
+        p_Ai_22 = Ai + (o_t[:, None] + 16) * (H*BT) + (o_i[None, :] + 16)
+        tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] < T))
+        tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 16 < T))
+        tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 16 < T))
     else:
         desc_o.store([i_t * BT + 0, 0], b_Ai_11.to(desc_o.dtype, fp_downcast_rounding="rtne"))
         desc_o.store([i_t * BT + 16, 0], b_Ai_21.to(desc_o.dtype, fp_downcast_rounding="rtne"))
@@ -219,15 +222,16 @@ def merge_16x16_to_64x64_inverse_kernel(
     A += (bos * H + i_h) * BT
     Ai += (bos * H + i_h) * BT
 
+    o_t = (i_t * BT + o_i).to(tl.int64)
     if not USE_TMA:
-        p_A_11 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
-        p_A_22 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
-        p_A_33 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 32, 32), (16, 16), (1, 0))
-        p_A_44 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 48, 48), (16, 16), (1, 0))
-        b_Ai_11 = tl.load(p_A_11, boundary_check=(0, 1)).to(tl.float32)
-        b_Ai_22 = tl.load(p_A_22, boundary_check=(0, 1)).to(tl.float32)
-        b_Ai_33 = tl.load(p_A_33, boundary_check=(0, 1)).to(tl.float32)
-        b_Ai_44 = tl.load(p_A_44, boundary_check=(0, 1)).to(tl.float32)
+        p_A_11 = A + o_t[:, None] * (H*BT) + o_i[None, :]
+        p_A_22 = A + (o_t[:, None] + 16) * (H*BT) + (o_i[None, :] + 16)
+        p_A_33 = A + (o_t[:, None] + 32) * (H*BT) + (o_i[None, :] + 32)
+        p_A_44 = A + (o_t[:, None] + 48) * (H*BT) + (o_i[None, :] + 48)
+        b_Ai_11 = tl.load(p_A_11, mask=(o_t[:, None] < T), other=0.0).to(tl.float32)
+        b_Ai_22 = tl.load(p_A_22, mask=(o_t[:, None] + 16 < T), other=0.0).to(tl.float32)
+        b_Ai_33 = tl.load(p_A_33, mask=(o_t[:, None] + 32 < T), other=0.0).to(tl.float32)
+        b_Ai_44 = tl.load(p_A_44, mask=(o_t[:, None] + 48 < T), other=0.0).to(tl.float32)
     else:
         desc = make_tensor_descriptor(A, [T, BT], [H*BT, 1], [16, 16])
         desc_o = make_tensor_descriptor(Ai, [T, BT], [H*BT, 1], [16, 16])
@@ -268,18 +272,18 @@ def merge_16x16_to_64x64_inverse_kernel(
     b_Ai_44 += m_I
 
     if not USE_TMA:
-        p_A_21 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
-        p_A_31 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 32, 0), (16, 16), (1, 0))
-        p_A_32 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 32, 16), (16, 16), (1, 0))
-        p_A_41 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 48, 0), (16, 16), (1, 0))
-        p_A_42 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0))
-        p_A_43 = tl.make_block_ptr(A, (T, BT), (H*BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0))
-        b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
-        b_A_31 = tl.load(p_A_31, boundary_check=(0, 1)).to(tl.float32)
-        b_A_32 = tl.load(p_A_32, boundary_check=(0, 1)).to(tl.float32)
-        b_A_41 = tl.load(p_A_41, boundary_check=(0, 1)).to(tl.float32)
-        b_A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
-        b_A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
+        p_A_21 = A + (o_t[:, None] + 16) * (H*BT) + o_i[None, :]
+        p_A_31 = A + (o_t[:, None] + 32) * (H*BT) + o_i[None, :]
+        p_A_32 = A + (o_t[:, None] + 32) * (H*BT) + (o_i[None, :] + 16)
+        p_A_41 = A + (o_t[:, None] + 48) * (H*BT) + o_i[None, :]
+        p_A_42 = A + (o_t[:, None] + 48) * (H*BT) + (o_i[None, :] + 16)
+        p_A_43 = A + (o_t[:, None] + 48) * (H*BT) + (o_i[None, :] + 32)
+        b_A_21 = tl.load(p_A_21, mask=(o_t[:, None] + 16 < T), other=0.0).to(tl.float32)
+        b_A_31 = tl.load(p_A_31, mask=(o_t[:, None] + 32 < T), other=0.0).to(tl.float32)
+        b_A_32 = tl.load(p_A_32, mask=(o_t[:, None] + 32 < T), other=0.0).to(tl.float32)
+        b_A_41 = tl.load(p_A_41, mask=(o_t[:, None] + 48 < T), other=0.0).to(tl.float32)
+        b_A_42 = tl.load(p_A_42, mask=(o_t[:, None] + 48 < T), other=0.0).to(tl.float32)
+        b_A_43 = tl.load(p_A_43, mask=(o_t[:, None] + 48 < T), other=0.0).to(tl.float32)
     else:
         b_A_21 = desc.load([i_t * BT + 16, 0]).to(tl.float32)
         b_A_31 = desc.load([i_t * BT + 32, 0]).to(tl.float32)
@@ -313,26 +317,26 @@ def merge_16x16_to_64x64_inverse_kernel(
     )
 
     if not USE_TMA:
-        p_Ai_11 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT, 0), (16, 16), (1, 0))
-        p_Ai_22 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
-        p_Ai_33 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 32, 32), (16, 16), (1, 0))
-        p_Ai_44 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 48, 48), (16, 16), (1, 0))
-        p_Ai_21 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
-        p_Ai_31 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 32, 0), (16, 16), (1, 0))
-        p_Ai_32 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 32, 16), (16, 16), (1, 0))
-        p_Ai_41 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 48, 0), (16, 16), (1, 0))
-        p_Ai_42 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0))
-        p_Ai_43 = tl.make_block_ptr(Ai, (T, BT), (H*BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0))
-        tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_33, b_Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_44, b_Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_31, b_Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_32, b_Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_41, b_Ai_41.to(p_Ai_41.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_42, b_Ai_42.to(p_Ai_42.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
-        tl.store(p_Ai_43, b_Ai_43.to(p_Ai_43.dtype.element_ty, fp_downcast_rounding="rtne"), boundary_check=(0, 1))
+        p_Ai_11 = Ai + o_t[:, None] * (H*BT) + o_i[None, :]
+        p_Ai_22 = Ai + (o_t[:, None] + 16) * (H*BT) + (o_i[None, :] + 16)
+        p_Ai_33 = Ai + (o_t[:, None] + 32) * (H*BT) + (o_i[None, :] + 32)
+        p_Ai_44 = Ai + (o_t[:, None] + 48) * (H*BT) + (o_i[None, :] + 48)
+        p_Ai_21 = Ai + (o_t[:, None] + 16) * (H*BT) + o_i[None, :]
+        p_Ai_31 = Ai + (o_t[:, None] + 32) * (H*BT) + o_i[None, :]
+        p_Ai_32 = Ai + (o_t[:, None] + 32) * (H*BT) + (o_i[None, :] + 16)
+        p_Ai_41 = Ai + (o_t[:, None] + 48) * (H*BT) + o_i[None, :]
+        p_Ai_42 = Ai + (o_t[:, None] + 48) * (H*BT) + (o_i[None, :] + 16)
+        p_Ai_43 = Ai + (o_t[:, None] + 48) * (H*BT) + (o_i[None, :] + 32)
+        tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] < T))
+        tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 16 < T))
+        tl.store(p_Ai_33, b_Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 32 < T))
+        tl.store(p_Ai_44, b_Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 48 < T))
+        tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 16 < T))
+        tl.store(p_Ai_31, b_Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 32 < T))
+        tl.store(p_Ai_32, b_Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 32 < T))
+        tl.store(p_Ai_41, b_Ai_41.to(p_Ai_41.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 48 < T))
+        tl.store(p_Ai_42, b_Ai_42.to(p_Ai_42.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 48 < T))
+        tl.store(p_Ai_43, b_Ai_43.to(p_Ai_43.dtype.element_ty, fp_downcast_rounding="rtne"), mask=(o_t[:, None] + 48 < T))
     else:
         desc_o.store([i_t * BT + 0, 0], b_Ai_11.to(desc_o.dtype, fp_downcast_rounding="rtne"))
         desc_o.store([i_t * BT + 16, 16], b_Ai_22.to(desc_o.dtype, fp_downcast_rounding="rtne"))

--- a/fla/ops/wall_attn/decode.py
+++ b/fla/ops/wall_attn/decode.py
@@ -63,7 +63,7 @@ def parallel_wall_attn_decode_kernel(
     USE_SINK_BIAS: tl.constexpr,
     USE_SCALAR_G: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
     RCP_LN2: tl.constexpr = 1.4426950216
@@ -72,24 +72,17 @@ def parallel_wall_attn_decode_kernel(
     bos_kv = (i_b * T_kv).to(tl.int64)
     bos_nc = (i_b * NC).to(tl.int64)
 
-    p_q = tl.make_block_ptr(
-        q + (bos_q * HQ + i_hq) * K, (T_q, K), (HQ * K, 1),
-        (i_t * BT, 0), (BT, BK), (1, 0),
-    )
-    p_pq = tl.make_block_ptr(
-        p_curr + (bos_q * HQ + i_hq) * K, (T_q, K), (HQ * K, 1),
-        (i_t * BT, 0), (BT, BK), (1, 0),
-    )
-    p_o = tl.make_block_ptr(
-        o + (bos_q * HQ + i_hq) * V, (T_q, V), (HQ * V, 1),
-        (i_t * BT, i_v * BV), (BT, BV), (1, 0),
-    )
-    p_lse = tl.make_block_ptr(
-        lse + bos_q * HQ + i_hq, (T_q,), (HQ,), (i_t * BT,), (BT,), (0,),
-    )
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_q = o_q < T_q
+    p_q = q + (bos_q * HQ + i_hq) * K + o_q[:, None] * (HQ * K) + o_d[None, :]
+    p_pq = p_curr + (bos_q * HQ + i_hq) * K + o_q[:, None] * (HQ * K) + o_d[None, :]
+    p_o = o + (bos_q * HQ + i_hq) * V + o_q[:, None] * (HQ * V) + o_v[None, :]
+    p_lse = lse + bos_q * HQ + i_hq + o_q * HQ
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_pq = tl.load(p_pq, boundary_check=(0, 1)).to(tl.float32)
+    b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
+    b_pq = tl.load(p_pq, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0).to(tl.float32)
 
     if USE_SCALAR_G:
         o_q_global = (T_kv - T_q) + i_t * BT + tl.arange(0, BT)
@@ -109,29 +102,21 @@ def parallel_wall_attn_decode_kernel(
     # Iterate over the KV cache one chunk at a time: BS == C
     for i_s in range(0, T_kv, BS):
         i_c = i_s // C
+        o_k = (i_s + tl.arange(0, BS)).to(tl.int64)
+        m_k = o_k < T_kv
         # Load anchor
-        p_r = tl.make_block_ptr(
-            r_cache + (bos_nc * HQ + i_hq) * K, (NC, K), (HQ * K, 1),
-            (i_c, 0), (1, BK), (1, 0),
-        )
-        b_R = tl.load(p_r, boundary_check=(0, 1)).to(tl.float32)
+        o_c = (i_c + tl.arange(0, 1)).to(tl.int64)
+        p_r = r_cache + (bos_nc * HQ + i_hq) * K + o_c[:, None] * (HQ * K) + o_d[None, :]
+        b_R = tl.load(p_r, mask=(o_c[:, None] < NC) & (o_d[None, :] < K), other=0.0).to(tl.float32)
         b_q_til = (b_q.to(tl.float32) * exp2(b_pq - b_R)).to(b_q.dtype)
 
-        p_kt = tl.make_block_ptr(
-            k_tilde + (bos_kv * HQ + i_hq) * K, (K, T_kv), (1, HQ * K),
-            (0, i_s), (BK, BS), (0, 1),
-        )
-        p_v = tl.make_block_ptr(
-            v + (bos_kv * H + i_h) * V, (T_kv, V), (H * V, 1),
-            (i_s, i_v * BV), (BS, BV), (1, 0),
-        )
-        b_kt = tl.load(p_kt, boundary_check=(0, 1))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        p_kt = k_tilde + (bos_kv * HQ + i_hq) * K + o_d[:, None] + o_k[None, :] * (HQ * K)
+        p_v = v + (bos_kv * H + i_h) * V + o_k[:, None] * (H * V) + o_v[None, :]
+        b_kt = tl.load(p_kt, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
 
         b_s = tl.dot(b_q_til, b_kt) * scale * RCP_LN2
 
-        o_k = i_s + tl.arange(0, BS)
-        m_k = o_k < T_kv
         if USE_SCALAR_G:
             b_ck = tl.load(
                 g_scalar_cumsum + (bos_kv + o_k) * HQ + i_hq,
@@ -154,9 +139,9 @@ def parallel_wall_attn_decode_kernel(
 
     b_o = b_o / b_acc[:, None]
     b_m += log2(b_acc)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_q[:, None] & (o_v[None, :] < V))
     if i_v == 0:
-        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty), mask=m_q)
 
 
 def parallel_wall_attn_decode(

--- a/fla/ops/wall_attn/parallel.py
+++ b/fla/ops/wall_attn/parallel.py
@@ -123,12 +123,12 @@ def parallel_wall_attn_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     USE_SCALAR_G: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -136,16 +136,22 @@ def parallel_wall_attn_fwd_kernel(
         bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
     RCP_LN2: tl.constexpr = 1.4426950216
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_o = tl.make_block_ptr(o + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_q = o_q < T
+    m_qk = m_q[:, None] & (o_d[None, :] < K)
+    p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    p_o = o + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+    p_lse = lse + bos * HQ + i_hq + o_q * HQ
 
-    p_pq = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_R = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (1, BK), (1, 0))
+    p_pq = g_cumsum + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    o_r = i_t * BT + tl.arange(0, 1)
+    p_R = g_cumsum + (bos * HQ + i_hq) * K + o_r[:, None] * (HQ*K) + o_d[None, :]
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_pq = tl.load(p_pq, boundary_check=(0, 1)).to(tl.float32)
-    b_R = tl.load(p_R, boundary_check=(0, 1)).to(tl.float32)
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_pq = tl.load(p_pq, mask=m_qk, other=0.0).to(tl.float32)
+    b_R = tl.load(p_R, mask=(o_r[:, None] < T) & (o_d[None, :] < K), other=0.0).to(tl.float32)
     # b_R is at i_t*BT; the same value is used in both off-diag and diag loops,
     # since |b_pq - b_R| within a BT-chunk is bounded by BT*|g_max|*RCP_LN2.
     # Off-diagonal: P_q - R <= 0 and R - P_k <= 0 -> exp2 <= 1 -> bf16 safe.
@@ -156,32 +162,31 @@ def parallel_wall_attn_fwd_kernel(
     b_acc = tl.zeros([BT], dtype=tl.float32)
 
     if USE_SCALAR_G:
-        p_cq = tl.make_block_ptr(g_scalar_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        b_cq = tl.load(p_cq, boundary_check=(0,)).to(tl.float32)
+        p_cq = g_scalar_cumsum + bos * HQ + i_hq + o_q * HQ
+        b_cq = tl.load(p_cq, mask=m_q, other=0.0).to(tl.float32)
 
     if USE_SINK_BIAS:
         b_sink_bias = tl.load(sink_bias + i_hq).to(tl.float32)
     else:
         b_sink_bias = None
 
-    o_q = i_t * BT + tl.arange(0, BT)
     i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0) if USE_WINDOW else 0
 
     b_R_t = tl.trans(b_R)
 
     for i_s in range(i_start, i_t * BT, BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-        p_pk = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (K, T), (1, HQ*K), (0, i_s), (BK, BS), (0, 1))
+        o_k = i_s + tl.arange(0, BS)
+        m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_k[:, None] * (H*V) + o_v[None, :]
+        p_pk = g_cumsum + (bos * HQ + i_hq) * K + o_d[:, None] + o_k[None, :] * (HQ*K)
 
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
+        b_pk = tl.load(p_pk, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0).to(tl.float32)
         b_k_til = (b_k.to(tl.float32) * exp2(b_R_t - b_pk)).to(b_k.dtype)
         b_s = tl.dot(b_q_til, b_k_til) * scale * RCP_LN2
 
-        o_k = i_s + tl.arange(0, BS)
-        m_k = o_k < T
         if USE_SCALAR_G:
             b_ck = tl.load(g_scalar_cumsum + (bos + o_k) * HQ + i_hq, mask=m_k, other=0).to(tl.float32)
             b_s += b_cq[:, None] - b_ck[None, :]
@@ -197,21 +202,22 @@ def parallel_wall_attn_fwd_kernel(
         b_mp = b_m
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-        p_pk = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (K, T), (1, HQ*K), (0, i_s), (BK, BS), (0, 1))
+        o_k = i_s + tl.arange(0, BS)
+        m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_k[:, None] * (H*V) + o_v[None, :]
+        p_pk = g_cumsum + (bos * HQ + i_hq) * K + o_d[:, None] + o_k[None, :] * (HQ*K)
 
         # Per-sub-block local reference to prevent exp2 overflow.
-        p_R_local = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (1, BK), (1, 0))
-        b_R_local = tl.load(p_R_local, boundary_check=(0, 1)).to(tl.float32)
+        o_r = i_s + tl.arange(0, 1)
+        p_R_local = g_cumsum + (bos * HQ + i_hq) * K + o_r[:, None] * (HQ*K) + o_d[None, :]
+        b_R_local = tl.load(p_R_local, mask=(o_r[:, None] < T) & (o_d[None, :] < K), other=0.0).to(tl.float32)
         b_R_local_bc = tl.broadcast_to(b_R_local, (BT, BK))
         b_R_local_t = tl.trans(b_R_local)
 
-        o_k = i_s + tl.arange(0, BS)
-        m_k = o_k < T
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
+        b_v = tl.load(p_v, mask=m_k[:, None] & (o_v[None, :] < V), other=0.0)
+        b_pk = tl.load(p_pk, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0).to(tl.float32)
 
         # k_til in local frame: exp2 bounded by BS positions <= 110 (fp32-safe with BK dot).
         b_exp_k = b_R_local_t - b_pk
@@ -246,9 +252,9 @@ def parallel_wall_attn_fwd_kernel(
 
     b_o = b_o / b_acc[:, None]
     b_m += log2(b_acc)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_q[:, None] & (o_v[None, :] < V))
     if i_v == 0:
-        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty), boundary_check=(0,))
+        tl.store(p_lse, b_m.to(p_lse.dtype.element_ty), mask=m_q)
 
 
 @triton.autotune(
@@ -294,7 +300,7 @@ def parallel_wall_attn_bwd_kernel_dq(
     IS_VARLEN: tl.constexpr,
     USE_SCALAR_G: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
@@ -306,7 +312,7 @@ def parallel_wall_attn_bwd_kernel_dq(
         dg_scalar_cumsum += i_v64 * B * T * HQ
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -315,46 +321,52 @@ def parallel_wall_attn_bwd_kernel_dq(
     RCP_LN2: tl.constexpr = 1.4426950216
     LN2: tl.constexpr = 0.6931471805599453
 
-    p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_pq = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_R = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (1, BK), (1, 0))
-    p_dq = tl.make_block_ptr(dq + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_do = tl.make_block_ptr(do + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-    p_delta = tl.make_block_ptr(delta + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
+    o_q = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_q = o_q < T
+    m_qk = m_q[:, None] & (o_d[None, :] < K)
+    m_o = m_q[:, None] & (o_v[None, :] < V)
+    p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    p_pq = g_cumsum + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    o_r = i_t * BT + tl.arange(0, 1)
+    p_R = g_cumsum + (bos * HQ + i_hq) * K + o_r[:, None] * (HQ*K) + o_d[None, :]
+    p_dq = dq + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    p_dg = dg_cumsum + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+    p_do = do + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+    p_lse = lse + bos * HQ + i_hq + o_q * HQ
+    p_delta = delta + bos * HQ + i_hq + o_q * HQ
 
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_pq = tl.load(p_pq, boundary_check=(0, 1)).to(tl.float32)
-    b_R = tl.load(p_R, boundary_check=(0, 1)).to(tl.float32)
+    b_q = tl.load(p_q, mask=m_qk, other=0.0)
+    b_pq = tl.load(p_pq, mask=m_qk, other=0.0).to(tl.float32)
+    b_R = tl.load(p_R, mask=(o_r[:, None] < T) & (o_d[None, :] < K), other=0.0).to(tl.float32)
     # Off-diagonal q_til (bf16 tensor cores, exp2 <= 1).
     b_q_til = (b_q.to(tl.float32) * exp2(b_pq - b_R)).to(b_q.dtype)
 
-    b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
-    b_lse = tl.load(p_lse, boundary_check=(0,))
-    b_delta = tl.load(p_delta, boundary_check=(0,))
+    b_do = tl.load(p_do, mask=m_o, other=0.0)
+    b_lse = tl.load(p_lse, mask=m_q, other=0.0)
+    b_delta = tl.load(p_delta, mask=m_q, other=0.0)
 
     b_dq_til = tl.zeros([BT, BK], dtype=tl.float32)
 
     if USE_SCALAR_G:
-        p_cq = tl.make_block_ptr(g_scalar_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        b_cq = tl.load(p_cq, boundary_check=(0,)).to(tl.float32)
+        p_cq = g_scalar_cumsum + bos * HQ + i_hq + o_q * HQ
+        b_cq = tl.load(p_cq, mask=m_q, other=0.0).to(tl.float32)
         b_dc = tl.zeros([BT], dtype=tl.float32)
 
-    o_q = i_t * BT + tl.arange(0, BT)
     i_start = tl.maximum((i_t * BT - W + 1) // BS * BS, 0) if USE_WINDOW else 0
     b_R_t = tl.trans(b_R)
 
     for i_s in range(i_start, i_t * BT, BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
-        p_pk = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (K, T), (1, HQ*K), (0, i_s), (BK, BS), (0, 1))
-
         o_k = i_s + tl.arange(0, BS)
         m_k = o_k < T
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_v[:, None] + o_k[None, :] * (H*V)
+        p_pk = g_cumsum + (bos * HQ + i_hq) * K + o_d[:, None] + o_k[None, :] * (HQ*K)
+
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
+        b_pk = tl.load(p_pk, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0).to(tl.float32)
+        b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_k[None, :], other=0.0)
         b_k_til = (b_k.to(tl.float32) * exp2(b_R_t - b_pk)).to(b_k.dtype)
         b_s = tl.dot(b_q_til, b_k_til) * scale * RCP_LN2
 
@@ -375,20 +387,21 @@ def parallel_wall_attn_bwd_kernel_dq(
     b_dq_diag = tl.zeros([BT, BK], dtype=tl.float32)
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (K, T), (1, H*K), (0, i_s), (BK, BS), (0, 1))
-        p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (V, T), (1, H*V), (i_v * BV, i_s), (BV, BS), (0, 1))
-        p_pk = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (K, T), (1, HQ*K), (0, i_s), (BK, BS), (0, 1))
+        o_k = i_s + tl.arange(0, BS)
+        m_k = o_k < T
+        p_k = k + (bos * H + i_h) * K + o_d[:, None] + o_k[None, :] * (H*K)
+        p_v = v + (bos * H + i_h) * V + o_v[:, None] + o_k[None, :] * (H*V)
+        p_pk = g_cumsum + (bos * HQ + i_hq) * K + o_d[:, None] + o_k[None, :] * (HQ*K)
 
-        p_R_local = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (1, BK), (1, 0))
-        b_R_local = tl.load(p_R_local, boundary_check=(0, 1)).to(tl.float32)
+        o_r = i_s + tl.arange(0, 1)
+        p_R_local = g_cumsum + (bos * HQ + i_hq) * K + o_r[:, None] * (HQ*K) + o_d[None, :]
+        b_R_local = tl.load(p_R_local, mask=(o_r[:, None] < T) & (o_d[None, :] < K), other=0.0).to(tl.float32)
         b_R_local_bc = tl.broadcast_to(b_R_local, (BT, BK))
         b_R_local_t = tl.trans(b_R_local)
 
-        o_k = i_s + tl.arange(0, BS)
-        m_k = o_k < T
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
-        b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+        b_k = tl.load(p_k, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0)
+        b_pk = tl.load(p_pk, mask=(o_d[:, None] < K) & m_k[None, :], other=0.0).to(tl.float32)
+        b_v = tl.load(p_v, mask=(o_v[:, None] < V) & m_k[None, :], other=0.0)
 
         # Local-ref k_til: exp2 arg bounded by BS positions <= 110 (fp32-safe with BK dot).
         b_exp_k = b_R_local_t - b_pk
@@ -426,11 +439,11 @@ def parallel_wall_attn_bwd_kernel_dq(
 
     # Structural: b_dg derived from b_dq (saves [BT,BK] fp32 accumulator).
     b_dg = LN2 * b_q.to(tl.float32) * b_dq
-    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_qk)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_qk)
     if USE_SCALAR_G:
-        p_dc = tl.make_block_ptr(dg_scalar_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_dc, b_dc.to(p_dc.dtype.element_ty), boundary_check=(0,))
+        p_dc = dg_scalar_cumsum + bos * HQ + i_hq + o_q * HQ
+        tl.store(p_dc, b_dc.to(p_dc.dtype.element_ty), mask=m_q)
 
 
 @triton.autotune(
@@ -478,7 +491,7 @@ def parallel_wall_attn_bwd_kernel_dkv(
     USE_SCALAR_G: tl.constexpr,
     DIAG_BF16: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hq = i_bh // HQ, i_bh % HQ
     i_h = i_hq // G
 
@@ -490,7 +503,7 @@ def parallel_wall_attn_bwd_kernel_dkv(
         dg_scalar_cumsum += i_v64 * B * T * HQ
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
@@ -499,41 +512,46 @@ def parallel_wall_attn_bwd_kernel_dkv(
     RCP_LN2: tl.constexpr = 1.4426950216
     LN2: tl.constexpr = 0.6931471805599453
 
-    p_k = tl.make_block_ptr(k + (bos * H + i_h) * K, (T, K), (H*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_pk = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_v = tl.make_block_ptr(v + (bos * H + i_h) * V, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dk = tl.make_block_ptr(dk + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-    p_dv = tl.make_block_ptr(dv + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-    p_dg = tl.make_block_ptr(dg_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
+    o_k = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < T
+    m_kk = m_k[:, None] & (o_d[None, :] < K)
+    m_kv = m_k[:, None] & (o_v[None, :] < V)
+    p_k = k + (bos * H + i_h) * K + o_k[:, None] * (H*K) + o_d[None, :]
+    p_pk = g_cumsum + (bos * HQ + i_hq) * K + o_k[:, None] * (HQ*K) + o_d[None, :]
+    p_v = v + (bos * H + i_h) * V + o_k[:, None] * (H*V) + o_v[None, :]
+    p_dk = dk + (bos * HQ + i_hq) * K + o_k[:, None] * (HQ*K) + o_d[None, :]
+    p_dv = dv + (bos * HQ + i_hq) * V + o_k[:, None] * (HQ*V) + o_v[None, :]
+    p_dg = dg_cumsum + (bos * HQ + i_hq) * K + o_k[:, None] * (HQ*K) + o_d[None, :]
 
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-    b_pk = tl.load(p_pk, boundary_check=(0, 1)).to(tl.float32)
+    b_k = tl.load(p_k, mask=m_kk, other=0.0)
+    b_pk = tl.load(p_pk, mask=m_kk, other=0.0).to(tl.float32)
     b_dk = tl.zeros([BT, BK], dtype=tl.float32)
-    b_v = tl.load(p_v, boundary_check=(0, 1), padding_option="zero")
+    b_v = tl.load(p_v, mask=m_kv, other=0.0)
     b_dv = tl.zeros([BT, BV], dtype=tl.float32)
 
-    o_k = i_t * BT + tl.arange(0, BT)
-
     if USE_SCALAR_G:
-        p_ck = tl.make_block_ptr(g_scalar_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        b_ck = tl.load(p_ck, boundary_check=(0,)).to(tl.float32)
+        p_ck = g_scalar_cumsum + bos * HQ + i_hq + o_k * HQ
+        b_ck = tl.load(p_ck, mask=m_k, other=0.0).to(tl.float32)
         b_dc = tl.zeros([BT], dtype=tl.float32)
 
     for i_s in range(i_t * BT, min((i_t + 1) * BT, T), BS):
-        p_Rq = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (1, BK), (1, 0))
-        p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (BS, BK), (1, 0))
-        p_pq = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (BS, BK), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-        p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-        p_delta = tl.make_block_ptr(delta + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-
         o_q = i_s + tl.arange(0, BS)
         m_q = o_q < T
-        b_Rq = tl.load(p_Rq, boundary_check=(0, 1)).to(tl.float32)
+        o_r = i_s + tl.arange(0, 1)
+        p_Rq = g_cumsum + (bos * HQ + i_hq) * K + o_r[:, None] * (HQ*K) + o_d[None, :]
+        p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+        p_pq = g_cumsum + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+        p_do = do + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_lse = lse + bos * HQ + i_hq + o_q * HQ
+        p_delta = delta + bos * HQ + i_hq + o_q * HQ
+
+        b_Rq = tl.load(p_Rq, mask=(o_r[:, None] < T) & (o_d[None, :] < K), other=0.0).to(tl.float32)
         b_Rq_bc_k = tl.broadcast_to(b_Rq, (BT, BK))
         b_Rq_bc_q = tl.broadcast_to(b_Rq, (BS, BK))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_pq = tl.load(p_pq, boundary_check=(0, 1)).to(tl.float32)
+        b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
+        b_pq = tl.load(p_pq, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0).to(tl.float32)
         b_exp_k = b_Rq_bc_k - b_pk
         # Non-causal keys (key_pos > last query in sub-block) can have
         # exp_k >> 110, overflowing the gradient headroom.  The causal mask
@@ -550,9 +568,9 @@ def parallel_wall_attn_bwd_kernel_dkv(
             # Precise path: fp32 tensor cores.
             b_q_til = b_q.to(tl.float32) * exp2(b_pq - b_Rq_bc_q)
             b_k_til = b_k.to(tl.float32) * b_exp_k_val
-        b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
-        b_lse = tl.load(p_lse, boundary_check=(0,))
-        b_delta = tl.load(p_delta, boundary_check=(0,))
+        b_do = tl.load(p_do, mask=m_q[:, None] & (o_v[None, :] < V), other=0.0)
+        b_lse = tl.load(p_lse, mask=m_q, other=0.0)
+        b_delta = tl.load(p_delta, mask=m_q, other=0.0)
         b_s = tl.dot(b_k_til, tl.trans(b_q_til)) * scale * RCP_LN2
         if USE_SCALAR_G:
             b_cq = tl.load(g_scalar_cumsum + (bos + o_q) * HQ + i_hq, mask=m_q, other=0).to(tl.float32)
@@ -578,27 +596,28 @@ def parallel_wall_attn_bwd_kernel_dkv(
     i_end = min(tl.cdiv(T, BS) * BS, (i_t + 1) * BT + W - 1) if USE_WINDOW else tl.cdiv(T, BS) * BS
 
     for i_s in range((i_t + 1) * BT, i_end, BS):
-        p_Rq = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (1, BK), (1, 0))
-        p_q = tl.make_block_ptr(q + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (BS, BK), (1, 0))
-        p_pq = tl.make_block_ptr(g_cumsum + (bos * HQ + i_hq) * K, (T, K), (HQ*K, 1), (i_s, 0), (BS, BK), (1, 0))
-        p_do = tl.make_block_ptr(do + (bos * HQ + i_hq) * V, (T, V), (HQ*V, 1), (i_s, i_v * BV), (BS, BV), (1, 0))
-        p_lse = tl.make_block_ptr(lse + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-        p_delta = tl.make_block_ptr(delta + bos * HQ + i_hq, (T,), (HQ,), (i_s,), (BS,), (0,))
-
         o_q = i_s + tl.arange(0, BS)
         m_q = o_q < T
-        b_Rq = tl.load(p_Rq, boundary_check=(0, 1)).to(tl.float32)
+        o_r = i_s + tl.arange(0, 1)
+        p_Rq = g_cumsum + (bos * HQ + i_hq) * K + o_r[:, None] * (HQ*K) + o_d[None, :]
+        p_q = q + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+        p_pq = g_cumsum + (bos * HQ + i_hq) * K + o_q[:, None] * (HQ*K) + o_d[None, :]
+        p_do = do + (bos * HQ + i_hq) * V + o_q[:, None] * (HQ*V) + o_v[None, :]
+        p_lse = lse + bos * HQ + i_hq + o_q * HQ
+        p_delta = delta + bos * HQ + i_hq + o_q * HQ
+
+        b_Rq = tl.load(p_Rq, mask=(o_r[:, None] < T) & (o_d[None, :] < K), other=0.0).to(tl.float32)
         b_Rq_bc_k = tl.broadcast_to(b_Rq, (BT, BK))
         b_Rq_bc_q = tl.broadcast_to(b_Rq, (BS, BK))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_pq = tl.load(p_pq, boundary_check=(0, 1)).to(tl.float32)
+        b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
+        b_pq = tl.load(p_pq, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0).to(tl.float32)
         b_q_til = (b_q.to(tl.float32) * exp2(b_pq - b_Rq_bc_q)).to(b_q.dtype)
         b_exp_k_off = b_Rq_bc_k - b_pk
         b_exp_k_off_val = exp2(b_exp_k_off)  # CSE: reused for k_til and final dk scaling
         b_k_til = (b_k.to(tl.float32) * b_exp_k_off_val).to(b_k.dtype)
-        b_do = tl.load(p_do, boundary_check=(0, 1), padding_option="zero")
-        b_lse = tl.load(p_lse, boundary_check=(0,))
-        b_delta = tl.load(p_delta, boundary_check=(0,))
+        b_do = tl.load(p_do, mask=m_q[:, None] & (o_v[None, :] < V), other=0.0)
+        b_lse = tl.load(p_lse, mask=m_q, other=0.0)
+        b_delta = tl.load(p_delta, mask=m_q, other=0.0)
         b_s = tl.dot(b_k_til, tl.trans(b_q_til)) * scale * RCP_LN2
         if USE_SCALAR_G:
             b_cq = tl.load(g_scalar_cumsum + (bos + o_q) * HQ + i_hq, mask=m_q, other=0).to(tl.float32)
@@ -617,12 +636,12 @@ def parallel_wall_attn_bwd_kernel_dkv(
 
     # Structural: b_dg derived from b_dk (saves [BT,BK] fp32 accumulator).
     b_dg = -LN2 * b_k.to(tl.float32) * b_dk
-    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_kk)
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_kv)
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_kk)
     if USE_SCALAR_G:
-        p_dc = tl.make_block_ptr(dg_scalar_cumsum + bos * HQ + i_hq, (T,), (HQ,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_dc, b_dc.to(p_dc.dtype.element_ty), boundary_check=(0,))
+        p_dc = dg_scalar_cumsum + bos * HQ + i_hq + o_k * HQ
+        tl.store(p_dc, b_dc.to(p_dc.dtype.element_ty), mask=m_k)
 
 
 @dispatch('attn')


### PR DESCRIPTION
## Why

triton main removed block pointers (`tl.make_block_ptr` / `tl.advance`) in triton-lang/triton#10833 — they now raise `NotImplementedError` at compile time, so fla no longer compiles against triton main (#1059).

## What

Migrate all 2147 call sites across 88 files under `fla/` (normal triton path only; `backends/triton_ascend/` untouched) to plain pointer arithmetic with explicit masks:

- `tl.make_block_ptr(base, shape, strides, offsets, block_shape, order)` → per-dimension offset vectors (`offset + tl.arange(0, B)`) and pointer expressions `base + Σ o_d * stride_d`; `order` is a pure layout hint and is dropped
- `boundary_check` dims → equivalent `mask=`; `padding_option` → `other=0.0`/`nan`; no `boundary_check` → no mask (unchanged semantics)
- `tl.advance` → accumulated scalar offsets, pointers rebuilt per iteration
- Sequence-scaled row indices are cast to `tl.int64` at the source (program ids / loaded chunk indices), matching the repo convention (abfa403d), since block_ptr computed offsets in int64 internally

Each file is migrated in its own commit for easier review sampling. A final minimality pass (one commit) removed migration leftovers (dead variables, no-op casts, duplicate definitions) and reverted incidental changes; comments are untouched.

## Why plain loads and not tensor descriptors

- `make_block_ptr` already lowered to regular vectorized loads, not TMA — plain loads are behavior- and performance-equivalent by construction, while descriptor migration is not a mechanical rename (offsets move to the load, boundary_check folds into padding, 16-byte alignment required)
- Several backward kernels use transposed blocks (stride-1 outermost) that TMA descriptors cannot express without reworking their data flow
- Plain loads keep the NV / AMD / NPU / Intel CI matrix green

## Verification (H200)

- **triton 3.6 (current release)**: every affected op suite passes — behavior unchanged.
- **triton main (source build, 3.8.0)**: the same suites pass — the repo compiles and runs where #1059 reported failure:
  - kda 29/29; base (utils+modules) 294, common/cp via gdn+delta chunk 33; delta 246 + gdn 114; linear-a 166; linear-b 111; attn (nsa/wall/path/attn) all green (33 passed in the final path_attn+attn pass; the two pre-existing tilelang-hang cases below deselected)
- Single wall_attn bwd cases can take up to ~6 min each on triton main due to pathological ptxas compile times for large fp32-ieee tiles (same family as the repo's existing fwd config pruning); correctness unaffected.

### Known pre-existing issues (also present on unmodified main; excluded from acceptance, NOT introduced by this change)

- `test_kda.py::test_chunk_varlen[H4-D60-...-chunk_size32]`: CUDA misaligned address (D=60 varlen shape)
- `test_simple_gla.py::test_chunk_state_v_first[B2-T256-H4-D64-fp32]`: tilelang layout error
- `test_attn.py::test_parallel_with_g[B1-T63-H1-HQ1-D64-scale1.0]`: hangs in tilelang JIT (>10 h), deselected in our runs
- `fla/ops/abc` mixed-dtype `initial_state` (fp32 h0, bf16 h) path: compile error with block_ptr on main (this migration's plain-pointer version happens not to trigger it)

Closes #1059.
