### PR TITLE
[KDA] Fix illegal memory access in SM100 backward autotuning

### DIFF
--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -20,7 +20,7 @@ from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_HOPPER, autotune_cache_kwargs, check_shared_mem
+from fla.utils import IS_NVIDIA_HOPPER, IS_NVIDIA_SM100, autotune_cache_kwargs, check_shared_mem
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
 BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
@@ -125,6 +125,7 @@ def chunk_kda_bwd_kernel_dAv(
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
         if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
+        if not (IS_NVIDIA_SM100 and BK == 32 and num_warps != 2)
     ],
     key=['BT', 'HV', 'STATE_V_FIRST'],
     **autotune_cache_kwargs,


### PR DESCRIPTION
## Summary

Fix an illegal memory access during `chunk_kda` backward autotuning on NVIDIA SM100 by excluding `BK == 32` configurations with `num_warps` 4 or 8 from `chunk_kda_bwd_kernel_wy_dqkg_fused`.

This extracts the Blackwell correctness fix from #1054 into a focused PR and narrows it from all Blackwell devices to the measured SM100 target. Hopper's autotune space and SM120 are unchanged. The approach matches the existing Hopper guard added in #807.

## Test plan

- Dependent tests identified with `python scripts/find_dependent_tests.py fla/ops/kda/chunk_bwd.py`.
- NVIDIA B200, CUDA 12.9, PyTorch `2.8.0a0+5228986c39.nv25.06`, Triton 3.3.0:
  - Before: `FLA_DISABLE_BACKEND_DISPATCH=1 pytest tests/ops/test_kda.py -v` reaches an illegal memory access while the first dense chunk backward test autotunes `chunk_kda_bwd_kernel_wy_dqkg_fused`; the CUDA context is then poisoned.
  - After: the same complete test file passes: **76 passed, 7 skipped**, including dense and varlen cases.
- `pre-commit run --files fla/ops/kda/chunk_bwd.py` passes.
- Remaining dependent tests are covered by the repository CI.

## Benchmark / NCU (kernel changes only)

There is no valid pre-fix B200 latency because autotuning crashes. After the fix, the same-hardware bf16 `chunk_kda` registry sweep completes all rows:

| B | T | H | D | Forward (ms) | Forward + backward (ms) |
|--:|--:|--:|--:|-------------:|------------------------:|
| 1 | 8192 | 96 | 128 | 2.236 | 9.585 |
| 2 | 16384 | 16 | 128 | 1.905 | 7.285 |
| 4 | 2048 | 16 | 128 | 0.595 | 1.754 |
| 4 | 4096 | 64 | 128 | 2.821 | 12.383 |
| 8 | 1024 | 8 | 64 | 0.588 | 1.657 |
| 8 | 2048 | 32 | 256 | 3.956 | 15.643 |

NCU was not collected: this changes only the autotune candidate list, not generated instructions for retained configs, and hardware-counter access was unavailable.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
