### PR TITLE
[KDA] Make `A_log` optional in lower bound gate for KDA

### DIFF
--- a/fla/ops/gdn2/chunk.py
+++ b/fla/ops/gdn2/chunk.py
@@ -224,46 +224,54 @@ def chunk_gdn2(
     Setting ``b = w = beta`` (scalar) recovers KDA.
 
     Args:
-        q: queries of shape ``[B, T, H, K]``.
-        k: keys of shape ``[B, T, H, K]``.
-        v: values of shape ``[B, T, H, V]``.
-        g: (forget) log-decay of shape ``[B, T, H, K]``. With
-            ``use_gate_in_kernel=True`` this is the raw pre-activation and the
-            kernel computes ``-exp(A_log) * softplus(g + dt_bias)`` (or the
-            bounded variant if ``lower_bound`` is set).
-        b: channel-wise ERASE gate of shape ``[B, T, H, K]``. Replaces KDA's
-            scalar beta. Typical range: ``[0, 2]``.
-        w: channel-wise WRITE gate of shape ``[B, T, H, V]``. New for GDN-2.
-            Typical range: ``[0, 1]``.
-        scale: attention scale. Defaults to ``1 / sqrt(K)``.
-        initial_state: optional ``[N, H, K, V]`` initial state in float32 (or
-            ``[N, H, V, K]`` if ``state_v_first=True``).
-        output_final_state: whether to output the final recurrent state.
-        use_qk_l2norm_in_kernel: L2-normalize q and k inside the kernel.
-        use_gate_in_kernel: compute the gate activation inside the kernel from
-            raw ``g`` and (required) ``A_log`` (plus optional ``dt_bias``,
-            ``lower_bound``).
-        cu_seqlens: ``[N+1]`` packed-sequence offsets. Requires batch size 1.
-        cu_seqlens_cpu: optional CPU mirror of ``cu_seqlens``, forwarded to the
-            state-recurrence kernel.
-        safe_gate: use the safe-gate intra kernel variant (M=16 TensorCore
-            path; requires gate values in ``[-5, 0)`` if combined with
-            ``use_gate_in_kernel=True``).
-        lower_bound: when ``safe_gate=True`` and ``use_gate_in_kernel=True``,
-            use the bounded gate activation
-            ``lower_bound * sigmoid(exp(A_log) * g)``. Must lie in ``[-5, 0)``.
-        disable_recompute: retain forward intermediates for a faster backward
-            at the cost of memory. Default: ``False``.
-        return_intermediate_states: when ``True``, also returns the per-chunk
-            pre-states ``h`` (shape ``[B, NT, H, K, V]``). Must be used inside
-            ``torch.inference_mode()``.
-        state_v_first: store the recurrent state in ``[V, K]`` layout instead
-            of the default ``[K, V]``.
+        q (torch.Tensor):
+            queries of shape ``[B, T, H, K]``.
+        k (torch.Tensor):
+            keys of shape ``[B, T, H, K]``.
+        v (torch.Tensor):
+            values of shape ``[B, T, H, V]``.
+        g (torch.Tensor):
+            (forget) log-decay of shape ``[B, T, H, K]``.
+            With ``use_gate_in_kernel=True`` this is the raw pre-activation,
+            and the kernel computes ``-exp(A_log) * softplus(g + dt_bias)`` (or the bounded variant if ``lower_bound`` is set).
+        b (torch.Tensor):
+            channel-wise ERASE gate of shape ``[B, T, H, K]``. Replaces KDA's scalar beta. Typical range: ``[0, 2]``.
+        w (torch.Tensor):
+            channel-wise WRITE gate of shape ``[B, T, H, V]``. New for GDN-2. Typical range: ``[0, 1]``.
+        scale (Optional[float]):
+            attention scale. Default: ``1 / sqrt(K)``.
+        initial_state (Optional[torch.Tensor]):
+            initial state in float32, of shape ``[N, H, K, V]`` (or ``[N, H, V, K]`` if ``state_v_first=True``).
+        output_final_state (Optional[bool]):
+            whether to output the final recurrent state. Default: `False`.
+        use_qk_l2norm_in_kernel (Optional[bool]):
+            L2-normalize q and k inside the kernel. Default: `False`.
+        use_gate_in_kernel (Optional[bool]):
+            compute the gate activation inside the kernel from raw ``g`` and ``A_log``
+            (plus optional ``dt_bias``, ``lower_bound``).
+            When ``lower_bound`` is set, ``A_log`` may be ``None``,
+            in which case the gate is ``lower_bound * sigmoid(g + dt_bias)``. Default: `False`.
+        cu_seqlens (Optional[torch.LongTensor]):
+            ``[N+1]`` packed-sequence offsets. Requires batch size 1.
+        cu_seqlens_cpu (Optional[torch.LongTensor]):
+            CPU mirror of ``cu_seqlens``, forwarded to the state-recurrence kernel.
+        safe_gate (Optional[bool]):
+            use the safe-gate intra kernel variant (M=16 TensorCore path;
+            requires gate values in ``[-5, 0)`` if combined with ``use_gate_in_kernel=True``). Default: `False`.
+        lower_bound (Optional[float]):
+            when ``safe_gate=True`` and ``use_gate_in_kernel=True``,
+            use the bounded gate activation ``lower_bound * sigmoid(exp(A_log) * g)``. Must lie in ``[-5, 0)``.
+        disable_recompute (Optional[bool]):
+            retain forward intermediates for a faster backward at the cost of memory. Default: `False`.
+        return_intermediate_states (Optional[bool]):
+            when ``True``, also returns the per-chunk pre-states ``h`` (shape ``[B, NT, H, K, V]``).
+            Must be used inside ``torch.inference_mode()``. Default: `False`.
+        state_v_first (Optional[bool]):
+            store the recurrent state in ``[V, K]`` layout instead of the default ``[K, V]``. Default: `False`.
 
     Returns:
         - Normal mode: ``(o, final_state)``.
-        - Intermediate mode (``return_intermediate_states=True``):
-          ``(o, final_state, h)``.
+        - Intermediate mode (``return_intermediate_states=True``): ``(o, final_state, h)``.
 
     Examples::
 
@@ -305,8 +313,9 @@ def chunk_gdn2(
 
     A_log, dt_bias = None, None
     if use_gate_in_kernel:
-        assert "A_log" in kwargs, "A_log must be provided when use_gate_in_kernel=True."
-        A_log, dt_bias = kwargs["A_log"], kwargs.get("dt_bias")
+        A_log, dt_bias = kwargs.get("A_log"), kwargs.get("dt_bias")
+        if A_log is None and lower_bound is None:
+            raise ValueError("`A_log` must be provided when `use_gate_in_kernel=True` and `lower_bound` is not set.")
 
     chunk_size = kwargs.pop("chunk_size", 64)
     if chunk_size != 64:

--- a/fla/ops/gdn2/fused_recurrent.py
+++ b/fla/ops/gdn2/fused_recurrent.py
@@ -52,7 +52,8 @@ from fla.utils import input_guard
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
-        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "HAS_A": lambda args: args["A_log"] is not None,
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
     }
 )
@@ -93,7 +94,8 @@ def fused_recurrent_gdn2_fwd_kernel(
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
-    HAS_DT_BIAS: tl.constexpr,
+    HAS_A: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
     USE_GATE_IN_KERNEL: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
@@ -177,14 +179,14 @@ def fused_recurrent_gdn2_fwd_kernel(
         b_g = tl.load(p_g, eviction_policy='evict_last').to(tl.float32)
 
         if USE_GATE_IN_KERNEL:
-            b_A = tl.load(A_log + i_hv).to(tl.float32)
+            b_A = tl.load(A_log + i_hv).to(tl.float32) if HAS_A else 1.0
 
-            if HAS_DT_BIAS:
+            if HAS_BIAS:
                 b_bias = tl.load(dt_bias + i_hv * K + o_k, mask=mask_k, other=0).to(tl.float32)
                 b_g = b_g + b_bias
 
             if USE_LOWER_BOUND:
-                b_gk = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+                b_gk = lower_bound * tl.sigmoid((exp(b_A) if HAS_A else b_A) * b_g)
             else:
                 b_gk = -exp(b_A) * softplus(b_g)
         else:
@@ -377,35 +379,49 @@ def fused_recurrent_gdn2(
     Setting ``b = w = beta`` (scalar) recovers KDA exactly.
 
     Args:
-        q (torch.Tensor): queries of shape ``[B, T, H, K]``.
-        k (torch.Tensor): keys of shape ``[B, T, H, K]``.
-        v (torch.Tensor): values of shape ``[B, T, HV, V]`` (GVA if HV > H).
-        g (torch.Tensor): channel-wise log-decay of shape ``[B, T, HV, K]``.
-            When ``use_gate_in_kernel=True``, this is the raw pre-activation and
-            the kernel computes ``-exp(A_log) * softplus(g + dt_bias)`` (or the
-            bounded variant if ``lower_bound`` is set).
-        b (torch.Tensor): channel-wise erase gate of shape ``[B, T, HV, K]``.
-        w (torch.Tensor): channel-wise write gate of shape ``[B, T, HV, V]``.
-        A_log (Optional[torch.Tensor]): decay parameter of shape ``[HV]``.
-            Required when ``use_gate_in_kernel=True``.
-        dt_bias (Optional[torch.Tensor]): per-channel bias of shape ``[HV * K]``,
-            only used when ``use_gate_in_kernel=True``.
-        scale (Optional[float]): attention scale, defaults to ``1/sqrt(K)``.
-        initial_state (Optional[torch.Tensor]): ``[N, HV, K, V]`` in float32
-            (or ``[N, HV, V, K]`` if ``state_v_first=True``).
-        output_final_state (bool): whether to output the final state.
-        use_qk_l2norm_in_kernel (bool): L2-normalize q and k inside the kernel.
-        use_gate_in_kernel (bool): compute the gate activation from raw ``g``.
-        lower_bound (Optional[float]): when ``use_gate_in_kernel=True`` and set,
-            use ``lower_bound * sigmoid(exp(A_log) * g)`` instead of the softplus
-            activation.
-        state_v_first (bool): store state as ``[V, K]`` instead of the default
-            ``[K, V]``.
-        cu_seqlens (Optional[torch.LongTensor]): ``[N+1]`` packed-sequence offsets.
+        q (torch.Tensor):
+            queries of shape ``[B, T, H, K]``.
+        k (torch.Tensor):
+            keys of shape ``[B, T, H, K]``.
+        v (torch.Tensor):
+            values of shape ``[B, T, HV, V]`` (GVA if HV > H).
+        g (torch.Tensor):
+            channel-wise log-decay of shape ``[B, T, HV, K]``.
+            When ``use_gate_in_kernel=True``, this is the raw pre-activation,
+            and the kernel computes ``-exp(A_log) * softplus(g + dt_bias)`` (or the bounded variant if ``lower_bound`` is set).
+        b (torch.Tensor):
+            channel-wise erase gate of shape ``[B, T, HV, K]``.
+        w (torch.Tensor):
+            channel-wise write gate of shape ``[B, T, HV, V]``.
+        A_log (Optional[torch.Tensor]):
+            decay parameter of shape ``[HV]``.
+            When ``use_gate_in_kernel=True`` together with ``lower_bound``,
+            may be ``None`` to use ``lower_bound * sigmoid(g + dt_bias)``.
+        dt_bias (Optional[torch.Tensor]):
+            per-channel bias of shape ``[HV * K]``, only used when ``use_gate_in_kernel=True``.
+        scale (Optional[float]):
+            attention scale. Default: ``1/sqrt(K)``.
+        initial_state (Optional[torch.Tensor]):
+            ``[N, HV, K, V]`` in float32 (or ``[N, HV, V, K]`` if ``state_v_first=True``).
+        output_final_state (Optional[bool]):
+            whether to output the final state. Default: `False`.
+        use_qk_l2norm_in_kernel (Optional[bool]):
+            L2-normalize q and k inside the kernel. Default: `False`.
+        use_gate_in_kernel (Optional[bool]):
+            compute the gate activation from raw ``g``. Default: `False`.
+        lower_bound (Optional[float]):
+            when ``use_gate_in_kernel=True`` and set,
+            use ``lower_bound * sigmoid(exp(A_log) * g)`` instead of the softplus activation.
+        state_v_first (Optional[bool]):
+            store state as ``[V, K]`` instead of the default ``[K, V]``. Default: `False`.
+        cu_seqlens (Optional[torch.LongTensor]):
+            ``[N+1]`` packed-sequence offsets.
 
     Returns:
-        o (torch.Tensor): outputs of shape ``[B, T, HV, V]``.
-        final_state (Optional[torch.Tensor]): ``[N, HV, K, V]`` if requested.
+        o (torch.Tensor):
+            outputs of shape ``[B, T, HV, V]``.
+        final_state (Optional[torch.Tensor]):
+            ``[N, HV, K, V]`` if requested.
     """
     if 'transpose_state_layout' in kwargs:
         if state_v_first:

--- a/fla/ops/kda/backends/triton_ascend/fused_recurrent.py
+++ b/fla/ops/kda/backends/triton_ascend/fused_recurrent.py
@@ -52,7 +52,8 @@ def _get_bv(K: int, V: int) -> int:
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
-        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "HAS_A": lambda args: args["A_log"] is not None,
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
     }
 )
@@ -92,7 +93,8 @@ def fused_recurrent_kda_fwd_kernel_npu(
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
-    HAS_DT_BIAS: tl.constexpr,
+    HAS_A: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
     USE_GATE_IN_KERNEL: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
     APPLY_BETA_SIGMOID: tl.constexpr,
@@ -151,8 +153,8 @@ def fused_recurrent_kda_fwd_kernel_npu(
             b_h = tl.zeros([BK, BV], dtype=tl.float32)
 
         if USE_GATE_IN_KERNEL:
-            b_A = tl.load(A_log + i_hv).to(tl.float32)
-            if HAS_DT_BIAS:
+            b_A = tl.load(A_log + i_hv).to(tl.float32) if HAS_A else 1.0
+            if HAS_BIAS:
                 b_bias = tl.load(dt_bias + i_hv * K + o_k, mask=mask_k, other=0).to(tl.float32)
             else:
                 b_bias = tl.zeros([BK], dtype=tl.float32)
@@ -196,7 +198,7 @@ def fused_recurrent_kda_fwd_kernel_npu(
             if USE_GATE_IN_KERNEL:
                 b_g = b_g + b_bias
                 if USE_LOWER_BOUND:
-                    b_gk = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+                    b_gk = lower_bound * tl.sigmoid((exp(b_A) if HAS_A else b_A) * b_g)
                 else:
                     b_gk = -exp(b_A) * softplus(b_g)
             else:

--- a/fla/ops/kda/backends/triton_ascend/gate.py
+++ b/fla/ops/kda/backends/triton_ascend/gate.py
@@ -75,6 +75,7 @@ def _get_chunk_cumsum_bs(BT: int, S: int) -> int:
 
 
 @triton.heuristics({
+    'HAS_A': lambda args: args['A_log'] is not None,
     'HAS_BIAS': lambda args: args['dt_bias'] is not None,
     'USE_LOWER_BOUND': lambda args: args['lower_bound'] is not None,
 })
@@ -90,6 +91,7 @@ def kda_gate_fwd_kernel_npu(
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
+    HAS_A: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
     NT_OFFSET: tl.constexpr,
@@ -98,7 +100,7 @@ def kda_gate_fwd_kernel_npu(
     i_t = tl.program_id(0) + NT_OFFSET
     i_h = tl.program_id(1) + H_OFFSET
 
-    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_A = tl.load(A_log + i_h).to(tl.float32) if HAS_A else 1.0
 
     p_g = tl.make_block_ptr(g + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
     p_yg = tl.make_block_ptr(yg + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
@@ -109,14 +111,14 @@ def kda_gate_fwd_kernel_npu(
     if not USE_LOWER_BOUND:
         b_yg = -exp(b_A) * softplus(b_g)
     else:
-        b_yg = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+        b_yg = lower_bound * tl.sigmoid((exp(b_A) if HAS_A else b_A) * b_g)
     tl.store(p_yg, b_yg.to(p_yg.dtype.element_ty), boundary_check=(0, 1))
 
 
 def _launch_gate_fwd(
     *,
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None,
     dt_bias: torch.Tensor | None,
     yg: torch.Tensor,
     lower_bound: float | None,
@@ -154,6 +156,7 @@ def _launch_gate_fwd(
 
 
 @triton.heuristics({
+    'HAS_A': lambda args: args['A_log'] is not None,
     'HAS_BIAS': lambda args: args['dt_bias'] is not None,
     'USE_LOWER_BOUND': lambda args: args['lower_bound'] is not None,
 })
@@ -171,6 +174,7 @@ def kda_gate_bwd_kernel_npu(
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
+    HAS_A: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
     NT_OFFSET: tl.constexpr,
@@ -179,7 +183,7 @@ def kda_gate_bwd_kernel_npu(
     i_t = tl.program_id(0) + NT_OFFSET
     i_h = tl.program_id(1) + H_OFFSET
 
-    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_A = tl.load(A_log + i_h).to(tl.float32) if HAS_A else 1.0
 
     p_g = tl.make_block_ptr(g + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
     p_dg = tl.make_block_ptr(dg + i_h * D, (T, D), (H * D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
@@ -198,26 +202,27 @@ def kda_gate_bwd_kernel_npu(
         b_dg = b_A * (b_dyg * tl.sigmoid(b_g))
         b_dA = tl.sum(tl.sum(b_dyg * b_yg, 1), 0)
     else:
-        b_A = exp(b_A)
+        b_A = exp(b_A) if HAS_A else b_A
         b_inner = b_A * b_g
         b_sig = tl.sigmoid(b_inner)
         b_dsig = b_sig * (1.0 - b_sig)
         b_d_inner_term = b_dyg * (lower_bound * b_dsig)
         b_dg = b_d_inner_term * b_A
-        b_dA = tl.sum(tl.sum(b_dg * b_g, 1), 0)
+        b_dA = tl.sum(tl.sum(b_dg * b_g, 1), 0) if HAS_A else 0.0
 
     tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(dA + i_t * H + i_h, b_dA)
+    if HAS_A:
+        tl.store(dA + i_t * H + i_h, b_dA)
 
 
 def _launch_gate_bwd(
     *,
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None,
     dt_bias: torch.Tensor | None,
     dyg: torch.Tensor,
     dg: torch.Tensor,
-    dA: torch.Tensor,
+    dA: torch.Tensor | None,
     lower_bound: float | None,
     T: int,
     H: int,
@@ -255,6 +260,7 @@ def _launch_gate_bwd(
 
 
 @triton.heuristics({
+    'HAS_A': lambda args: args['A_log'] is not None,
     'HAS_BIAS': lambda args: args['dt_bias'] is not None,
     'HAS_SCALE': lambda args: args['scale'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
@@ -276,6 +282,7 @@ def kda_gate_chunk_cumsum_vector_kernel_npu(
     BT: tl.constexpr,
     BS: tl.constexpr,
     REVERSE: tl.constexpr,
+    HAS_A: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -304,11 +311,11 @@ def kda_gate_chunk_cumsum_vector_kernel_npu(
         b_bias = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
         b_s = b_s + b_bias[None, :]
 
-    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_A = tl.load(A_log + i_h).to(tl.float32) if HAS_A else 1.0
     if not USE_LOWER_BOUND:
         b_gate = -exp(b_A) * softplus(b_s)
     else:
-        b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
+        b_gate = lower_bound * tl.sigmoid((exp(b_A) if HAS_A else b_A) * b_s)
 
     if REVERSE:
         b_o = tl.cumsum(b_gate, axis=0, reverse=True)
@@ -323,7 +330,7 @@ def kda_gate_chunk_cumsum_vector_kernel_npu(
 def _launch_gate_chunk_cumsum(
     *,
     s: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None,
     dt_bias: torch.Tensor | None,
     o: torch.Tensor,
     scale: float | None,
@@ -377,7 +384,7 @@ def _launch_gate_chunk_cumsum(
 @input_guard
 def kda_gate_fwd_npu(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     lower_bound: float | None = None,
     output_dtype: torch.dtype = torch.float32,
@@ -403,17 +410,17 @@ def kda_gate_fwd_npu(
 @input_guard
 def kda_gate_bwd_npu(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     dyg: torch.Tensor | None = None,
     lower_bound: float | None = None,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     H, K = g.shape[-2:]
     T = g.numel() // (H * K)
     BT = _get_gate_bwd_bt(T, K)
     dg = torch.empty_like(g, dtype=torch.float32)
     NT = triton.cdiv(T, BT)
-    dA = A_log.new_empty(NT, H, dtype=torch.float32)
+    dA = g.new_empty(NT, H, dtype=torch.float32) if A_log is not None else None
     _launch_gate_bwd(
         g=g,
         A_log=A_log,
@@ -428,7 +435,7 @@ def kda_gate_bwd_npu(
         BT=BT,
     )
     dg = dg.view_as(g).type_as(g)
-    dA = dA.sum(0).view_as(A_log).type_as(A_log)
+    dA = dA.sum(0).view_as(A_log).type_as(A_log) if A_log is not None else None
     dbias = dg.view(-1, H * K).sum(0).to(dt_bias) if dt_bias is not None else None
     return dg, dA, dbias
 
@@ -436,7 +443,7 @@ def kda_gate_bwd_npu(
 @input_guard
 def kda_gate_chunk_cumsum_npu(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None,
     chunk_size: int,
     scale: float = None,
     dt_bias: torch.Tensor | None = None,
@@ -486,7 +493,7 @@ class KDAGateFunctionNPU(torch.autograd.Function):
     def forward(
         ctx,
         g: torch.Tensor,
-        A_log: torch.Tensor,
+        A_log: torch.Tensor | None = None,
         dt_bias: torch.Tensor | None = None,
         lower_bound: float | None = None,
         output_dtype: torch.dtype = torch.float32,
@@ -519,7 +526,7 @@ class KDAGateFunctionNPU(torch.autograd.Function):
 
 def fused_kda_gate_npu(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     lower_bound: float | None = None,
     output_dtype: torch.dtype = torch.float32,

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -231,6 +231,8 @@ def chunk_kda(
               The passed ``g`` acts as the raw input for ``-exp(A_log) * softplus(g + dt_bias.view(HV, K))``.
               Note that as part of the input arguments,
               ``A_log`` (shape ``[HV]``) and the optional ``dt_bias`` (shape ``[HV * K]``) should be provided.
+              When ``lower_bound`` is set, ``A_log`` may be ``None``,
+              in which case the gate is ``lower_bound * sigmoid(g + dt_bias)``.
             - If ``False``, ``g`` is expected to be the pre-computed decay value.
             Default: ``False``.
         use_beta_sigmoid_in_kernel (bool):
@@ -384,8 +386,9 @@ def chunk_kda(
 
     A_log, dt_bias = None, None
     if use_gate_in_kernel:
-        assert "A_log" in kwargs, "A_log must be provided when use_gate_in_kernel=True."
-        A_log, dt_bias = kwargs["A_log"], kwargs.get("dt_bias")
+        A_log, dt_bias = kwargs.get("A_log"), kwargs.get("dt_bias")
+        if A_log is None and lower_bound is None:
+            raise ValueError("`A_log` must be provided when `use_gate_in_kernel=True` and `lower_bound` is not set.")
 
     chunk_size = kwargs.pop("chunk_size", 64)
     if chunk_size not in (32, 64):

--- a/fla/ops/kda/fused_recurrent.py
+++ b/fla/ops/kda/fused_recurrent.py
@@ -26,7 +26,8 @@ from fla.utils import input_guard
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
-        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "HAS_A": lambda args: args["A_log"] is not None,
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
     }
 )
@@ -67,7 +68,8 @@ def fused_recurrent_kda_fwd_kernel(
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
     STORE_FINAL_STATE: tl.constexpr,
-    HAS_DT_BIAS: tl.constexpr,
+    HAS_A: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
     USE_GATE_IN_KERNEL: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
     APPLY_BETA_SIGMOID: tl.constexpr,
@@ -159,14 +161,14 @@ def fused_recurrent_kda_fwd_kernel(
         b_g = tl.load(p_g, eviction_policy='evict_last').to(tl.float32)
 
         if USE_GATE_IN_KERNEL:
-            b_A = tl.load(A_log + i_hv).to(tl.float32)
+            b_A = tl.load(A_log + i_hv).to(tl.float32) if HAS_A else 1.0
 
-            if HAS_DT_BIAS:
+            if HAS_BIAS:
                 b_bias = tl.load(dt_bias + i_hv * K + o_k, mask=mask_k, other=0).to(tl.float32)
                 b_g = b_g + b_bias
 
             if USE_LOWER_BOUND:
-                b_gk = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+                b_gk = lower_bound * tl.sigmoid((exp(b_A) if HAS_A else b_A) * b_g)
             else:
                 b_gk = -exp(b_A) * softplus(b_g)
         else:
@@ -368,10 +370,11 @@ def fused_recurrent_kda(
         beta (torch.Tensor):
             betas of shape `[B, T, HV]`.
         A_log (Optional[torch.Tensor]):
-            Decay parameter of shape `[HV]`. Required when `use_gate_in_kernel=True`.
+            Decay parameter of shape `[HV]`.
+            When `use_gate_in_kernel=True` together with `lower_bound`,
+            may be `None` to use `lower_bound * sigmoid(g + dt_bias)`.
         dt_bias (Optional[torch.Tensor]):
-            Bias added to `g` before activation, of shape `[HV]`.
-            Only used when `use_gate_in_kernel=True`.
+            Bias added to `g` before activation, of shape `[HV]`. Only used when `use_gate_in_kernel=True`.
         scale (Optional[float]):
             Scale factor for the RetNet attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
@@ -385,8 +388,8 @@ def fused_recurrent_kda(
             Whether to use L2 normalization in the kernel. Default: `False`.
         use_gate_in_kernel (Optional[bool]):
             Whether to compute the log-space KDA decay internally.
-            When `True`, `g` is the raw input and `A_log` must be provided; the kernel fuses
-            gate activation into the recurrence. Default: `False`.
+            When `True`, `g` is the raw input and the kernel fuses gate activation into the recurrence.
+            Default: `False`.
         use_beta_sigmoid_in_kernel (Optional[bool]):
             Whether to apply `torch.sigmoid(beta)` inside the kernel.
             - If `True`, the passed `beta` acts as the raw beta logits.

--- a/fla/ops/kda/gate.py
+++ b/fla/ops/kda/gate.py
@@ -57,20 +57,44 @@ def naive_kda_gate(
 
 def naive_kda_lowerbound_gate(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     lower_bound: float = -5.0,
     output_dtype: torch.dtype = torch.float32,
 ) -> torch.Tensor:
+    """
+    Torch reference implementation for KDA lowerbound gate computation.
+
+    Computes: ``g = lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``.
+    When ``A_log`` is ``None``: ``g = lower_bound * sigmoid(g + dt_bias)``.
+
+    Args:
+        g (torch.Tensor):
+            Input tensor of shape `[..., H, K]`.
+        A_log (torch.Tensor | None):
+            Optional parameter tensor with `H` elements.
+        dt_bias (torch.Tensor | None):
+            Optional bias tensor added to `g` before activation, shape `[H * K]`.
+        lower_bound (float):
+            Lower bound for the gate output. Default: `-5.0`.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float32`.
+
+    Returns:
+        Output tensor of shape `[..., H, K]`.
+    """
     H, _ = g.shape[-2:]
     g = g.float()
     if dt_bias is not None:
         g = g + dt_bias.view(H, -1)
-    g = lower_bound * F.sigmoid(A_log.view(H, 1).exp() * g)
+    if A_log is not None:
+        g = A_log.view(H, 1).float().exp() * g
+    g = lower_bound * F.sigmoid(g)
     return g.to(output_dtype)
 
 
 @triton.heuristics({
+    "HAS_A": lambda args: args["A_log"] is not None,
     "HAS_BIAS": lambda args: args["dt_bias"] is not None,
     "HAS_BETA": lambda args: args["beta"] is not None,
     'USE_LOWER_BOUND': lambda args: args['lower_bound'] is not None,
@@ -99,13 +123,14 @@ def kda_gate_fwd_kernel(
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
+    HAS_A: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_BETA: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
 ):
     i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
-    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_A = tl.load(A_log + i_h).to(tl.float32) if HAS_A else 1.0
 
     o_t = i_t * BT + tl.arange(0, BT)
     o_d = tl.arange(0, BD)
@@ -121,7 +146,7 @@ def kda_gate_fwd_kernel(
     if not USE_LOWER_BOUND:
         b_yg = -exp(b_A) * softplus(b_g)
     else:
-        b_yg = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+        b_yg = lower_bound * tl.sigmoid((exp(b_A) if HAS_A else b_A) * b_g)
     tl.store(p_yg, b_yg.to(p_yg.dtype.element_ty), mask=m_g)
 
     if HAS_BETA:
@@ -132,6 +157,7 @@ def kda_gate_fwd_kernel(
 
 
 @triton.heuristics({
+    "HAS_A": lambda args: args["A_log"] is not None,
     "HAS_BIAS": lambda args: args["dt_bias"] is not None,
     "HAS_BETA": lambda args: args["beta"] is not None,
     'USE_LOWER_BOUND': lambda args: args['lower_bound'] is not None,
@@ -162,13 +188,14 @@ def kda_gate_bwd_kernel(
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
+    HAS_A: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_BETA: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
 ):
     i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
-    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_A = tl.load(A_log + i_h).to(tl.float32) if HAS_A else 1.0
 
     o_t = i_t * BT + tl.arange(0, BT)
     o_d = tl.arange(0, BD)
@@ -193,7 +220,7 @@ def kda_gate_bwd_kernel(
         b_dg = b_A * (b_dyg * tl.sigmoid(b_g))
         b_dA = tl.sum(tl.sum(b_dyg * b_yg, 1), 0)
     else:
-        b_A = exp(b_A)
+        b_A = exp(b_A) if HAS_A else b_A
         b_inner = b_A * b_g
         b_sig = tl.sigmoid(b_inner)
         b_dsig = b_sig * (1.0 - b_sig)
@@ -201,10 +228,11 @@ def kda_gate_bwd_kernel(
         b_d_inner_term = b_dyg * (lower_bound * b_dsig)
         # dg = d_inner_term * A
         b_dg = b_d_inner_term * b_A
-        b_dA = tl.sum(tl.sum(b_dg * b_g, 1), 0)
+        b_dA = tl.sum(tl.sum(b_dg * b_g, 1), 0) if HAS_A else 0.0
 
     tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_g)
-    tl.store(dA + i_t * H + i_h, b_dA)
+    if HAS_A:
+        tl.store(dA + i_t * H + i_h, b_dA)
 
     if HAS_BETA:
         p_b = beta + i_h + o_t * H
@@ -219,7 +247,7 @@ def kda_gate_bwd_kernel(
 @dispatch('kda')
 def kda_gate_fwd(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     lower_bound: float | None = None,
     output_dtype: torch.dtype = torch.float32,
@@ -251,18 +279,18 @@ def kda_gate_fwd(
 @dispatch('kda')
 def kda_gate_bwd(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     dyg: torch.Tensor | None = None,
     lower_bound: float | None = None,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     H, K = g.shape[-2:]
     T = g.numel() // (H * K)
     BT = 32
     NT = triton.cdiv(T, BT)
 
     dg = torch.empty_like(g, dtype=torch.float32)
-    dA = A_log.new_empty(NT, H, dtype=torch.float32)
+    dA = g.new_empty(NT, H, dtype=torch.float32) if A_log is not None else None
 
     grid = (triton.cdiv(T, BT), H)
     kda_gate_bwd_kernel[grid](
@@ -284,7 +312,7 @@ def kda_gate_bwd(
     )
 
     dg = dg.view_as(g).type_as(g)
-    dA = dA.sum(0).view_as(A_log).type_as(A_log)
+    dA = dA.sum(0).view_as(A_log).type_as(A_log) if A_log is not None else None
     dbias = dg.view(-1, H * K).sum(0).to(dt_bias) if dt_bias is not None else None
 
     return dg, dA, dbias
@@ -297,7 +325,7 @@ class KDAGateFunction(torch.autograd.Function):
     def forward(
         ctx,
         g: torch.Tensor,
-        A_log: torch.Tensor,
+        A_log: torch.Tensor | None = None,
         dt_bias: torch.Tensor | None = None,
         lower_bound: float | None = None,
         output_dtype: torch.dtype = torch.float32,
@@ -332,7 +360,7 @@ class KDAGateFunction(torch.autograd.Function):
 @torch.compiler.disable
 def fused_kda_gate(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     lower_bound: float | None = None,
     output_dtype: torch.dtype = torch.float32,
@@ -341,12 +369,15 @@ def fused_kda_gate(
     Fused KDA gate computation with autograd support.
 
     Computes: g = -A_log.exp().unsqueeze(-1) * softplus(g + dt_bias.view(g.shape[-2:]))
+    When ``lower_bound`` is set: g = lower_bound * sigmoid(exp(A_log) * (g + dt_bias)).
+    When ``A_log`` is ``None`` (requires ``lower_bound``): g = lower_bound * sigmoid(g + dt_bias).
 
     Args:
         g (torch.Tensor):
             Input tensor of shape `[..., H, K]`.
-        A_log (torch.Tensor):
-            Parameter tensor with `H` elements.
+        A_log (torch.Tensor | None):
+            Optional parameter tensor with `H` elements.
+            When ``None``, the gate reduces to ``lower_bound * sigmoid(g + dt_bias)`` (requires ``lower_bound``).
         dt_bias (torch.Tensor | None):
             Optional bias tensor added to `g` before activation, shape `[H * K]`.
 
@@ -357,6 +388,7 @@ def fused_kda_gate(
 
 
 @triton.heuristics({
+    "HAS_A": lambda args: args["A_log"] is not None,
     "HAS_BIAS": lambda args: args["dt_bias"] is not None,
     'HAS_SCALE': lambda args: args['scale'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
@@ -387,6 +419,7 @@ def kda_gate_chunk_cumsum_vector_kernel(
     BT: tl.constexpr,
     BS: tl.constexpr,
     REVERSE: tl.constexpr,
+    HAS_A: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -414,12 +447,12 @@ def kda_gate_chunk_cumsum_vector_kernel(
         b_bias = tl.load(dt_bias + i_h * S + o_s, mask=o_s < S, other=0.0).to(tl.float32)
         b_s = b_s + b_bias[None, :]
 
-    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_A = tl.load(A_log + i_h).to(tl.float32) if HAS_A else 1.0
     if not USE_LOWER_BOUND:
         # Apply gate: -exp(A_log) * softplus(g + bias)
         b_gate = -exp(b_A) * softplus(b_s)
     else:
-        b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
+        b_gate = lower_bound * tl.sigmoid((exp(b_A) if HAS_A else b_A) * b_s)
 
     # Apply chunk local cumsum
     if REVERSE:
@@ -436,7 +469,7 @@ def kda_gate_chunk_cumsum_vector_kernel(
 @dispatch('kda')
 def kda_gate_chunk_cumsum(
     g: torch.Tensor,
-    A_log: torch.Tensor,
+    A_log: torch.Tensor | None,
     chunk_size: int,
     scale: float = None,
     dt_bias: torch.Tensor | None = None,

--- a/tests/ops/test_gdn2.py
+++ b/tests/ops/test_gdn2.py
@@ -42,9 +42,17 @@ from fla.utils import assert_close, device
 def _activate_g(g, A_log, dt_bias, safe_gate, lower_bound):
     """Reference gate activation matching the kernel's use_gate_in_kernel path."""
     if safe_gate:
-        return naive_kda_lowerbound_gate(g.float(), A_log.float(), dt_bias.float() if dt_bias is not None else None,
-                                         lower_bound=lower_bound)
-    return naive_kda_gate(g.float(), A_log.float(), dt_bias.float() if dt_bias is not None else None)
+        return naive_kda_lowerbound_gate(
+            g=g.float(),
+            A_log=A_log.float() if A_log is not None else None,
+            dt_bias=dt_bias.float() if dt_bias is not None else None,
+            lower_bound=lower_bound,
+        )
+    return naive_kda_gate(
+        g=g.float(),
+        A_log=A_log.float(),
+        dt_bias=dt_bias.float() if dt_bias is not None else None,
+    )
 
 
 def _rand_inputs(B, T, H, K, V, dtype, *, gate_in_kernel=False, b_scale=1.0, seed=42):
@@ -112,20 +120,24 @@ def test_fused_recurrent(B, T, H, K, V, scale, use_qk_l2norm_in_kernel, dtype):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize(
-    ("B", "T", "H", "K", "V", "has_dt_bias", "safe_gate"),
+    ("B", "T", "H", "K", "V", "has_a_log", "has_dt_bias", "safe_gate"),
     [
-        pytest.param(*p, id="B{}-T{}-H{}-K{}-V{}-dt_bias{}-safe_gate{}".format(*p))
+        pytest.param(*p, id="B{}-T{}-H{}-K{}-V{}-a_log{}-dt_bias{}-safe_gate{}".format(*p))
         for p in [
-            (2, 100, 2, 64, 64, True, False),
-            (2, 100, 2, 64, 64, False, False),
-            (1, 128, 2, 64, 64, True, True),
+            (2, 100, 2, 64, 64, True, True, False),
+            (2, 100, 2, 64, 64, True, False, False),
+            (1, 128, 2, 64, 64, True, True, True),
+            (2, 100, 2, 64, 64, False, False, True),
+            (1, 128, 2, 64, 64, False, True, True),
         ]
     ],
 )
-def test_fused_recurrent_gate_in_kernel(B, T, H, K, V, has_dt_bias, safe_gate):
+def test_fused_recurrent_gate_in_kernel(B, T, H, K, V, has_a_log, has_dt_bias, safe_gate):
     """use_gate_in_kernel=True must match the manually-activated gate path."""
     dtype = torch.float32
     q, k, v, g, b, w, A_log, dt_bias = _rand_inputs(B, T, H, K, V, dtype, gate_in_kernel=True)
+    if not has_a_log:
+        A_log = None
     if not has_dt_bias:
         dt_bias = None
     lower_bound = -5.0 if safe_gate else None

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -292,18 +292,20 @@ def test_fused_recurrent_state_v_first(
 
 
 @pytest.mark.parametrize(
-    ("B", "T", "H", "HV", "D", "scale", "has_dt_bias", "safe_gate", "dtype"),
+    ("B", "T", "H", "HV", "D", "scale", "has_a_log", "has_dt_bias", "safe_gate", "dtype"),
     [
         pytest.param(
             *test,
-            id="B{}-T{}-H{}-HV{}-D{}-scale{}-has_dt_bias{}-safe_gate{}-{}".format(*test),
+            id="B{}-T{}-H{}-HV{}-D{}-scale{}-has_a_log{}-has_dt_bias{}-safe_gate{}-{}".format(*test),
         )
         for test in [
-            (1, 64, 1, 1, 64, 1, False, False, torch.float),
-            (2, 256, 2, 2, 64, 1, True, False, torch.float),
-            (2, 512, 2, 4, 64, 0.1, True, True, torch.float16),
-            (3, 1000, 2, 8, 128, 1, False, False, torch.float16),
-            (4, 1024, 4, 4, 128, 0.1, True, True, torch.float16),
+            (1, 64, 1, 1, 64, 1, True, False, False, torch.float),
+            (2, 256, 2, 2, 64, 1, True, True, False, torch.float),
+            (2, 512, 2, 4, 64, 0.1, True, True, True, torch.float16),
+            (3, 1000, 2, 8, 128, 1, True, False, False, torch.float16),
+            (4, 1024, 4, 4, 128, 0.1, True, True, True, torch.float16),
+            (1, 64, 1, 1, 64, 1, False, False, True, torch.float),
+            (2, 256, 2, 4, 64, 1, False, True, True, torch.float),
         ]
     ],
 )
@@ -314,6 +316,7 @@ def test_fused_recurrent_gate_in_kernel(
     HV: int,
     D: int,
     scale: float,
+    has_a_log: bool,
     has_dt_bias: bool,
     safe_gate: bool,
     dtype: torch.dtype,
@@ -328,7 +331,7 @@ def test_fused_recurrent_gate_in_kernel(
     v = torch.rand(B, T, HV, D, dtype=dtype, device=device)
     beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
     g_raw = torch.randn(B, T, HV, D, dtype=torch.float32, device=device)
-    A_log = torch.log(torch.empty(HV, dtype=torch.float32, device=device).uniform_(1, 16))
+    A_log = torch.log(torch.empty(HV, dtype=torch.float32, device=device).uniform_(1, 16)) if has_a_log else None
     dt_bias = torch.randn(HV * D, dtype=torch.float32, device=device) if has_dt_bias else None
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device)
 
@@ -353,7 +356,7 @@ def test_fused_recurrent_gate_in_kernel(
         v=v.clone(),
         g=g_raw.clone(),
         beta=beta.clone(),
-        A_log=A_log.clone(),
+        A_log=A_log.clone() if A_log is not None else None,
         dt_bias=dt_bias.clone() if dt_bias is not None else None,
         scale=scale,
         initial_state=h0.clone(),
@@ -1041,20 +1044,24 @@ def test_chunk_varlen_prefill(
 
 
 @pytest.mark.parametrize(
-    ("B", "T", "H", "D", "HAS_BIAS", "LOWER_BOUND"),
+    ("B", "T", "H", "D", "HAS_A_LOG", "HAS_BIAS", "LOWER_BOUND"),
     [
-        pytest.param(*test, id="B{}-T{}-H{}-D{}-bias{}-lowerbound{}".format(*test))
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-a_log{}-bias{}-lowerbound{}".format(*test))
         for test in [
-            (1, 2, 2, 12, False, -5.0),
-            (1, 32, 2, 16, False, -5.0),
-            (2, 64, 4, 32, False, -5.0),
-            (4, 128, 8, 64, False, -5.0),
-            (4, 128, 8, 128, False, None),
-            (1, 2, 2, 12, True, None),
-            (1, 32, 2, 16, True, None),
-            (2, 64, 4, 32, True, None),
-            (4, 128, 8, 64, True, None),
-            (4, 128, 8, 128, True, None),
+            (1, 2, 2, 12, True, False, -5.0),
+            (1, 32, 2, 16, True, False, -5.0),
+            (2, 64, 4, 32, True, False, -5.0),
+            (4, 128, 8, 64, True, False, -5.0),
+            (4, 128, 8, 128, True, False, None),
+            (1, 2, 2, 12, True, True, None),
+            (1, 32, 2, 16, True, True, None),
+            (2, 64, 4, 32, True, True, None),
+            (4, 128, 8, 64, True, True, None),
+            (4, 128, 8, 128, True, True, None),
+            (1, 2, 2, 12, False, False, -5.0),
+            (2, 64, 4, 32, False, False, -5.0),
+            (4, 128, 8, 64, False, True, -5.0),
+            (4, 128, 8, 128, False, True, -5.0),
         ]
     ],
 )
@@ -1063,48 +1070,60 @@ def test_gate(
     T: int,
     H: int,
     D: int,
+    HAS_A_LOG: bool,
     HAS_BIAS: bool,
     LOWER_BOUND: float | None,
 ):
     torch.manual_seed(42)
     g = torch.randn(B, T, H, D, dtype=torch.float32) * 10
-    A_log = torch.log(torch.randn(1, 1, H, 1, dtype=torch.float32).uniform_(1, 16))
+    A_log = torch.log(torch.randn(1, 1, H, 1, dtype=torch.float32).uniform_(1, 16)) if HAS_A_LOG else None
     dt_bias = torch.randn(H * D, dtype=torch.float32) if HAS_BIAS else None
-    g, A_log = map(lambda x: x.to(device).requires_grad_(True), (g, A_log))
+    g = g.to(device).requires_grad_(True)
+    if A_log is not None:
+        A_log = A_log.to(device).requires_grad_(True)
     if dt_bias is not None:
         dt_bias = dt_bias.to(device).requires_grad_(True)
     do = torch.randn_like(g).view(B, T, H, D)
 
     if LOWER_BOUND is not None:
         ref = naive_kda_lowerbound_gate(
-            g.clone(), A_log.clone(), dt_bias.clone() if dt_bias is not None else None, LOWER_BOUND
+            g=g.clone(),
+            A_log=A_log.clone() if A_log is not None else None,
+            dt_bias=dt_bias.clone() if dt_bias is not None else None,
+            lower_bound=LOWER_BOUND,
         )
     else:
         ref = naive_kda_gate(
-            g.clone(), A_log.clone(), dt_bias.clone() if dt_bias is not None else None,
+            g=g.clone(),
+            A_log=A_log.clone(),
+            dt_bias=dt_bias.clone() if dt_bias is not None else None,
         )
     tri = fused_kda_gate(
-        g.clone(), A_log.clone(), dt_bias.clone() if dt_bias is not None else None,
-        lower_bound=LOWER_BOUND
+        g=g.clone(),
+        A_log=A_log.clone() if A_log is not None else None,
+        dt_bias=dt_bias.clone() if dt_bias is not None else None,
+        lower_bound=LOWER_BOUND,
     )
     (ref * do).sum().backward(retain_graph=True)
 
-    ref_dg, ref_dA = g.grad, A_log.grad
+    ref_dg = g.grad
+    ref_dA = A_log.grad if A_log is not None else None
     ref_dbias = dt_bias.grad if dt_bias is not None else None
-    g.grad = A_log.grad = None
+    g.grad = None
+    if A_log is not None:
+        A_log.grad = None
     if dt_bias is not None:
         dt_bias.grad = None
 
     ((tri * do).sum()).backward(retain_graph=True)
-    tri_dg, tri_dA = g.grad, A_log.grad
+    tri_dg = g.grad
+    tri_dA = A_log.grad if A_log is not None else None
     tri_dbias = dt_bias.grad if dt_bias is not None else None
-    g.grad = A_log.grad = None
-    if dt_bias is not None:
-        dt_bias.grad = None
 
     assert_close("o", ref, tri, 1e-4)
     assert_close("dg", ref_dg, tri_dg, 1e-4)
-    assert_close("dA", ref_dA, tri_dA, 1e-4)
+    if HAS_A_LOG:
+        assert_close("dA", ref_dA, tri_dA, 1e-4)
     if HAS_BIAS:
         assert_close("dbias", ref_dbias, tri_dbias, 1e-4)
 


### PR DESCRIPTION
## Summary

When `lower_bound` is set, `A_log` can now be `None` to use the simpler gate form `lower_bound * sigmoid(g + dt_bias)` without the per-head decay rate `exp(A_log)`.

This is useful for models that want the bounded gate activation (safe_gate) without learning a per-head decay parameter.

## Changes

- Add `HAS_A` heuristic to all lowerbound gate kernels (fwd/bwd/cumsum) in `fla/ops/kda/gate.py`, `fused_recurrent.py` (KDA + GDN-2), and `triton_ascend` NPU backends
- Relax `A_log` requirement in `chunk_kda`/`chunk_gdn2` entry points: `A_log=None` is valid when `lower_bound` is set
- Update docstrings to document the `A_log=None` behavior
- Unify `HAS_DT_BIAS` → `HAS_BIAS` across all KDA/GDN-2 kernels
- Add `has_a_log` parametrize cases to `test_gate` and `test_fused_recurrent_gate_in_kernel` in `test_kda.py` and `test_gdn2.py`

## Test plan

- Unit tests modified: `tests/ops/test_kda.py::test_gate`, `tests/ops/test_kda.py::test_fused_recurrent_gate_in_kernel`, `tests/ops/test_gdn2.py::test_fused_recurrent_gate_in_kernel`, `tests/ops/test_gdn2.py::test_chunk`
- New `has_a_log=False` parametrize cases cover `A_log=None` forward and backward

## Benchmark / NCU (kernel changes only)

Neutral — this is a feature addition, not a performance change. The `HAS_A` heuristic adds a compile-time branch with no runtime overhead when `A_log` is provided.

## Breaking changes

None. `A_log` remains required when `lower_bound` is not set. Existing callers passing `A_log` are unaffected.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).