### PR TITLE
[Fix] Handle chunk-boundary-straddling key tiles in DeltaFormer forward

### DIFF
--- a/fla/ops/deltaformer/parallel.py
+++ b/fla/ops/deltaformer/parallel.py
@@ -172,7 +172,8 @@ def parallel_deltaformer_fwd_kernel(
         k = tl.load(k_blk_ptr, mask=m_kv[None, :], other=0.0)
         qk = tl.dot(q, k) * qk_scale
 
-        if kv_i >= T - C:
+        # tiles straddling the T - C boundary need the mask too; prefix columns evaluate to false
+        if kv_i + BLOCK_T > T - C:
             mask = (T - C - kv_i + rowid_block[:, None] - colid_block[None, :] < 1)
             qk = tl.where(mask, -1e6, qk)
 
@@ -188,7 +189,9 @@ def parallel_deltaformer_fwd_kernel(
 
         if kv_i < T - C:
             u_blk_ptr = u_ptr + pid_h * D + o_kv[:, None] * (H * D) + o_d[None, :]
-            u = tl.load(u_blk_ptr, mask=m_kv[:, None], other=0.0)
+            # rows at and past T - C are this launch's own output, not yet written
+            m_u = o_kv < T - C
+            u = tl.load(u_blk_ptr, mask=m_u[:, None], other=0.0)
             acc = tl.dot(p.to(u_ptr.dtype.element_ty), u, acc)
 
     lse = rowmax + tl.math.log2(rowsum)

--- a/tests/ops/test_deltaformer.py
+++ b/tests/ops/test_deltaformer.py
@@ -23,14 +23,18 @@ pytestmark = [
 
 
 @pytest.mark.parametrize(
-    ('B', 'T', 'H', 'D', 'dtype'),
+    ('B', 'T', 'H', 'D', 'C', 'dtype'),
     [
-        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-C{}-{}".format(*test))
         for test in [
-            (2, 128, 2, 64, torch.float16),
-            (1, 256, 4, 64, torch.float16),
-            (2, 512, 4, 64, torch.float16),
-            (4, 1024, 4, 128, torch.float16),
+            (2, 128, 2, 64, 512, torch.float16),
+            (1, 256, 4, 64, 512, torch.float16),
+            (2, 512, 4, 64, 512, torch.float16),
+            (4, 1024, 4, 128, 512, torch.float16),
+            # chunk sizes the autotuned BLOCK_T values (64, 32) do not divide, so a key
+            # tile straddles the chunk boundary
+            (2, 200, 2, 64, 48, torch.float16),
+            (1, 400, 2, 64, 96, torch.float16),
         ]
     ],
 )
@@ -43,6 +47,7 @@ def test_deltaformer_attn(
     T: int,
     H: int,
     D: int,
+    C: int,
     dtype: torch.dtype,
 ):
     """
@@ -64,7 +69,7 @@ def test_deltaformer_attn(
     ref_dv, v.grad = v.grad.clone(), None
     ref_dbeta, beta.grad = beta.grad.clone(), None
 
-    tri = deltaformer_attn(q, k, v, beta)
+    tri = deltaformer_attn(q, k, v, beta, C=C)
     tri.backward(do)
     tri_dq, q.grad = q.grad.clone(), None
     tri_dk, k.grad = k.grad.clone(), None

--- a/tests/ops/test_deltaformer.py
+++ b/tests/ops/test_deltaformer.py
@@ -5,21 +5,24 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+import math
+
 import pytest
 import torch
 
 from fla.ops.deltaformer import deltaformer_attn
-from fla.ops.deltaformer.naive import naive_deltaformer_attn
+from fla.ops.deltaformer.naive import naive_deltaformer_attn, tril_softmax
+from fla.ops.deltaformer.parallel import ParallelDeltaformerFunction
 from fla.utils import IS_INTEL_ALCHEMIST, assert_close, device, find_spec_cached
 
-pytestmark = [
-    # Module-level importorskip would exit pytest with code 5 (no tests collected), which
-    # breaks CI's per-file `pytest "$f" || exit 1` loop; mark tests as skipped instead.
-    pytest.mark.skipif(
-        find_spec_cached("flash_attn") is None,
-        reason="deltaformer_attn requires flash-attn (`pip install flash-attn --no-build-isolation`).",
-    ),
-]
+# Only the public deltaformer_attn needs flash-attn (to consume u); the u computation itself
+# does not, so the mark sits on individual tests rather than the module. A module-level
+# importorskip would also exit pytest with code 5 (no tests collected), which breaks CI's
+# per-file `pytest "$f" || exit 1` loop.
+requires_flash_attn = pytest.mark.skipif(
+    find_spec_cached("flash_attn") is None,
+    reason="deltaformer_attn requires flash-attn (`pip install flash-attn --no-build-isolation`).",
+)
 
 
 @pytest.mark.parametrize(
@@ -33,11 +36,12 @@ pytestmark = [
             (4, 1024, 4, 128, 512, torch.float16),
             # chunk sizes the autotuned BLOCK_T values (64, 32) do not divide, so a key
             # tile straddles the chunk boundary
-            (2, 200, 2, 64, 48, torch.float16),
-            (1, 400, 2, 64, 96, torch.float16),
+            (2, 192, 2, 64, 48, torch.float16),
+            (1, 384, 2, 64, 96, torch.float16),
         ]
     ],
 )
+@requires_flash_attn
 @pytest.mark.skipif(
     IS_INTEL_ALCHEMIST,
     reason="Skipping test on Intel Alchemist due to known issues with SRAM.",
@@ -83,6 +87,86 @@ def test_deltaformer_attn(
     assert_close('dbeta', ref_dbeta, tri_dbeta, 0.008)
 
 
+def naive_deltaformer_u(q, k, v, beta):
+    """
+    Stage 1 of naive_deltaformer_attn (which only returns o), sequence-first layout:
+    u[t] = v[t] - beta[t] * sum_{j<t} softmax(q[t] @ k[:t]^T)[j] * u[j], computed in fp32.
+    """
+    qf, kf, vf = (t.float().transpose(1, 2) for t in (q, k, v))
+    betaf = beta.float().transpose(1, 2)
+    scores = qf @ kf.transpose(-1, -2) * (1.0 / math.sqrt(q.shape[-1]))
+    probs = tril_softmax(scores, strict=True)
+    us = []
+    for t in range(q.shape[1]):
+        u_t = vf[:, :, t]
+        if t > 0:
+            u_prev = torch.stack(us, dim=-2)
+            u_t = u_t - betaf[:, :, t, None] * (probs[:, :, t, :t, None] * u_prev).sum(-2)
+        us.append(u_t)
+    return torch.stack(us, dim=2).transpose(1, 2).to(q.dtype)
+
+
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'D', 'C', 'dtype'),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-C{}-{}".format(*test))
+        for test in [
+            # chunk sizes the autotuned BLOCK_T values (64, 32) do not divide, so a key
+            # tile straddles the chunk boundary; C=64 is the aligned control
+            (2, 192, 2, 64, 16, torch.float16),
+            (2, 192, 2, 64, 48, torch.float16),
+            (2, 192, 2, 64, 64, torch.float16),
+        ]
+    ],
+)
+@pytest.mark.skipif(
+    IS_INTEL_ALCHEMIST,
+    reason="Skipping test on Intel Alchemist due to known issues with SRAM.",
+)
+def test_parallel_deltaformer_u(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    C: int,
+    dtype: torch.dtype,
+):
+    """
+    Test the u-computation stage (ParallelDeltaformerFunction) against the naive recurrence.
+
+    Unlike test_deltaformer_attn this needs no flash-attn, so it also runs on CI runners
+    without a flash-attn build.
+    """
+    torch.manual_seed(42)
+
+    q = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    k = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    v = torch.randn((B, T, H, D), dtype=dtype, device=device).requires_grad_(True)
+    beta = torch.randn((B, T, H), dtype=dtype, device=device).sigmoid().requires_grad_(True)
+
+    du = torch.randn((B, T, H, D), dtype=dtype, device=device)
+
+    ref = naive_deltaformer_u(q, k, v, beta)
+    ref.backward(du)
+    ref_dq, q.grad = q.grad.clone(), None
+    ref_dk, k.grad = k.grad.clone(), None
+    ref_dv, v.grad = v.grad.clone(), None
+    ref_dbeta, beta.grad = beta.grad.clone(), None
+
+    tri = ParallelDeltaformerFunction.apply(q, k, v, beta, C, None)
+    tri.backward(du)
+    tri_dq, q.grad = q.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dv, v.grad = v.grad.clone(), None
+    tri_dbeta, beta.grad = beta.grad.clone(), None
+
+    assert_close('u', ref, tri, 0.006)
+    assert_close('dq', ref_dq, tri_dq, 0.008)
+    assert_close('dk', ref_dk, tri_dk, 0.008)
+    assert_close('dv', ref_dv, tri_dv, 0.008)
+    assert_close('dbeta', ref_dbeta, tri_dbeta, 0.008)
+
+
 @pytest.mark.parametrize(
     ('H', 'D', 'cu_seqlens', 'dtype'),
     [
@@ -95,6 +179,7 @@ def test_deltaformer_attn(
         ]
     ],
 )
+@requires_flash_attn
 @pytest.mark.skipif(
     IS_INTEL_ALCHEMIST,
     reason="Skipping test on Intel Alchemist due to known issues with SRAM.",


### PR DESCRIPTION
## Summary

`parallel_deltaformer_fwd_kernel` decides per `BLOCK_T` tile, from the tile's start offset alone, whether a key tile belongs to earlier chunks (read `u`, no causal mask) or to the current chunk (causal mask, no `u` read). The chunk size `C` is a public, unvalidated keyword of `deltaformer_attn`; when it is not a multiple of the autotuned `BLOCK_T` (64 or 32), a prefix/current-chunk boundary `T - C` can fall strictly inside one key tile. That straddling tile is treated wholly as "earlier chunks": the current chunk's columns enter the softmax statistics unmasked, and the `u` load sweeps into rows `[T-C, T)`, the launch's own not-yet-written output region (uninitialized `torch.empty_like` memory). The result is wrong (`max |u - naive| = 0.487` at `C=16, T=64` vs `0.0009` for the aligned control) and nondeterministic (changes by up to 0.56 with the garbage the allocator left behind). The bug needs an explicitly non-aligned `C`: the default `C = 512` is a multiple of both `BLOCK_T` values, so every boundary lands on a tile edge — the shipped layer and the existing test shapes never hit it.

Fixes #1104.

Two changes in the kernel, following the treatment `parallel_deltaformer_bwd_kernel_u` in the same file already uses for its own boundary (`kv_i + BLOCK_T >= ...` with an elementwise mask):

- The causal-mask branch now also covers straddling tiles: `if kv_i >= T - C` becomes `if kv_i + BLOCK_T > T - C`. The mask expression is unchanged — it is already elementwise in global column indices, so prefix columns of a straddling tile evaluate to false and keep their scores.
- The `u` load is bounded by the boundary instead of the tensor end: mask `o_kv < T - C` instead of `o_kv < T`, so a straddling tile reads only initialized prefix rows (masked lanes load 0.0 and contribute nothing, matching the aligned behavior where current-chunk tiles skip the `u` dot entirely).

Aligned chunk sizes compile to the same tile behavior as before; open PR #603 restructures this loop for performance but does not address the straddling-tile boundary handling.

## Test plan

- `python scripts/find_dependent_tests.py fla/ops/deltaformer/parallel.py` → `tests/ops/test_deltaformer.py`.
- New `test_parallel_deltaformer_u` tests the stage this PR touches — `ParallelDeltaformerFunction` — directly against the naive `u` recurrence, forward output and all four gradients, at `(B, T, H, D) = (2, 192, 2, 64)` with straddling chunk sizes `C = 16` and `C = 48` plus an aligned control `C = 64`. It needs no flash-attn, so it runs on the CI GPU runners where the rest of this file is skipped; the flash-attn skip moved from module scope onto the two `deltaformer_attn`-level tests it actually applies to.
- `test_deltaformer_attn` keeps the new `C` axis with chunk sizes the `BLOCK_T` values do not divide, now at lengths the chunk size divides — `(B, T, C) = (2, 192, 48)` and `(1, 384, 96)` — so these cases stay clear of an unrelated pre-existing backward issue when `C` does not divide `T` (forward chunks from 0, backward walks back from `T - C`, and `ws` is indexed with mismatched offsets).
- The straddling cases fail deterministically without the fix: the NaN memory poisoning in `tests/conftest.py` fills the not-yet-written `u` rows the unfixed kernel reads. Verified by reverting the kernel change, on both an L40S (sm_89) and an H100 (sm_90): `C = 16` and `C = 48` fail, the `C = 64` control passes. With the fix, on both GPUs: 3 passed, 10 skipped (no local flash-attn build; the CI runners exercise the full `deltaformer_attn` path), worst error ratio 5.3e-4 against bounds of 6e-3/8e-3.
- Without the fix, at `C=16, T=64` fp32: `max |u - naive| = 0.48`, gradient errors through `ParallelDeltaformerFunction` up to `1.02` (`dbeta`); with the fix: `0.001`–`0.013`, identical to the aligned control's noise floor.
- `compute-sanitizer --tool initcheck` on the public `C=16` path: 1,024 uninitialized global reads at `parallel.py:191` before, 0 errors after.

## Benchmark / NCU

`triton.testing.do_bench` on an NVIDIA L40S, fp16, `(B, T, H, D) = (1, 4096, 8, 128)` at the default `C = 512` (block-aligned, so both versions do identical work); three interleaved before/after runs:

| workload | before | after |
|---|---|---|
| full `u` computation (8 chunks) | 4.813–4.840 ms | 4.791–4.822 ms |
| last-chunk forward kernel alone | 161.4–164.8 us | 161.7–163.5 us |

Conclusion: neutral — differences are within run-to-run spread. Straddling chunk sizes previously computed a wrong answer, so there is no meaningful "before" to compare there.

## Breaking changes

None. Aligned chunk sizes (including the default) are unchanged; straddling chunk sizes go from silently wrong and nondeterministic to correct.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

## Environment

- Commit base: 2501ac83 (main)
- GPU: NVIDIA L40S (sm_89), driver CUDA 12.4
- torch 2.13.0+cu129, triton 3.7.1, Python 3.12
