### PR TITLE
[Fix] Reject invalid context-parallel token partitions

### DIFF
--- a/fla/ops/cp/context.py
+++ b/fla/ops/cp/context.py
@@ -80,6 +80,14 @@ def get_cp_cu_seqlens(
     # Get total tokens and current rank's responsible range
     # Assume cu_seqlens is [0, s1, s1+s2, ..., total]
     total_tokens = cu_seqlens_cpu[-1].item()
+    if total_tokens < world_size:
+        raise ValueError(
+            f"`total_tokens` ({total_tokens}) must be at least `world_size` ({world_size}) for context parallelism."
+        )
+    if total_tokens % world_size != 0:
+        raise ValueError(
+            f"`total_tokens` ({total_tokens}) must be divisible by `world_size` ({world_size}) for context parallelism."
+        )
     part_len = total_tokens // world_size
     rank_start = part_len * rank
     rank_end = rank_start + part_len

--- a/tests/context_parallel/test_cp_context.py
+++ b/tests/context_parallel/test_cp_context.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.ops.cp.context import get_cp_cu_seqlens
+
+
+@pytest.mark.parametrize(
+    ('total_tokens', 'world_size'),
+    [
+        pytest.param(10, 3, id='remainder'),
+        pytest.param(14, 4, id='remainder-varlen'),
+    ],
+)
+def test_get_cp_cu_seqlens_rejects_non_divisible_total_tokens(total_tokens: int, world_size: int):
+    cu_seqlens = torch.tensor([0, total_tokens], dtype=torch.long)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"`total_tokens` \({total_tokens}\) must be divisible by `world_size` \({world_size}\)",
+    ):
+        get_cp_cu_seqlens(cu_seqlens, world_size=world_size, rank=0)
+
+
+def test_get_cp_cu_seqlens_rejects_empty_rank_partition():
+    total_tokens = 2
+    world_size = 3
+    cu_seqlens = torch.tensor([0, total_tokens], dtype=torch.long)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"`total_tokens` \({total_tokens}\) must be at least `world_size` \({world_size}\)",
+    ):
+        get_cp_cu_seqlens(cu_seqlens, world_size=world_size, rank=0)
+
+
+def test_get_cp_cu_seqlens_preserves_divisible_varlen_partition():
+    context = get_cp_cu_seqlens(
+        torch.tensor([0, 5, 12], dtype=torch.long),
+        world_size=3,
+        rank=1,
+    )
+
+    assert context.cu_seqlens_cpu.tolist() == [0, 1, 4]
+    assert context.pre_num_conv_tokens == 4
+    assert context.pre_num_ranks == 1
+    assert not context.is_first_rank
+    assert context.post_num_ranks == 1
+    assert not context.is_last_rank


### PR DESCRIPTION
Fixes #1092.

## Problem

Context parallelism partitions packed tokens into equal contiguous ranges. Previously, `get_cp_cu_seqlens` used integer division without validating that the packed token total can form those ranges:

```text
total = 10, world_size = 3

before: [0---3][3---6][6---9]  token 9 unassigned
after:  reject: 10 % 3 != 0
```

When `total_tokens < world_size`, an empty rank partition instead reaches `max()` and raises `ZeroDivisionError`.

## Change

Validate `total_tokens >= world_size` and exact divisibility before constructing rank-local sequence metadata. Divisible packed variable-length inputs keep their existing behavior.

## Regression coverage

`tests/context_parallel/test_cp_context.py` covers non-divisible totals, empty rank partitions, and a divisible variable-length partition. The new tests fail on the base behavior: the empty-partition case raises `ZeroDivisionError`, while non-divisible totals are accepted.

## Validation

- `.venv-tests/bin/python -m pytest tests/context_parallel/test_cp_context.py -q` — 4 passed

## Breaking changes

None; invalid equal-partition inputs now fail at validation rather than producing truncated or invalid partition metadata.