### PR TITLE
[GDN] Match SM120 exactly for FlashQLA dispatch

### DIFF
--- a/fla/utils/_device.py
+++ b/fla/utils/_device.py
@@ -131,7 +131,8 @@ IS_NVIDIA_HOPPER = (
     )
 )
 IS_NVIDIA_SM100 = (IS_NVIDIA and torch.cuda.get_device_capability()[0] == 10)
-IS_NVIDIA_SM120 = (IS_NVIDIA and torch.cuda.get_device_capability()[0] == 12)
+# NOTE: exactly 12.0 — 12.1 (GB10) is a different target that FlashQLA rejects at import time.
+IS_NVIDIA_SM120 = (IS_NVIDIA and torch.cuda.get_device_capability() == (12, 0))
 IS_NVIDIA_BLACKWELL = (IS_NVIDIA and torch.cuda.get_device_capability()[0] in (10, 12))
 
 # Nvidia Ampere or newer, haven't check AMD and intel yet.

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -1676,6 +1676,13 @@ def test_flash_qla_verifier_sm120_rejects_float16(monkeypatch):
     assert passed and reason is None
 
 
+@pytest.mark.skipif(not IS_NVIDIA_SM120, reason="only meaningful where the SM120 flag is set")
+def test_flash_qla_sm120_flag_is_exact_capability():
+    """FlashQLA matches the '12.0' target string exactly and raises ValueError at import on 12.1
+    (GB10), so widening this flag to major == 12 would turn a Triton fallback into a hard error."""
+    assert torch.cuda.get_device_capability() == (12, 0)
+
+
 @_SKIP_FLASH_QLA_FWD
 @pytest.mark.parametrize(
     ("B", "T", "H", "HV", "D", "dtype"),


### PR DESCRIPTION
Follow-up to #1094.

## Problem

`IS_NVIDIA_SM120` tests only the capability major version:

```python
IS_NVIDIA_SM120 = (IS_NVIDIA and torch.cuda.get_device_capability()[0] == 12)
```

so it also matches **12.1 (GB10)**. FlashQLA compares tilelang's target compute version against exact
strings and raises from the `else` branch at *import* time
(`flash_qla/ops/gated_delta_rule/chunk/__init__.py`, and likewise in `chunk/cp_context.py`):

```python
elif tilelang.contrib.nvcc.get_target_compute_version() == "12.0":
    from .blackwell_sm120 import ...
else:
    raise ValueError(f"FlashQLA now support sm90, sm100, sm103 and sm120 only. Found ...")
```

On a 12.1 device with `flash_qla` installed this is a hard failure rather than a fallback:

1. `is_available()` uses `find_spec`, which does not import — so it returns `True`.
2. The verifier accepts the call (major == 12, bf16, no grad).
3. `FlashQLABackend.chunk_gated_delta_rule` runs `import flash_qla` → `ValueError`.

`dispatch()` calls `impl(*args, **kwargs)` outside any `try`/`except` (`fla/ops/backends/__init__.py`),
so it propagates to the caller. Before #1094 the arch gate rejected 12.1 and the op fell back to Triton
cleanly, so this is a regression introduced by that PR.

## Fix

Match the capability exactly, which is also what the flag's name implies:

```python
IS_NVIDIA_SM120 = (IS_NVIDIA and torch.cuda.get_device_capability() == (12, 0))
```

`IS_NVIDIA_BLACKWELL` still covers 12.x as a family, so the Triton-level Blackwell workarounds that key
off it are unaffected on GB10.

## Tests

Adds `test_flash_qla_sm120_flag_is_exact_capability`, which pins the invariant so the flag is not
widened back to `major == 12`.

Two limits worth stating plainly: the test only executes where the flag is already set, so it guards
future edits rather than demonstrating the GB10 fix, and it will skip on the H100 CI runner. I do not
have a 12.1 device to reproduce on — the analysis above comes from reading upstream's arch dispatch,
which compares against the literal `"12.0"` in both affected modules.

The existing FlashQLA suite is unchanged on SM120: 8 passed, 13 skipped on an RTX PRO 6000 (SM 12.0).
