### PR TITLE
[CI] Forbid tl.make_block_ptr/advance in lint and skip H100 CI for NPU-only PRs

### DIFF
--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -21,11 +21,52 @@ on:
       - main
 
 jobs:
+  # Detect PRs that only touch NPU-only code (triton-ascend backend files,
+  # Ascend workflow definitions) so the H100 jobs below can skip them.
+  # Shared files — including backend __init__.py files, which GPU imports
+  # unconditionally — always get the full GPU pipeline. Push events and
+  # titles containing '[nv]' force the full pipeline.
+  changes:
+    name: Detect NPU-only changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      npu_only: ${{ steps.detect.outputs.npu_only }}
+    steps:
+      - name: Detect NPU-only diff
+        id: detect
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            if (context.eventName !== 'pull_request' && context.eventName !== 'pull_request_review') {
+              core.setOutput('npu_only', 'false');
+              return;
+            }
+            const pr = context.payload.pull_request;
+            if (pr.title.includes('[nv]')) {
+              core.info('title contains [nv]: forcing H100 CI');
+              core.setOutput('npu_only', 'false');
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            // Safe set: triton-ascend backend files (except __init__.py, which
+            // GPU imports unconditionally) and Ascend workflow definitions.
+            const safePattern = /^fla\/(.+\/)?backends\/triton_ascend\/(?!.*__init__\.py$)|^\.github\/workflows\/ascend-/;
+            const unsafe = files.filter(f => !safePattern.test(f.filename)).map(f => f.filename);
+            if (unsafe.length > 0) {
+              core.info('GPU-affecting files changed: ' + unsafe.join(', '));
+            }
+            core.setOutput('npu_only', files.length > 0 && unsafe.length === 0 ? 'true' : 'false');
+
   test-h100-pytorch-2-12:
     name: Test H100 (PyTorch 2.12)
     # Test on all main commits and PRs, but skip on closed PRs
-    # to avoid running tests on merged PRs.
-    if: github.event_name != 'pull_request_review' && (github.event_name != 'pull_request' || github.event.action != 'closed')
+    # to avoid running tests on merged PRs, and skip NPU-only PRs.
+    needs: changes
+    if: needs.changes.outputs.npu_only != 'true' && github.event_name != 'pull_request_review' && (github.event_name != 'pull_request' || github.event.action != 'closed')
     uses: ./.github/workflows/reusable-ci-tests.yml
     with:
       runner: 'nvidia-h100-1'
@@ -35,9 +76,11 @@ jobs:
 
   check_h100_pytorch_2_7:
     name: Check H100 PyTorch 2.7 Eligibility
+    needs: changes
     if: >
-      (github.event_name == 'pull_request' && github.event.action != 'closed') ||
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.state == 'open')
+      needs.changes.outputs.npu_only != 'true' &&
+      ((github.event_name == 'pull_request' && github.event.action != 'closed') ||
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.state == 'open'))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     outputs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,15 @@ repos:
   - id: autopep8
     args: [--in-place]
     exclude: ^tests/conftest\.py$
+
+- repo: local
+  hooks:
+  # tl.make_block_ptr / tl.advance were removed in triton main (issue #1059);
+  # GPU kernels were migrated off them in #1062. The triton-ascend fork still
+  # supports these APIs, so NPU backend files are exempt.
+  - id: no-make-block-ptr
+    name: forbid tl.make_block_ptr / tl.advance (removed in triton main)
+    language: pygrep
+    entry: 'make_block_ptr|tl\.advance\b'
+    types: [python]
+    exclude: 'backends/triton_ascend/'

--- a/fla/modules/fused_norm_gate.py
+++ b/fla/modules/fused_norm_gate.py
@@ -244,8 +244,8 @@ def layer_norm_gated_bwd_kernel(
 
     # the caller guarantees NS = min(SM, T), so every program has at least one token.
     # the last program's range may slightly exceed T (since BS = ceil(T/NS));
-    # make_block_ptr uses the true tensor shape (T, D), so boundary_check
-    # handles the partial tail tile by zero-padding loads and skipping stores.
+    # accesses are bounded by the true tensor shape (T, D), so the partial
+    # tail tile is handled by zero-padding loads and skipping stores.
     # the m_t mask below further ensures dw/db only accumulate valid rows (< T).
     for i_t in range(i_s * BS, i_s * BS + BS, BT):
         o_t = (i_t + tl.arange(0, BT)).to(tl.int64)
@@ -570,7 +570,7 @@ def layer_norm_gated_bwd(
         raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
     # cap program count to T so no program is completely idle.
     # without this, high-SM GPUs (e.g. B200, 160 SMs) with small T would
-    # launch idle programs whose make_block_ptr offsets exceed the tensor shape.
+    # launch idle programs whose tile offsets exceed the tensor shape.
     NS = min(get_multiprocessor_count(x.device.index), T)
     BS = math.ceil(T / NS)
 

--- a/fla/modules/layernorm.py
+++ b/fla/modules/layernorm.py
@@ -381,7 +381,7 @@ def layer_norm_bwd_kernel(
         b_b = tl.load(b + i_g * D + o_d, mask=m_d, other=0.0).to(tl.float32)
         b_db = tl.zeros((BT, BD), dtype=tl.float32)
 
-    # Tg: number of tokens per group, used as the logical shape for make_block_ptr.
+    # Tg: number of tokens per group, used as the logical row count for tile indexing.
     # for mean/rstd with shape (T,) and stride (G,), the strided view has Tg elements per group.
     # the caller guarantees NS capped so every program has work.
     # the last program's range may slightly exceed Tg (since BS = cdiv(T, NS));
@@ -664,7 +664,7 @@ def layer_norm_bwd(
     # each program handles one group only.
     # cap per-group program count to T // G so no program is completely idle.
     # without this, high-SM GPUs (e.g. B200, 160 SMs) with small T would
-    # launch idle programs whose make_block_ptr offsets exceed the tensor shape.
+    # launch idle programs whose tile offsets exceed the tensor shape.
     NS = min(triton.cdiv(get_multiprocessor_count(x.device.index), G), T // G) * G
     BS = triton.cdiv(T, NS)
     GS = NS // G

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -24,7 +24,7 @@ BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
 def _prune_gla_bwd_configs(configs, nargs, **kwargs):
     # Keep a tile only if it leaves headroom below its dim, or is the smallest
     # option (so small dims still autotune); this avoids a software-pipelined
-    # make_block_ptr prefetching past the tensor. K/V arrive as launch kwargs.
+    # block load prefetching past the tensor. K/V arrive as launch kwargs.
     args = {**(nargs or {}), **kwargs}
     K, V = args['K'], args['V']
     min_bk = min(c.kwargs['BK'] for c in configs)

--- a/tests/modules/test_layernorm.py
+++ b/tests/modules/test_layernorm.py
@@ -231,7 +231,7 @@ def test_rmsnorm_linear(N: int, D: int):
 # when T (total tokens) is small relative to the SM count,
 # some Triton programs in layer_norm_bwd_kernel have no work
 # (i_sg * BS >= T // G). Without an early-exit guard, these
-# idle programs access invalid memory via make_block_ptr,
+# idle programs access invalid memory via out-of-bounds tile loads,
 # causing "CUDA error: illegal memory access."
 #
 # The bug triggers when:


### PR DESCRIPTION
## Summary

Two CI improvements:

**1. Lint: forbid `tl.make_block_ptr` / `tl.advance`** (both locally and in CI)

`triton main` removed these APIs (#1059); GPU kernels were migrated off them in #1062. This adds a `pygrep` local hook to `.pre-commit-config.yaml` so any reintroduction fails both local `pre-commit` and the lint workflow (which runs `pre-commit run --files`) — no CI wiring needed. The `triton-ascend` fork still supports these APIs, so `backends/triton_ascend/` files are exempt. Six stale comments that referenced the API by name are reworded in this PR (the hook scans whole changed files, so leaving them would trip unrelated future edits).

**2. Skip H100 CI for NPU-only PRs**

A fast `changes` job (ubuntu-latest, ~5s) lists PR files via the API and marks a PR as NPU-only when every changed file is under `fla/**/backends/triton_ascend/` — **except `__init__.py`, which GPU imports unconditionally** — or `.github/workflows/ascend-*`. `test-h100-pytorch-2-12` and `check_h100_pytorch_2_7` then skip via `needs.changes.outputs.npu_only != 'true'`; `benchmark-h100` and the 2.7 ops job follow through their `needs` chains. Deliberately NOT title-based: recent Ascend-titled PRs (#1056/#1057/#1060) all touched shared files that run on H100, so title matching would have skipped real GPU validation. Escape hatches: push to main always runs the full pipeline, and a PR title containing `[nv]` forces H100 CI.

The 2.7 eligibility job's condition is updated together with the 2.12 job — it polls for the 2.12 check runs and would otherwise wait 85 min and fail on skipped checks.

## Test plan

- [x] `pre-commit run --all-files` passes (hook included)
- [x] Hook fires on `tl.make_block_ptr`, `tl.advance`, and `from triton.language import make_block_ptr`; skips `backends/triton_ascend/` files
- [x] Path regex validated against 14 representative changed-file cases (shared `backends/__init__.py`, tests, benchmarks, workflows, pyproject all correctly GPU-affecting)
- [x] Workflow YAML parses; github-script body syntax-checked
- [ ] This PR itself touches shared files → `changes` must output `npu_only=false` and H100 CI must run (self-demonstrating)