### PR TITLE
[Fix] Restore tuple-form legacy cache round trips

### DIFF
--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -349,7 +349,7 @@ class LegacyFLACache(HFCacheBase):
         """Converts a cache in the legacy cache format into an equivalent `Cache`."""
 
         cache = cls(seen_tokens)
-        if isinstance(past_key_values, list):
+        if isinstance(past_key_values, (list, tuple)):
             for layer_idx in range(len(past_key_values)):
                 cache.states.append(past_key_values[layer_idx])
         return cache

--- a/tests/models/test_cache.py
+++ b/tests/models/test_cache.py
@@ -312,6 +312,28 @@ def test_cache_from_legacy_preserves_seen_tokens():
     _assert_attn_state_tokens(cache[0]["attn_state"], torch.arange(10, 14))
 
 
+def test_legacy_cache_tuple_round_trip():
+    class InitializableLegacyFLACache(LegacyFLACache):
+        def __init__(self, seen_tokens: int = 0):
+            self.states = []
+            self._seen_tokens = seen_tokens
+
+    seen_tokens = 17
+    cache = InitializableLegacyFLACache(seen_tokens=seen_tokens)
+    cache.states.append({
+        "recurrent_state": None,
+        "attn_state": _make_attn_state(10, 4),
+        "conv_state": None,
+        "ffn_state": None,
+    })
+
+    legacy_cache = cache.to_legacy_cache()
+    restored = InitializableLegacyFLACache.from_legacy_cache(legacy_cache, seen_tokens=seen_tokens)
+
+    assert restored.to_legacy_cache() == legacy_cache
+    assert restored.get_seq_length(0) == seen_tokens
+
+
 # ===================================================================================
 # Tests for GitHub Issue #766: Cache seen-token count committed too early during decode
 # ===================================================================================


### PR DESCRIPTION
Fixes #1087.

## Summary

Restore tuple-form legacy caches without changing cache serialization or state ownership.

## Problem

`LegacyFLACache.to_legacy_cache()` returns `tuple(self.states)`, but the base `from_legacy_cache()` copied entries only when `past_key_values` was a list. A one-layer tuple round trip therefore silently restored zero layers and reset the observable sequence length.

The base behavior was:

```text
states ──to_legacy_cache()──> tuple(states)
                               └── list-only restore check -> empty cache
```

## Change

`LegacyFLACache.from_legacy_cache()` now accepts both tuple and list containers. The conversion still appends the existing state objects in order and preserves the caller-provided `seen_tokens` value.

## Regression coverage

The new public round-trip test constructs a legacy cache with one layer, converts it through `to_legacy_cache()` and `from_legacy_cache()`, and verifies the tuple contents and sequence length. The test fails on the base revision because the restored tuple is empty.

## Validation

- `/home/morluto/.venvs/fla-cu128/bin/python -m pytest -q tests/models/test_cache.py` — 20 passed, 5 expected compatibility skips.
- Legacy compatibility-path checks on Transformers 4.45.0 and 4.53.3 — 7 passed and 3 expected new-cache skips at each version.
- Generation and hybrid-attention validation — 213 passed, 2 skipped.
- `uvx pre-commit run --files fla/models/utils.py tests/models/test_cache.py` — all configured hooks passed.

## Compatibility and breaking changes

None. This broadens the accepted legacy container to match the tuple emitted by the existing serializer; list inputs continue to work unchanged.