### PR TITLE
[Fix] Hoist in-kernel triton.next_power_of_2 to host launchers

### DIFF
--- a/fla/ops/gdn2/chunk_intra_token_parallel.py
+++ b/fla/ops/gdn2/chunk_intra_token_parallel.py
@@ -52,6 +52,7 @@ def chunk_gdn2_fwd_kernel_intra_token_parallel(
     T,
     H: tl.constexpr,
     K: tl.constexpr,
+    BK: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
     BH: tl.constexpr,
@@ -92,7 +93,6 @@ def chunk_gdn2_fwd_kernel_intra_token_parallel(
     Aqk += bos * H * BT
     Akk += bos * H * BC
 
-    BK: tl.constexpr = triton.next_power_of_2(K)
     o_h = tl.arange(0, BH)
     o_k = tl.arange(0, BK)
     m_h = (i_hg * BH + o_h) < H
@@ -149,6 +149,7 @@ def chunk_gdn2_fwd_intra_token_parallel(
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
     BT = chunk_size
     BC = sub_chunk_size
+    BK = triton.next_power_of_2(K)
 
     def grid(meta):
         return (B * T, triton.cdiv(H, meta['BH']))
@@ -166,6 +167,7 @@ def chunk_gdn2_fwd_intra_token_parallel(
         T=T,
         H=H,
         K=K,
+        BK=BK,
         BT=BT,
         BC=BC,
     )

--- a/fla/ops/kda/chunk_intra_token_parallel.py
+++ b/fla/ops/kda/chunk_intra_token_parallel.py
@@ -44,6 +44,7 @@ def chunk_kda_fwd_kernel_intra_token_parallel(
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
+    BK: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
     BH: tl.constexpr,
@@ -91,7 +92,6 @@ def chunk_kda_fwd_kernel_intra_token_parallel(
     Akk += bos * HV*BC
     beta += bos * HV
 
-    BK: tl.constexpr = triton.next_power_of_2(K)
     o_hv = i_hg * BH + tl.arange(0, BH)
     o_h = o_hv // G
     o_k = tl.arange(0, BK)
@@ -158,6 +158,7 @@ def chunk_kda_fwd_intra_token_parallel(
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
     BT = chunk_size
     BC = sub_chunk_size
+    BK = triton.next_power_of_2(K)
 
     def grid(meta): return (B * T, triton.cdiv(HV, meta['BH']))
     chunk_kda_fwd_kernel_intra_token_parallel[grid](
@@ -174,6 +175,7 @@ def chunk_kda_fwd_intra_token_parallel(
         H=H,
         HV=HV,
         K=K,
+        BK=BK,
         BT=BT,
         BC=BC,
     )


### PR DESCRIPTION
## Summary

Fixes #1106.

Triton 3.6's JIT rejects host-function references from kernel bodies. Two token-parallel intra kernels compute their `BK` block size in-kernel via `triton.next_power_of_2(K)`:

- `chunk_kda_fwd_kernel_intra_token_parallel` (`fla/ops/kda/chunk_intra_token_parallel.py`)
- `chunk_gdn2_fwd_kernel_intra_token_parallel` (`fla/ops/gdn2/chunk_intra_token_parallel.py`)

Both fail to compile on Triton 3.6 with `RuntimeError: Unsupported function referenced: next_power_of_2`.

`K` is already a `tl.constexpr` kernel argument and `BK` only feeds `tl.arange(0, BK)` and the `o_k < K` mask, so compute it in the host launcher and pass it in as a `constexpr` — matching what the other launchers already do (e.g. `chunk_intra.py`, `wy_fast.py`). Numerics, tiling, and masks are unchanged.

Scope: an AST sweep of all `@triton.jit` bodies for host calls (`triton.next_power_of_2` / `triton.cdiv`) finds no other GPU-path occurrences; the two `simple_gla/parallel.py` hits are inside `@triton.heuristics` lambdas and are evaluated host-side. The Triton-Ascend copy (`fla/ops/kda/backends/triton_ascend/chunk_intra_token_parallel.py`) is intentionally left untouched.

## Test plan

- `pytest tests/ops/test_kda.py -k test_chunk` — identical results as `main` (same pass/fail set; the 5 failures are a pre-existing `TritonGPUHoistTMEMAlloc` issue in `chunk_delta_h.py` on this Triton 3.4 setup, present on `main` as well).
- `pytest tests/ops/test_gdn2.py` — identical results as `main`.
- torch 2.8.0 / triton 3.4.0 for the regression runs. The Triton 3.6 compile error itself is removed by construction: the rejected construct (host call in kernel body) no longer exists.

## Benchmark / NCU (kernel changes only)

Neutral — host-side-only change; the generated kernels are unchanged apart from where `BK` is computed.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). — N/A, performance-neutral host-side change.
