### PR TITLE
[GQA] Add strict divisibility validation for all GQA entry points

### DIFF
--- a/fla/ops/attn/decoding.py
+++ b/fla/ops/attn/decoding.py
@@ -163,6 +163,7 @@ def attn_decoding_one_step(
     B, T, H, K, V = *k.shape, v.shape[-1]
     N = len(cu_seqlens) - 1
     HQ = q.shape[2]
+    assert HQ % H == 0, f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})"
     G = HQ // H
     if scale is None:
         scale = K ** -0.5

--- a/fla/ops/attn/naive.py
+++ b/fla/ops/attn/naive.py
@@ -45,6 +45,7 @@ def naive_parallel_attn(
     """
     B, T, HQ, D = q.shape
     H = k.shape[2]
+    assert HQ % H == 0, f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})"
     G = HQ // H
 
     if scale is None:
@@ -126,6 +127,7 @@ def naive_attn_decoding(
     HQ, D = q.shape[-2], q.shape[-1]
     V = v.shape[-1]
     H = k.shape[2]
+    assert HQ % H == 0, f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})"
     G = HQ // H
     if scale is None:
         scale = D ** -0.5

--- a/fla/ops/attn/parallel.py
+++ b/fla/ops/attn/parallel.py
@@ -837,6 +837,10 @@ def parallel_attn(
             f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`. "
             f"Please flatten variable-length inputs before processing.",
         )
+    if q.shape[2] % k.shape[2] != 0:
+        raise ValueError(
+            f"num_query_heads ({q.shape[2]}) must be divisible by num_kv_heads ({k.shape[2]})"
+        )
     if sink_bias is not None:
         assert sink_bias.shape == (q.shape[2],), "sink_bias must have shape [HQ]"
 

--- a/fla/ops/forgetting_attn/naive.py
+++ b/fla/ops/forgetting_attn/naive.py
@@ -35,6 +35,7 @@ def naive_forgetting_attn(
     """
     _, T, HQ, D = q.shape
     H = k.shape[2]
+    assert HQ % H == 0, f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})"
     G = HQ // H
 
     if scale is None:

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -1217,6 +1217,8 @@ def chunk_gsa(
     chunk_size = kwargs.pop('chunk_size', None)
     if chunk_size is not None and chunk_size != 2 ** (chunk_size.bit_length() - 1):
         raise ValueError(f"`chunk_size` must be a power of 2, got {chunk_size}.")
+    if q.shape[2] % k.shape[2] != 0:
+        raise ValueError(f"num_query_heads ({q.shape[2]}) must be divisible by num_kv_heads ({k.shape[2]})")
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(

--- a/fla/ops/gsa/fused_recurrent.py
+++ b/fla/ops/gsa/fused_recurrent.py
@@ -508,6 +508,8 @@ def fused_recurrent_gsa(
         >>> assert hk.allclose(hk_var)
         >>> assert hv.allclose(hv_var)
     """
+    if q.shape[2] % k.shape[2] != 0:
+        raise ValueError(f"num_query_heads ({q.shape[2]}) must be divisible by num_kv_heads ({k.shape[2]})")
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(

--- a/fla/ops/nsa/parallel.py
+++ b/fla/ops/nsa/parallel.py
@@ -896,7 +896,10 @@ def parallel_nsa(
             f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`. "
             f"Please flatten variable-length inputs before processing.",
         )
-    G = q.shape[2] // k.shape[2]
+    HQ, H = q.shape[2], k.shape[2]
+    if HQ % H != 0:
+        raise ValueError(f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})")
+    G = HQ // H
     assert G >= 16 and (G & (G - 1)) == 0, "Group size (HQ/H) must be a power of 2 and >= 16 in NSA"
 
     if cu_seqlens is not None:

--- a/fla/ops/parallax/decode.py
+++ b/fla/ops/parallax/decode.py
@@ -165,6 +165,8 @@ def parallax_decode(
     """
     B, Sq, HQ, K = q.shape
     Skv, H = k.shape[1], k.shape[2]
+    if HQ % H != 0:
+        raise ValueError(f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})")
     G = HQ // H
     if scale is None:
         scale = K ** -0.5
@@ -320,6 +322,8 @@ def parallax_decode_one_step(
     if Sq != 1:
         raise ValueError(f"parallax_decode_one_step expects a single query (Sq=1), got Sq={Sq}")
     Skv, H = k.shape[1], k.shape[2]
+    if HQ % H != 0:
+        raise ValueError(f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})")
     G = HQ // H
     if scale is None:
         scale = K ** -0.5

--- a/fla/ops/parallax/naive.py
+++ b/fla/ops/parallax/naive.py
@@ -56,6 +56,8 @@ def naive_parallax(
     """
     B, T, HQ, D = q.shape
     H = k.shape[2]
+    if HQ % H != 0:
+        raise ValueError(f"num_query_heads ({HQ}) must be divisible by num_kv_heads ({H})")
     G = HQ // H
 
     if scale is None:

--- a/fla/ops/parallax/parallel.py
+++ b/fla/ops/parallax/parallel.py
@@ -809,6 +809,10 @@ def parallel_parallax(
             f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`. "
             f"Please flatten variable-length inputs before processing.",
         )
+    if q.shape[2] % k.shape[2] != 0:
+        raise ValueError(
+            f"num_query_heads ({q.shape[2]}) must be divisible by num_kv_heads ({k.shape[2]})"
+        )
     # The kernel keeps cols [i - W + 1, i] (W keys total, diagonal included),
     # matching FLA's `window_size=W` semantics exactly (no off-by-one).
     window_size_left = -1 if window_size is None else window_size

--- a/tests/ops/test_gqa_validation.py
+++ b/tests/ops/test_gqa_validation.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.ops.attn.decoding import attn_decoding_one_step
+from fla.ops.attn.naive import naive_attn_decoding, naive_parallel_attn
+from fla.ops.attn.parallel import parallel_attn
+from fla.ops.forgetting_attn.naive import naive_forgetting_attn
+from fla.ops.parallax.naive import naive_parallax
+from fla.ops.parallax.parallel import parallel_parallax
+from fla.utils import device
+
+# ── Non-divisible GQA heads must raise ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ('op_name', 'op_fn', 'HQ', 'H', 'kw'),
+    [
+        pytest.param("naive_parallel_attn", naive_parallel_attn, 3, 2, {}, id="naive_parallel_attn"),
+        pytest.param("parallel_attn", parallel_attn, 3, 2, {}, id="parallel_attn"),
+    ],
+)
+def test_gqa_validation_attn(op_name, op_fn, HQ, H, kw):
+    """Non-divisible HQ/H must raise ValueError."""
+    B, T, D = 1, 8, 64
+    q = torch.randn(B, T, HQ, D, device=device)
+    k = torch.randn(B, T, H, D, device=device)
+    v = torch.randn(B, T, H, D, device=device)
+    with pytest.raises((ValueError, AssertionError, RuntimeError)):
+        op_fn(q=q, k=k, v=v, **kw)
+
+
+@pytest.mark.parametrize(
+    ('op_name', 'op_fn', 'HQ', 'H', 'kw'),
+    [
+        pytest.param("naive_forgetting_attn", naive_forgetting_attn, 3, 2, {}, id="naive_forgetting_attn"),
+    ],
+)
+def test_gqa_validation_forgetting(op_name, op_fn, HQ, H, kw):
+    B, T, D = 1, 8, 64
+    q = torch.randn(B, T, HQ, D, device=device)
+    k = torch.randn(B, T, H, D, device=device)
+    v = torch.randn(B, T, H, D, device=device)
+    g = torch.randn(B, T, HQ, device=device)
+    with pytest.raises((ValueError, AssertionError, RuntimeError)):
+        op_fn(q=q, k=k, v=v, g=g, **kw)
+
+
+@pytest.mark.parametrize(
+    ('op_name', 'op_fn', 'HQ', 'H', 'kw'),
+    [
+        pytest.param("naive_parallax", naive_parallax, 3, 2, {}, id="naive_parallax"),
+        pytest.param("parallel_parallax", parallel_parallax, 3, 2, {}, id="parallel_parallax"),
+    ],
+)
+def test_gqa_validation_parallax(op_name, op_fn, HQ, H, kw):
+    B, T, D = 1, 8, 64
+    q = torch.randn(B, T, HQ, D, device=device, dtype=torch.float16)
+    r = torch.randn(B, T, HQ, D, device=device, dtype=torch.float16)
+    k = torch.randn(B, T, H, D, device=device, dtype=torch.float16)
+    v = torch.randn(B, T, H, D, device=device, dtype=torch.float16)
+    with pytest.raises((ValueError, AssertionError, RuntimeError)):
+        op_fn(q=q, r=r, k=k, v=v, **kw)
+
+
+# ── Decoding entry points ────────────────────────────────────────────────────
+
+def test_gqa_validation_attn_decoding():
+    """attn_decoding_one_step with non-divisible heads must raise."""
+    B, T, HQ, H, K, V = 2, 32, 3, 2, 64, 64
+    cu_seqlens = torch.tensor([0, 16, 32], dtype=torch.long, device=device)
+    q = torch.randn(1, B, HQ, K, device=device)
+    k = torch.randn(1, T, H, K, device=device)
+    v = torch.randn(1, T, H, V, device=device)
+    with pytest.raises((ValueError, AssertionError, RuntimeError)):
+        attn_decoding_one_step(q=q, k=k, v=v, cu_seqlens=cu_seqlens)
+
+
+def test_gqa_validation_naive_attn_decoding():
+    """naive_attn_decoding with non-divisible heads must raise."""
+    B, T, HQ, H, D = 2, 32, 3, 2, 64
+    cu_seqlens = torch.tensor([0, 16, 32], dtype=torch.long, device=device)
+    q = torch.randn(1, B, HQ, D, device=device)
+    k = torch.randn(1, T, H, D, device=device)
+    v = torch.randn(1, T, H, D, device=device)
+    with pytest.raises((ValueError, AssertionError, RuntimeError)):
+        naive_attn_decoding(q=q, k=k, v=v, cu_seqlens=cu_seqlens)
+
+
+# ── Valid composite GQA configurations must still work ─────────────────────
+
+@pytest.mark.parametrize(
+    ('HQ', 'H', 'G'),
+    [
+        (4, 2, 2),   # G=2
+        (8, 2, 4),   # G=4
+    ],
+)
+def test_gqa_valid_attn_forward(HQ, H, G):
+    """Valid divisible GQA should not raise for parallel_attn."""
+    B, T, D = 1, 8, 64
+    q = torch.randn(B, T, HQ, D, device=device, dtype=torch.float16)
+    k = torch.randn(B, T, H, D, device=device, dtype=torch.float16)
+    v = torch.randn(B, T, H, D, device=device, dtype=torch.float16)
+    o = parallel_attn(q=q, k=k, v=v)
+    assert o.shape == (B, T, HQ, D), f"Expected {(B, T, HQ, D)}, got {o.shape}"


### PR DESCRIPTION
## Summary

Floor-division of query-head count by key-head count (`G = HQ // H`) silently discards a non-zero remainder, causing out-of-bounds memory reads in Triton kernels and shape-mismatch crashes in PyTorch references. Every GQA entry point must reject `HQ % H != 0` before repeating KV heads or launching a kernel.

Fixes #1029.

## Changes

- Add `assert HQ % H == 0` / `ValueError` to:
  - `attn/naive.py` — `naive_parallel_attn`, `naive_attn_decoding`
  - `attn/parallel.py` — `parallel_attn`
  - `attn/decoding.py` — `attn_decoding_one_step`
  - `forgetting_attn/naive.py` — `naive_forgetting_attn`
  - `nsa/parallel.py` — `parallel_nsa` (strengthen existing assert)
  - `parallax/naive.py` — `naive_parallax`
  - `parallax/parallel.py` — `parallel_parallax`
  - `parallax/decode.py` — `parallax_decode`, `parallax_decode_one_step`
  - `gsa/chunk.py` — `chunk_gsa`
  - `gsa/fused_recurrent.py` — `fused_recurrent_gsa`
- Add regression test `tests/ops/test_gqa_validation.py`

## Test plan

- [x] All 26 existing attn tests pass
- [x] All 71 existing GDN tests pass  
- [x] All 9 new GQA validation tests pass
- [x] Valid composite GQA configurations (HQ=8, H=2, G=4) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)