### PR TITLE
[Fix] Zero-init Ascend chunk_scaled_dot_kkt output and add solve_tril to CI

### DIFF
--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -100,7 +100,7 @@ jobs:
           assert IS_NPU, "Expected NPU backend (IS_NPU=True)"
           PY
 
-      - name: Run fla/modules and fla/ops/utils, gdn, kda, attnres tests
+      - name: Run tests/modules and tests/ops/utils, gdn, kda, attnres, solve_tril
         shell: bash
         env:
           FLA_NPU_XDIST: "1"
@@ -112,4 +112,5 @@ jobs:
             tests/ops/test_gdn_kernels.py \
             tests/ops/test_gdn.py \
             tests/ops/test_kda.py \
-            tests/ops/test_attnres.py
+            tests/ops/test_attnres.py \
+            tests/ops/test_solve_tril.py

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -155,7 +155,7 @@ def chunk_scaled_dot_kkt_fwd_npu(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
-    A = torch.empty(B, T, HV, BT, device=k.device, dtype=output_dtype)
+    A = torch.zeros(B, T, HV, BT, device=k.device, dtype=output_dtype)
     BK = _get_bk(K)
     use_g = g is not None
     g_arg = g if use_g else beta


### PR DESCRIPTION
## Summary

Fix incorrect `chunk_scaled_dot_kkt_fwd` output on Ascend NPU for `chunk_size >= 32`.

The NPU kernel writes only lower-triangular 16×16 sub-blocks into each BT×BT tile and does not cover the upper triangle (e.g. rows 0–15, cols 16–31 when BT=32). Using `torch.empty()` left uninitialized values there, so downstream `solve_tril` varlen tests failed for BT=32/64.

- Initialize the output buffer with `torch.zeros()` instead of `torch.empty()`.
- Add `tests/ops/test_solve_tril.py` to Ascend A2 CI to catch regressions in the GDN/KDA intra-chunk pipeline.

## Test plan

- [x] `pytest tests/ops/test_solve_tril.py` — all tests pass on NPU
- [x] Ascend A2 CI includes `test_solve_tril.py`