### PR TITLE
[Perf] Optimize Ascend prepare_wy_repr_bwd with fused KV kernel, core-grid launch, and varlen tests

### DIFF
--- a/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
@@ -29,32 +29,72 @@ def get_npu_properties():
     return driver.active.utils.get_device_properties(device)
 
 
-_NUM_WARPS = 2
-# prepare_wy_repr_bwd: multiple [BT,BT] fp32 tiles + [BT,BK/BV] tiles
-_PREPARE_BWD_MEM_MULT = 18.0
+# prepare_wy_repr_bwd stage-specific UB models
+_PREPARE_BWD_K_MEM_MULT = 4.5
+_PREPARE_BWD_V_MEM_MULT = 8.0
 _SAFETY_MARGIN = 0.75
 _FALLBACK_TILE = 8
-_MAX_TILE_BWD = 32
+_MAX_TILE_BWD = 128
 
 
-def _get_bwd_tiles(BT: int, K: int, V: int) -> tuple[int, int]:
-    BK = compute_row_tile_block_size(
-        BT, K, _PREPARE_BWD_MEM_MULT,
+def _g_npu_arg(g: torch.Tensor | None, HV: int) -> tuple[torch.Tensor | None, bool]:
+    if g is None or HV == 1:
+        return g, False
+    return g.transpose(1, 2).contiguous(), True
+
+
+def _beta_npu_arg(beta: torch.Tensor, HV: int) -> tuple[torch.Tensor, bool]:
+    if HV == 1:
+        return beta, False
+    return beta.transpose(1, 2).contiguous(), True
+
+
+def _t_npu_buf(
+    B: int, T: int, HV: int, *, dtype: torch.dtype, device: torch.device,
+) -> tuple[torch.Tensor, bool]:
+    if HV == 1:
+        return torch.empty(B, T, HV, dtype=dtype, device=device), False
+    return torch.empty(B, HV, T, dtype=dtype, device=device), True
+
+
+def _get_bwd_k_tile(BT: int, K: int) -> int:
+    return compute_row_tile_block_size(
+        BT, K, _PREPARE_BWD_K_MEM_MULT,
         tiling_row=False,
         safety_margin=_SAFETY_MARGIN,
         fallback=_FALLBACK_TILE,
         min_block=8,
         max_block=min(_MAX_TILE_BWD, triton.next_power_of_2(K)),
     )
-    BV = compute_row_tile_block_size(
-        BT, V, _PREPARE_BWD_MEM_MULT,
+
+
+def _get_bwd_v_tile(BT: int, V: int) -> int:
+    return compute_row_tile_block_size(
+        BT, V, _PREPARE_BWD_V_MEM_MULT,
         tiling_row=False,
         safety_margin=_SAFETY_MARGIN,
         fallback=_FALLBACK_TILE,
         min_block=8,
         max_block=min(_MAX_TILE_BWD, triton.next_power_of_2(V)),
     )
-    return BK, BV
+
+
+def _get_bwd_tiles(BT: int, K: int, V: int) -> tuple[int, int]:
+    return _get_bwd_k_tile(BT, K), _get_bwd_v_tile(BT, V)
+
+
+@triton.jit
+def _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN: tl.constexpr):
+    if IS_VARLEN:
+        return g + bos + i_h * T_seq
+    return g + i_b * HV * T_seq + i_h * T_seq
+
+
+@triton.jit
+def _t_block_ptr(base, T, offset, BLK, CONTIG: tl.constexpr, HV: tl.constexpr):
+    if CONTIG:
+        return tl.make_block_ptr(base, (T,), (1,), (offset,), (BLK,), (0,))
+    return tl.make_block_ptr(base, (T,), (HV,), (offset,), (BLK,), (0,))
 
 
 def _launch_wy_kernel(kernel, *, NT: int, bh_total: int, kernel_kwargs: dict) -> None:
@@ -73,6 +113,11 @@ def _launch_wy_kernel(kernel, *, NT: int, bh_total: int, kernel_kwargs: dict) ->
             bh_len = min(max_bh, bh_total - bh_off)
             kernel_kwargs['BH_OFFSET'] = bh_off
             kernel[(nt_len, bh_len)](**kernel_kwargs)
+
+
+def _launch_wy_core_grid(kernel, *, task_num: int, kernel_kwargs: dict) -> None:
+    num_core = get_npu_properties()["num_aicore"]
+    kernel[(num_core,)](task_num=task_num, num_core=num_core, **kernel_kwargs)
 
 
 @triton.heuristics({
@@ -169,152 +214,136 @@ def recompute_w_u_fwd_kernel_npu(
             b_kb = b_k * b_beta[:, None]
             if USE_G:
                 b_kb = b_kb * b_g[:, None]
-            b_w = tl.dot(b_A, b_kb)
+            b_w = tl.dot(b_A, b_kb, allow_tf32=False)
 
             ptr_w = w + (bos * HV + i_h) * K + offs_t_2d * (HV * K) + offs_k * 1
             tl.store(ptr_w, b_w.to(ptr_w.dtype.element_ty), mask=mask_k)
 
 
-@triton.jit(do_not_specialize=['T'])
-def prepare_wy_repr_bwd_k_npu(
-    k, beta, g, A, dw, dk, dA_scr, db, dg,
-    cu_seqlens, chunk_indices, T,
-    H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr,
-    BT: tl.constexpr, BK: tl.constexpr,
+@triton.heuristics({
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+})
+@triton.jit(do_not_specialize=["T", "B", "task_num", "num_core"])
+def prepare_wy_repr_bwd_kv_npu(
+    k, v, beta, g, A, dw, du, dk, dv, dA_scr, db, dg,
+    cu_seqlens, chunk_indices, T, B,
+    task_num, num_core,
+    H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr,
     USE_G: tl.constexpr, IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr, BH_OFFSET: tl.constexpr,
+    G_T_CONTIG: tl.constexpr, BETA_T_CONTIG: tl.constexpr,
+    DG_T_CONTIG: tl.constexpr, DB_T_CONTIG: tl.constexpr,
+    G_EXP_PRECOMP: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_h = i_bh // HV, i_bh % HV
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
-    else:
-        bos, eos = i_b * T, i_b * T + T
+    T_seq = T
+    core_id = tl.program_id(0)
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t_o = task_id // (B * HV)
+        i_bh = task_id % (B * HV)
+        i_b, i_h = i_bh // HV, i_bh % HV
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t_o * 2).to(tl.int32), tl.load(
+                chunk_indices + i_t_o * 2 + 1
+            ).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+                cu_seqlens + i_n + 1
+            ).to(tl.int32)
+            T = eos - bos
+        else:
+            i_t = i_t_o
+            bos, eos = i_b * T_seq, i_b * T_seq + T_seq
 
-    p_b = tl.make_block_ptr(beta + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_dA = tl.make_block_ptr(dA_scr + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-
-    b_b = tl.load(p_b, boundary_check=(0,))
-    b_db = tl.zeros([BT], dtype=tl.float32)
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
-
-    if USE_G:
-        p_g = tl.make_block_ptr(g + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
-        b_g_exp = exp2(b_g)
-        b_dg = tl.zeros([BT], dtype=tl.float32)
-
-    for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(
-            k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
+        if BETA_T_CONTIG:
+            beta_ptr = _g_contig_base(beta, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+            p_b = _t_block_ptr(beta_ptr, T, i_t * BT, BT, True, HV)
+        else:
+            p_b = tl.make_block_ptr(beta + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        if DB_T_CONTIG:
+            db_ptr = _g_contig_base(db, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+            p_db = _t_block_ptr(db_ptr, T, i_t * BT, BT, True, HV)
+        else:
+            p_db = tl.make_block_ptr(db + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        p_A = tl.make_block_ptr(
+            A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1),
         )
-        p_dk = tl.make_block_ptr(dk + (bos * HV + i_h) * K, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dw = tl.make_block_ptr(dw + (bos * HV + i_h) * K, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_dA = tl.make_block_ptr(
+            dA_scr + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1),
+        )
+
+        b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+        b_db = tl.zeros([BT], dtype=tl.float32)
+        b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+        b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+
         if USE_G:
-            b_kbg = b_k * (b_b * b_g_exp)[:, None]
-        else:
-            b_kbg = b_k * b_b[:, None]
-        b_dw = tl.load(p_dw, boundary_check=(0, 1))
-        b_dA += tl.dot(b_dw, tl.trans(b_kbg).to(b_dw.dtype))
-        b_dkbg = tl.dot(b_A.to(b_dw.dtype), b_dw)
+            if G_T_CONTIG:
+                g_ptr = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+                p_g = _t_block_ptr(g_ptr, T, i_t * BT, BT, True, HV)
+            else:
+                p_g = tl.make_block_ptr(g + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+            b_g_exp = b_g if G_EXP_PRECOMP else exp2(b_g)
+            b_dg = tl.zeros([BT], dtype=tl.float32)
+
+        for i_k in range(tl.cdiv(K, BK)):
+            p_k = tl.make_block_ptr(
+                k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
+            )
+            p_dk = tl.make_block_ptr(
+                dk + (bos * HV + i_h) * K, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
+            )
+            p_dw = tl.make_block_ptr(
+                dw + (bos * HV + i_h) * K, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+            if USE_G:
+                b_kbg = b_k * (b_b * b_g_exp)[:, None]
+            else:
+                b_kbg = b_k * b_b[:, None]
+            b_dw = tl.load(p_dw, boundary_check=(0, 1)).to(tl.float32)
+            b_dA += tl.dot(b_dw, tl.trans(b_kbg), allow_tf32=False)
+            b_dkbg = tl.dot(b_A, b_dw, allow_tf32=False)
+            if USE_G:
+                b_dk = b_dkbg * (b_g_exp * b_b)[:, None]
+                b_db += tl.sum(b_dkbg * b_k * b_g_exp[:, None], 1)
+                b_dg += tl.sum(b_dkbg * b_kbg, 1)
+            else:
+                b_dk = b_dkbg * b_b[:, None]
+                b_db += tl.sum(b_dkbg * b_k, 1)
+            tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+
+        for i_v in range(tl.cdiv(V, BV)):
+            p_v = tl.make_block_ptr(
+                v + (bos * HV + i_h) * V, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0),
+            )
+            p_dv = tl.make_block_ptr(
+                dv + (bos * HV + i_h) * V, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0),
+            )
+            p_du = tl.make_block_ptr(
+                du + (bos * HV + i_h) * V, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0),
+            )
+            b_v = tl.load(p_v, boundary_check=(0, 1)).to(tl.float32)
+            b_du = tl.load(p_du, boundary_check=(0, 1)).to(tl.float32)
+            b_vb = b_v * b_b[:, None]
+            b_dA += tl.dot(b_du, tl.trans(b_vb), allow_tf32=False)
+            b_dvb = tl.dot(b_A, b_du, allow_tf32=False)
+            b_dv = b_dvb * b_b[:, None]
+            b_db += tl.sum(b_dvb * b_v, 1)
+            tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+        tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
         if USE_G:
-            b_dk = b_dkbg * (b_g_exp * b_b)[:, None]
-            b_db += tl.sum(b_dkbg * b_k * b_g_exp[:, None], 1)
-            b_dg += tl.sum(b_dkbg * b_kbg, 1)
-        else:
-            b_dk = b_dkbg * b_b[:, None]
-            b_db += tl.sum(b_dkbg * b_k, 1)
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
-    if USE_G:
-        p_dg = tl.make_block_ptr(dg + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+            if DG_T_CONTIG:
+                dg_ptr = _g_contig_base(dg, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+                p_dg = _t_block_ptr(dg_ptr, T, i_t * BT, BT, True, HV)
+            else:
+                p_dg = tl.make_block_ptr(dg + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+            tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
 
 
 @triton.jit(do_not_specialize=['T'])
-def prepare_wy_repr_bwd_v_npu(
-    v, beta, A, du, dv, dA_scr, db,
-    cu_seqlens, chunk_indices, T,
-    HV: tl.constexpr, V: tl.constexpr,
-    BT: tl.constexpr, BV: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr, BH_OFFSET: tl.constexpr,
-):
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_h = i_bh // HV, i_bh % HV
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
-    else:
-        bos, eos = i_b * T, i_b * T + T
-
-    p_b = tl.make_block_ptr(beta + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_dA = tl.make_block_ptr(dA_scr + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-
-    b_b = tl.load(p_b, boundary_check=(0,))
-    b_db = tl.load(p_db, boundary_check=(0,)).to(tl.float32)
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
-
-    for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v + (bos * HV + i_h) * V, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv + (bos * HV + i_h) * V, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_du = tl.make_block_ptr(du + (bos * HV + i_h) * V, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1))
-        b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
-        b_du = tl.load(p_du, boundary_check=(0, 1))
-        b_dA += tl.dot(b_du, tl.trans(b_vb))
-        b_dvb = tl.dot(b_A, b_du)
-        b_dv = b_dvb * b_b[:, None]
-        b_db += tl.sum(b_dvb * b_v, 1)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
-
-
-@triton.jit(do_not_specialize=['T'])
-def prepare_wy_repr_bwd_da_mask_npu(
-    dA_scr,
-    cu_seqlens, chunk_indices, T,
-    HV: tl.constexpr, BT: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr, BH_OFFSET: tl.constexpr,
-):
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_h = i_bh // HV, i_bh % HV
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
-    else:
-        bos, eos = i_b * T, i_b * T + T
-
-    p_dA = tl.make_block_ptr(dA_scr + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
-    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
-    b_dA = tl.where(m_A, b_dA, 0)
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-
-
-@triton.jit(do_not_specialize=['T'])
-def prepare_wy_repr_bwd_da_dot1_npu(
+def prepare_wy_repr_bwd_da_mask_dot1_npu(
     A, dA_scr, dA_mid,
     cu_seqlens, chunk_indices, T,
     HV: tl.constexpr, BT: tl.constexpr,
@@ -325,18 +354,32 @@ def prepare_wy_repr_bwd_da_dot1_npu(
     i_bh = tl.program_id(1) + BH_OFFSET
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_in = tl.make_block_ptr(dA_scr + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_out = tl.make_block_ptr(dA_mid + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    p_A = tl.make_block_ptr(
+        A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1),
+    )
+    p_in = tl.make_block_ptr(
+        dA_scr + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1),
+    )
+    p_out = tl.make_block_ptr(
+        dA_mid + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1),
+    )
+    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
     b_dA = tl.load(p_in, boundary_check=(0, 1)).to(tl.float32)
-    b_out = tl.dot(b_dA, b_A.to(tl.float32))
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
+    b_dA = tl.where(m_A, b_dA, 0)
+    b_out = tl.dot(b_dA, b_A, allow_tf32=False)
     tl.store(p_out, b_out.to(p_out.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -361,9 +404,9 @@ def prepare_wy_repr_bwd_da_dot2_npu(
     p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
     p_in = tl.make_block_ptr(dA_mid + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
     p_out = tl.make_block_ptr(dA_out + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
     b_dA = tl.load(p_in, boundary_check=(0, 1)).to(tl.float32)
-    b_dA = tl.dot(b_A.to(tl.float32), b_dA)
+    b_dA = tl.dot(b_A, b_dA, allow_tf32=False)
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
@@ -379,24 +422,33 @@ def prepare_wy_repr_bwd_da_gate_npu(
     g, dA_out,
     cu_seqlens, chunk_indices, T,
     HV: tl.constexpr, BT: tl.constexpr, BC: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
+    IS_VARLEN: tl.constexpr, G_T_CONTIG: tl.constexpr,
     NT_OFFSET: tl.constexpr, BH_OFFSET: tl.constexpr,
 ):
     i_t = tl.program_id(0) + NT_OFFSET
     i_bh = tl.program_id(1) + BH_OFFSET
     i_b, i_h = i_bh // HV, i_bh % HV
+    T_seq = T
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
 
     n_sub = BT // BC
+    if G_T_CONTIG:
+        g_ptr = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+    else:
+        g_ptr = g + (bos * HV + i_h)
 
     for r in range(n_sub):
         i_tr = i_t * BT + r * BC
-        p_gr = tl.make_block_ptr(g + (bos * HV + i_h), (T,), (HV,), (i_tr,), (BC,), (0,))
+        p_gr = _t_block_ptr(g_ptr, T, i_tr, BC, G_T_CONTIG, HV)
         b_gr = tl.load(p_gr, boundary_check=(0,)).to(tl.float32)
         for c in range(n_sub):
             i_tc = i_t * BT + c * BC
@@ -405,59 +457,78 @@ def prepare_wy_repr_bwd_da_gate_npu(
                 (r * BC, i_t * BT + c * BC), (BC, BC), (0, 1),
             )
             b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
-            p_gc = tl.make_block_ptr(g + (bos * HV + i_h), (T,), (HV,), (i_tc,), (BC,), (0,))
+            p_gc = _t_block_ptr(g_ptr, T, i_tc, BC, G_T_CONTIG, HV)
             b_gc = tl.load(p_gc, boundary_check=(0,)).to(tl.float32)
-            b_diff = b_gr[:, None] - b_gc[None, :]
-            b_gate = exp2(b_diff)
+            b_gate = exp2(b_gr[:, None] - b_gc[None, :])
             b_prod = b_dA * b_gate
             b_dA = tl.where(b_prod == b_prod, b_prod, 0.0)
             tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.jit(do_not_specialize=['T'])
+@triton.heuristics({
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+})
+@triton.jit(do_not_specialize=["T", "B", "task_num", "num_core"])
 def prepare_wy_repr_bwd_finalize_k_npu(
     k, beta, dA_out, dk, db,
-    cu_seqlens, chunk_indices, T,
+    cu_seqlens, chunk_indices, T, B,
+    task_num, num_core,
     H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr,
     BT: tl.constexpr, BK: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr, BH_OFFSET: tl.constexpr,
+    IS_VARLEN: tl.constexpr, BETA_T_CONTIG: tl.constexpr, DB_T_CONTIG: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_h = i_bh // HV, i_bh % HV
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
-    else:
-        bos, eos = i_b * T, i_b * T + T
+    T_seq = T
+    core_id = tl.program_id(0)
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t_o = task_id // (B * HV)
+        i_bh = task_id % (B * HV)
+        i_b, i_h = i_bh // HV, i_bh % HV
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t_o * 2).to(tl.int32), tl.load(
+                chunk_indices + i_t_o * 2 + 1
+            ).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+                cu_seqlens + i_n + 1
+            ).to(tl.int32)
+            T = eos - bos
+        else:
+            i_t = i_t_o
+            bos, eos = i_b * T_seq, i_b * T_seq + T_seq
 
-    p_b = tl.make_block_ptr(beta + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_dA = tl.make_block_ptr(dA_out + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-
-    b_b = tl.load(p_b, boundary_check=(0,))
-    b_db = tl.load(p_db, boundary_check=(0,)).to(tl.float32)
-    b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
-
-    for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(
-            k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
+        if BETA_T_CONTIG:
+            beta_ptr = _g_contig_base(beta, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+            p_b = _t_block_ptr(beta_ptr, T, i_t * BT, BT, True, HV)
+        else:
+            p_b = tl.make_block_ptr(beta + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        if DB_T_CONTIG:
+            db_ptr = _g_contig_base(db, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+            p_db = _t_block_ptr(db_ptr, T, i_t * BT, BT, True, HV)
+        else:
+            p_db = tl.make_block_ptr(db + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        p_dA = tl.make_block_ptr(
+            dA_out + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1),
         )
-        p_dk = tl.make_block_ptr(dk + (bos * HV + i_h) * K, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
-        b_kb = b_k * b_b[:, None]
-        b_dkb = tl.dot(b_dA, b_k)
-        b_db += tl.sum(b_dkb * b_k, 1)
-        b_dk = b_dkb * b_b[:, None] + tl.trans(tl.dot(tl.trans(b_kb), b_dA))
-        b_dk += tl.load(p_dk, boundary_check=(0, 1)).to(tl.float32)
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+        b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+        b_db = tl.load(p_db, boundary_check=(0,)).to(tl.float32)
+        b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
 
+        for i_k in range(tl.cdiv(K, BK)):
+            p_k = tl.make_block_ptr(
+                k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
+            )
+            p_dk = tl.make_block_ptr(
+                dk + (bos * HV + i_h) * K, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+            b_kb = b_k * b_b[:, None]
+            b_dkb = tl.dot(b_dA, b_k, allow_tf32=False)
+            b_db += tl.sum(b_dkb * b_k, 1)
+            b_dk = b_dkb * b_b[:, None] + tl.trans(tl.dot(tl.trans(b_kb), b_dA, allow_tf32=False))
+            b_dk += tl.load(p_dk, boundary_check=(0, 1)).to(tl.float32)
+            tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 
-_DG_ROW_BR = 16
+        tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -466,12 +537,13 @@ def prepare_wy_repr_bwd_finalize_a2_npu(
     cu_seqlens, chunk_indices, T,
     H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr,
     BT: tl.constexpr, BK: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
+    IS_VARLEN: tl.constexpr, BETA_T_CONTIG: tl.constexpr,
     NT_OFFSET: tl.constexpr, BH_OFFSET: tl.constexpr,
 ):
     i_t = tl.program_id(0) + NT_OFFSET
     i_bh = tl.program_id(1) + BH_OFFSET
     i_b, i_h = i_bh // HV, i_bh % HV
+    T_seq = T
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
@@ -479,16 +551,20 @@ def prepare_wy_repr_bwd_finalize_a2_npu(
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    p_b = tl.make_block_ptr(beta + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    if BETA_T_CONTIG:
+        beta_ptr = _g_contig_base(beta, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+        p_b = _t_block_ptr(beta_ptr, T, i_t * BT, BT, True, HV)
+    else:
+        p_b = tl.make_block_ptr(beta + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
     p_a2 = tl.make_block_ptr(a2_scr + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_b = tl.load(p_b, boundary_check=(0,))
+    b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
     b_A2 = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
         p_k = tl.make_block_ptr(
             k + (bos * H + i_h // (HV // H)) * K, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0),
         )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_A2 += tl.dot(b_k, tl.trans(b_k))
+        b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+        b_A2 += tl.dot(b_k, tl.trans(b_k), allow_tf32=False)
     b_A2 *= b_b[:, None]
     tl.store(p_a2, b_A2.to(p_a2.dtype.element_ty), boundary_check=(0, 1))
 
@@ -498,12 +574,13 @@ def prepare_wy_repr_bwd_finalize_dg_npu(
     dA_out, a2_scr, dg, col_acc_scr,
     cu_seqlens, chunk_indices, T,
     HV: tl.constexpr, BT: tl.constexpr, BC: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
+    IS_VARLEN: tl.constexpr, DG_T_CONTIG: tl.constexpr,
     NT_OFFSET: tl.constexpr, BH_OFFSET: tl.constexpr,
 ):
     i_t = tl.program_id(0) + NT_OFFSET
     i_bh = tl.program_id(1) + BH_OFFSET
     i_b, i_h = i_bh // HV, i_bh % HV
+    T_seq = T
     if IS_VARLEN:
         i_tg = i_t
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
@@ -519,9 +596,14 @@ def prepare_wy_repr_bwd_finalize_dg_npu(
     p_col0 = tl.make_block_ptr(col_acc_scr + col_off, (BT,), (1,), (0,), (BT,), (0,))
     tl.store(p_col0, tl.zeros([BT], dtype=tl.float32), boundary_check=(0,))
 
+    if DG_T_CONTIG:
+        dg_ptr = _g_contig_base(dg, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+    else:
+        dg_ptr = dg + (bos * HV + i_h)
+
     for r in range(n_sub):
         i_tr = i_t * BT + r * BC
-        p_dg_r = tl.make_block_ptr(dg + (bos * HV + i_h), (T,), (HV,), (i_tr,), (BC,), (0,))
+        p_dg_r = _t_block_ptr(dg_ptr, T, i_tr, BC, DG_T_CONTIG, HV)
         b_dg_r = tl.load(p_dg_r, boundary_check=(0,)).to(tl.float32)
         for c in range(n_sub):
             p_dA = tl.make_block_ptr(
@@ -544,7 +626,7 @@ def prepare_wy_repr_bwd_finalize_dg_npu(
             tl.store(p_col, b_col.to(p_col.dtype.element_ty), boundary_check=(0,))
         tl.store(p_dg_r, b_dg_r.to(p_dg_r.dtype.element_ty), boundary_check=(0,))
 
-    p_dg = tl.make_block_ptr(dg + (bos * HV + i_h), (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    p_dg = _t_block_ptr(dg_ptr, T, i_t * BT, BT, DG_T_CONTIG, HV)
     p_col = tl.make_block_ptr(col_acc_scr + col_off, (BT,), (1,), (0,), (BT,), (0,))
     b_dg = tl.load(p_dg, boundary_check=(0,)).to(tl.float32)
     b_col = tl.load(p_col, boundary_check=(0,)).to(tl.float32)
@@ -602,8 +684,6 @@ def recompute_w_u_fwd_npu(
         BT=BT,
         BK=BK,
         BV=BV,
-        num_warps=4,
-        num_stages=3,
     )
     return w, u
 
@@ -630,9 +710,19 @@ def prepare_wy_repr_bwd_npu(
 
     dk = k.new_empty(B, T, HV, K)
     dv = torch.empty_like(v)
-    dg = torch.empty_like(g) if use_g else None
-    db = torch.empty_like(beta)
-    g_arg = g if use_g else beta
+    dg, dg_t_contig = None, False
+    if use_g:
+        dg, dg_t_contig = _t_npu_buf(B, T, HV, dtype=g.dtype, device=k.device)
+    db, db_t_contig = _t_npu_buf(B, T, HV, dtype=beta.dtype, device=k.device)
+    beta_arg, beta_t_contig = _beta_npu_arg(beta, HV)
+    g_gate, g_t_contig = None, False
+    g_exp_precomp = False
+    if use_g:
+        g_gate, g_t_contig = _g_npu_arg(g, HV)
+        g_k_arg = g_gate
+        if not is_varlen:
+            g_k_arg = torch.exp2(g_gate.float()).to(g_gate.dtype)
+            g_exp_precomp = True
     dg_arg = dg if use_g else beta
     dA_scr = torch.zeros_like(A, dtype=torch.float32)
     dA_mid = torch.zeros_like(A, dtype=torch.float32)
@@ -647,41 +737,24 @@ def prepare_wy_repr_bwd_npu(
         T=T,
         BT=BT,
         IS_VARLEN=is_varlen,
-        num_warps=_NUM_WARPS,
     )
-    _launch_wy_kernel(
-        prepare_wy_repr_bwd_k_npu,
-        NT=NT,
-        bh_total=B * HV,
+    core_base = dict(B=B, **base)
+    task_num = NT * B * HV
+    _launch_wy_core_grid(
+        prepare_wy_repr_bwd_kv_npu,
+        task_num=task_num,
         kernel_kwargs=dict(
-            k=k, beta=beta, g=g_arg, A=A, dw=dw,
-            dk=dk, dA_scr=dA_scr, db=db, dg=dg_arg,
-            H=H, HV=HV, K=K, BK=BK, USE_G=use_g,
-            **base,
+            k=k, v=v, beta=beta_arg, g=g_k_arg if use_g else k, A=A, dw=dw, du=du,
+            dk=dk, dv=dv, dA_scr=dA_scr, db=db, dg=dg_arg,
+            H=H, HV=HV, K=K, V=V, BK=BK, BV=BV, USE_G=use_g,
+            G_T_CONTIG=g_t_contig, BETA_T_CONTIG=beta_t_contig,
+            DG_T_CONTIG=dg_t_contig, DB_T_CONTIG=db_t_contig,
+            G_EXP_PRECOMP=g_exp_precomp,
+            **core_base,
         ),
     )
     _launch_wy_kernel(
-        prepare_wy_repr_bwd_v_npu,
-        NT=NT,
-        bh_total=B * HV,
-        kernel_kwargs=dict(
-            v=v, beta=beta, A=A, du=du, dv=dv, dA_scr=dA_scr, db=db,
-            HV=HV, V=V, BV=BV,
-            **base,
-        ),
-    )
-    _launch_wy_kernel(
-        prepare_wy_repr_bwd_da_mask_npu,
-        NT=NT,
-        bh_total=B * HV,
-        kernel_kwargs=dict(
-            dA_scr=dA_scr,
-            HV=HV,
-            **base,
-        ),
-    )
-    _launch_wy_kernel(
-        prepare_wy_repr_bwd_da_dot1_npu,
+        prepare_wy_repr_bwd_da_mask_dot1_npu,
         NT=NT,
         bh_total=B * HV,
         kernel_kwargs=dict(
@@ -706,19 +779,18 @@ def prepare_wy_repr_bwd_npu(
             NT=NT,
             bh_total=B * HV,
             kernel_kwargs=dict(
-                g=g_arg, dA_out=dA_out,
-                HV=HV, BC=_DG_BLK,
+                g=g_gate, dA_out=dA_out,
+                HV=HV, BC=_DG_BLK, G_T_CONTIG=g_t_contig,
                 **base,
             ),
         )
-    _launch_wy_kernel(
+    _launch_wy_core_grid(
         prepare_wy_repr_bwd_finalize_k_npu,
-        NT=NT,
-        bh_total=B * HV,
+        task_num=task_num,
         kernel_kwargs=dict(
-            k=k, beta=beta, dA_out=dA_out, dk=dk, db=db,
-            H=H, HV=HV, K=K, BK=BK,
-            **base,
+            k=k, beta=beta_arg, dA_out=dA_out, dk=dk, db=db,
+            H=H, HV=HV, K=K, BK=BK, BETA_T_CONTIG=beta_t_contig, DB_T_CONTIG=db_t_contig,
+            **core_base,
         ),
     )
     if use_g:
@@ -727,8 +799,8 @@ def prepare_wy_repr_bwd_npu(
             NT=NT,
             bh_total=B * HV,
             kernel_kwargs=dict(
-                k=k, beta=beta, a2_scr=a2_scr,
-                H=H, HV=HV, K=K, BK=BK,
+                k=k, beta=beta_arg, a2_scr=a2_scr,
+                H=H, HV=HV, K=K, BK=BK, BETA_T_CONTIG=beta_t_contig,
                 **base,
             ),
         )
@@ -738,10 +810,14 @@ def prepare_wy_repr_bwd_npu(
             bh_total=B * HV,
             kernel_kwargs=dict(
                 dA_out=dA_out, a2_scr=a2_scr, dg=dg_arg, col_acc_scr=col_acc_scr,
-                HV=HV, BC=_DG_BLK,
+                HV=HV, BC=_DG_BLK, DG_T_CONTIG=dg_t_contig,
                 **base,
             ),
         )
     if H != HV:
         dk = dk.view(B, T, H, HV // H, K).sum(3)
+    if db_t_contig:
+        db = db.transpose(1, 2).contiguous()
+    if use_g and dg_t_contig:
+        dg = dg.transpose(1, 2).contiguous()
     return dk, dv, db, dg

--- a/tests/ops/test_gdn_kernels.py
+++ b/tests/ops/test_gdn_kernels.py
@@ -106,6 +106,56 @@ def recompute_w_u_fwd_ref(
     return w, u
 
 
+def recompute_w_u_fwd_varlen_ref(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    g: torch.Tensor | None,
+    cu_seqlens: torch.LongTensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-sequence torch baseline for varlen `recompute_w_u_fwd`."""
+    assert k.shape[0] == 1
+    w = k.new_empty(k.shape[0], k.shape[1], v.shape[2], k.shape[-1])
+    u = torch.empty_like(v)
+    for i in range(len(cu_seqlens) - 1):
+        s, e = cu_seqlens[i].item(), cu_seqlens[i + 1].item()
+        g_seq = g[:, s:e] if g is not None else None
+        w_seq, u_seq = recompute_w_u_fwd_ref(k[:, s:e], v[:, s:e], beta[:, s:e], A[:, s:e], g_seq)
+        w[:, s:e] = w_seq
+        u[:, s:e] = u_seq
+    return w, u
+
+
+def prepare_wy_repr_bwd_varlen_ref(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    dw: torch.Tensor,
+    du: torch.Tensor,
+    g: torch.Tensor | None,
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-sequence torch baseline for varlen `prepare_wy_repr_bwd`."""
+    assert k.shape[0] == 1
+    dk = k.new_zeros(k.shape)
+    dv = torch.zeros_like(v)
+    db = torch.zeros_like(beta)
+    for i in range(len(cu_seqlens) - 1):
+        s, e = cu_seqlens[i].item(), cu_seqlens[i + 1].item()
+        g_seq = g[:, s:e] if g is not None else None
+        dk_seq, dv_seq, db_seq = prepare_wy_repr_bwd_ref(
+            k[:, s:e], v[:, s:e], beta[:, s:e], A[:, s:e],
+            dw[:, s:e], du[:, s:e], g_seq, chunk_size,
+        )
+        dk[:, s:e] = dk_seq
+        dv[:, s:e] = dv_seq
+        db[:, s:e] = db_seq
+    return dk, dv, db
+
+
 @pytest.mark.parametrize(
     ('B', 'T', 'H', 'HV', 'D', 'use_g', 'dtype'),
     [
@@ -928,6 +978,8 @@ def prepare_wy_repr_bwd_ref(
             (2, 128, 2, 4, 64, True, torch.bfloat16),
             (1, 256, 4, 4, 32, True, torch.float16),
             (2, 128, 2, 2, 64, False, torch.bfloat16),
+            (2, 128, 2, 4, 64, False, torch.bfloat16),
+            (1, 128, 1, 1, 64, False, torch.bfloat16),
         ]
     ],
 )
@@ -949,11 +1001,97 @@ def test_prepare_wy_repr_bwd(B: int, T: int, H: int, HV: int, D: int, use_g: boo
     du = torch.randn(B, T, HV, D, dtype=dtype, device=device)
 
     dk_ref, dv_ref, db_ref = prepare_wy_repr_bwd_ref(k, v, beta, A, dw, du, g, BT)
-    dk_tri, dv_tri, db_tri, _ = prepare_wy_repr_bwd(k=k, v=v, beta=beta, A=A, dw=dw, du=du, g=g)
+    dk_tri, dv_tri, db_tri, dg_tri = prepare_wy_repr_bwd(k=k, v=v, beta=beta, A=A, dw=dw, du=du, g=g)
 
     assert_close('dk', dk_ref, dk_tri, 0.006)
     assert_close('dv', dv_ref, dv_tri, 0.006)
     assert_close('db', db_ref, db_tri, 0.006)
+    if use_g:
+        assert dg_tri is not None
+    else:
+        assert dg_tri is None
+
+
+@pytest.mark.parametrize(
+    ('H', 'HV', 'D', 'cu_seqlens', 'use_g', 'dtype'),
+    [
+        pytest.param(H, HV, D, cu_seqlens, use_g, dtype,
+                     id=f"H{H}-HV{HV}-D{D}-cu{cu_seqlens}-use_g{use_g}-{dtype}")
+        for (H, HV, D, cu_seqlens, use_g, dtype) in [
+            (2, 2, 64, [0, 64, 128], False, torch.bfloat16),
+            (2, 4, 64, [0, 128, 256], False, torch.bfloat16),
+            (1, 1, 64, [0, 64, 128], False, torch.bfloat16),
+            (2, 2, 64, [0, 64, 128], True, torch.bfloat16),
+        ]
+    ],
+)
+def test_recompute_w_u_fwd_varlen(
+    H: int,
+    HV: int,
+    D: int,
+    cu_seqlens: list[int],
+    use_g: bool,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    BT = 64
+    cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
+    T = cu_seqlens[-1].item()
+    k = torch.randn(1, T, H, D, dtype=dtype, device=device)
+    v = torch.randn(1, T, HV, D, dtype=dtype, device=device)
+    beta = torch.rand(1, T, HV, dtype=dtype, device=device).sigmoid()
+    g = torch.randn(1, T, HV, dtype=torch.float32, device=device) * 0.1 if use_g else None
+    A = _make_wy_inverse(1, T, HV, BT, dtype)
+
+    w_ref, u_ref = recompute_w_u_fwd_varlen_ref(k, v, beta, A, g, cu_seqlens)
+    w_tri, u_tri = recompute_w_u_fwd(k, v, beta, A, g, cu_seqlens=cu_seqlens)
+
+    assert_close('u', u_ref, u_tri, 0.005)
+    assert_close('w', w_ref, w_tri, 0.005)
+
+
+@pytest.mark.parametrize(
+    ('H', 'HV', 'D', 'cu_seqlens', 'dtype'),
+    [
+        pytest.param(H, HV, D, cu_seqlens, dtype,
+                     id=f"H{H}-HV{HV}-D{D}-cu{cu_seqlens}-{dtype}")
+        for (H, HV, D, cu_seqlens, dtype) in [
+            (2, 2, 64, [0, 64, 128], torch.bfloat16),
+            (2, 4, 64, [0, 128, 256], torch.bfloat16),
+            (1, 1, 64, [0, 64, 128], torch.bfloat16),
+        ]
+    ],
+)
+def test_prepare_wy_repr_bwd_varlen(
+    H: int,
+    HV: int,
+    D: int,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+):
+    torch.manual_seed(42)
+    BT = 64
+    cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
+    T = cu_seqlens[-1].item()
+    k = torch.randn(1, T, H, D, dtype=dtype, device=device)
+    k = F.normalize(k, p=2, dim=-1)
+    v = torch.randn(1, T, HV, D, dtype=dtype, device=device)
+    beta = torch.rand(1, T, HV, dtype=dtype, device=device).sigmoid()
+    A = chunk_kkt_solve_ref(k, None, beta, BT)
+    dw = torch.randn(1, T, HV, D, dtype=dtype, device=device)
+    du = torch.randn(1, T, HV, D, dtype=dtype, device=device)
+
+    dk_ref, dv_ref, db_ref = prepare_wy_repr_bwd_varlen_ref(
+        k, v, beta, A, dw, du, None, cu_seqlens, BT,
+    )
+    dk_tri, dv_tri, db_tri, dg_tri = prepare_wy_repr_bwd(
+        k=k, v=v, beta=beta, A=A, dw=dw, du=du, g=None, cu_seqlens=cu_seqlens,
+    )
+
+    assert_close('dk', dk_ref, dk_tri, 0.006)
+    assert_close('dv', dv_ref, dv_tri, 0.006)
+    assert_close('db', db_ref, db_tri, 0.006)
+    assert dg_tri is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Optimize the Ascend NPU `prepare_wy_repr_bwd` backward pass for performance and numerical stability, and add varlen correctness tests.
- **Fused K/V backward kernel**: Merge `prepare_wy_repr_bwd_k_npu` and `prepare_wy_repr_bwd_v_npu` into `prepare_wy_repr_bwd_kv_npu`, computing dk/dv/dA/db (and dg) in a single kernel to reduce launch overhead and intermediate synchronization.
- **Core-grid task scheduling**: Add `_launch_wy_core_grid` to distribute `(NT × B × HV)` tasks across AICores via `tl.range(core_id, task_num, num_core)`. `prepare_wy_repr_bwd_finalize_k_npu` uses the same launch pattern.
- **UB tiling tuning**: Split the unified UB model into stage-specific coefficients (`_PREPARE_BWD_K_MEM_MULT=4.5`, `_PREPARE_BWD_V_MEM_MULT=8.0`) and raise `_MAX_TILE_BWD` from 32 to 128 for better UB utilization.
- **T-contiguous memory layout (G_T_CONTIG)**: When `HV > 1`, transpose and make `g`/`beta`/`dg`/`db` contiguous on the host; kernels access the time dimension with stride 1 via `_g_contig_base` / `_t_block_ptr` for improved MTE efficiency.
- **Gate precomputation**: Precompute `exp2(g)` on the host for non-varlen paths (`G_EXP_PRECOMP`) to avoid redundant exp2 inside kernels.
- **dA stage fusion**: Merge `prepare_wy_repr_bwd_da_mask_npu` and `prepare_wy_repr_bwd_da_dot1_npu` into `prepare_wy_repr_bwd_da_mask_dot1_npu`.
- **Numerical precision**: Set `allow_tf32=False` on all `tl.dot` calls; cast key intermediates to fp32 for accumulation.
- **NPU launch cleanup**: Remove unused `num_warps`/`num_stages` from `recompute_w_u_fwd` (not used on NPU).

GDN:
<img width="1209" height="672" alt="2b366ec262483ca1aa348154e89f2f27" src="https://github.com/user-attachments/assets/81217487-7cde-438f-af52-4c71e75e88a7" />
