### PR TITLE
[Perf] Refactor Ascend KDA WY backward: split dA finalize and precompute dw workspace

### DIFF
--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -345,16 +345,12 @@ def chunk_kda_bwd_kernel_wy_k_part_npu(
     k,
     v_new,
     g,
-    beta,
-    A,
     h,
     do,
     dh,
     dq,
     dk,
     dg,
-    dA_acc,
-    db_acc,
     cu_seqlens,
     chunk_indices,
     scale,
@@ -384,26 +380,20 @@ def chunk_kda_bwd_kernel_wy_k_part_npu(
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
-        NT = tl.cdiv(T, BT)
     else:
-        NT = tl.cdiv(T, BT)
-        i_tg = (i_b * NT + i_t).to(tl.int64)
+        i_tg = (i_b * tl.cdiv(T, BT) + i_t).to(tl.int64)
         bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
     v_new += (bos * HV + i_hv) * V
     g += (bos * HV + i_hv) * K
-    beta += bos * HV + i_hv
-    A += (bos * HV + i_hv) * BT
     h += (i_tg * HV + i_hv) * K * V
     do += (bos * HV + i_hv) * V
     dh += (i_tg * HV + i_hv) * K * V
     dq += (bos * HV + i_hv) * K
     dk += (bos * HV + i_hv) * K
     dg += (bos * HV + i_hv) * K
-    dA_acc += (bos * HV + i_hv) * BT
-    db_acc += bos * HV + i_hv
 
     o_k = i_k * BK + tl.arange(0, BK)
     m_k = o_k < K
@@ -509,6 +499,7 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
     A,
     h,
     dv,
+    dw,
     dA_acc,
     db_acc,
     dg,
@@ -551,6 +542,7 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
     A += (bos * HV + i_hv) * BT
     h += (i_tg * HV + i_hv).to(tl.int64) * K * V
     dv += (bos * HV + i_hv) * V
+    dw += (bos * HV + i_hv) * K
     dA_acc += (bos * HV + i_hv) * BT
     db_acc += bos * HV + i_hv
     dg += (bos * HV + i_hv) * K
@@ -558,49 +550,46 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
 
     n_sub = BT // BC
 
-    for s_r in range(n_sub):
-        i_tc_r = i_t * BT + s_r * BC
-
-        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
-        p_beta_r = tl.make_block_ptr(beta, (T,), (HV,), (i_tc_r,), (BC,), (0,))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-        b_beta_r = tl.load(p_beta_r, boundary_check=(0,))
-        b_gk_exp = exp2(b_g)
-        b_kg = b_k * b_gk_exp
-        b_gb = b_gk_exp * b_beta_r[:, None]
-
-        b_dw_r = tl.zeros([BC, BK], dtype=tl.float32)
+    # Precompute dw[s] = -dv[s] @ h once per sub-block.
+    for s in range(n_sub):
+        i_tc = i_t * BT + s * BC
+        b_dw = tl.zeros([BC, BK], dtype=tl.float32)
         for i_v in range(tl.cdiv(V, BV)):
-            p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_tc_r, i_v * BV), (BC, BV), (1, 0))
+            p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_tc, i_v * BV), (BC, BV), (1, 0))
             if STATE_V_FIRST:
                 p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
             else:
                 p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
             b_dv = tl.load(p_dv, boundary_check=(0, 1))
             b_h = tl.load(p_h, boundary_check=(0, 1))
-            b_dw_r += tl.dot(b_dv.to(b_h.dtype), b_h.to(b_h.dtype), allow_tf32=False)
-        b_dw_r = -b_dw_r.to(b_k.dtype)
+            b_dw += tl.dot(b_dv.to(b_h.dtype), b_h.to(b_h.dtype), allow_tf32=False)
+        p_dw = tl.make_block_ptr(dw, (T, K), (HV * K, 1), (i_tc, i_k * BK), (BC, BK), (1, 0))
+        tl.store(p_dw, (-b_dw).to(p_dw.dtype.element_ty), boundary_check=(0, 1))
+
+    for s_r in range(n_sub):
+        i_tc_r = i_t * BT + s_r * BC
+
+        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
+        p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
+        p_beta_r = tl.make_block_ptr(beta, (T,), (HV,), (i_tc_r,), (BC,), (0,))
+        p_dw_r = tl.make_block_ptr(dw, (T, K), (HV * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        b_beta_r = tl.load(p_beta_r, boundary_check=(0,))
+        b_dw_r = tl.load(p_dw_r, boundary_check=(0, 1))
+        b_gk_exp = exp2(b_g)
+        b_kg = b_k * b_gk_exp
+        b_gb = b_gk_exp * b_beta_r[:, None]
 
         b_dkgb_r = tl.zeros([BC, BK], dtype=tl.float32)
         for s_c in range(n_sub):
             i_tc_c = i_t * BT + s_c * BC
-            b_dw_c = tl.zeros([BC, BK], dtype=tl.float32)
-            for i_v in range(tl.cdiv(V, BV)):
-                p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_tc_c, i_v * BV), (BC, BV), (1, 0))
-                if STATE_V_FIRST:
-                    p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-                else:
-                    p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-                b_dv = tl.load(p_dv, boundary_check=(0, 1))
-                b_h = tl.load(p_h, boundary_check=(0, 1))
-                b_dw_c += tl.dot(b_dv.to(b_h.dtype), b_h.to(b_h.dtype), allow_tf32=False)
-            b_dw_c = -b_dw_c.to(b_k.dtype)
+            p_dw_c = tl.make_block_ptr(dw, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
+            b_dw_c = tl.load(p_dw_c, boundary_check=(0, 1))
 
             p_A_rc = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (s_r * BC, i_tc_c), (BC, BC), (0, 1))
             b_A_rc = tl.load(p_A_rc, boundary_check=(0, 1))
-            b_dkgb_r += tl.dot(b_A_rc, b_dw_c, allow_tf32=False)
+            b_dkgb_r += tl.dot(b_A_rc.to(tl.float32), b_dw_c.to(tl.float32), allow_tf32=False)
 
             p_k_c = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
             p_g_c = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
@@ -610,7 +599,7 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
 
             p_dA_acc = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_tc_r, s_c * BC), (BC, BC), (1, 0))
             b_dA_rc = tl.load(p_dA_acc, boundary_check=(0, 1)).to(tl.float32)
-            b_dA_rc += tl.dot(b_dw_r, tl.trans(b_kg_c.to(b_k.dtype)), allow_tf32=False)
+            b_dA_rc += tl.dot(b_dw_r.to(tl.float32), tl.trans(b_kg_c.to(tl.float32)), allow_tf32=False)
             tl.store(p_dA_acc, b_dA_rc.to(p_dA_acc.dtype.element_ty), boundary_check=(0, 1))
 
         p_db_acc = tl.make_block_ptr(db_acc, (T,), (HV,), (i_tc_r,), (BC,), (0,))
@@ -630,13 +619,9 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
 
 
 @triton.jit(do_not_specialize=['T'])
-def chunk_kda_bwd_kernel_wy_dA_finalize_npu(
+def chunk_kda_bwd_kernel_wy_dA_mask_npu(
     beta,
-    A,
     dA_acc,
-    db_acc,
-    dA,
-    db,
     cu_seqlens,
     chunk_indices,
     T,
@@ -647,73 +632,131 @@ def chunk_kda_bwd_kernel_wy_dA_finalize_npu(
     NT_OFFSET: tl.constexpr,
     BH_OFFSET: tl.constexpr,
 ):
+    """In-place: dA_acc = mask * dA_acc * beta[None, :]."""
     i_t = tl.program_id(0) + NT_OFFSET
     i_bh = tl.program_id(1) + BH_OFFSET
     i_b, i_hv = i_bh // HV, i_bh % HV
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
 
     beta += bos * HV + i_hv
-    A += (bos * HV + i_hv) * BT
     dA_acc += (bos * HV + i_hv) * BT
-    db_acc += bos * HV + i_hv
-    dA += (bos * HV + i_hv) * BT
-    db += bos * HV + i_hv
 
     o_i = tl.arange(0, BC)
     n_sub = BT // BC
 
-    for s_r in range(n_sub):
-        i_tc_r = i_t * BT + s_r * BC
-        m_r = (i_tc_r + o_i) < T
+    for s_a in range(n_sub):
+        i_tc_a = i_t * BT + s_a * BC
+        m_a = (i_tc_a + o_i) < T
+        o_t_a = i_tc_a + o_i
+        for s_b in range(n_sub):
+            i_tc_b = i_t * BT + s_b * BC
+            m_b = (i_tc_b + o_i) < T
+            o_t_b = i_tc_b + o_i
+            p_dA = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_tc_a, s_b * BC), (BC, BC), (1, 0))
+            p_beta_b = tl.make_block_ptr(beta, (T,), (HV,), (i_tc_b,), (BC,), (0,))
+            b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
+            b_beta_b = tl.load(p_beta_b, boundary_check=(0,))
+            m_A = (o_t_a[:, None] > o_t_b[None, :]) & (m_a[:, None] & m_b[None, :])
+            b_M = tl.where(m_A, b_dA * b_beta_b[None, :], 0)
+            tl.store(p_dA, b_M.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
 
-        for s_c in range(n_sub):
-            i_tc_c = i_t * BT + s_c * BC
-            m_c = (i_tc_c + o_i) < T
 
-            b_dA_rc = tl.zeros([BC, BC], dtype=tl.float32)
-            for s_a in range(n_sub):
-                i_tc_a = i_t * BT + s_a * BC
-                m_a = (i_tc_a + o_i) < T
-                b_T_ac = tl.zeros([BC, BC], dtype=tl.float32)
-                for s_b in range(n_sub):
-                    i_tc_b = i_t * BT + s_b * BC
-                    m_b = (i_tc_b + o_i) < T
+@triton.jit(do_not_specialize=['T'])
+def chunk_kda_bwd_kernel_wy_dA_mid_npu(
+    A,
+    dA_acc,
+    dA_mid,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    HV: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
+):
+    """T = dA_acc @ A after mask*beta has been applied to dA_acc."""
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_bh = tl.program_id(1) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
 
-                    p_dA_ab = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_tc_a, s_b * BC), (BC, BC), (1, 0))
-                    p_beta_b = tl.make_block_ptr(beta, (T,), (HV,), (i_tc_b,), (BC,), (0,))
-                    p_A_bc = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (s_b * BC, i_tc_c), (BC, BC), (0, 1))
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
+    else:
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
 
-                    b_dA_ab = tl.load(p_dA_ab, boundary_check=(0, 1)).to(tl.float32)
-                    b_beta_b = tl.load(p_beta_b, boundary_check=(0,))
-                    b_A_bc = tl.load(p_A_bc, boundary_check=(0, 1))
+    A += (bos * HV + i_hv) * BT
+    dA_acc += (bos * HV + i_hv) * BT
+    dA_mid += (bos * HV + i_hv) * BT
 
-                    o_t_a = i_tc_a + o_i
-                    o_t_b = i_tc_b + o_i
-                    m_A_ab = (o_t_a[:, None] > o_t_b[None, :]) & (m_a[:, None] & m_b)
-                    b_M_ab = tl.where(m_A_ab, b_dA_ab * b_beta_b[None, :], 0)
-                    b_T_ac += tl.dot(b_M_ab.to(b_A_bc.dtype), b_A_bc, allow_tf32=False)
+    p_A = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
+    p_dA = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_out = tl.make_block_ptr(dA_mid, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
+    b_out = tl.dot(b_dA.to(b_A.dtype), b_A, allow_tf32=False)
+    tl.store(p_out, b_out.to(p_out.dtype.element_ty), boundary_check=(0, 1))
 
-                p_A_ra = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (s_r * BC, i_tc_a), (BC, BC), (0, 1))
-                b_A_ra = tl.load(p_A_ra, boundary_check=(0, 1))
-                b_dA_rc += tl.dot(b_A_ra, b_T_ac.to(b_A_ra.dtype), allow_tf32=False)
 
-            o_t_r = i_tc_r + o_i
-            o_t_c = i_tc_c + o_i
-            m_A_rc = (o_t_r[:, None] > o_t_c[None, :]) & (m_r[:, None] & m_c)
-            b_dA_rc = tl.where(m_A_rc, -b_dA_rc, 0)
+@triton.jit(do_not_specialize=['T'])
+def chunk_kda_bwd_kernel_wy_dA_finalize_npu(
+    A,
+    dA_mid,
+    db_acc,
+    dA,
+    db,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    HV: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
+):
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_bh = tl.program_id(1) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
 
-            p_dA = tl.make_block_ptr(dA, (T, BT), (HV * BT, 1), (i_tc_r, s_c * BC), (BC, BC), (1, 0))
-            tl.store(p_dA, b_dA_rc.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
+    else:
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
 
-        p_db_acc = tl.make_block_ptr(db_acc, (T,), (HV,), (i_tc_r,), (BC,), (0,))
-        p_db = tl.make_block_ptr(db, (T,), (HV,), (i_tc_r,), (BC,), (0,))
-        tl.store(p_db, tl.load(p_db_acc, boundary_check=(0,)).to(p_db.dtype.element_ty), boundary_check=(0,))
+    A += (bos * HV + i_hv) * BT
+    dA_mid += (bos * HV + i_hv) * BT
+    db_acc += bos * HV + i_hv
+    dA += (bos * HV + i_hv) * BT
+    db += bos * HV + i_hv
+
+    p_A = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
+    p_T = tl.make_block_ptr(dA_mid, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_T = tl.load(p_T, boundary_check=(0, 1)).to(tl.float32)
+    b_dA = tl.dot(b_A, b_T.to(b_A.dtype), allow_tf32=False)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t[None, :])
+    b_dA = tl.where(m_A, -b_dA, 0)
+
+    p_dA = tl.make_block_ptr(dA, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+
+    p_db_acc = tl.make_block_ptr(db_acc, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    tl.store(p_db, tl.load(p_db_acc, boundary_check=(0,)).to(p_db.dtype.element_ty), boundary_check=(0,))
 
 
 @input_guard
@@ -752,23 +795,24 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
     dA = torch.empty_like(A, dtype=torch.float)
     dA_acc = torch.zeros(B, T, HV, BT, dtype=torch.float, device=A.device)
     db_acc = torch.zeros(B, T, HV, dtype=torch.float, device=beta.device)
+    dw = g.new_empty(B, T, HV, K)
 
     BK = _get_bk(K)
     BV = _get_bv(V)
     NK = triton.cdiv(K, BK)
     is_varlen = cu_seqlens is not None
 
-    common = dict(
+    common_launch = dict(
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         T=T,
         HV=HV,
         BT=BT,
-        BC=_BC,
         IS_VARLEN=is_varlen,
         NT_OFFSET=0,
         BH_OFFSET=0,
     )
+    common = dict(BC=_BC, **common_launch)
 
     _launch_2d_kernel(
         chunk_kda_bwd_kernel_wy_v_part_npu,
@@ -798,16 +842,12 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
             k=k,
             v_new=v_new,
             g=g,
-            beta=beta,
-            A=A,
             h=h,
             do=do,
             dh=dh,
             dq=dq,
             dk=dk,
             dg=dg,
-            dA_acc=dA_acc,
-            db_acc=db_acc,
             scale=scale,
             H=H,
             K=K,
@@ -827,6 +867,7 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
         A=A,
         h=h,
         dv=dv,
+        dw=dw,
         dA_acc=dA_acc,
         db_acc=db_acc,
         dg=dg,
@@ -850,17 +891,40 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
         )
 
     _launch_2d_kernel(
-        chunk_kda_bwd_kernel_wy_dA_finalize_npu,
+        chunk_kda_bwd_kernel_wy_dA_mask_npu,
         nt=NT,
         bh_total=B * HV,
         kernel_kwargs=dict(
             beta=beta,
+            dA_acc=dA_acc,
+            BC=_BC,
+            **common_launch,
+        ),
+    )
+
+    _launch_2d_kernel(
+        chunk_kda_bwd_kernel_wy_dA_mid_npu,
+        nt=NT,
+        bh_total=B * HV,
+        kernel_kwargs=dict(
             A=A,
             dA_acc=dA_acc,
+            dA_mid=dA_acc,
+            **common_launch,
+        ),
+    )
+
+    _launch_2d_kernel(
+        chunk_kda_bwd_kernel_wy_dA_finalize_npu,
+        nt=NT,
+        bh_total=B * HV,
+        kernel_kwargs=dict(
+            A=A,
+            dA_mid=dA_acc,
             db_acc=db_acc,
             dA=dA,
             db=db,
-            **common,
+            **common_launch,
         ),
     )
 


### PR DESCRIPTION
## Summary

Refactors the Ascend NPU KDA chunk backward WY path (`chunk_bwd.py`) to improve performance and simplify kernel responsibilities:
- **Split `dA` finalize into a 3-stage pipeline**
  - `chunk_kda_bwd_kernel_wy_dA_mask_npu`: in-place apply causal mask and `beta` to `dA_acc`
  - `chunk_kda_bwd_kernel_wy_dA_mid_npu`: compute `T = dA_acc @ A` at chunk granularity via block matmul
  - `chunk_kda_bwd_kernel_wy_dA_finalize_npu`: compute final `dA = A @ T` with causal mask/negation, and copy `db`
- **Precompute `dw` in `wy_dw_part`**
  - Add a `dw` workspace buffer and compute `dw[s] = -dv[s] @ h` once per sub-block before the main loop
  - Reuse stored `dw` in nested `(s_r, s_c)` iterations instead of recomputing the same dot products
- **Simplify `wy_k_part`**
  - Remove unused `beta`, `A`, `dA_acc`, and `db_acc` arguments now that `dA`/`db` accumulation lives in the dw/dA pipeline
- **Numerics**
  - Use `float32` accumulators for key `tl.dot` paths in dw/dA stages

KDA:
<img width="1179" height="660" alt="image" src="https://github.com/user-attachments/assets/3f55cbf0-be49-4751-b82d-b1291d5d0212" />
