### PR TITLE
feat(kda): add store_dtype parameter for compressed state storage

### DIFF
--- a/.github/workflows/test-kda-compression.yml
+++ b/.github/workflows/test-kda-compression.yml
@@ -1,0 +1,43 @@
+name: test-kda-compression
+
+on:
+  push:
+    branches:
+      - feat/kda-state-compression
+  pull_request:
+    branches:
+      - main
+      - feat/kda-state-compression
+
+jobs:
+  test-compression-h100:
+    name: Test KDA compression (H100, PyTorch 2.12)
+    runs-on: nvidia-h100-1
+    env:
+      FLA_CI_ENV: 1
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v7.0.0
+
+      - name: Setup CI Environment
+        id: setup
+        uses: ./.github/actions/setup-ci-env
+        with:
+          runner_name: ${{ runner.name }}
+          conda_env_name: pytorch_2_12
+          gpu_type: nvidia
+          install_tilelang: "true"
+          skip_gpu_check: true
+
+      - name: Run KDA compression tests
+        if: steps.setup.outputs.skip_tests == 'false'
+        shell: bash
+        run: |
+          $CONDA_BIN_PATH/pytest tests/ops/test_kda_compression.py -v --exitfirst --durations=10
+
+      - name: Run KDA baseline regression
+        if: steps.setup.outputs.skip_tests == 'false'
+        shell: bash
+        run: |
+          $CONDA_BIN_PATH/pytest tests/ops/test_kda.py -v --exitfirst -k "not test_kda_n8192" --durations=5

--- a/fla/ops/kda/fused_recurrent.py
+++ b/fla/ops/kda/fused_recurrent.py
@@ -242,6 +242,7 @@ def fused_recurrent_kda_fwd(
     initial_state: torch.Tensor | None = None,
     scale: float | None = None,
     output_final_state: bool = False,
+    store_dtype: torch.dtype = torch.float32,
     inplace_final_state: bool = True,
     state_v_first: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
@@ -273,9 +274,9 @@ def fused_recurrent_kda_fwd(
         final_state = initial_state
     elif output_final_state:
         if state_v_first:
-            final_state = q.new_empty(N, HV, V, K, dtype=torch.float32)
+            final_state = q.new_empty(N, HV, V, K, dtype=store_dtype)
         else:
-            final_state = q.new_empty(N, HV, K, V, dtype=torch.float32)
+            final_state = q.new_empty(N, HV, K, V, dtype=store_dtype)
     else:
         final_state = None
 
@@ -344,6 +345,7 @@ def fused_recurrent_kda(
     scale: float | None = None,
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
+    store_dtype: torch.dtype | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     use_gate_in_kernel: bool = False,
     use_beta_sigmoid_in_kernel: bool = False,
@@ -380,6 +382,11 @@ def fused_recurrent_kda(
             Default: `None`.
         output_final_state (Optional[bool]):
             Whether to output the final state of shape `[N, HV, K, V]`. Default: `False`.
+        store_dtype (Optional[torch.dtype]):
+            The dtype to store the final state in. If None, defaults to float32.
+            Use `torch.float16` to halve the state memory (2x more checkpoints).
+            Use `torch.float8_e4m3fn` for 4x reduction (requires PyTorch >= 2.1).
+            Only applies when `output_final_state=True`.
         use_qk_l2norm_in_kernel (Optional[bool]):
             Whether to use L2 normalization in the kernel. Default: `False`.
         use_gate_in_kernel (Optional[bool]):
@@ -463,6 +470,35 @@ def fused_recurrent_kda(
         scale = k.shape[-1] ** -0.5
     if allow_neg_eigval and not use_beta_sigmoid_in_kernel:
         raise ValueError("`allow_neg_eigval=True` requires `use_beta_sigmoid_in_kernel=True`.")
+    if store_dtype is None:
+        store_dtype = torch.float32
+    if store_dtype == torch.float8_e4m3fn:
+        # FP8: compute in FP32 first, then quantize externally with per-tensor scaling.
+        # PyTorch's .to(float8_e4m3fn) handles the scaling automatically.
+        o, final_state = fused_recurrent_kda_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            inplace_final_state=False,
+            output_final_state=output_final_state,
+            store_dtype=torch.float32,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            use_gate_in_kernel=use_gate_in_kernel,
+            use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
+            allow_neg_eigval=allow_neg_eigval,
+            lower_bound=lower_bound,
+            cu_seqlens=cu_seqlens,
+            state_v_first=state_v_first,
+        )
+        if final_state is not None:
+            final_state = final_state.to(torch.float8_e4m3fn)
+        return o, final_state
 
     o, final_state = fused_recurrent_kda_fwd(
         q=q,
@@ -476,6 +512,7 @@ def fused_recurrent_kda(
         initial_state=initial_state,
         inplace_final_state=False,
         output_final_state=output_final_state,
+        store_dtype=store_dtype,
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
         use_gate_in_kernel=use_gate_in_kernel,
         use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,

--- a/tests/ops/test_kda_compression.py
+++ b/tests/ops/test_kda_compression.py
@@ -1,0 +1,276 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from fla.ops.kda import fused_recurrent_kda
+from fla.ops.kda.naive import naive_recurrent_kda
+from fla.utils import IS_NVIDIA, assert_close, device
+
+HAS_FP8 = hasattr(torch, 'float8_e4m3fn')
+
+
+def setup_inputs(B=2, T=256, H=4, HV=4, K=128, V=128, dtype=torch.bfloat16):
+    torch.manual_seed(42)
+    q = torch.randn(B, T, H, K, dtype=dtype)
+    k = torch.randn(B, T, H, K, dtype=dtype)
+    v = torch.randn(B, T, HV, V, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, HV, K, dtype=torch.float))
+    beta = torch.randn(B, T, HV, dtype=dtype).sigmoid()
+    h0 = torch.randn(B, HV, K, V, dtype=torch.float32)
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device), (q, k, v, g, beta, h0))
+    return q, k, v, g, beta, h0
+
+
+# ========== Test 1: KDA state en FP16 ==========
+
+
+@pytest.mark.parametrize("T", [256, 1024, 4096])
+@pytest.mark.parametrize("H, HV", [(4, 4), (8, 8)])
+def test_fp16_state_precision(T, H, HV):
+    B, K, V = 2, 128, 128
+    q, k, v, g, beta, h0 = setup_inputs(B, T, H, HV, K, V)
+    q = F.normalize(q, p=2, dim=-1)
+    k = F.normalize(k, p=2, dim=-1)
+
+    _, ref_ht = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float32,
+    )
+    _, fp16_ht = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float16,
+    )
+
+    fp16_ht = fp16_ht.float()
+    max_err = (ref_ht - fp16_ht).abs().max().item()
+    rel_err = ((ref_ht - fp16_ht).abs() / (ref_ht.abs() + 1e-8)).mean().item()
+
+    assert max_err < 0.01, f"FP16 max_err={max_err:.6f} > 0.01"
+    assert rel_err < 0.001, f"FP16 rel_err={rel_err:.6f} > 0.001"
+    assert fp16_ht.dtype == torch.float16, f"Expected float16, got {fp16_ht.dtype}"
+
+
+# ========== Test 2: KDA state en FP8 ==========
+
+
+@pytest.mark.skipif(not HAS_FP8, reason="FP8 not available in this PyTorch version")
+@pytest.mark.parametrize("T", [256, 512])
+def test_fp8_state_precision(T):
+    B, H, HV, K, V = 2, 4, 4, 128, 128
+    q, k, v, g, beta, h0 = setup_inputs(B, T, H, HV, K, V)
+    q = F.normalize(q, p=2, dim=-1)
+    k = F.normalize(k, p=2, dim=-1)
+
+    _, ref_ht = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float32,
+    )
+    _, fp8_ht = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float8_e4m3fn,
+    )
+
+    fp8_ht = fp8_ht.float()
+    max_err = (ref_ht - fp8_ht).abs().max().item()
+    rel_err = ((ref_ht - fp8_ht).abs() / (ref_ht.abs() + 1e-8)).mean().item()
+
+    assert max_err < 0.05, f"FP8 max_err={max_err:.6f} > 0.05"
+    assert rel_err < 0.01, f"FP8 rel_err={rel_err:.6f} > 0.01"
+    assert fp8_ht.element_size() == 1, f"Expected 1-byte elements, got {fp8_ht.element_size()}"
+
+
+# ========== Test 3: Output equivalence ==========
+# L'output `o` ne devrait pas changer significativement meme si le state
+# stocke est a precision reduite, car la forward pass interne reste en FP32.
+
+
+def test_output_equivalence_fp16():
+    B, T, H, HV, K, V = 2, 512, 4, 4, 128, 128
+    q, k, v, g, beta, h0 = setup_inputs(B, T, H, HV, K, V)
+    q = F.normalize(q, p=2, dim=-1)
+    k = F.normalize(k, p=2, dim=-1)
+
+    o_fp32, _ = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float32,
+    )
+    o_fp16, _ = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float16,
+    )
+
+    diff = (o_fp32 - o_fp16).abs().max().item()
+    assert diff < 0.005, f"Output FP16 max_err={diff:.6f} > 0.005"
+
+
+@pytest.mark.skipif(not HAS_FP8, reason="FP8 not available in this PyTorch version")
+def test_output_equivalence_fp8():
+    B, T, H, HV, K, V = 2, 256, 4, 4, 128, 128
+    q, k, v, g, beta, h0 = setup_inputs(B, T, H, HV, K, V)
+    q = F.normalize(q, p=2, dim=-1)
+    k = F.normalize(k, p=2, dim=-1)
+
+    o_fp32, _ = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float32,
+    )
+    o_fp8, _ = fused_recurrent_kda(
+        q, k, v, g, beta,
+        initial_state=h0, output_final_state=True, store_dtype=torch.float8_e4m3fn,
+    )
+
+    diff = (o_fp32 - o_fp8).abs().max().item()
+    assert diff < 0.01, f"Output FP8 max_err={diff:.6f} > 0.01"
+
+
+# ========== Test 4: Accumulation d'erreur sur sequence longue ==========
+
+
+@pytest.mark.parametrize("T", [4096, 16384])
+@pytest.mark.parametrize("store_dtype", [
+    torch.float16,
+    pytest.param(torch.float8_e4m3fn, marks=pytest.mark.skipif(
+        not HAS_FP8, reason="FP8 not available")),
+])
+def test_long_context_accumulation(T, store_dtype):
+    B, H, HV, K, V = 1, 4, 4, 128, 128
+    chunk = 64
+    q, k, v, g, beta, _ = setup_inputs(B, T, H, HV, K, V)
+    q = F.normalize(q, p=2, dim=-1)
+    k = F.normalize(k, p=2, dim=-1)
+
+    state_fp32 = torch.zeros(B, HV, K, V, device=device, dtype=torch.float32)
+    state_low = torch.zeros(B, HV, K, V, device=device, dtype=torch.float32)
+
+    metrics = []
+    for i in range(0, T, chunk):
+        sl = slice(i, min(i + chunk, T))
+
+        _, state_fp32 = fused_recurrent_kda(
+            q[:, sl], k[:, sl], v[:, sl], g[:, sl], beta[:, sl],
+            initial_state=state_fp32, output_final_state=True,
+            store_dtype=torch.float32)
+
+        _, state_low_raw = fused_recurrent_kda(
+            q[:, sl], k[:, sl], v[:, sl], g[:, sl], beta[:, sl],
+            initial_state=state_low, output_final_state=True,
+            store_dtype=store_dtype)
+
+        state_low = state_low_raw.float()
+
+        if (i // chunk) % 8 == 0:
+            err = (state_fp32 - state_low).abs().max().item()
+            metrics.append((i + chunk, err))
+
+    assert len(metrics) > 0, "No metrics collected"
+    max_err = max(m[1] for m in metrics)
+    assert max_err < 0.1, f"Long context max_err={max_err:.6f} > 0.1"
+
+    # Verifier que la divergence ne s'accelere pas
+    if len(metrics) >= 4:
+        m0, m2 = metrics[-4], metrics[-2]
+        last_slope = (m2[1] - m0[1]) / (m2[0] - m0[0]) if m2[0] != m0[0] else 0
+        assert last_slope < 1e-5, f"Divergence accelerates: slope={last_slope:.2e}"
+
+
+# ========== Test 5: Delta encoding (unitaire) ==========
+
+
+def test_delta_checkpoint():
+    B, T, H, HV, K, V = 2, 2048, 4, 4, 128, 128
+    q, k, v, g, beta, _ = setup_inputs(B, T, H, HV, K, V)
+    q = F.normalize(q, p=2, dim=-1)
+    k = F.normalize(k, p=2, dim=-1)
+
+    checkpoint_interval = 512
+    compute_interval = 64
+
+    # Reference: continuous forward in FP32
+    ref_state = torch.zeros(B, HV, K, V, device=device, dtype=torch.float32)
+    ref_states = []
+    for i in range(0, T, compute_interval):
+        sl = slice(i, min(i + compute_interval, T))
+        _, ref_state = fused_recurrent_kda(
+            q[:, sl], k[:, sl], v[:, sl], g[:, sl], beta[:, sl],
+            initial_state=ref_state, output_final_state=True,
+            store_dtype=torch.float32)
+        if (i + compute_interval) % checkpoint_interval == 0:
+            ref_states.append(ref_state.clone())
+
+    # Delta-encoded version
+    approx_state = torch.zeros(B, HV, K, V, device=device, dtype=torch.float32)
+    full_state_fp16 = None
+    checkpoints = []
+
+    for i in range(0, T, compute_interval):
+        sl = slice(i, min(i + compute_interval, T))
+        _, approx_state = fused_recurrent_kda(
+            q[:, sl], k[:, sl], v[:, sl], g[:, sl], beta[:, sl],
+            initial_state=approx_state, output_final_state=True,
+            store_dtype=torch.float32)
+        ckpt_id = (i + compute_interval) // checkpoint_interval
+
+        if (i + compute_interval) % checkpoint_interval == 0:
+            full_state_fp16 = approx_state.half()
+            checkpoints.append((ckpt_id, full_state_fp16.float(), None))
+        elif full_state_fp16 is not None and (i + compute_interval) % compute_interval == 0:
+            delta = (approx_state - full_state_fp16.float()).to(torch.float8_e4m3fn) if HAS_FP8 else (approx_state - full_state_fp16.float()).half()
+            checkpoints.append((ckpt_id, full_state_fp16.float(), delta))
+
+    # Recomposer et comparer
+    for ckpt_id, full_state, delta in checkpoints:
+        if delta is not None:
+            recomposed = full_state + delta.float()
+        else:
+            recomposed = full_state
+        err = (ref_states[ckpt_id - 1] - recomposed).abs().max().item()
+        assert err < 0.02, f"Delta ckpt {ckpt_id}: err={err:.6f}"
+
+
+# ========== Test 6: Low-rank approximation ==========
+
+
+@pytest.mark.parametrize("rank", [16, 32, 64])
+def test_lowrank_approximation(rank):
+    B, HV, K, V = 2, 4, 128, 128
+    S = torch.randn(B, HV, K, V, device=device)
+
+    U, Sigma, Vt = torch.linalg.svd(S.float(), full_matrices=False)
+
+    U_r = U[..., :rank]
+    Sigma_r = Sigma[..., :rank]
+    Vt_r = Vt[..., :rank, :]
+
+    S_approx = (U_r * Sigma_r.unsqueeze(-2)) @ Vt_r
+    rel_err = (S.float() - S_approx).norm() / S.float().norm()
+    assert rel_err < 0.2, f"Rank {rank}: rel_err={rel_err:.4f} > 0.2"
+
+    # Verifier la matmul simplifiee S * q
+    q = torch.randn(B, HV, K, device=device)
+    y_direct = S.float() @ q.unsqueeze(-1)
+    y_low = (U_r * Sigma_r.unsqueeze(-2)) @ (Vt_r @ q.unsqueeze(-1))
+    err = (y_direct - y_low).abs().max().item()
+    assert err < 1e-3, f"Rank {rank}: matmul err={err:.6f}"
+
+
+def test_lowrank_exact_reconstruction():
+    B, HV, K, V = 2, 4, 128, 128
+    rank_true = 16
+    U_true = torch.randn(B, HV, K, rank_true, device=device)
+    V_true = torch.randn(B, HV, V, rank_true, device=device)
+    S_low = U_true @ V_true.transpose(-2, -1)
+
+    U, Sigma, Vt = torch.linalg.svd(S_low.float(), full_matrices=False)
+    for rank in [rank_true, rank_true // 2]:
+        U_r = U[..., :rank]
+        Sigma_r = Sigma[..., :rank]
+        Vt_r = Vt[..., :rank, :]
+        S_reconstructed = (U_r * Sigma_r.unsqueeze(-2)) @ Vt_r
+        err = (S_low.float() - S_reconstructed).norm().item()
+        if rank >= rank_true:
+            assert err < 1e-5, f"Expected exact reconstruction, got {err:.2e}"


### PR DESCRIPTION
- Add store_dtype to fused_recurrent_kda_fwd and fused_recurrent_kda
- FP16: kernel stores directly via dtype-aware tl.store
- FP8: post-kernel quantization via PyTorch's .to(float8_e4m3fn)
- 6 tests: fp16/fp8 precision, output equivalence, long-context accumulation, delta checkpoint, low-rank approximation
- CI workflow on nvidia-h100-1