### PR TITLE
[Fix] Gate the recomputed output in layer_norm_gated backward

### DIFF
--- a/fla/modules/backends/triton_ascend/fused_norm_gate.py
+++ b/fla/modules/backends/triton_ascend/fused_norm_gate.py
@@ -263,8 +263,6 @@ def layer_norm_gated_bwd_kernel(
         b_y = b_xhat * b_w[None, :] if HAS_WEIGHT else b_xhat
         if HAS_BIAS:
             b_y = b_y + b_b[None, :]
-        if RECOMPUTE_OUTPUT:
-            tl.store(y + row_off, b_y.to(y.dtype.element_ty), mask=mask)
 
         b_g = tl.load(g + row_off, mask=mask, other=0.0).to(tl.float32)
         b_dy = tl.load(dy + row_off, mask=mask, other=0.0).to(tl.float32)
@@ -272,15 +270,20 @@ def layer_norm_gated_bwd_kernel(
         if ACTIVATION == 0:
             # silu'(g) = sigmoid(g) * (1 + g * (1 - sigmoid(g)))
             b_dsilu = b_sigmoid_g * (1 + b_g * (1 - b_sigmoid_g))
+            b_gate = b_g * b_sigmoid_g
             tl.store(dg + row_off, (b_dy * b_y * b_dsilu).to(dg.dtype.element_ty), mask=mask)
-            b_dy = b_dy * b_g * b_sigmoid_g
         else:
+            b_gate = b_sigmoid_g
             tl.store(
                 dg + row_off,
                 (b_dy * b_y * b_sigmoid_g * (1 - b_sigmoid_g)).to(dg.dtype.element_ty),
                 mask=mask,
             )
-            b_dy = b_dy * b_sigmoid_g
+        # dg needs the pre-gate b_y, but the recomputed output must match what the
+        # forward stored, i.e. the gated value the caller fed to its linear layer.
+        if RECOMPUTE_OUTPUT:
+            tl.store(y + row_off, (b_y * b_gate).to(y.dtype.element_ty), mask=mask)
+        b_dy = b_dy * b_gate
 
         if HAS_WEIGHT:
             b_dw += tl.sum(tl.where(mask, b_dy * b_xhat, 0.0), axis=0)

--- a/fla/modules/fused_norm_gate.py
+++ b/fla/modules/fused_norm_gate.py
@@ -273,17 +273,20 @@ def layer_norm_gated_bwd_kernel(
         b_y = b_xhat * b_w[None, :] if HAS_WEIGHT else b_xhat
         if HAS_BIAS:
             b_y = b_y + b_b[None, :]
-        if RECOMPUTE_OUTPUT:
-            p_y = y + o_t[:, None] * D + o_d[None, :]
-            tl.store(p_y, b_y.to(p_y.dtype.element_ty), mask=m_x)
 
         b_sigmoid_g = tl.sigmoid(b_g)
         if ACTIVATION == "swish" or ACTIVATION == "silu":
+            b_gate = b_g * b_sigmoid_g
             b_dg = b_dy * b_y * (b_sigmoid_g + b_g * b_sigmoid_g * (1 - b_sigmoid_g))
-            b_dy = b_dy * b_g * b_sigmoid_g
         elif ACTIVATION == "sigmoid":
+            b_gate = b_sigmoid_g
             b_dg = b_dy * b_y * b_sigmoid_g * (1 - b_sigmoid_g)
-            b_dy = b_dy * b_sigmoid_g
+        # b_dg needs the pre-gate b_y, but the recomputed output must match what the
+        # forward stored, i.e. the gated value the caller fed to its linear layer.
+        if RECOMPUTE_OUTPUT:
+            p_y = y + o_t[:, None] * D + o_d[None, :]
+            tl.store(p_y, (b_y * b_gate).to(p_y.dtype.element_ty), mask=m_x)
+        b_dy = b_dy * b_gate
         b_wdy = b_dy
 
         if HAS_WEIGHT or HAS_BIAS:
@@ -398,16 +401,19 @@ def layer_norm_gated_bwd_kernel1(
         b_y = b_xhat * b_w if HAS_WEIGHT else b_xhat
         if HAS_BIAS:
             b_y = b_y + b_b
-        if RECOMPUTE_OUTPUT:
-            tl.store(y + o_d, b_y, mask=mask)
 
         b_sigmoid_g = tl.sigmoid(b_g)
         if ACTIVATION == "swish" or ACTIVATION == "silu":
+            b_gate = b_g * b_sigmoid_g
             b_dg = b_dy * b_y * (b_sigmoid_g + b_g * b_sigmoid_g * (1 - b_sigmoid_g))
-            b_dy = b_dy * b_g * b_sigmoid_g
         elif ACTIVATION == "sigmoid":
+            b_gate = b_sigmoid_g
             b_dg = b_dy * b_y * b_sigmoid_g * (1 - b_sigmoid_g)
-            b_dy = b_dy * b_sigmoid_g
+        # b_dg needs the pre-gate b_y, but the recomputed output must match what the
+        # forward stored, i.e. the gated value the caller fed to its linear layer.
+        if RECOMPUTE_OUTPUT:
+            tl.store(y + o_d, b_y * b_gate, mask=mask)
+        b_dy = b_dy * b_gate
         b_wdy = b_dy
         if HAS_WEIGHT:
             b_wdy = b_dy * b_w

--- a/tests/modules/test_layernorm_gated.py
+++ b/tests/modules/test_layernorm_gated.py
@@ -10,7 +10,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from fla.modules import FusedLayerNormGated, FusedRMSNormGated
+from fla.modules import (
+    FusedLayerNormGated,
+    FusedLayerNormSwishGateLinear,
+    FusedRMSNormGated,
+    FusedRMSNormSwishGateLinear,
+)
 from fla.utils import IS_NVIDIA_BLACKWELL, assert_close, device
 
 
@@ -96,6 +101,53 @@ def test_rmsnorm_gated(B: int, H: int, T: int, D: int, activation: str):
     assert_close('dx', ref_dx, tri_dx, 1e-3)
     assert_close('dg', ref_dg, tri_dg, 1e-3)
     assert_close('dw', ref_dw, tri_dw, 1e-3)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'D', 'O', 'is_rms_norm', 'linear_bias'),
+    [
+        # D <= 512 and D > 512 select the two different backward kernels
+        pytest.param(*test, id=f"B{test[0]}_T{test[1]}_D{test[2]}_O{test[3]}_rms{test[4]}_bias{test[5]}")
+        for test in [
+            (2, 64,  64,   32,  False, False),
+            (2, 64,  64,   32,  True,  True),
+            (2, 500, 1024, 256, False, True),
+            (2, 500, 1024, 256, True,  False),
+        ]
+    ],
+)
+def test_norm_swish_gate_linear(B: int, T: int, D: int, O: int, is_rms_norm: bool, linear_bias: bool):
+    torch.manual_seed(42)
+    eps = 1e-5
+    x = torch.randn(B, T, D).to(device)
+    g = torch.randn(B, T, D).to(device)
+    nw = torch.randn(D).to(device)
+    lw = (torch.randn(O, D) / D ** 0.5).to(device)
+    lb = torch.randn(O).to(device) if linear_bias else None
+    do = torch.randn(B, T, O).to(device)
+
+    def leaves():
+        return [t.clone().requires_grad_(True) if t is not None else None for t in (x, g, lw, lb)]
+
+    tri_x, tri_g, tri_lw, tri_lb = leaves()
+    tri = (FusedRMSNormSwishGateLinear if is_rms_norm else FusedLayerNormSwishGateLinear)(D, eps=eps).to(device)
+    tri.weight.data.copy_(nw)
+    tri(tri_x, tri_g, tri_lw, tri_lb).backward(do)
+
+    ref_x, ref_g, ref_lw, ref_lb = leaves()
+    ref_nw = nw.clone().requires_grad_(True)
+    if is_rms_norm:
+        ref_norm = ref_x * torch.rsqrt(ref_x.pow(2).mean(-1, keepdim=True) + eps) * ref_nw
+    else:
+        ref_norm = F.layer_norm(ref_x, (D,), ref_nw, None, eps)
+    F.linear(ref_norm * F.silu(ref_g), ref_lw, ref_lb).backward(do)
+
+    assert_close('            dx', ref_x.grad, tri_x.grad, 1e-3)
+    assert_close('            dg', ref_g.grad, tri_g.grad, 1e-3)
+    assert_close('  dnorm_weight', ref_nw.grad, tri.weight.grad, 1e-3)
+    assert_close('dlinear_weight', ref_lw.grad, tri_lw.grad, 1e-3)
+    if linear_bias:
+        assert_close('  dlinear_bias', ref_lb.grad, tri_lb.grad, 1e-3)
 
 
 @pytest.mark.skipif(not IS_NVIDIA_BLACKWELL, reason="large-offset repro requires a Blackwell/B200-class CUDA GPU")


### PR DESCRIPTION
## Summary

`FusedLayerNormSwishGateLinear` / `FusedRMSNormSwishGateLinear` (and the `*GatedLinear` bases they derive from) produce a wrong gradient for the linear weight. The forward is correct, so this is silent: inference and any
forward-only check pass, and only training is affected. 
The forward stores the gated output and feeds exactly that to the linear layer:

```python
# layer_norm_gated_fwd_kernel, fla/modules/fused_norm_gate.py
b_y = b_y * b_g * tl.sigmoid(b_g)   # y = norm(x) * w * silu(g)
...
# LayerNormGatedLinearFunction.forward
out = F.linear(y, linear_weight, linear_bias)
```

To save memory, `y` is not saved; the backward recomputes it under `RECOMPUTE_OUTPUT`. But the recompute stored the **pre-gate** value `norm(x) * w`, while the backward then uses it as the linear input:

```python
# LayerNormGatedLinearFunction.backward
dlinear_weight = torch.einsum("bo,bi->oi", dout, y)
```

Since `out = y_gated @ Wᵀ`, the weight gradient must contract `dout` with the gated `y`. Contracting with the pre-gate value makes `dlinear_weight` wrong by a per-element `silu(g)` factor — generically far from 1, and exactly zero when `g = 0`. Measured against an autograd reference the relative error is ~1.6 (i.e. the gradient is simply wrong, not slightly off); `dx`, `dg` and `dnorm_weight` are all correct.

The fix stores the gated value at the recompute site. The pre-gate `b_y` is still needed there — the gate derivative `dg = dy * y_pre * silu'(g)` uses it — so the gate factor is hoisted into `b_gate` and applied only to the stored
output and to `b_dy`, leaving `b_dg` on the pre-gate value as before.

Both CUDA backward kernels share the defect (`layer_norm_gated_bwd_kernel`, the `D <= 512` block path, and `layer_norm_gated_bwd_kernel1`, the `D > 512` per-row path), as does the `triton_ascend` backend; all three are fixed. The `layernorm_gated.py` sibling already stores the gated value at its recompute site, which is the behavior this restores.

## Blast radius

- **Affected**: anyone training with `FusedLayerNormSwishGateLinear`, `FusedRMSNormSwishGateLinear`, `FusedLayerNormGatedLinear`,  `FusedRMSNormGatedLinear`, or the `layer_norm_swish_gate_linear` /
  `rms_norm_swish_gate_linear` functions. All dtypes, all shapes, both backward kernel paths, CUDA and Ascend. Any run that trained through these modules had a corrupted linear weight gradient.
- **Not affected**: forward / inference outputs are unchanged, so no checkpoint or state-dict compatibility change. `dx`, `dg` and `dnorm_weight` were already correct and stay bit-identical. The non-linear gated modules
  (`FusedLayerNormGated`, `FusedRMSNormGated`) never set `recompute_output`, so their behavior is unchanged.
- No layer or model in this repo uses the fused norm+linear modules, so nothing in `fla/layers/` or `fla/models/` changes. That is also why no existing test caught this: `tests/modules/test_layernorm_gated.py` only covered the
  non-linear gated variants.

## Test plan

New test `test_norm_swish_gate_linear` in `tests/modules/test_layernorm_gated.py` compares `dx`, `dg`, `dnorm_weight`, `dlinear_weight` and `dlinear_bias` against a plain-PyTorch autograd reference, parametrized over LayerNorm/RMSNorm, with/without linear bias, and `D = 64` and `D = 1024` so both backward kernels are exercised.

Verified the test actually catches the bug: reverting only the kernel change fails all four cases on `dlinear_weight` (`ratio` 1.51–1.64) while every other gradient still passes.

Run on H100 NVL, torch 2.13.0+cu129 / triton 3.7.1:

```
pytest tests/modules/test_layernorm_gated.py -k norm_swish_gate_linear   # 4 passed
pytest tests/modules/                                                    # 551 passed, 28 skipped
pytest tests/layers/test_gated_deltanet.py                               # 3 passed
```

Dependent tests were selected with `python scripts/find_dependent_tests.py fla/modules/fused_norm_gate.py`.

The Ascend backend change is the same edit applied to the same defect; I have no NPU to run it on, so it is untested hardware-side.

## Benchmark

Not a performance change. The gate multiply that was already applied to `b_dy` is hoisted into a variable and reused; the only added arithmetic is one elementwise multiply on the recompute store, which happens solely on the `recompute_output=True` path.

## Breaking changes

None. This restores intended behavior — a gradient that was wrong becomes correct. Training runs that depended on the buggy gradient will see different (correct) updates.
