### PR TITLE
[Docs] Add fla-ascend-performance agent skill for Ascend NPU profiling and optimization

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -18,6 +18,7 @@ Current skills:
 | -------------------------- | ------------------------------------------------------------------------------- |
 | `fla-optimization-loop`    | Correctness-gated kernel optimization loop (contract, phases, iteration, traps) |
 | `fla-nvidia-performance`   | NVIDIA GPU kernel / Triton / Gluon / TileLang / CUDA backend performance work   |
+| `fla-ascend-performance`   | Ascend NPU profiling, bottleneck diagnosis, and Triton-Ascend kernel optimization |
 | `fla-kda`                  | KDA-specific gate, intra/inter, backend, and test workflow                      |
 | `fla-dispatch-backends`    | `@dispatch` decorator and backend registry workflow                             |
 | `fla-correctness-coverage` | Kernel correctness testing and coverage for `fla/ops/**`                        |

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -19,6 +19,7 @@ Do not add a `README.md` inside individual skill directories; the canonical entr
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `fla-optimization-loop`    | Disciplined, reproducible kernel optimization loop (task contract, three phases, iteration protocol, trap catalog) anchored on the frozen pytest correctness gate |
 | `fla-nvidia-performance`   | NVIDIA GPU kernel performance workflow for Triton, Gluon, TileLang, CUDA backends, hardware baselines, and MR-ready profiling evidence                            |
+| `fla-ascend-performance`   | Ascend NPU profiling, bottleneck diagnosis, and Triton-Ascend kernel optimization                                                                                 |
 | `fla-kda`                  | KDA-specific gate, intra/inter, backend, and test workflow                                                                                                        |
 | `fla-dispatch-backends`    | `@dispatch` decorator and backend registry workflow                                                                                                               |
 | `fla-correctness-coverage` | Coverage matrix and test guidance for `fla/ops/**` kernels                                                                                                        |

--- a/.agents/skills/fla-ascend-performance/SKILL.md
+++ b/.agents/skills/fla-ascend-performance/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: fla-ascend-performance
+description: >
+  Guidelines for Ascend NPU kernel / Triton-Ascend backend performance work in the FLA repo.
+  Covers profiling with torch_npu, PipeUtilization/MemoryUB CSV analysis, Cube/Vector/MTE/UB
+  bottleneck diagnosis, and kernel optimization (UB tiling, grid splits, fusion/split, varlen,
+  G_T_CONTIG gate loading, correctness gates). NPU kernels must not use num_warps/num_stages.
+  Use when working on NPU profiling, kernel_details/op_statistic, aic_metrics,
+  fla triton_ascend backends, g transpose stride-1, UB overflow, grid limits, or Ascend performance.
+---
+
+# FLA Ascend NPU: Profiling → Bottlenecks → Optimization
+
+Use this skill for Ascend operator performance work under `fla/ops/**/triton_ascend/**`.
+
+Multi-round iteration discipline (frozen tests, task contract, when to stop): **`fla-optimization-loop`**. MR packaging: **`fla-mr-readiness`**.
+
+Collection **must** use this skill's **generic scripts** — do not copy `torch_npu.profiler` boilerplate per op.
+
+Environment: **Use the Python/NPU environment already active in the current terminal** (including any activated conda/venv). Run collection, analysis, and benchmarks in the same shell; do not spawn a new shell or switch environments mid-workflow. If the terminal has no NPU stack loaded yet, activate the project's Ascend environment first, then continue in that same session. Metrics, failure modes, code index: [reference.md](references/reference.md). Past kernel notes: [cases.md](references/cases.md).
+
+Make the target backend semantically correct before optimizing; never hide missing capability or kernel bugs behind a Torch fallback. What generalizes: UB modeling, grid splits, layout/precision, and verification. Values like `BC=16`, K slabs of 64, or specific `mem_mult` are starting points only — do not copy them as rules.
+
+**Hard constraint (NPU launch params):** Ascend Triton kernels **do not support** `num_warps` or `num_stages`. During optimization these kwargs must **never** appear in `@triton.jit` launches, `triton.autotune` configs — do not copy them from CUDA Triton. Tune via tiles, grid, layout, fusion/split, and UB budget only.
+
+## Progress checklist
+
+```
+- [ ] 1. Freeze semantics, workload, and baseline latency
+- [ ] 2. Collect with generic scripts (first pass: PipeUtilization)
+- [ ] 3. Parse CSVs and classify the bottleneck
+- [ ] 4. Triton-Ascend optimize for that bottleneck (MemoryUB if needed)
+- [ ] 5. Correctness gate + synchronized benchmark
+- [ ] 6. Re-profile to confirm metrics, then decide whether to continue
+```
+
+## 1. Freeze semantics and baseline
+
+1. Locate the public entry, `@dispatch`, default impl, and closest Ascend impl; list layout, dtype, fixed/varlen, head mapping, fwd/bwd, and optional args.
+2. Keep Torch reference implementations only in tests/benchmarks as the oracle.
+3. Pick shape/dtype/fwd±bwd; freeze tests, tolerances, and shapes during optimization — do not change tests to manufacture speedups.
+4. Baseline with synchronized timing (warmup + `torch.npu.synchronize()` + repeats); confirm the target NPU kernel runs, not a Torch fallback.
+5. Do not change the public API to fit the kernel; register backends under `IS_NPU` with lazy imports; verifiers must state real support ranges.
+
+## 2. Generic collection (required)
+
+Scripts live under `.agents/skills/fla-ascend-performance/scripts/` (run from that directory or set `PYTHONPATH`).
+
+| Script | Role |
+|--------|------|
+| `scripts/profile_npu.py` | Trace any `workload()` |
+| `scripts/analyze_profile.py` | Parse `op_statistic` / `kernel_details` |
+
+```bash
+SKILL_DIR=.agents/skills/fla-ascend-performance
+cd "$SKILL_DIR"
+
+python scripts/profile_npu.py \
+  --name my_op --out-dir npu_prof \
+  --metrics PipeUtilization --analyze \
+  --kernel-filter my_kernel_substr \
+  --exec-file path/to/workload_only.py
+```
+
+`workload_only.py` only defines `workload()` — no profiler boilerplate:
+
+```python
+def workload():
+    y = op(...)
+    y.backward(grad)
+```
+
+Library usage (when not using `--exec-file`):
+
+```python
+from profile_npu import profile_callable
+
+def workload():
+    y = op(...)
+    y.backward(grad)
+
+trace_dir = profile_callable(
+    workload,
+    name="my_op",
+    out_dir="npu_prof",
+    aic_metrics="PipeUtilization",  # or MemoryUB / L2Cache / ...
+)
+```
+
+Default schedule: `wait=0, warmup=1, active=1, repeat=1`. One `aic_metrics` per run; start with `PipeUtilization`, collect `MemoryUB` separately for UB bandwidth.
+
+## 3. Diagnose bottlenecks
+
+```bash
+cd .agents/skills/fla-ascend-performance
+python scripts/analyze_profile.py path/to/*_profiling_* --kernel-filter <substr>
+```
+
+1. **`op_statistic`**: who owns Total Time; is the target kernel the real hotspot?
+2. **`kernel_details`** (by Duration): read pipe / UB columns.
+
+| Signal | Bottleneck | Prefer |
+|--------|------------|--------|
+| High `aiv_vec_ratio`, Cube≈0 | Vector-bound | Larger row tile, less scalar, fuse load/store |
+| High `aic_mac_ratio` / `cube_utilization` | Cube-bound | Better matmul tiles/alignment, less non-Cube prelude |
+| High `mte2/mte3_ratio`, low compute | Memory-move-bound | More reuse, fewer writebacks; check strides — **gate `g` stride-HV gather** often 10×+ slower ([g-contiguous-loading.md](references/g-contiguous-loading.md)) |
+| High `scalar_ratio` | Scalar-bound | Vectorize, kill branches, heuristics |
+| High UB bw under MemoryUB, low vec/mac | UB bandwidth saturated | Larger tiles / more fusion |
+| Low target Ratio, many tiny ops | Unfused / fallback | Fix dispatch and fusion first |
+| Two kernels share `o` + high MTE | Intermediate writeback | Fuse producer/consumer if UB fits; else keep split |
+| Frequent host grid chunking | Launch / grid-product overhead | Prefer 1D `num_aicore` core-grid + flat `task_id` |
+
+Colloquial “CUDA utilization” → read **Cube/MAC** (`aic_mac_ratio`). Host UB model complements the profiler — see [reference.md](references/reference.md).
+
+Prioritize fixes by **Duration share** in `kernel_details` / `op_statistic` (largest hotspot first). Low pipe ratios on a dominant kernel usually mean room remains on that pipe.
+
+## 4. Optimize (Triton-Ascend)
+
+Change only levers that match the bottleneck; one hypothesis per round. Before tuning, classify the issue: **compile failure / UB overflow / grid limit / numeric error / real performance bottleneck** — do not treat all five the same way.
+
+### UB and tiles
+
+- UB is usually the primary constraint, not theoretical FLOPs. Enumerate peak live tiles (fp32 accum, transpose copies, masks, temp dots).
+- `peak ≈ memory_multiplier * tiled_elements * dtype_size`; comment where the multiplier comes from.
+- Use `fla.utils.ascend_ub_manager` (`compute_row_tile_block_size`, etc.); do not hard-code capacity; keep ~0.75–0.85 safety margin.
+- Prefer power-of-two tiles; matrix ops prefer 16-alignment; model fwd/bwd separately (bwd usually smaller tiles).
+- If a fused kernel cannot fit a reliable UB budget, split stages + scratch/recompute — do not keep an inevitably overflowing live set for “fusion”.
+- Persistently unused safe budget → consider non-PoT tiles / calibrate `mem_mult`; near 100% and still slow → look at pipe/bandwidth.
+
+### Layout, grid, numerics
+
+- Innermost block-pointer dim should be contiguous; `tl.make_block_ptr` + `boundary_check`; `@input_guard` for layout — do not emulate arbitrary strides in-kernel.
+- **Gate `g` along T (critical on Ascend)**: if `g` is `[B, T, HV]`, host `g.transpose(1, 2).contiguous()` and load via `G_T_CONTIG` + stride-1 `g_ptr` (see [g-contiguous-loading.md](references/g-contiguous-loading.md)). Stride-`HV` gathers in bwd hot loops can be **10×–35× slower** than contiguous loads; HV==1 needs no transpose. Match fwd pointer math; keep `T_seq` before varlen overwrites `T`.
+- Distinct shapes (e.g. `HV==1`, layout flags) get separate paths — no expensive hot-loop branches.
+- Grid product cap `ASCEND_MAX_GRID_DIM=65535`: host-split with `iter_axis_launch_chunks`, pass `*_OFFSET`; after varlen slicing, zero the matching offset — never slice and also add a global offset. UB and grid are independent constraints.
+- **1D core-grid** (prefer when there are many independent tiles and multi-axis grids need host chunking): launch `grid=(num_aicore,)` from `driver.active.utils.get_device_properties(device)["num_aicore"]`, flatten work into `task_num`, and schedule with `for task_id in tl.range(core_id, task_num, num_core)`. Decode `task_id` → tile indices inside the kernel. One launch, no `ASCEND_MAX_GRID_DIM` host loop, better load balance when `task_num` is irregular (varlen chunks × heads × V tiles). Keep `do_not_specialize` on `T` / `task_num` / `num_core` / dynamic extents.
+- In a core-grid task loop, **rebind local pointers each iteration** (`q_ptr = q + …`); do not accumulate with in-place `ptr +=` across tasks — Ascend Triton can mis-compile that pattern.
+- **int64 before multiply on runtime indices**: with `do_not_specialize` on `T`, values like `NT = cdiv(T, BT)` are runtime int32. `(NT - 1) * DH_CS` or `i_t * HV * K * V` can wrap past 2³¹ before `.to(tl.int64)` (e.g. K=V=128, HV=64 overflows at T>131K). Cast the index first: `(NT - 1).to(tl.int64) * DH_CS`, not `((NT - 1) * DH_CS).to(tl.int64)`.
+- Reductions / recurrence / grads use fp32 accum, cast on store; sensitive solves: `input_precision='ieee'` / `allow_tf32=False`; mask before exp on gated paths; keep a consistent `exp`/`exp2` base.
+- For separable gate differences, compute `exp2(gs)[:, None] / exp2(gc)[None, :]` instead of `exp2(gs[:, None] - gc[None, :])` to replace a matrix of exponentials with two vectors. Verify numerics on the target compiler; multiplying by `exp2(-gc)` can produce materially different Ascend results.
+
+### Fusion, compile, varlen
+
+- Fuse only stages that share loads, cut traffic, and keep live set under control; split independent grad chains to ease UB.
+- **Producer → consumer on the same output** (e.g. inter `o += q@h` then intra `o += A@v` with `ACCUMULATE_OUTPUT`): if both need the same `q` (and live set fits), fuse into one kernel — keep `b_o` / `b_A` in UB, single store. Profiler cue: two kernels own the op and MTE is high from the intermediate `o` writeback. If fused peak UB overflows, keep the split; do not force fusion.
+- When fused live set is dominated by fixed tiles (e.g. `BT×BT` + `BT×BV`), fix the Cube-aligned outer tile (`BV`) and **autotune** the K-slab (`BK`) rather than host-hardcoding both.
+- Multi-tile contribs to one grad: fp32 partials + deterministic finalize; atomics sparingly. `tl.debug_barrier` only for same-program deps.
+- `do_not_specialize=['T']` (and other dynamic launch extents); kill runtime branches with `tl.constexpr` / `triton.heuristics`.
+- **No `num_warps` / `num_stages` anywhere**: NPU does not support them. Omit from kernel call sites, autotune config dicts, and wrappers. Do not leave them commented-out “for CUDA parity”; delete them.
+- Varlen is first-class: reuse `prepare_chunk_indices` / `prepare_chunk_offsets`. With 1D core-grid, flatten over `total_chunks` and map `global_t → (i_n, i_t)` via `chunk_offsets` (largest `i_n` with `chunk_offsets[i_n] <= global_t`). Tests cover empty tails, non-aligned lengths, multi-length, and fixed/varlen equivalence.
+
+Failure modes and repo paths: [reference.md](references/reference.md). Detailed past cases: [cases.md](references/cases.md).
+
+## 5. Verification loop
+
+Each round, in order:
+
+1. Single kernel vs Torch oracle (fp16/bf16, fwd+bwd).
+2. Shape matrix: small/large T, non-aligned tiles, head sharing, gate/state, fixed/varlen.
+3. End-to-end tests; confirm dispatch hits `triton_ascend`.
+4. Frozen full pytest gate (incl. NaN poisoning); on failure, stop — do not claim speedups.
+5. Synchronized benchmark (latency/throughput, fwd and fwd+bwd); re-profile with the same `aic_metrics` and confirm Duration/pipe/UB move as expected.
+6. Metrics unchanged → reclassify bottleneck or switch metrics; do not pile unrelated changes.
+
+Prefer: `tests/ops/test_gdn_kernels.py`, `tests/utils/test_ascend_ub_manager.py`, `python -m benchmarks.ops.verify --op <op> --base <ref>` (`--gate-k` is a quick signal only).
+
+### Round summary template
+
+After re-profile, report:
+
+- Target kernel Duration (before → after)
+- Pipe ratios: Cube/MAC, Vector, scalar, MTE1, MTE2, MTE3
+- UB bandwidth (if MemoryUB run collected)
+- Any unsupported triton-ascend ops encountered and workarounds used
+- Whether another round is warranted (per `fla-optimization-loop` stop criteria)
+
+Generalizable fixes discovered during optimization belong in this skill (`SKILL.md`, `references/reference.md`, or `references/cases.md`) in a separate doc commit — not bundled into a perf PR.
+
+## Review checklist
+
+- [ ] Same algorithm/control flow as CUDA reference (tiling/grid/layout adaptations only)
+- [ ] No Torch fallback on production paths; unsupported cases error / verifier rejects
+- [ ] No `num_warps` / `num_stages` in Ascend kernel launches, autotune configs, or wrappers
+- [ ] Backend registration, lazy import, public signatures correct
+- [ ] Peak live tiles estimated; tiles from shared helpers + safety margin
+- [ ] Grid ≤ 65535 **or** 1D core-grid (`num_aicore`); host-split offsets not double-counted with varlen; task-loop pointers rebound each iteration
+- [ ] Block pointers contiguous innermost; **gate `g` uses G_T_CONTIG** when `[B,T,HV]` (see [g-contiguous-loading.md](references/g-contiguous-loading.md)); tail `boundary_check`
+- [ ] fp32 accum consistent with output/exp base; fusion worth the complexity (no gratuitous `ACCUMULATE_OUTPUT` writeback when UB allows)
+- [ ] fwd/bwd/varlen/layout branches covered; no unwritten regions under NaN poisoning
+- [ ] Runtime chunk indices (`NT`, `i_t`, …) cast to `tl.int64` **before** stride multiply when `T` is `do_not_specialize`
+- [ ] Optional-arg paths exercised (e.g. `use_g` True/False with `g=None` reference) when PR touches gated and ungated paths
+- [ ] Did not weaken tests/tolerances/benchmarks for “wins”; synced bench + re-profile on target NPU
+- [ ] Round summary includes pipe/UB metrics (template above)
+
+## Anti-patterns
+
+- Copying profiler boilerplate into every `test_*.py`
+- Treating async launch time as latency; missing warmup/synchronize
+- Expecting Pipe and MemoryUB columns from a single run
+- Tuning MTE before confirming the fused NPU kernel is hit
+- Loosening tolerances, dropping cases, or editing benchmarks to fake speedups
+- Adding or keeping `num_warps` / `num_stages` on Ascend paths (unsupported; not a tuning lever)
+- Hiding unsupported triton-ascend ops without documenting workarounds
+
+## Related files
+
+- Collect / analyze: `scripts/profile_npu.py`, `scripts/analyze_profile.py`
+- Metrics, failure modes, code index: [references/reference.md](references/reference.md)
+- Past kernel case notes: [references/cases.md](references/cases.md)
+- **Gate `g` stride-1 loading (G_T_CONTIG)**: [g-contiguous-loading.md](references/g-contiguous-loading.md)
+- Ad-hoc workload output dir: `npu_prof/` (new collection must use the generic scripts)

--- a/.agents/skills/fla-ascend-performance/references/cases.md
+++ b/.agents/skills/fla-ascend-performance/references/cases.md
@@ -1,0 +1,23 @@
+# Ascend optimization case notes
+
+Experience notes from past kernel work. Read the current code before applying — numbers are not immutable hardware constants. Paths are relative to the `flash-linear-attention` repo root.
+
+## `chunk_delta_h.py` — bwd `dhu`
+
+File: `fla/ops/common/backends/triton_ascend/chunk_delta_h.py`
+
+- Host-transpose `g` → `[B,HV,T]` (stride-`HV` gather was ~30–45× slower; Pipe: tiny `aic_mac_ratio`, huge `aiv_mte3`/`aiv_scalar`). See [g-contiguous-loading.md](g-contiguous-loading.md).
+- Fold gate+scale into `do` once; host-precompute `g_exp`/`g_ratio=exp2(g_last-g)` when `T%BT==0` (log-space only — **not** `exp2(g_last)/exp2(g)`).
+- Avoid in-place `ptr -=` across chunks (Ascend miscompile/NaN). `tl.advance` + vectorized last-lane extract **regressed** — keep remake-`block_ptr` + scalar `bg_last_exp`.
+- Dropping `boundary_check` via aligned constexpr flags was **neutral** (cost is address-gen, not masks).
+- **In-place `dv`**: callers rebind `dh,dh0,dv = bwd_dhu(...)`; store corrected residual through `p_dv` (no `dv2` buffer/ptr).
+- **Tile selection is cost-model, not max-BK**: minimize `cdiv(V,BV)*(3+4*cdiv(K,BK))` under soft UB (`peak <= UB*1.15`, multi-slab dh live) on the **host-precomputed gate** path. Max oneslab `BK=min(256,pow2(K))` with BV capped at 64 loses on D256 to **BK=128/BV=128** (nv 4→2 beats extra K-slab ptrs). Shrinking BV only to grow BK (e.g. BV 64→32) remains a loss. Measured B8 T2048 H32 bf16: D256 ~15.5→11.4ms, D128 ~6.2→3.3ms; still AIC-scalar dominated (`aic_scalar_ratio`~0.66, `aic_mac_ratio`~0.07).
+- **Gate-inline UB (T%BT!=0 / varlen)**: in-kernel `exp2(g)` inflates compile UB ~1.7× vs analytical peak — `BK=128/BV=128` fails (`req 262400 > 196608`) on D128 unaligned even though host util≈0.75. Use `gate_inline` → soft cap `UB*0.60` (D128→`BK=128/BV=64`, D256→`BK=256/BV=32`); keep precomp tiles unchanged.
+
+## `chunk_o.py` — fwd fuse + bwd G_T_CONTIG
+
+File: `fla/ops/common/backends/triton_ascend/chunk_o.py`
+
+- Fwd: fuse inter+intra, 1D core-grid, host `g.transpose(1,2).contiguous()`.
+- Bwd `G_T_CONTIG`: `chunk_bwd_dv_local_npu`, `chunk_bwd_dqkwg_npu`, `chunk_bwd_kernel_dg_npu` — stride-1 `g_ptr` (`i_b*HV*T+i_h*T` / varlen `bos+i_h*T`), `T_seq` before varlen.
+- dv_local kernel ~6.5→0.18ms, dqkwg ~10.8→0.91ms (B2 T2048 HV8). Fix `BV`, autotune `BK`. Details: [g-contiguous-loading.md](g-contiguous-loading.md).

--- a/.agents/skills/fla-ascend-performance/references/g-contiguous-loading.md
+++ b/.agents/skills/fla-ascend-performance/references/g-contiguous-loading.md
@@ -1,0 +1,115 @@
+# Gate `g` contiguous T-loading (G_T_CONTIG)
+
+Apply when a Triton-Ascend bwd/fwd kernel loads gate `g` along the **time axis** but `g` is laid out as `[B, T, HV]`. Strided loads with inner stride `HV` (e.g. `block_ptr(..., stride=(HV,))`) are often **orders of magnitude slower** on Ascend than stride-1 contiguous loads — even when Cube utilization looks high.
+
+Reference implementation: `fla/ops/common/backends/triton_ascend/chunk_o.py` (`chunk_fwd_kernel_o_npu`, `chunk_bwd_kernel_dv_local_npu`, `chunk_bwd_kernel_dqkwg_npu`, `chunk_bwd_kernel_dg_npu`).
+
+## Symptom
+
+- Kernel Duration in the **milliseconds** range for modest shapes (e.g. B=2, T=2048, HV=8) while Cube ~98%
+- PipeUtilization: high **MTE2** (aiv/aic), high **scalar**; fix does not require larger tiles
+- A/B: same kernel with `G_T_CONTIG=False` vs `True` shows **10×–35×** wall-clock gap on kernel-only timing
+
+## Root cause
+
+`g[b, t, h]` is stored with stride `HV` along `T`. A block load of `g[t0:t0+BC, h]` becomes a **gather** (stride `HV`), which Ascend MTE handles poorly in hot loops (many repeated small loads in bwd sub-block loops).
+
+## Fix: host transpose + kernel stride-1 pointer
+
+### 1. Host wrapper
+
+```python
+g_t_contig = g is not None and HV != 1
+g_arg = g.transpose(1, 2).contiguous() if g_t_contig else g
+# pass g=g_arg, G_T_CONTIG=g_t_contig to kernel
+```
+
+- **HV == 1**: skip transpose (stride along T is already 1).
+- Transpose cost is ~10–15 µs — negligible vs multi-ms saved.
+- Output tensors (`dg`, etc.) stay in original `[B, T, HV]` layout; only **input g reads** use transposed storage.
+
+### 2. Kernel: `G_T_CONTIG` constexpr
+
+Save packed length **before** varlen overwrites `T`:
+
+```python
+T_seq = T
+if IS_VARLEN:
+    ...
+    T = eos - bos   # local sequence length for block_ptr bounds
+```
+
+**Pointer** (must match `chunk_fwd_kernel_o_npu` — do not reuse `g += bos * HV + i_h` with transposed storage):
+
+| Mode | `g_ptr` |
+|------|---------|
+| Fixed batch | `g + i_b * HV * T_seq + i_h * T_seq` |
+| Varlen (packed) | `g + bos + i_h * T_seq` |
+
+**Block loads** (stride 1 along T):
+
+```python
+p_g = tl.make_block_ptr(g_ptr, (T,), (1,), (i_t * BT,), (BT,), (0,))          # full chunk
+p_gr = tl.make_block_ptr(g_ptr, (T,), (1,), (i_tc_r,), (BC,), (0,))         # sub-block
+b_g_last = tl.load(g_ptr + last_idx).to(tl.float32)                          # scalar tail
+```
+
+**Fallback** when `G_T_CONTIG=False` (legacy `[B,T,HV]` layout):
+
+```python
+g += bos * HV + i_h
+p_gr = tl.make_block_ptr(g, (T,), (HV,), (i_tc_r,), (BC,), (0,))
+b_g_last = tl.load(g + last_idx * HV).to(tl.float32)
+```
+
+Only offset `g` once in the non-contiguous branch; all loads in that branch use the offset base.
+
+### 3. Varlen checklist
+
+- `T_seq` = host-passed total packed length (used in `i_h * T_seq` term).
+- `T` after varlen setup = `eos - bos` (sequence length for `(T,)` block_ptr shape).
+- Token offsets (`i_t * BT`, `i_tc_r`) are **relative to sequence start** (same as k/q/do pointers after `bos` offset).
+
+## Measured wins (chunk_o.py, B=2, T=2048, H=4, HV=8, K=V=64)
+
+| Kernel / entry | Before (stride HV) | After (G_T_CONTIG) |
+|----------------|-------------------|---------------------|
+| `chunk_bwd_kernel_dv_local_npu` (kernel only) | ~6.5 ms | ~0.18 ms |
+| `chunk_bwd_dqkwg_npu` (kernel only) | ~10.8 ms | ~0.91 ms |
+| `chunk_bwd_dqkwg_npu` (e2e incl. dg + transpose) | — | ~1.5 ms |
+
+MTE2 (aiv) on dv_local dropped from ~31% to ~12% after fix.
+
+## Correctness gates
+
+- `tests/ops/test_gdn_kernels.py::test_chunk_bwd_dv_local`
+- `tests/ops/test_gdn_kernels.py::test_chunk_bwd_dqkwg`
+- Compare against Torch ref on T=2048 after optimization (not only small T).
+
+## Anti-patterns (verified on Ascend Triton 3.2)
+
+| Attempt | Result |
+|---------|--------|
+| Host transpose + kernel `g += bos*HV + i_h` + stride `(HV,)` | Wrong pointer → UB alignment crash or wrong values |
+| `b_g[tl.arange(0, BC)]` after one BT load | Unsupported tensor index |
+| `tl.reshape(b_dof, [2, BC, BV])` then sub-tile | `reshape() cannot change total number of elements` |
+| `tl.join(b_dv0, b_dv1)` + reshape for single dv store | Compiles but **wrong layout** (~15 max diff vs split store) |
+| `exp2(g_col) / exp2(g_row)` instead of `exp2(g_col - g_row)` | Risky on Ascend; verify numerics before using |
+| Runtime `if r == 0` on task_id-derived index | Correctness bugs on Ascend; use fused constexpr paths instead |
+
+## When to apply elsewhere
+
+Any `triton_ascend` kernel that:
+
+1. Reads `g` at multiple `(t, h)` positions inside nested `BC` / `BT` loops, and
+2. Currently uses `make_block_ptr(g + bos*HV + i_h, (T,), (HV,), ...)`.
+
+Also see `chunk_delta_h.py` bwd `dhu` notes in [reference.md](reference.md) (same stride-HV gather issue; additional gate precompute patterns there).
+
+## Optimization round template
+
+1. Baseline kernel-only timing with `G_T_CONTIG=False`.
+2. Add host transpose + `G_T_CONTIG` kernel path (keep fallback for HV==1 / tests).
+3. Run pytest gates above.
+4. Re-profile PipeUtilization; confirm Duration and MTE2 drop.
+5. Report **wall-clock** kernel time (one grid launch), not summed per-block Duration if profiler aggregates differently.

--- a/.agents/skills/fla-ascend-performance/references/reference.md
+++ b/.agents/skills/fla-ascend-performance/references/reference.md
@@ -1,0 +1,100 @@
+# Ascend Profiling + Optimization Reference
+
+Diagnosis table (profiler signal → bottleneck → fix): see [SKILL.md §3](../SKILL.md#3-diagnose-bottlenecks).
+
+## Choosing AiCMetrics
+
+Each profiling run supports **exactly one** `aic_metrics`. Collect multiple times when you need different evidence.
+
+| metrics | Key CSV columns | Question answered |
+|---------|-----------------|-------------------|
+| `PipeUtilization` (default first pass) | `aic_mac_ratio`, `aiv_vec_ratio`, `*_mte1/2/3_ratio`, `*_scalar_ratio`, `cube_utilization(%)` | Compute vs move vs scalar dominance |
+| `MemoryUB` | `aiv_ub_read/write_bw_*`, `aic_ub_*` | UB bandwidth saturation / R/W imbalance |
+| `Memory` / `MemoryAccess` / `MemoryL0` | matching memory columns | Finer memory paths |
+| `L2Cache` | L2 / icache related | Cache hit / reuse |
+| `ArithmeticUtilization` | arithmetic pipes | Arithmetic unit busy time |
+| `ResourceConflictRatio` | conflict related | Whether resource conflicts stall |
+
+Colloquial “CUDA utilization” → Ascend **Cube / MAC** (`aic_mac_ratio` / `cube_utilization(%)`).
+
+## Output layout
+
+```
+{name}_profiling_{timestamp}/
+  localhost..._ascend_pt/
+    ASCEND_PROFILER_OUTPUT/
+      kernel_details.csv
+      op_statistic.csv
+      operator_details.csv
+      api_statistic.csv
+      step_trace_time.csv
+      trace_view.json
+```
+
+## Host UB model
+
+```text
+peak ≈ memory_multiplier * BT * BD * dtype_size
+util = peak / ub_capacity
+safe_util = peak / (ub_capacity * safety_margin)
+```
+
+| Host signal | Next step |
+|-------------|-----------|
+| `safe_util` underused | Calibrate `mem_mult`, non-PoT tiles; measure compile-safe UB limit |
+| `safe_util` ≈ 100% still slow | Not a capacity issue — revisit pipe/bandwidth (SKILL §3) |
+
+After changing `mem_mult`/tiles, always re-check compile + numeric correctness.
+
+## Common failures and fixes
+
+- **UB overflow**: fewer concurrent fp32 tiles; smaller BK/BV; split kernels; avoid accidental large broadcasts.
+- **Grid limit**: host-split axes + offsets, **or** switch to 1D core-grid (`num_aicore` × flat `task_num`); do not only grow tiles.
+- **Varlen wrong only on long seqs**: after slicing `chunk_indices`, check for a second global `NT_OFFSET`; on core-grid paths, verify `chunk_offsets` → `(i_n, i_t)` against `cu_seqlens`.
+- **Wrong results only in multi-task core-grid loops**: rebind local base pointers each `task_id`; avoid in-place `ptr +=` across iterations.
+- **Occasional bf16 NaN**: mask before exp, fp32 accum, exp/exp2 scale, solve precision.
+- **Correct but slower**: launch count (split inter/intra + host grid chunks), tiny tiles, full-size fp32 scratch, extra layout converts, unsynced fake baselines.
+- **Local pass, full gate NaN**: tail writeback, boundary masks, invalid exp regions, scratch init before read.
+- **Compile-variant explosion**: do not specialize on T; move feature flags to heuristics/constexpr.
+- **`num_warps` / `num_stages` on NPU**: unsupported by Ascend Triton — remove from launches/autotune; never use as an optimization knob.
+- **int32 chunk-address overflow**: `NT = cdiv(T, BT)` under `do_not_specialize` is int32; `(NT-1)*HV*K*V` wraps before `.to(tl.int64)` on long context (K=V=128, HV=64 → T>131K). Fix: `(NT-1).to(tl.int64)*DH_CS` (same rule for any runtime `i_t`/offset × stride).
+- **Ungated path untested**: kernel tests that always pass `g` miss `g=None` regressions (in-place `dv`, scale folds, tiling). Parametrize `use_g` on the existing test + `g=None` reference branch — no new CI file required.
+- **Unsupported triton-ascend ops**: work around in-kernel; list every unsupported op in the round summary so follow-ups can track compiler gaps.
+
+## Repo code index
+
+Paths relative to the `flash-linear-attention` repo root. Detailed case notes: [cases.md](cases.md).
+
+### Backend wiring
+
+- `fla/ops/backends/__init__.py` — `BaseBackend` / `dispatch` / verifier
+- `fla/ops/common/backends/triton_ascend/__init__.py` — `IS_NPU` + lazy import
+- `fla/ops/gated_delta_rule/backends/triton_ascend/__init__.py` — multi-function backend example
+
+### UB / tile / grid
+
+- `fla/utils/ascend_ub_manager.py` — `compute_row_tile_block_size`, `iter_axis_launch_chunks`
+- `fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py` — peak tile, BC, UB-safe BK
+- `fla/ops/common/backends/triton_ascend/chunk_delta_h.py` — fwd recurrence, V tiling, bwd `dhu` (see [cases.md](cases.md))
+- `fla/ops/common/backends/triton_ascend/chunk_o.py` — fwd fuse + bwd G_T_CONTIG (see [cases.md](cases.md))
+- `fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py` — different fwd/bwd `mem_mult`; multi-stage bwd
+- `fla/ops/utils/backends/triton_ascend/cumsum.py` — scalar/vector split and leftover UB budget
+
+### Split / numerics / varlen
+
+- `fla/ops/gated_delta_rule/backends/triton_ascend/chunk_fwd.py` — stage split for UB
+- `fla/ops/utils/backends/triton_ascend/solve_tril.py` — blocked triangular solve, ieee/RTNE
+- `fla/ops/gated_delta_rule/backends/triton_ascend/gate.py` — heuristics, `do_not_specialize=['T']`
+
+### Tests and benchmarks
+
+- `tests/ops/test_gdn_kernels.py` — per-kernel oracle
+- `tests/utils/test_ascend_ub_manager.py` — tiling/grid boundaries
+- `tests/conftest.py` — NaN memory poisoning
+- `benchmarks/ops/verify.py` — correctness-gated benchmark (do not claim wins with `--no-gate`)
+- `benchmarks/ops/run.py` / `registry.py` — unified timing entrypoints
+- `.github/workflows/ascend-a2-ci.yml` — A2 CI; new ops need their own test entrypoints
+
+## Environment
+
+Use the Python/NPU environment already active in the current terminal (including any activated conda/venv). Run collection, analysis, and benchmarks in the same shell; do not spawn a new shell or switch environments mid-workflow. If the terminal has no NPU stack loaded yet, activate the project's Ascend environment first, then continue in that same session.

--- a/.agents/skills/fla-ascend-performance/scripts/analyze_profile.py
+++ b/.agents/skills/fla-ascend-performance/scripts/analyze_profile.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Generic Ascend profiler CSV analyzer.
+
+Parses ASCEND_PROFILER_OUTPUT under a trace directory and prints:
+- op_statistic top kernels by total time
+- kernel_details pipe / UB / bandwidth columns (whatever the run collected)
+
+Op-agnostic: no fla imports. Filter by kernel name substring when needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import os
+from collections.abc import Iterable
+
+
+def find_csv(trace_dir: str, filename: str) -> str | None:
+    paths = glob.glob(os.path.join(trace_dir, "**", filename), recursive=True)
+    return paths[0] if paths else None
+
+
+def _pick_cols(keys: Iterable[str], *needles: str) -> list[str]:
+    out = []
+    for c in keys:
+        cl = c.lower()
+        if any(n in cl for n in needles):
+            out.append(c)
+    return out
+
+
+def _nonzero_vals(row: dict, cols: list[str]) -> dict:
+    out = {}
+    for c in cols:
+        v = row.get(c, "")
+        if v not in (None, "", "N/A"):
+            out[c] = v
+    return out
+
+
+def summarize_op_statistic(trace_dir: str, top_k: int = 15) -> None:
+    path = find_csv(trace_dir, "op_statistic.csv")
+    if not path:
+        print(f"[analyze] no op_statistic.csv under {trace_dir}")
+        return
+    with open(path, newline="") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        print(f"[analyze] empty op_statistic.csv: {path}")
+        return
+
+    def _total(r):
+        try:
+            return float(r.get("Total Time(us)", 0) or 0)
+        except ValueError:
+            return 0.0
+
+    rows = sorted(rows, key=_total, reverse=True)
+    print(f"\n=== op_statistic top {top_k} ({path}) ===")
+    print(f"{'OP Type':<48} {'Core':<16} {'Count':>6} {'Total(us)':>12} {'Ratio%':>8}")
+    for r in rows[:top_k]:
+        print(
+            f"{r.get('OP Type', '?'):<48} "
+            f"{r.get('Core Type', '?'):<16} "
+            f"{r.get('Count', '?'):>6} "
+            f"{r.get('Total Time(us)', '?'):>12} "
+            f"{r.get('Ratio(%)', '?'):>8}"
+        )
+
+
+def summarize_kernel_details(
+    trace_dir: str,
+    kernel_filter: str | None = None,
+    top_k: int = 20,
+) -> None:
+    path = find_csv(trace_dir, "kernel_details.csv")
+    if not path:
+        print(f"[analyze] no kernel_details.csv under {trace_dir}")
+        return
+    with open(path, newline="") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        print(f"[analyze] empty kernel_details.csv: {path}")
+        return
+
+    keys = list(rows[0].keys())
+    if kernel_filter:
+        targets = [r for r in rows if kernel_filter in r.get("Name", "")]
+        if not targets:
+            print(f"[analyze] no kernel Name containing {kernel_filter!r}; showing top by duration")
+            targets = rows
+    else:
+        targets = rows
+
+    def _dur(r):
+        try:
+            return float(r.get("Duration(us)", 0) or 0)
+        except ValueError:
+            return 0.0
+
+    targets = sorted(targets, key=_dur, reverse=True)[:top_k]
+
+    # PipeUtilization groups
+    groups = {
+        "Cube(MAC)": _pick_cols(keys, "mac_ratio", "cube_utilization"),
+        "Vector": _pick_cols(keys, "vec_ratio"),
+        "Scalar": _pick_cols(keys, "scalar_ratio", "scalar_time"),
+        "MTE1": _pick_cols(keys, "mte1"),
+        "MTE2": _pick_cols(keys, "mte2"),
+        "MTE3": _pick_cols(keys, "mte3"),
+        "Fixpipe": _pick_cols(keys, "fixpipe"),
+        "UB_bw": _pick_cols(keys, "ub_"),
+        "L2/cache": _pick_cols(keys, "l2", "icache"),
+    }
+    # Drop empty groups so output matches the metrics that were actually collected.
+    groups = {k: v for k, v in groups.items() if v}
+
+    print(f"\n=== kernel_details ({path}) ===")
+    print(f"columns present: {sorted({c for cols in groups.values() for c in cols})}")
+    if not groups:
+        print("  (no pipe/UB metric columns; re-profile with --metrics PipeUtilization or MemoryUB)")
+        print(f"  available columns: {keys}")
+        return
+
+    for r in targets:
+        name = r.get("Name", "?")
+        dur = r.get("Duration(us)", "")
+        core = r.get("Accelerator Core", r.get("Type", ""))
+        print(f"\n  {name}  Duration={dur} us  core={core}")
+        for label, cols in groups.items():
+            vals = _nonzero_vals(r, cols)
+            if vals:
+                print(f"    {label}: {vals}")
+
+
+def summarize_trace(
+    trace_dir: str,
+    kernel_filter: str | None = None,
+    top_k: int = 20,
+) -> None:
+    """Print op_statistic + kernel_details summary for a profiling run."""
+    if not os.path.isdir(trace_dir):
+        raise FileNotFoundError(trace_dir)
+    summarize_op_statistic(trace_dir, top_k=min(top_k, 15))
+    summarize_kernel_details(trace_dir, kernel_filter=kernel_filter, top_k=top_k)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Analyze Ascend profiler CSV outputs")
+    parser.add_argument("trace_dir", help="Profiling output directory (or parent containing ASCEND_PROFILER_OUTPUT)")
+    parser.add_argument("--kernel-filter", default=None, help="Substring match on kernel Name")
+    parser.add_argument("--top-k", type=int, default=20)
+    args = parser.parse_args(argv)
+    summarize_trace(args.trace_dir, kernel_filter=args.kernel_filter, top_k=args.top_k)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/fla-ascend-performance/scripts/profile_npu.py
+++ b/.agents/skills/fla-ascend-performance/scripts/profile_npu.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Generic Ascend NPU profiling collector.
+
+Op-agnostic: wrap any callable that runs the workload (fwd / bwd / both).
+Does not import fla or any specific operator.
+
+Examples
+--------
+# As a library
+from profile_npu import profile_callable
+
+def workload():
+    y = op(x)
+    y.backward(dy)
+
+trace_dir = profile_callable(workload, name="my_op", aic_metrics="PipeUtilization")
+
+# CLI (inline python defining `workload`)
+python profile_npu.py --name my_op --metrics PipeUtilization --exec '
+import torch
+from my_mod import op
+from fla.utils import device
+x = torch.randn(1024, 1024, device=device, dtype=torch.bfloat16, requires_grad=True)
+def workload():
+    y = op(x); y.backward(torch.ones_like(y))
+'
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from collections.abc import Callable
+
+
+def _resolve_aic_metrics(name: str):
+    import torch_npu
+
+    metrics = torch_npu.profiler.AiCMetrics
+    aliases = {
+        "pipe": "PipeUtilization",
+        "pipeutilization": "PipeUtilization",
+        "ub": "MemoryUB",
+        "memoryub": "MemoryUB",
+        "memory": "Memory",
+        "l2": "L2Cache",
+        "l2cache": "L2Cache",
+        "arith": "ArithmeticUtilization",
+        "arithmeticutilization": "ArithmeticUtilization",
+        "memaccess": "MemoryAccess",
+        "memoryaccess": "MemoryAccess",
+        "memoryl0": "MemoryL0",
+        "conflict": "ResourceConflictRatio",
+        "resourceconflictratio": "ResourceConflictRatio",
+        "none": "AiCoreNone",
+        "aicorenone": "AiCoreNone",
+    }
+    key = name.replace("_", "").replace("-", "").lower()
+    attr = aliases.get(key, name)
+    if not hasattr(metrics, attr):
+        available = [x for x in dir(metrics) if not x.startswith("_")]
+        raise ValueError(f"Unknown aic_metrics={name!r}. Available: {available}")
+    return getattr(metrics, attr)
+
+
+def profile_callable(
+    fn: Callable[[], None],
+    *,
+    name: str = "npu_op",
+    out_dir: str | None = None,
+    aic_metrics: str = "PipeUtilization",
+    profiler_level: str = "Level1",
+    wait: int = 0,
+    warmup: int = 1,
+    active: int = 1,
+    repeat: int = 1,
+    skip_first: int = 0,
+    steps: int | None = None,
+    record_shapes: bool = True,
+    with_modules: bool = True,
+) -> str:
+    """Run ``fn`` under torch_npu.profiler and return the trace directory.
+
+    Schedule semantics (torch_npu): for each repeat, the profiler advances
+    wait → warmup → active steps. Call ``prof.step()`` once per iteration.
+    Default loop count is ``(wait + warmup + active) * repeat`` (plus skip_first).
+    """
+    import torch_npu
+
+    if out_dir is None:
+        out_dir = os.getcwd()
+    os.makedirs(out_dir, exist_ok=True)
+    trace_dir = os.path.join(out_dir, f"{name}_profiling_{time.time()}")
+
+    level = getattr(torch_npu.profiler.ProfilerLevel, profiler_level)
+    metrics = _resolve_aic_metrics(aic_metrics)
+    if steps is None:
+        steps = skip_first + (wait + warmup + active) * repeat
+
+    experimental_config = torch_npu.profiler._ExperimentalConfig(
+        profiler_level=level,
+        aic_metrics=metrics,
+    )
+
+    with torch_npu.profiler.profile(
+        activities=[
+            torch_npu.profiler.ProfilerActivity.CPU,
+            torch_npu.profiler.ProfilerActivity.NPU,
+        ],
+        schedule=torch_npu.profiler.schedule(
+            wait=wait,
+            warmup=warmup,
+            active=active,
+            repeat=repeat,
+            skip_first=skip_first,
+        ),
+        experimental_config=experimental_config,
+        record_shapes=record_shapes,
+        with_modules=with_modules,
+        on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(trace_dir),
+    ) as prof:
+        for _ in range(steps):
+            fn()
+            prof.step()
+
+    print(f"[profile_npu] trace written to {trace_dir}")
+    print(f"[profile_npu] aic_metrics={aic_metrics} level={profiler_level} steps={steps}")
+    return trace_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generic Ascend NPU profiler. Provide a Python snippet that defines workload().",
+    )
+    parser.add_argument("--name", default="npu_op", help="Trace directory prefix")
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="Parent directory for traces (default: cwd)",
+    )
+    parser.add_argument(
+        "--metrics",
+        default="PipeUtilization",
+        help="AiCMetrics name or alias: PipeUtilization|MemoryUB|Memory|L2Cache|...",
+    )
+    parser.add_argument("--level", default="Level1", help="ProfilerLevel: Level0|Level1|Level2")
+    parser.add_argument("--wait", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--active", type=int, default=1)
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--skip-first", type=int, default=0)
+    parser.add_argument("--steps", type=int, default=None, help="Override loop iterations")
+    parser.add_argument(
+        "--exec",
+        dest="exec_src",
+        default=None,
+        help="Python source that defines workload(). Runs in an isolated globals dict.",
+    )
+    parser.add_argument(
+        "--exec-file",
+        default=None,
+        help="Path to a .py file that defines workload().",
+    )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="After profiling, run analyze_profile on the trace",
+    )
+    parser.add_argument(
+        "--kernel-filter",
+        default=None,
+        help="Substring filter for kernel Name when analyzing",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.exec_src and not args.exec_file:
+        parser.error("Provide --exec or --exec-file that defines workload()")
+
+    g: dict = {"__name__": "__profile_workload__"}
+    if args.exec_file:
+        with open(args.exec_file, encoding="utf-8") as f:
+            src = f.read()
+        # Allow relative imports from the file's directory.
+        sys.path.insert(0, os.path.dirname(os.path.abspath(args.exec_file)))
+        exec(compile(src, args.exec_file, "exec"), g, g)
+    else:
+        exec(compile(args.exec_src, "<--exec>", "exec"), g, g)
+
+    if "workload" not in g or not callable(g["workload"]):
+        raise SystemExit("Snippet must define a callable workload()")
+
+    trace_dir = profile_callable(
+        g["workload"],
+        name=args.name,
+        out_dir=args.out_dir,
+        aic_metrics=args.metrics,
+        profiler_level=args.level,
+        wait=args.wait,
+        warmup=args.warmup,
+        active=args.active,
+        repeat=args.repeat,
+        skip_first=args.skip_first,
+        steps=args.steps,
+    )
+
+    if args.analyze:
+        # Late import so this file stays usable without analyze_profile on PYTHONPATH.
+        from analyze_profile import summarize_trace
+
+        summarize_trace(trace_dir, kernel_filter=args.kernel_filter)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/fla-optimization-loop/SKILL.md
+++ b/.agents/skills/fla-optimization-loop/SKILL.md
@@ -16,6 +16,7 @@ across more than one iteration, in any FLA backend language (Triton, Gluon, Tile
 This skill is the **search discipline** that ties the other skills together; it does not replace them:
 
 - **`fla-nvidia-performance`** — how to profile (NCU), hardware baselines, MR-ready perf evidence.
+- **`fla-ascend-performance`** — how to profile (torch_npu), diagnose Cube/Vector/MTE/UB bottlenecks, and optimize Triton-Ascend kernels.
 - **`fla-correctness-coverage`** — how to design the test coverage matrix for an op.
 - **`fla-mr-readiness`** — how to package the promoted change into a PR.
 
@@ -77,7 +78,7 @@ Run these in order; repeat 2 and 3 with progressively higher targets.
 - **Phase 1 — correct baseline.** Confirm the current kernel passes the full gate, and record baseline numbers:
   `python -m benchmarks.ops.verify --op <op> --base main`.
   For a brand-new kernel, get the gate green first; performance is secondary here.
-- **Phase 2 — profile-guided optimization.** Use `fla-nvidia-performance` for NCU evidence.
+- **Phase 2 — profile-guided optimization.** Use `fla-nvidia-performance` for NCU evidence on NVIDIA backends, or `fla-ascend-performance` for Ascend NPU / Triton-Ascend backends.
   Enumerate candidate directions, rank them by expected benefit vs. implementation risk,
   and explore each for at most a few iterations. Keep, revise, or reject each with evidence — don't optimize blindly.
 - **Phase 3 — shape specialization.** Only when profiling shows *different* bottlenecks across shape regimes
@@ -155,7 +156,7 @@ a speedup you can't account for is a silent-skip suspect, not a result (see §5)
 
 - Keep the diff minimal — change only what the win needs,
   plus light cleanups (CONTRIBUTING "Protect battle-tested paths; keep diffs minimal").
-- Collect perf evidence per `fla-nvidia-performance` — before/after, NCU summary, dense + varlen coverage,
+- Collect perf evidence per backend skill — `fla-nvidia-performance` (before/after, NCU summary, dense + varlen coverage) or `fla-ascend-performance` (before/after, pipe/UB metrics, round summary template) —
   and a full final-claim stats block (median/mean/std/min/p10/p90 per shape, equal-weight geomean speedup,
   exact commands, baseline commit + candidate SHA, GPU id/model with idle-clock evidence —
   the last guards the clock-drift trap in §5).


### PR DESCRIPTION
## Summary

Adds **`fla-ascend-performance`**, a repo-local agent skill for Ascend NPU / Triton-Ascend kernel performance work. It mirrors the existing `fla-nvidia-performance` pattern: a end-to-end workflow from profiling → bottleneck diagnosis → optimization → verification, with progressive disclosure across supporting files.

**New skill contents:**
- `SKILL.md` — main workflow (freeze baseline, collect, diagnose, optimize, verify), hard constraints (`num_warps`/`num_stages` unsupported on NPU), review checklist, round-summary template
- `reference.md` — AiCMetrics selection, CSV layout, host UB model, common failure modes, repo code index
- `cases.md` — distilled notes from past `chunk_delta_h` / `chunk_o` optimizations
- `g-contiguous-loading.md` — G_T_CONTIG gate loading guide (stride-1 `g` along T)
- `scripts/profile_npu.py` — generic op-agnostic `torch_npu` profiler collector (CLI + library)
- `scripts/analyze_profile.py` — generic CSV parser for `op_statistic` / `kernel_details`

**Wiring:**
- Registers the skill in `.agents/README.md` and `.agents/skills/README.md`
- Links `fla-ascend-performance` from `fla-optimization-loop` (Phase 2 profiling + promotion evidence)

No runtime/kernel code changes — agent documentation and helper scripts only.