### PR TITLE
[Fix] Mask out-of-bounds accesses in RWKV7 channel mixing kernels

### DIFF
--- a/fla/ops/rwkv7/channel_mixing.py
+++ b/fla/ops/rwkv7/channel_mixing.py
@@ -82,16 +82,18 @@ def rwkv_seq_mix_kernel(
 def rwkv_channel_mixing_pow_and_relu(
     in_ptr,
     out_ptr,
+    n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
     """Fused ReLU and Power operation: x = ReLU(x)^2"""
     xoffset = tl.program_id(0).to(tl.int64) * BLOCK_SIZE
     xindex = xoffset + tl.arange(0, BLOCK_SIZE)
     x0 = xindex
-    x = tl.load(in_ptr + (x0), None)
+    xmask = xindex < n_elements
+    x = tl.load(in_ptr + (x0), mask=xmask, other=0.0)
     x = tl.maximum(x, 0.0).to(tl.float32)
     x = tl.cast(x * x, dtype=out_ptr.dtype.element_ty, fp_downcast_rounding='rtne')
-    tl.store(out_ptr + (x0), x, None)
+    tl.store(out_ptr + (x0), x, mask=xmask)
 
 
 def rwkv_mix_torch(x: torch.Tensor, x_prev: torch.Tensor, x_k: torch.Tensor):
@@ -162,6 +164,7 @@ def rwkv_relu_and_square_fwd(x: torch.Tensor, inplace: bool = True):
     rwkv_channel_mixing_pow_and_relu[grid](
         x,
         output,
+        output.numel(),
         BLOCK_SIZE=4096,
     )
 
@@ -172,6 +175,7 @@ def rwkv_relu_and_square_fwd(x: torch.Tensor, inplace: bool = True):
 def relu_square_bwd_kernel(
     out_ptr,
     forward_input_ptr,
+    n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
     """ReLU(x)^2 backward kernel
@@ -180,15 +184,16 @@ def relu_square_bwd_kernel(
     pid = tl.program_id(0).to(tl.int64)
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
 
-    x = tl.load(forward_input_ptr + offsets).to(tl.float32)
-    grad = tl.load(out_ptr + offsets).to(tl.float32)
+    x = tl.load(forward_input_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    grad = tl.load(out_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
 
     x = tl.maximum(x, 0.0)
 
     grad_input = grad * 2 * x
 
-    tl.store(out_ptr + offsets, grad_input.to(out_ptr.dtype.element_ty))
+    tl.store(out_ptr + offsets, grad_input.to(out_ptr.dtype.element_ty), mask=mask)
 
 
 @triton.autotune(
@@ -238,7 +243,7 @@ def rwkv_mix_bwd_kenel(
     tl.store(
         dx_prev_ptr + dx_prev_offset,
         tl.cast(prod, dtype=dx_prev_ptr.dtype.element_ty),
-        mask=is_first_step,
+        mask=is_first_step & is_valid,
     )
 
 
@@ -272,6 +277,7 @@ def rwkv_channel_mixing_bwd(grad_output, x, x_prev, x_k, key_weight, value_weigh
     relu_square_bwd_kernel[grid](
         dk,
         k1_K,
+        dk.numel(),
         BLOCK_SIZE=BLOCK_SIZE,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,9 @@ def _guarded_empty(*args, **kwargs):
     if not (dtype.is_floating_point or dtype.is_complex):
         return _ORIGINAL_EMPTY(*args, **kwargs)
 
-    if is_compiling() or not _is_called_from_fla():
+    # fill_ raises on leaf tensors that require grad; such allocations (e.g. inductor's
+    # pattern-matcher example inputs) are never kernel scratch buffers, so leave them unpoisoned
+    if is_compiling() or kwargs.get('requires_grad', False) or not _is_called_from_fla():
         return _ORIGINAL_EMPTY(*args, **kwargs)
 
     result = _ORIGINAL_EMPTY(*args, **kwargs)
@@ -88,7 +90,7 @@ def _guarded_empty(*args, **kwargs):
 
 def _guarded_empty_like(input, **kwargs):
     """Create a tensor filled with NaN instead of uninitialized values."""
-    if is_compiling() or not _is_called_from_fla():
+    if is_compiling() or kwargs.get('requires_grad', False) or not _is_called_from_fla():
         return _ORIGINAL_EMPTY_LIKE(input, **kwargs)
 
     if kwargs.get('dtype') is None:
@@ -110,7 +112,7 @@ def _guarded_empty_like(input, **kwargs):
 
 def _guarded_new_empty(self, *args, **kwargs):
     """Create a tensor filled with NaN instead of uninitialized values."""
-    if is_compiling() or not _is_called_from_fla():
+    if is_compiling() or kwargs.get('requires_grad', False) or not _is_called_from_fla():
         return _ORIGINAL_NEW_EMPTY(self, *args, **kwargs)
 
     if kwargs.get('dtype') is None:

--- a/tests/ops/test_rwkv7.py
+++ b/tests/ops/test_rwkv7.py
@@ -14,7 +14,14 @@ import torch.nn.functional as F
 from fla.ops.generalized_delta_rule.dplr import chunk_dplr_delta_rule
 from fla.ops.generalized_delta_rule.dplr.fused_recurrent import fused_recurrent_dplr_delta_rule
 from fla.ops.rwkv7 import chunk_rwkv7
-from fla.ops.rwkv7.channel_mixing import channel_mixing_rwkv7, channel_mixing_rwkv7_torch
+from fla.ops.rwkv7.channel_mixing import (
+    channel_mixing_rwkv7,
+    channel_mixing_rwkv7_torch,
+    relu_square_bwd_kernel,
+    rwkv_channel_mixing_bwd,
+    rwkv_mix_fwd,
+    rwkv_relu_and_square_fwd,
+)
 from fla.ops.rwkv7.fused_addcmul import fused_addcmul_rwkv7, torch_addcmul_rwkv7
 from fla.ops.rwkv7.fused_k_update import fused_k_rwkv7, k_update_ref
 from fla.ops.rwkv7.fused_recurrent import fused_mul_recurrent_rwkv7
@@ -77,6 +84,48 @@ def test_channel_mixing_gradients(B, T, n_embd, dim_ffn, dtype, inplace, xprevdi
     assert_close(" dx_k", x_k.grad, x_k2.grad, ratio=5e-3)
     assert_close(" dK_", K_.grad, K_2.grad, ratio=5e-3)
     assert_close(" dV_", V_.grad, V_2.grad, ratio=5e-3)
+
+
+@pytest.mark.skipif(
+    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
+    reason="Skipping test because TEST_CHUNK_VARLEN is enabled",
+)
+def test_channel_mixing_no_out_of_bounds_writes():
+    torch.manual_seed(42)
+    # element counts that no block size in [128, 8192] divides, so every launch has a partial tail block
+    B, T, n_embd, dim_ffn = 1, 7, 200, 700
+    sentinel = 777.0
+    n_ffn = B * T * dim_ffn
+    # the store window the fixed 4096 grid covers
+    window = (n_ffn + 4095) // 4096 * 4096
+
+    # rwkv_relu_and_square_fwd writes into its input's storage when inplace, so hand it a
+    # view of a guard-banded buffer and check the band past the tensor end stays intact
+    buf = torch.full((2 * window,), sentinel, device=device)
+    rwkv_relu_and_square_fwd(buf[:n_ffn].view(B, T, dim_ffn), inplace=True)
+    assert (buf[n_ffn:] == sentinel).all(), 'rwkv_channel_mixing_pow_and_relu stored past the tensor end'
+
+    # relu_square_bwd_kernel operates on tensors rwkv_channel_mixing_bwd allocates internally;
+    # launch it exactly as that wrapper does, on guard-banded views
+    buf = torch.full((2 * window,), sentinel, device=device)
+    dk, k1_K = buf[:n_ffn], buf[window:window + n_ffn]
+    relu_square_bwd_kernel[((n_ffn + 4095) // 4096,)](dk, k1_K, dk.numel(), BLOCK_SIZE=4096)
+    assert (buf[n_ffn:window] == sentinel).all(), 'relu_square_bwd_kernel stored past the end of dk'
+
+    # rwkv_mix_bwd_kenel with inplace=True uses the caller's x_prev as dx_prev; dead tail
+    # lanes whose seq_idx wraps to 0 must not store past its (B, n_embd) extent
+    big = torch.full((1 << 20,), sentinel, device=device)
+    x = torch.randn(B, T, n_embd, device=device)
+    x_prev = big[:B * n_embd].view(B, n_embd)
+    x_k = torch.randn(1, 1, n_embd, device=device)
+    key_weight = torch.randn(n_embd, dim_ffn, device=device)
+    value_weight = torch.randn(dim_ffn, n_embd, device=device)
+    k1 = rwkv_mix_fwd(x, x_prev, x_k)
+    k1_K = k1 @ key_weight
+    k = rwkv_relu_and_square_fwd(k1_K, inplace=False)
+    grad_output = torch.randn(B, T, n_embd, device=device)
+    rwkv_channel_mixing_bwd(grad_output, x, x_prev, x_k, key_weight, value_weight, k1, k1_K, k, inplace=True)
+    assert (big[B * n_embd:] == sentinel).all(), 'rwkv_mix_bwd_kenel stored past the end of dx_prev'
 
 
 @pytest.mark.parametrize('B', [2])

--- a/tests/ops/test_rwkv7.py
+++ b/tests/ops/test_rwkv7.py
@@ -86,10 +86,6 @@ def test_channel_mixing_gradients(B, T, n_embd, dim_ffn, dtype, inplace, xprevdi
     assert_close(" dV_", V_.grad, V_2.grad, ratio=5e-3)
 
 
-@pytest.mark.skipif(
-    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "0",
-    reason="Skipping test because TEST_CHUNK_VARLEN is enabled",
-)
 def test_channel_mixing_no_out_of_bounds_writes():
     torch.manual_seed(42)
     # element counts that no block size in [128, 8192] divides, so every launch has a partial tail block


### PR DESCRIPTION
## Summary

Three kernels in `fla/ops/rwkv7/channel_mixing.py` launch over grids that round up to the block size but leave the tail lanes unmasked, so any shape whose element count is not a multiple of the block size reads and writes past the end of the tensors involved — silently, through the public `channel_mixing_rwkv7` forward and backward. `rwkv_channel_mixing_pow_and_relu` and `relu_square_bwd_kernel` had no bounds concept at all (no element-count argument, no masks, `BLOCK_SIZE` hardcoded to 4096); `rwkv_mix_bwd_kenel` computes `is_valid` and applies it on three of its four accesses but stores `dx_prev` under `is_first_step` alone, so dead tail lanes whose `seq_idx` wraps to 0 store past the end of `dx_prev` — the caller's own `x_prev` when `inplace=True`. The corruption lands on whatever the allocator placed after those tensors; in our runs a first (autotune-sweep) `backward()` corrupted previously computed gradients of an unrelated reference path (max abs grad error 6e+01, vs 8e-06 once masked). Common RWKV7 configurations hide the bug because power-of-two `n_embd`/`dim_ffn` make every element count block-aligned.

Fixes #1102.

The fix follows the pattern this file's `rwkv_seq_mix_kernel` already uses:

- `rwkv_channel_mixing_pow_and_relu` and `relu_square_bwd_kernel` gain an `n_elements` argument and mask every load and store; their two launch sites (same file) pass `output.numel()` / `dk.numel()`. Neither kernel is exported or called anywhere else in the repo.
- `rwkv_mix_bwd_kenel`'s `dx_prev` store mask becomes `is_first_step & is_valid`, matching the three accesses above it.

In-bounds results are unchanged: masked lanes never contributed to any in-bounds output.

## Test plan

- `python scripts/find_dependent_tests.py fla/ops/rwkv7/channel_mixing.py` → `tests/ops/test_rwkv7.py`; full file passes on an L40S: 38 passed, 4 skipped (the pre-existing Hopper-only T=131072 skips on this sm_89 card).
- New `test_channel_mixing_no_out_of_bounds_writes`: sentinel guard bands around the storage each site writes through, at element counts (1, 7, 200, 700) that no block size in [128, 8192] divides — a view fed to `rwkv_relu_and_square_fwd(inplace=True)`, the exact `relu_square_bwd_kernel` launch `rwkv_channel_mixing_bwd` performs, and a full `rwkv_channel_mixing_bwd(inplace=True)` whose `dx_prev` is a view of a larger buffer. The existing suite could not see the bug: its shapes are block-aligned, and in-bounds outputs are correct anyway.
- Reverting the kernel changes makes the new test fail at the first guard-band assert; reverting only the one-line `dx_prev` mask makes it fail at that site's assert (`rwkv_mix_bwd_kenel stored past the end of dx_prev`).
- Under `compute-sanitizer --tool memcheck` with `PYTORCH_NO_CUDA_MEMORY_CACHING=1`, the public forward+backward goes from 3,606 invalid global reads/writes attributed to `channel_mixing.py:91/94/184/185/240` to zero device errors.
- The new test's shapes force a fresh `torch.compile` of this file's `compute_x_k_grad` helper, which exposed a latent `tests/conftest.py` issue on the PyTorch 2.12 CI runner: inductor's one-time pattern-matcher init allocates `requires_grad=True` example tensors through the patched `torch.empty`, and `fill_(nan)` raises on a leaf tensor that requires grad. The conftest now skips poisoning for allocations that require grad — kernel scratch buffers never do, so no coverage is lost.

## Benchmark / NCU

do_bench per kernel on an NVIDIA L40S at (B, T, n_embd, dim_ffn) = (2, 4096, 1024, 4096), bf16 — element counts block-aligned so both versions do identical work (no tail): the mix numel is 8Mi, the FFN numel 32Mi.

| kernel | before | after |
|---|---|---|
| `rwkv_channel_mixing_pow_and_relu` | 210.3–211.3 us | 211.2–211.5 us |
| `relu_square_bwd_kernel` | 310.5–310.6 us | 311.0–311.5 us |
| `rwkv_mix_bwd_kenel` | 54.1 us | 54.7–55.1 us |

(three interleaved before/after runs each; `triton.testing.do_bench`, kernels driven exactly as their wrappers launch them)

Conclusion: neutral for the two fully-unmasked kernels (≤ 0.3%, within run-to-run spread); `rwkv_mix_bwd_kenel` pays up to ~1 us (~1.5%) at this shape for the corrected store predicate. Varlen: not applicable, these kernels have no varlen path.

## Breaking changes

None. In-bounds outputs are unchanged. The two previously unmasked kernels gain an `n_elements` parameter; they are internal launch targets of their same-file wrappers and are not exported from `fla.ops.rwkv7`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

## Environment

- Commit base: 2501ac83 (main)
- GPU: NVIDIA L40S (sm_89), driver CUDA 12.4
- torch 2.13.0+cu129, triton 3.7.1, Python 3.12
