### PR TITLE
[Fix] Preserve explicit cu_seqlens with attention masks

### DIFF
--- a/fla/layers/attn.py
+++ b/fla/layers/attn.py
@@ -137,7 +137,7 @@ class Attention(nn.Module):
                 v = rearrange(v, '... (h d) -> ... h d', d=self.head_dim)
 
         # Contains at least one padding token in the sequence
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             if q.shape[1] == 1 and self.window_size is not None:
                 attention_mask = attention_mask[:, -self.window_size:]
             q, (k, v), indices_q, cu_seqlens, max_seq_lens = unpad_input(q, (k, v), attention_mask, q_len)

--- a/fla/layers/bitattn.py
+++ b/fla/layers/bitattn.py
@@ -128,7 +128,7 @@ class BitAttention(nn.Module):
             raise ImportError("Please install Flash Attention via `pip install flash-attn --no-build-isolation` first")
 
         # Contains at least one padding token in the sequence
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             q, (k, v), indices_q, cu_seqlens, max_seq_lens = unpad_input(q, (k, v), attention_mask, q_len)
             cu_seqlens_q, cu_seqlens_k = cu_seqlens
             max_seqlen_q, max_seqlen_k = max_seq_lens

--- a/fla/layers/comba.py
+++ b/fla/layers/comba.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 from einops import rearrange, repeat
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.ops.comba import chunk_comba, fused_recurrent_comba
 
@@ -233,10 +233,7 @@ class Comba(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -328,7 +325,6 @@ class Comba(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/comba.py
+++ b/fla/layers/comba.py
@@ -233,6 +233,7 @@ class Comba(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -327,7 +328,7 @@ class Comba(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/delta_net.py
+++ b/fla/layers/delta_net.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 from einops import rearrange
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.ops.delta_rule import chunk_delta_rule, fused_recurrent_delta_rule
 
@@ -190,10 +190,7 @@ class DeltaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -287,7 +284,6 @@ class DeltaNet(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/delta_net.py
+++ b/fla/layers/delta_net.py
@@ -190,6 +190,7 @@ class DeltaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -286,7 +287,7 @@ class DeltaNet(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/forgetting_attn.py
+++ b/fla/layers/forgetting_attn.py
@@ -117,7 +117,7 @@ class ForgettingAttention(nn.Module):
         k = rearrange(k, '... (h d) -> ... h d', d=self.head_dim)
         v = rearrange(v, '... (h d) -> ... h d', d=self.head_dim)
 
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             q, (k, v, f), indices_q, cu_seqlens, max_seq_lens = unpad_input(q, (k, v, f), attention_mask, q_len, keepdim=True)
             _, cu_seqlens_k = cu_seqlens
             cu_seqlens = cu_seqlens_k
@@ -129,7 +129,7 @@ class ForgettingAttention(nn.Module):
                 o = parallel_forgetting_attn(q, k, v, f, cu_seqlens=cu_seqlens)
         else:
             o = parallel_forgetting_attn(q, k, v, f, cu_seqlens=cu_seqlens)
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             o = pad_input(o.squeeze(0), indices_q, batch_size, q_len)
         o = rearrange(o, '... h d -> ... (h d)')
         if self.use_output_gate:

--- a/fla/layers/forgetting_attn.py
+++ b/fla/layers/forgetting_attn.py
@@ -117,6 +117,7 @@ class ForgettingAttention(nn.Module):
         k = rearrange(k, '... (h d) -> ... h d', d=self.head_dim)
         v = rearrange(v, '... (h d) -> ... h d', d=self.head_dim)
 
+        indices_q = None
         if cu_seqlens is None and attention_mask is not None:
             q, (k, v, f), indices_q, cu_seqlens, max_seq_lens = unpad_input(q, (k, v, f), attention_mask, q_len, keepdim=True)
             _, cu_seqlens_k = cu_seqlens
@@ -129,7 +130,7 @@ class ForgettingAttention(nn.Module):
                 o = parallel_forgetting_attn(q, k, v, f, cu_seqlens=cu_seqlens)
         else:
             o = parallel_forgetting_attn(q, k, v, f, cu_seqlens=cu_seqlens)
-        if cu_seqlens is None and attention_mask is not None:
+        if indices_q is not None:
             o = pad_input(o.squeeze(0), indices_q, batch_size, q_len)
         o = rearrange(o, '... h d -> ... (h d)')
         if self.use_output_gate:

--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 from einops import rearrange
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.modules.convolution import causal_conv1d
 from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
@@ -241,10 +241,7 @@ class GatedDeltaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         conv_state_q, conv_state_k, conv_state_v = None, None, None
         if self._use_fused_qkv_conv(last_state, use_cache, cu_seqlens):
@@ -362,7 +359,6 @@ class GatedDeltaNet(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -241,6 +241,7 @@ class GatedDeltaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -361,7 +362,7 @@ class GatedDeltaNet(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gated_deltaproduct.py
+++ b/fla/layers/gated_deltaproduct.py
@@ -186,6 +186,7 @@ class GatedDeltaProduct(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -286,7 +287,7 @@ class GatedDeltaProduct(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gated_deltaproduct.py
+++ b/fla/layers/gated_deltaproduct.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 from einops import rearrange, repeat
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.ops.gated_delta_product import chunk_gated_delta_product
 from fla.ops.gated_delta_rule import fused_recurrent_gated_delta_rule
@@ -186,10 +186,7 @@ class GatedDeltaProduct(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -287,7 +284,6 @@ class GatedDeltaProduct(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gdn2.py
+++ b/fla/layers/gdn2.py
@@ -22,7 +22,7 @@ import torch.nn as nn
 from einops import rearrange, repeat
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, ShortConvolution
 from fla.ops.gdn2 import chunk_gdn2, fused_recurrent_gdn2
 
@@ -220,10 +220,7 @@ class GatedDeltaNet2(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get("cu_seqlens")
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -321,7 +318,6 @@ class GatedDeltaNet2(nn.Module):
         o = self.o_norm(o, rearrange(self.g_proj(hidden_states), "... (h d) -> ... h d", d=self.head_v_dim))
         o = rearrange(o, "b t h d -> b t (h d)")
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gdn2.py
+++ b/fla/layers/gdn2.py
@@ -220,6 +220,7 @@ class GatedDeltaNet2(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get("cu_seqlens")
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -320,7 +321,7 @@ class GatedDeltaNet2(nn.Module):
         o = self.o_norm(o, rearrange(self.g_proj(hidden_states), "... (h d) -> ... h d", d=self.head_v_dim))
         o = rearrange(o, "b t h d -> b t (h d)")
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gla.py
+++ b/fla/layers/gla.py
@@ -196,6 +196,7 @@ class GatedLinearAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -298,7 +299,7 @@ class GatedLinearAttention(nn.Module):
         else:
             o = rearrange(self.g_norm(o), '... h d -> ... (h d)')
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gla.py
+++ b/fla/layers/gla.py
@@ -14,7 +14,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange, repeat
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.modules.activations import ACT2FN
 from fla.ops.gla import chunk_gla, fused_chunk_gla, fused_recurrent_gla
@@ -196,10 +196,7 @@ class GatedLinearAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -299,7 +296,6 @@ class GatedLinearAttention(nn.Module):
         else:
             o = rearrange(self.g_norm(o), '... h d -> ... (h d)')
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gsa.py
+++ b/fla/layers/gsa.py
@@ -151,6 +151,7 @@ class GatedSlotAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -236,7 +237,7 @@ class GatedSlotAttention(nn.Module):
 
         o = rearrange(o, '... h d -> ... (h d)')
         o = rms_norm_linear(F.silu(o), self.g_norm.weight, self.g_norm.bias, self.o_proj.weight, self.o_proj.bias)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/gsa.py
+++ b/fla/layers/gsa.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange, repeat
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import RMSNorm, ShortConvolution
 from fla.modules.feature_map import ReLUFeatureMap, SwishFeatureMap, T2RFeatureMap
 from fla.modules.layernorm import rms_norm_linear
@@ -151,10 +151,7 @@ class GatedSlotAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -237,7 +234,6 @@ class GatedSlotAttention(nn.Module):
 
         o = rearrange(o, '... h d -> ... (h d)')
         o = rms_norm_linear(F.silu(o), self.g_norm.weight, self.g_norm.bias, self.o_proj.weight, self.o_proj.bias)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/hgrn2.py
+++ b/fla/layers/hgrn2.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import RMSNorm, ShortConvolution
 from fla.modules.activations import swish
 from fla.modules.layernorm import rms_norm_linear
@@ -124,10 +124,7 @@ class HGRN2Attention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_f, conv_state_i = None, None, None
@@ -212,7 +209,6 @@ class HGRN2Attention(nn.Module):
 
         o = rearrange(o, '... h d -> ... (h d)')
         o = rms_norm_linear(o, self.g_norm.weight, self.g_norm.bias, self.o_proj.weight, self.o_proj.bias)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/hgrn2.py
+++ b/fla/layers/hgrn2.py
@@ -124,6 +124,7 @@ class HGRN2Attention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -211,7 +212,7 @@ class HGRN2Attention(nn.Module):
 
         o = rearrange(o, '... h d -> ... (h d)')
         o = rms_norm_linear(o, self.g_norm.weight, self.g_norm.bias, self.o_proj.weight, self.o_proj.bias)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/kda.py
+++ b/fla/layers/kda.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 from einops import rearrange
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, ShortConvolution
 from fla.ops.kda import chunk_kda, fused_recurrent_kda
 
@@ -216,10 +216,7 @@ class KimiDeltaAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get("cu_seqlens")
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -310,7 +307,6 @@ class KimiDeltaAttention(nn.Module):
         o = self.o_norm(o, rearrange(self.g_proj(hidden_states), "... (h d) -> ... h d", d=self.head_v_dim))
         o = rearrange(o, "b t h d -> b t (h d)")
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/kda.py
+++ b/fla/layers/kda.py
@@ -216,7 +216,8 @@ class KimiDeltaAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get("cu_seqlens")
-        if attention_mask is not None:
+        indices = None
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
@@ -309,7 +310,7 @@ class KimiDeltaAttention(nn.Module):
         o = self.o_norm(o, rearrange(self.g_proj(hidden_states), "... (h d) -> ... h d", d=self.head_v_dim))
         o = rearrange(o, "b t h d -> b t (h d)")
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/mamba3.py
+++ b/fla/layers/mamba3.py
@@ -19,9 +19,8 @@ from transformers.utils import logging
 
 from fla.layers.utils import (
     get_layer_cache,
-    get_unpad_data,
-    index_first_axis,
-    pad_input,
+    repad_hidden_states,
+    unpad_hidden_states,
     update_layer_cache,
 )
 from fla.modules.layernorm_gated import RMSNormGated
@@ -424,11 +423,8 @@ class Mamba3(nn.Module):
         # Prefill with padding mask: pack [B, T, D] -> [1, sum(lens), D] so the
         # upstream varlen kernels (which require batch=1) can consume it.
         indices_q = None
-        if last_state is None and cu_seqlens is None and attention_mask is not None and q_len > 1:
-            indices_q, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(
-                rearrange(hidden_states, "b s ... -> (b s) ..."), indices_q,
-            ).unsqueeze(0)
+        if last_state is None and q_len > 1:
+            hidden_states, indices_q, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         output, new_state = self.cuda_kernels_forward(
             hidden_states,
@@ -440,8 +436,7 @@ class Mamba3(nn.Module):
         if new_state is not None:
             update_layer_cache(self, past_key_values, recurrent_state=new_state, offset=q_len)
 
-        if indices_q is not None:
-            output = pad_input(output.squeeze(0), indices_q, batch_size, q_len)
+        output = repad_hidden_states(output, indices_q, batch_size, q_len)
 
         return output, None, past_key_values
 

--- a/fla/layers/mesa_net.py
+++ b/fla/layers/mesa_net.py
@@ -14,7 +14,7 @@ import torch.nn as nn
 from einops import rearrange
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.modules.l2norm import l2_norm
 from fla.ops.mesa_net import chunk_mesa_net, mesa_net_decoding_one_step
@@ -145,10 +145,7 @@ class MesaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         conv_state_q, conv_state_k = None, None
         if last_state is not None:
@@ -222,6 +219,5 @@ class MesaNet(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
         return o, None, past_key_values

--- a/fla/layers/mesa_net.py
+++ b/fla/layers/mesa_net.py
@@ -145,6 +145,7 @@ class MesaNet(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -221,6 +222,6 @@ class MesaNet(nn.Module):
             o = self.o_norm(o)
         o = rearrange(o, 'b t h d -> b t (h d)')
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
         return o, None, past_key_values

--- a/fla/layers/mom.py
+++ b/fla/layers/mom.py
@@ -23,7 +23,16 @@ if TYPE_CHECKING:
 
     from fla.models.utils import Cache
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, unpad_input, update_layer_cache
+from fla.layers.utils import (
+    get_layer_cache,
+    get_unpad_data,
+    index_first_axis,
+    pad_input,
+    repad_hidden_states,
+    unpad_hidden_states,
+    unpad_input,
+    update_layer_cache,
+)
 
 
 def _upad_input(
@@ -678,11 +687,9 @@ class MomAttention(nn.Module):
         if self.training:
             assert mode == 'chunk', "Only chunk mode is supported in training."
 
-        cu_seqlens = None
-        if attention_mask is not None:
-            batch_size, q_len = hidden_states.shape[0], hidden_states.shape[1]
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        cu_seqlens = kwargs.get('cu_seqlens')
+        batch_size, q_len = hidden_states.shape[0], hidden_states.shape[1]
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             q, conv_state_q[1] = self.q_conv1d(
@@ -741,8 +748,7 @@ class MomAttention(nn.Module):
         else:
             raise NotImplementedError(f"Not supported mode `{mode}`.")
 
-        if attention_mask is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
         return o
 
     def cu2pad(self, x, cu_seqlens):

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -190,6 +190,7 @@ class MultiScaleRetention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -302,7 +303,7 @@ class MultiScaleRetention(nn.Module):
         else:
             o = rearrange(self.g_norm(o), '... h d -> ... (h d)')
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -14,7 +14,7 @@ import torch.nn as nn
 from einops import rearrange, repeat
 from transformers.activations import ACT2FN
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.modules.rotary import RotaryEmbedding
 from fla.ops.retention import chunk_retention, fused_chunk_retention, fused_recurrent_retention, parallel_retention
@@ -190,10 +190,7 @@ class MultiScaleRetention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         if self.use_short_conv:
             conv_state_q, conv_state_k, conv_state_v = None, None, None
@@ -303,7 +300,6 @@ class MultiScaleRetention(nn.Module):
         else:
             o = rearrange(self.g_norm(o), '... h d -> ... (h d)')
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/parallax.py
+++ b/fla/layers/parallax.py
@@ -167,7 +167,7 @@ class Parallax(nn.Module):
             # single-token step -> optimized vector decode; chunked prefill -> tile kernel
             decode_fn = parallax_decode_one_step if q_len == 1 else parallax_decode
             o = decode_fn(q, r, k, v, window_size=self.window_size, cache_start=cache_start)
-        elif attention_mask is not None:
+        elif cu_seqlens is None and attention_mask is not None:
             # Unpad to a single packed sequence (batch folded into the seq axis).
             q, (r, k, v), indices_q, cu_seqlens, _ = unpad_input(
                 q, (r, k, v), attention_mask, q_len, keepdim=True,

--- a/fla/layers/path_attn.py
+++ b/fla/layers/path_attn.py
@@ -111,11 +111,8 @@ class PaTHAttention(nn.Module):
         beta = self.bt_proj(hidden_states).float().sigmoid() * 2  # allowing negative eigenvalues
         g = F.logsigmoid(self.g_proj(hidden_states).float()) if self.use_forget_gate else None
         cu_seqlens = kwargs.get('cu_seqlens')
-        assert not (cu_seqlens is not None and attention_mask is not None), (
-            "cu_seqlens should not be provided when attention_mask is not None"
-        )
         # Training
-        if attention_mask is None:
+        if cu_seqlens is not None or attention_mask is None:
             assert use_cache is False, "use_cache should be False in training"
             if self.use_w_shortconv:
                 w, _ = self.w_conv1d(w, cache=None, output_final_state=False, cu_seqlens=cu_seqlens)

--- a/fla/layers/raven.py
+++ b/fla/layers/raven.py
@@ -19,7 +19,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange, repeat
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, RotaryEmbedding
 from fla.modules.activations import ACT2FN
 from fla.modules.feature_map import ReLUFeatureMap, SwishFeatureMap, T2RFeatureMap
@@ -249,17 +249,14 @@ class Raven(nn.Module):
             max_seqlen = q_len + _max_offset(seqlen_offset)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
-            # Shift RoPE positions by each sequence's left padding only when decoding on
-            # top of cached tokens. During prefill the unpadded tokens are already packed
-            # contiguously per `cu_seqlens`, so positions start at 0; adding `lens - mask_len`
-            # there would push them negative.
-            if _max_offset(seqlen_offset) > 0:
-                seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q_len + _max_offset(seqlen_offset)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
+        # Shift RoPE positions by each sequence's left padding only when decoding on
+        # top of cached tokens. During prefill the unpadded tokens are already packed
+        # contiguously per `cu_seqlens`, so positions start at 0; adding `lens - mask_len`
+        # there would push them negative.
+        if indices is not None and _max_offset(seqlen_offset) > 0:
+            seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
+            max_seqlen = q_len + _max_offset(seqlen_offset)
 
         q = rearrange(self.q_proj(hidden_states), '... (h d) -> ... h d', d=self.head_k_dim)
         k = rearrange(self.k_proj(hidden_states), '... (h d) -> ... h d', d=self.head_k_dim)
@@ -361,7 +358,6 @@ class Raven(nn.Module):
             else:
                 o = self.o_proj(self.g_norm(o))
 
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values

--- a/fla/layers/rodimus.py
+++ b/fla/layers/rodimus.py
@@ -19,10 +19,10 @@ from transformers.utils import logging
 
 from fla.layers.utils import (
     get_layer_cache,
-    get_unpad_data,
-    index_first_axis,
     pad_input,
+    repad_hidden_states,
     require_cache_layer_idx,
+    unpad_hidden_states,
     unpad_input,
     update_layer_cache,
 )
@@ -149,10 +149,7 @@ class RodimusAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         hidden_states, final_gate = self.up_proj(hidden_states), self.gate_proj(hidden_states)
 
@@ -245,8 +242,7 @@ class RodimusAttention(nn.Module):
         o = self.activation_norm(o, final_gate)
         o = self.down_proj(o)
 
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
 
         if self.block_type == 'rodimus':
             return o, None, past_key_values

--- a/fla/layers/rodimus.py
+++ b/fla/layers/rodimus.py
@@ -149,6 +149,7 @@ class RodimusAttention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
+        indices = None
         if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
@@ -244,7 +245,7 @@ class RodimusAttention(nn.Module):
         o = self.activation_norm(o, final_gate)
         o = self.down_proj(o)
 
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
 
         if self.block_type == 'rodimus':

--- a/fla/layers/utils.py
+++ b/fla/layers/utils.py
@@ -102,6 +102,72 @@ def get_unpad_data(
     return indices, cu_seqlens, max_seqlen_in_batch
 
 
+def unpad_hidden_states(
+    hidden_states: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None,
+    attention_mask: torch.Tensor | None,
+    q_len: int,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.LongTensor | None]:
+    """Unpad hidden states via attention_mask, unless explicit cu_seqlens are given.
+
+    Explicit `cu_seqlens` take precedence: when they are provided, the input is
+    returned unchanged and no unpadding happens. Only when `cu_seqlens` is None
+    and `attention_mask` is present are the hidden states unpadded via the mask.
+
+    Arguments:
+        hidden_states (`torch.Tensor`):
+            Input hidden states with padding. Shape: [batch_size, q_len, ...].
+        cu_seqlens (`torch.LongTensor | None`):
+            Explicit cumulative sequence lengths provided by the caller.
+        attention_mask (`torch.Tensor | None`):
+            Boolean or int tensor of shape (batch_size, sequence_length), 1 means valid and 0 means not valid.
+        q_len (`int`):
+            Target length.
+
+    Return:
+        hidden_states (`torch.Tensor`):
+            The unpadded hidden states of shape [1, total_tokens, ...],
+            or the input unchanged when unpadding is skipped.
+        indices (`torch.Tensor | None`):
+            The indices of non-masked tokens, or None when unpadding is skipped.
+        cu_seqlens (`torch.LongTensor | None`):
+            The cumulative sequence lengths derived from the mask,
+            or the explicit value passed in when unpadding is skipped.
+    """
+    if cu_seqlens is None and attention_mask is not None:
+        indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+        hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
+        return hidden_states, indices, cu_seqlens
+    return hidden_states, None, cu_seqlens
+
+
+def repad_hidden_states(
+    hidden_states: torch.Tensor,
+    indices: torch.Tensor | None,
+    batch_size: int,
+    q_len: int,
+) -> torch.Tensor:
+    """Inverse of `unpad_hidden_states`; a no-op when `indices` is None.
+
+    Arguments:
+        hidden_states (`torch.Tensor`):
+            Hidden states of shape [1, total_tokens, ...].
+        indices (`torch.Tensor | None`):
+            The indices returned by `unpad_hidden_states`, or None.
+        batch_size (`int`):
+            Batch size for the padded sequence.
+        q_len (`int`):
+            Target length.
+
+    Return:
+        hidden_states of shape [batch_size, q_len, ...],
+        or the input unchanged when `indices` is None.
+    """
+    if indices is None:
+        return hidden_states
+    return pad_input(hidden_states.squeeze(0), indices, batch_size, q_len)
+
+
 def unpad_input(
     q: torch.Tensor | tuple[torch.Tensor, ...],
     states: tuple[torch.Tensor],

--- a/fla/layers/wall_attn.py
+++ b/fla/layers/wall_attn.py
@@ -187,7 +187,7 @@ class WallAttention(nn.Module):
                     o = self._decode_rebuild(q, k, v, g, gs)
                 else:
                     o = parallel_wall_attn(q, k, v, g, g_scalar=gs, window_size=self.window_size)
-        elif attention_mask is not None:
+        elif cu_seqlens is None and attention_mask is not None:
             states = (k, v, g, gs) if self.use_scalar_gate else (k, v, g)
             q, states, indices_q, cu_seqlens, max_seq_lens = unpad_input(q, states, attention_mask, q_len, keepdim=True)
             if self.use_scalar_gate:

--- a/fla/layers/yoco.py
+++ b/fla/layers/yoco.py
@@ -15,7 +15,14 @@ import torch.nn.functional as F
 from einops import rearrange
 from transformers.utils import logging
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, unpad_input, update_layer_cache
+from fla.layers.utils import (
+    get_layer_cache,
+    pad_input,
+    repad_hidden_states,
+    unpad_hidden_states,
+    unpad_input,
+    update_layer_cache,
+)
 from fla.modules import FusedRMSNormGated, RMSNorm, RotaryEmbedding
 from fla.modules.activations import swiglu
 from fla.modules.rotary import rotary_embedding
@@ -155,10 +162,7 @@ class YOCOGatedRetention(nn.Module):
         last_state = get_layer_cache(self, past_key_values)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        indices = None
-        if cu_seqlens is None and attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
-            hidden_states = index_first_axis(rearrange(hidden_states, 'b s ... -> (b s) ...'), indices).unsqueeze(0)
+        hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
 
         q = rearrange(self.q_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
         k = rearrange(self.k_proj(hidden_states), '... (h d) -> ... h d', d=self.head_dim)
@@ -217,8 +221,7 @@ class YOCOGatedRetention(nn.Module):
             o = swiglu(g, o)
 
         o = self.o_proj(o)
-        if indices is not None:
-            o = pad_input(o.squeeze(0), indices, batch_size, q_len)
+        o = repad_hidden_states(o, indices, batch_size, q_len)
         attentions = None
         return o, attentions, past_key_values
 

--- a/fla/layers/yoco.py
+++ b/fla/layers/yoco.py
@@ -156,7 +156,7 @@ class YOCOGatedRetention(nn.Module):
 
         cu_seqlens = kwargs.get('cu_seqlens')
         indices = None
-        if attention_mask is not None:
+        if cu_seqlens is None and attention_mask is not None:
             indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = index_first_axis(rearrange(hidden_states, 'b s ... -> (b s) ...'), indices).unsqueeze(0)
 
@@ -217,7 +217,7 @@ class YOCOGatedRetention(nn.Module):
             o = swiglu(g, o)
 
         o = self.o_proj(o)
-        if attention_mask is not None:
+        if indices is not None:
             o = pad_input(o.squeeze(0), indices, batch_size, q_len)
         attentions = None
         return o, attentions, past_key_values

--- a/tests/layers/test_attn_varlen_pack_layout.py
+++ b/tests/layers/test_attn_varlen_pack_layout.py
@@ -8,6 +8,21 @@
 import pytest
 import torch
 
+from fla.layers import (
+    Comba,
+    DeltaNet,
+    GatedDeltaNet,
+    GatedDeltaNet2,
+    GatedDeltaProduct,
+    GatedLinearAttention,
+    GatedSlotAttention,
+    HGRN2Attention,
+    KimiDeltaAttention,
+    MesaNet,
+    MultiScaleRetention,
+    RodimusAttention,
+    YOCOGatedRetention,
+)
 from fla.layers.attn import Attention
 from fla.utils import device
 
@@ -44,3 +59,81 @@ def test_attention_varlen_accepts_batched_layout_with_cu_seqlens(B: int, T: int,
     out, _, _ = layer(hidden_states=hidden_states, cu_seqlens=cu_seqlens)
     assert out.shape == (B, T, hidden_size)
     assert torch.isfinite(out).all()
+
+
+@pytest.mark.parametrize(
+    ("layer_cls", "layer_kwargs"),
+    [
+        pytest.param(
+            Comba,
+            dict(hidden_size=16, head_dim=8, num_heads=2, num_v_heads=2, expand_v=1, use_short_conv=False),
+            id="comba",
+        ),
+        pytest.param(
+            DeltaNet,
+            dict(hidden_size=16, num_heads=2, expand_k=1, expand_v=1, use_short_conv=False),
+            id="delta-net",
+        ),
+        pytest.param(
+            GatedDeltaNet,
+            dict(hidden_size=16, head_dim=8, num_heads=2, num_v_heads=2, expand_v=1, use_short_conv=False),
+            id="gated-deltanet",
+        ),
+        pytest.param(
+            GatedDeltaNet2,
+            dict(hidden_size=16, head_dim=8, num_heads=2, num_v_heads=2, expand_v=1, use_short_conv=False),
+            id="gated-deltanet-2",
+        ),
+        pytest.param(
+            GatedDeltaProduct,
+            dict(hidden_size=16, head_dim=8, num_heads=2, num_v_heads=2, expand_v=1, use_short_conv=False),
+            id="gated-delta-product",
+        ),
+        pytest.param(
+            GatedLinearAttention,
+            dict(hidden_size=16, num_heads=2, num_kv_heads=2, expand_k=1, expand_v=1),
+            id="gated-linear-attention",
+        ),
+        pytest.param(
+            GatedSlotAttention,
+            dict(hidden_size=16, num_heads=2, num_kv_heads=2, num_slots=4, expand_k=1, expand_v=1),
+            id="gated-slot-attention",
+        ),
+        pytest.param(HGRN2Attention, dict(hidden_size=16, num_heads=2, expand_ratio=8), id="hgrn2"),
+        pytest.param(
+            KimiDeltaAttention,
+            dict(hidden_size=16, num_heads=2, num_v_heads=2, head_dim=8, expand_v=1, use_short_conv=False),
+            id="kimi-delta-attention",
+        ),
+        pytest.param(
+            MesaNet,
+            dict(hidden_size=16, num_heads=2, head_dim=8, use_short_conv=False),
+            id="mesa-net",
+        ),
+        pytest.param(
+            MultiScaleRetention,
+            dict(hidden_size=16, num_heads=2, num_kv_heads=2, expand_k=1, expand_v=1),
+            id="multiscale-retention",
+        ),
+        pytest.param(
+            RodimusAttention,
+            dict(hidden_size=16, expand_ratio=8, mode="fused_recurrent", use_short_conv=False),
+            id="rodimus",
+        ),
+        pytest.param(YOCOGatedRetention, dict(hidden_size=16, num_heads=2), id="yoco-gated-retention"),
+    ],
+)
+def test_layer_prefers_explicit_cu_seqlens_over_attention_mask(layer_cls: type, layer_kwargs: dict) -> None:
+    torch.manual_seed(42)
+    hidden_states = torch.randn(1, 6, 16, device=device, dtype=torch.float16)
+    attention_mask = torch.ones(1, 6, device=device, dtype=torch.long)
+    padding_mask = torch.tensor([[1, 1, 1, 1, 0, 0]], device=device, dtype=torch.long)
+    cu_seqlens = torch.tensor([0, 3, 6], device=device, dtype=torch.int32)
+    layer = layer_cls(**layer_kwargs).to(device=device, dtype=torch.float16).eval()
+
+    expected, _, _ = layer(hidden_states=hidden_states, cu_seqlens=cu_seqlens)
+    actual, _, _ = layer(hidden_states=hidden_states, attention_mask=attention_mask, cu_seqlens=cu_seqlens)
+    masked, _, _ = layer(hidden_states=hidden_states, attention_mask=padding_mask)
+
+    torch.testing.assert_close(actual, expected)
+    assert masked.shape == hidden_states.shape


### PR DESCRIPTION
Fixes #1086.

## Summary

Preserve caller-provided `cu_seqlens` whenever an attention mask is also passed, and only repad outputs when mask-derived indices were actually created.

## Problem

The base revision handled the two inputs asymmetrically. Some layers skipped mask-derived unpadding when explicit `cu_seqlens` was present but still called `pad_input` because `attention_mask` was non-null, producing an `UnboundLocalError`. KimiDeltaAttention and YOCOGatedRetention also still allowed the mask path to replace explicit packed boundaries.

A base reproduction with `GatedLinearAttention` raised:

```text
UnboundLocalError: cannot access local variable 'indices' where it is not associated with a value
```

A base KimiDeltaAttention comparison using `cu_seqlens=[0, 3, 6]` and an all-ones mask returned the same shape but differed from the explicit-cu-only result by `max_abs_diff = 0.92431640625`.

## Change

The affected layer wrappers now use one consistent precedence rule:

```text
cu_seqlens supplied? ── yes ──> use explicit boundaries; do not derive indices; do not repad
                    └─ no ───> derive indices from attention_mask and repad the result
```

This updates the input and output pairing across Comba, DeltaNet, GatedDeltaNet, GatedDeltaNet2, GatedDeltaProduct, GLA, GSA, HGRN2, KDA, MesaNet, MultiScaleRetention, Rodimus, and YOCOGatedRetention. Mask-only calls retain their existing padded layout.

## Regression coverage

`test_layer_prefers_explicit_cu_seqlens_over_attention_mask` exercises all modified layer implementations. It compares explicit-cu-only against explicit-cu-plus-all-ones-mask calls and checks that mask-only calls still return the original padded shape. The test would fail on the base revision through either the exception or the changed packed-boundary result.

## Validation

- `/home/morluto/.venvs/fla-cu128/bin/python -m pytest -q tests/layers/test_attn_varlen_pack_layout.py -k test_layer_prefers_explicit_cu_seqlens_over_attention_mask` — 13 passed, 2 deselected.
- Dependency-mapped layer/model validation — 85 passed, 18 skipped, 1 failure; the sole MesaNet generation tolerance failure reproduced identically on clean `origin/main` and is pre-existing.
- Changed-file pre-commit hooks — passed, including Ruff, autopep8, conflict/secret checks, and the banned Triton API check.

## Breaking changes

None. Explicit `cu_seqlens` precedence is restored/extended; calls that provide only `attention_mask` retain their prior behavior.