### PR TITLE
[CI] Enforce PR checklist and add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->
+
+## Test plan
+
+<!-- How you verified it: commands run, hardware used.
+     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->
+
+## Benchmark / NCU (kernel changes only)
+
+<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
+     State "neutral" if the change is not performance-related. -->
+
+## Breaking changes
+
+<!-- None / list any API or behavior changes and the migration path. -->
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
+- [ ] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
+- [ ] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
+- [ ] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
+- [ ] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
+
+### If you cannot tick the "not minor" box above
+
+Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
+If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:
+
+<!-- justification, or delete this section if not applicable -->

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -25,3 +25,31 @@ jobs:
             echo "Actual title: $PR_TITLE"
             exit 1
           fi
+
+      - name: Check the PR body for a complete checklist
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          fail() { echo "::error::$1"; exit 1; }
+          [ -z "$PR_BODY" ] && fail "PR body is empty. Please fill in the template — every checklist box matters."
+
+          require_checked() {
+            local pattern="$1" label="$2"
+            if ! grep -qiE "^[[:space:]]*- \[x\][[:space:]].*$pattern" <<<"$PR_BODY"; then
+              fail "Checklist item not ticked: \"$label\". Read it, act on it, and tick it before merging."
+            fi
+          }
+
+          require_checked "I have read \[CONTRIBUTING.md\]" "I have read CONTRIBUTING.md"
+          require_checked "I have read \[AGENTS.md\]" "I have read AGENTS.md"
+          require_checked "Dependent tests pass" "dependent tests"
+          require_checked "Kernel changes include" "benchmark numbers (kernel changes)"
+
+          if ! grep -qiE "^[[:space:]]*- \[x\][[:space:]].*This is not a minor/cosmetic-only PR" <<<"$PR_BODY"; then
+            just=$(sed -n '/### If you cannot tick/,$p' <<<"$PR_BODY" | sed 's/<!--[^>]*-->//g' | tail -n +2 | tr -d '[:space:]')
+            if [ ${#just} -lt 20 ]; then
+              fail "Minor PR without justification: tick the 'not minor' box, or use the justification section to explain why this minor change is worth a maintainer's review time."
+            fi
+          fi
+
+          echo "PR checklist complete."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,6 +381,8 @@ Once your change is implemented, tested, and (if it touches performance) benchma
 
 - **Keep the scope focused**: one PR should do one thing. If you have multiple unrelated changes, please split them into separate PRs.
 - **Use Draft PRs**: feel free to open a draft early for design feedback or work-in-progress discussion.
+- **Read `AGENTS.md` and `.agents/skills/fla-mr-readiness` first**: they cover the PR checklist, test-plan requirements, and benchmark evidence standards expected of every pull request.
+- **No busywork PRs**: don't open standalone PRs for typos or isolated style tweaks; fold them into a related substantive change instead.
 
 ### Commit Message Convention
 


### PR DESCRIPTION
## Summary

Adds a PR template and enforces its checklist in CI, so every new PR must confirm the author has read the contribution rules before it can merge:

- `.github/pull_request_template.md` (new): Summary / Test plan / Benchmark / Breaking changes + a 5-item checklist. The "not minor" item works as a forced choice: tick it, or justify in the dedicated section why the minor change is worth a maintainer's review time.
- `.github/workflows/check-pr-title.yml`: same workflow and job name as before (branch protection keeps working unchanged), with a new step that fails the check when any box is unticked — or when the "not minor" box is unticked and the justification section is empty (<20 chars, placeholders excluded).
- `CONTRIBUTING.md`: cross-references `AGENTS.md` / `.agents/skills/fla-mr-readiness` and spells out the no-busywork-PRs rule in Submit Pull Requests.

## Test plan

- Bash logic tested locally against four PR-body variants: all-ticked (pass), unticked (fail), minor-with-justification (pass), minor-with-placeholder-only (fail).
- This PR's own body dogfoods the new template and must pass the new check itself.
- Dependent tests: none (CI/meta-only change, no Python code touched).

## Benchmark / NCU (kernel changes only)

neutral

## Breaking changes

- None. The check only triggers on newly opened/edited PRs; existing open PRs are unaffected unless edited. The workflow/job name is unchanged, so the existing required-check entry in branch protection keeps matching.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).