### PR TITLE
[Fix] Ascend NPU: guard against tl.dot left-operand clobber across triton_ascend kernels

### DIFF
--- a/.agents/skills/fla-ascend-performance/SKILL.md
+++ b/.agents/skills/fla-ascend-performance/SKILL.md
@@ -4,9 +4,10 @@ description: >
   Guidelines for Ascend NPU kernel / Triton-Ascend backend performance work in the FLA repo.
   Covers profiling with torch_npu, PipeUtilization/MemoryUB CSV analysis, Cube/Vector/MTE/UB
   bottleneck diagnosis, and kernel optimization (UB tiling, grid splits, fusion/split, varlen,
-  G_T_CONTIG gate loading, correctness gates). NPU kernels must not use num_warps/num_stages.
+  G_T_CONTIG gate loading, correctness gates, tl.dot left-operand clobber). NPU kernels must not use num_warps/num_stages.
+  Per-kernel tl.dot clobber catalog: references/cases.md.
   Use when working on NPU profiling, kernel_details/op_statistic, aic_metrics,
-  fla triton_ascend backends, g transpose stride-1, UB overflow, grid limits, or Ascend performance.
+  fla triton_ascend backends, g transpose stride-1, UB overflow, grid limits, tl.dot reuse, or Ascend performance.
 ---
 
 # FLA Ascend NPU: Profiling → Bottlenecks → Optimization
@@ -138,6 +139,9 @@ Change only levers that match the bottleneck; one hypothesis per round. Before t
 - **int64 before multiply on runtime indices**: with `do_not_specialize` on `T`, values like `NT = cdiv(T, BT)` are runtime int32. `(NT - 1) * DH_CS` or `i_t * HV * K * V` can wrap past 2³¹ before `.to(tl.int64)` (e.g. K=V=128, HV=64 overflows at T>131K). Cast the index first: `(NT - 1).to(tl.int64) * DH_CS`, not `((NT - 1) * DH_CS).to(tl.int64)`.
 - **Varlen `cu_seqlens` → int64 for pointer math**: host `cu_seqlens` is `torch.long` (int64). Loading with `.to(tl.int32)` then computing `(bos * HV + i_hv) * V` overflows int32 well before `bos` hits 2³¹ (e.g. HV=32, V=4096 → safe `bos` ≈ 16K tokens). Pattern: `bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64); T = (eos - bos).to(tl.int32)`. Non-varlen else-branch: `(i_b * T).to(tl.int64)`. Alternative (when `T_cur` only needs int32): load `bos`/`eos` as int32 but cast before multiply — `(bos * HV + i_h).to(tl.int64) * K`. Never rely on post-multiply `.to(tl.int64)`.
 - Reductions / recurrence / grads use fp32 accum, cast on store; sensitive solves: `input_precision='ieee'` / `allow_tf32=False`; mask before exp on gated paths; keep a consistent `exp`/`exp2` base.
+- **Ascend `tl.dot` clobbers the left operand**: on NPU, `tl.dot(lhs, rhs, …)` may overwrite `lhs` in UB (CUDA Triton does not). Any later read of that tile (second lhs, rhs, store) sees corrupted data unless you reload from GM or copy with `tile + 0.0` **before** the first lhs dot. Full per-kernel catalog: [cases.md § tl.dot lhs clobber](references/cases.md#tldot-lhs-clobber--repo-wide-case-catalog). Symptom: silent numeric drift vs Torch oracle with no compile error.
+- **Audit checklist for new/changed kernels**: (1) `rg 'tl\.dot\(' fla/ops/**/triton_ascend/**` — only 8 op files use `tl.dot`; (2) for each lhs tile, flag lhs→lhs, lhs→rhs/store, or post-dot copy; (3) prefer GM reload for one reuse between stages, `+ 0.0` for tight multi-dot sequences; (4) re-run `tests/ops/test_gdn_kernels.py` + op-specific kernel tests.
+- **Upstream**: lhs clobber is a Triton-Ascend backend limitation (UB capacity / in-place matmul), not intentional API. Durable fix belongs in the compiler (preserve lhs or emit a diagnostic on post-dot read). Track via the Triton-Ascend / Ascend backend issue tracker.
 - For separable gate differences, compute `exp2(gs)[:, None] / exp2(gc)[None, :]` instead of `exp2(gs[:, None] - gc[None, :])` to replace a matrix of exponentials with two vectors. Verify numerics on the target compiler; multiplying by `exp2(-gc)` can produce materially different Ascend results.
 
 ### Fusion, compile, varlen
@@ -163,7 +167,7 @@ Each round, in order:
 5. Synchronized benchmark (latency/throughput, fwd and fwd+bwd); re-profile with the same `aic_metrics` and confirm Duration/pipe/UB move as expected.
 6. Metrics unchanged → reclassify bottleneck or switch metrics; do not pile unrelated changes.
 
-Prefer: `tests/ops/test_gdn_kernels.py`, `tests/utils/test_ascend_ub_manager.py`, `python -m benchmarks.ops.verify --op <op> --base <ref>` (`--gate-k` is a quick signal only).
+Prefer: `tests/ops/test_gdn_kernels.py`, `tests/ops/test_solve_tril.py`, `tests/utils/test_ascend_ub_manager.py`, `python -m benchmarks.ops.verify --op <op> --base <ref>` (`--gate-k` is a quick signal only).
 
 ### Round summary template
 
@@ -187,6 +191,7 @@ Generalizable fixes discovered during optimization belong in this skill (`SKILL.
 - [ ] Grid ≤ 65535 **or** 1D core-grid (`num_aicore`); host-split offsets not double-counted with varlen; task-loop pointers rebound each iteration
 - [ ] Block pointers contiguous innermost; **gate `g` uses G_T_CONTIG** when `[B,T,HV]` (see [g-contiguous-loading.md](references/g-contiguous-loading.md)); tail `boundary_check`
 - [ ] fp32 accum consistent with output/exp base; fusion worth the complexity (no gratuitous `ACCUMULATE_OUTPUT` writeback when UB allows)
+- [ ] Reused `tl.dot` left-hand tiles: GM reload or `tile + 0.0` **before** first lhs dot (post-dot copy invalid); see [cases.md § tl.dot catalog](references/cases.md#tldot-lhs-clobber--repo-wide-case-catalog)
 - [ ] fwd/bwd/varlen/layout branches covered; no unwritten regions under NaN poisoning
 - [ ] Runtime chunk indices (`NT`, `i_t`, …) cast to `tl.int64` **before** stride multiply when `T` is `do_not_specialize`
 - [ ] Varlen `bos`/`eos` from `cu_seqlens` loaded as `tl.int64` (or `.to(tl.int64)` before `(bos * HV + …) * stride`); `T_cur = (eos - bos).to(tl.int32)` only

--- a/.agents/skills/fla-ascend-performance/SKILL.md
+++ b/.agents/skills/fla-ascend-performance/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Guidelines for Ascend NPU kernel / Triton-Ascend backend performance work in the FLA repo.
   Covers profiling with torch_npu, PipeUtilization/MemoryUB CSV analysis, Cube/Vector/MTE/UB
   bottleneck diagnosis, and kernel optimization (UB tiling, grid splits, fusion/split, varlen,
-  G_T_CONTIG gate loading, correctness gates). NPU kernels must not use num_warps/num_stages.
+  G_T_CONTIG gate loading, correctness gates, tl.dot left-operand clobber). NPU kernels must not use num_warps/num_stages.
   Use when working on NPU profiling, kernel_details/op_statistic, aic_metrics,
-  fla triton_ascend backends, g transpose stride-1, UB overflow, grid limits, or Ascend performance.
+  fla triton_ascend backends, g transpose stride-1, UB overflow, grid limits, tl.dot reuse, or Ascend performance.
 ---
 
 # FLA Ascend NPU: Profiling → Bottlenecks → Optimization
@@ -138,6 +138,7 @@ Change only levers that match the bottleneck; one hypothesis per round. Before t
 - **int64 before multiply on runtime indices**: with `do_not_specialize` on `T`, values like `NT = cdiv(T, BT)` are runtime int32. `(NT - 1) * DH_CS` or `i_t * HV * K * V` can wrap past 2³¹ before `.to(tl.int64)` (e.g. K=V=128, HV=64 overflows at T>131K). Cast the index first: `(NT - 1).to(tl.int64) * DH_CS`, not `((NT - 1) * DH_CS).to(tl.int64)`.
 - **Varlen `cu_seqlens` → int64 for pointer math**: host `cu_seqlens` is `torch.long` (int64). Loading with `.to(tl.int32)` then computing `(bos * HV + i_hv) * V` overflows int32 well before `bos` hits 2³¹ (e.g. HV=32, V=4096 → safe `bos` ≈ 16K tokens). Pattern: `bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64); T = (eos - bos).to(tl.int32)`. Non-varlen else-branch: `(i_b * T).to(tl.int64)`. Alternative (when `T_cur` only needs int32): load `bos`/`eos` as int32 but cast before multiply — `(bos * HV + i_h).to(tl.int64) * K`. Never rely on post-multiply `.to(tl.int64)`.
 - Reductions / recurrence / grads use fp32 accum, cast on store; sensitive solves: `input_precision='ieee'` / `allow_tf32=False`; mask before exp on gated paths; keep a consistent `exp`/`exp2` base.
+- **Ascend `tl.dot` clobbers the left operand**: on NPU, `tl.dot(lhs, rhs, ...)` may overwrite `lhs` in UB (CUDA Triton does not). If the same left-hand tile is reused across sequential dot calls in one kernel, reload from GM between stages — e.g. fwd `u` then `w` both need `b_A`: run the `u` loop (`b_u = tl.dot(b_A, b_vb, ...)`), then `b_A = tl.load(ptr_A, ...)` before the `w` loop (`b_w = tl.dot(b_A, b_kb, ...)`). Symptom: silent numeric drift vs Torch oracle with no compile error. See [cases.md](references/cases.md) (`wy_fast.py`).
 - For separable gate differences, compute `exp2(gs)[:, None] / exp2(gc)[None, :]` instead of `exp2(gs[:, None] - gc[None, :])` to replace a matrix of exponentials with two vectors. Verify numerics on the target compiler; multiplying by `exp2(-gc)` can produce materially different Ascend results.
 
 ### Fusion, compile, varlen
@@ -187,6 +188,7 @@ Generalizable fixes discovered during optimization belong in this skill (`SKILL.
 - [ ] Grid ≤ 65535 **or** 1D core-grid (`num_aicore`); host-split offsets not double-counted with varlen; task-loop pointers rebound each iteration
 - [ ] Block pointers contiguous innermost; **gate `g` uses G_T_CONTIG** when `[B,T,HV]` (see [g-contiguous-loading.md](references/g-contiguous-loading.md)); tail `boundary_check`
 - [ ] fp32 accum consistent with output/exp base; fusion worth the complexity (no gratuitous `ACCUMULATE_OUTPUT` writeback when UB allows)
+- [ ] Reused `tl.dot` left-hand tiles reloaded from GM between sequential dots on Ascend (see `wy_fast.py` u→w / k→v)
 - [ ] fwd/bwd/varlen/layout branches covered; no unwritten regions under NaN poisoning
 - [ ] Runtime chunk indices (`NT`, `i_t`, …) cast to `tl.int64` **before** stride multiply when `T` is `do_not_specialize`
 - [ ] Varlen `bos`/`eos` from `cu_seqlens` loaded as `tl.int64` (or `.to(tl.int64)` before `(bos * HV + …) * stride`); `T_cur = (eos - bos).to(tl.int32)` only

--- a/.agents/skills/fla-ascend-performance/references/cases.md
+++ b/.agents/skills/fla-ascend-performance/references/cases.md
@@ -13,6 +13,7 @@ File: `fla/ops/common/backends/triton_ascend/chunk_delta_h.py`
 - **In-place `dv`**: callers rebind `dh,dh0,dv = bwd_dhu(...)`; store corrected residual through `p_dv` (no `dv2` buffer/ptr).
 - **Tile selection is cost-model, not max-BK**: minimize `cdiv(V,BV)*(3+4*cdiv(K,BK))` under soft UB (`peak <= UB*1.15`, multi-slab dh live) on the **host-precomputed gate** path. Max oneslab `BK=min(256,pow2(K))` with BV capped at 64 loses on D256 to **BK=128/BV=128** (nv 4→2 beats extra K-slab ptrs). Shrinking BV only to grow BK (e.g. BV 64→32) remains a loss. Measured B8 T2048 H32 bf16: D256 ~15.5→11.4ms, D128 ~6.2→3.3ms; still AIC-scalar dominated (`aic_scalar_ratio`~0.66, `aic_mac_ratio`~0.07).
 - **Gate-inline UB (T%BT!=0 / varlen)**: in-kernel `exp2(g)` inflates compile UB ~1.7× vs analytical peak — `BK=128/BV=128` fails (`req 262400 > 196608`) on D128 unaligned even though host util≈0.75. Use `gate_inline` → soft cap `UB*0.60` (D128→`BK=128/BV=64`, D256→`BK=256/BV=32`); keep precomp tiles unchanged.
+- **`tl.dot` lhs clobber (bwd `dhu`)**: `b_do` reused as lhs across K-slabs; `b_dv` corrected in-place then subtracted. See [§ tl.dot catalog — chunk_delta_h](cases.md#chunk_delta_hpy).
 
 ## `chunk_o.py` — fwd fuse + bwd G_T_CONTIG
 
@@ -21,6 +22,7 @@ File: `fla/ops/common/backends/triton_ascend/chunk_o.py`
 - Fwd: fuse inter+intra, 1D core-grid, host `g.transpose(1,2).contiguous()`.
 - Bwd `G_T_CONTIG`: `chunk_bwd_dv_local_npu`, `chunk_bwd_dqkwg_npu`, `chunk_bwd_kernel_dg_npu` — stride-1 `g_ptr` (`i_b*HV*T+i_h*T` / varlen `bos+i_h*T`), `T_seq` before varlen.
 - dv_local kernel ~6.5→0.18ms, dqkwg ~10.8→0.91ms (B2 T2048 HV8). Fix `BV`, autotune `BK`. Details: [g-contiguous-loading.md](g-contiguous-loading.md).
+- **`tl.dot` lhs clobber**: fwd `b_q`/`b_q_c`; bwd `b_k0_c`, `b_ds_c`, `b_A_pristine`. See [§ tl.dot catalog](cases.md#chunk_opy).
 
 ## `chunk_bwd.py` — varlen `cu_seqlens` int32 overflow
 
@@ -28,3 +30,131 @@ File: `fla/ops/kda/backends/triton_ascend/chunk_bwd.py`
 
 - `chunk_kda_bwd_kernel_dAv_npu` and `chunk_kda_bwd_kernel_wy_v_part_npu` loaded `bos`/`eos` via `.to(tl.int32)` then `(bos * HV + i_hv) * V` — int32 wrap on packed varlen offsets (e.g. HV=32, V=4096 safe `bos` ≈ 16K). Later kernels in the same file already used `tl.int64`.
 - Fix: load `bos`/`eos` as int64; `T = (eos - bos).to(tl.int32)`; non-varlen else-branch `(i_b * T).to(tl.int64)`.
+
+## `wy_fast.py` — Ascend `tl.dot` left-operand clobber
+
+Files: `fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py`, `fla/ops/kda/backends/triton_ascend/wy_fast.py`
+
+See also the full catalog in [§ `tl.dot` lhs clobber — repo-wide case catalog](#tldot-lhs-clobber--repo-wide-case-catalog) below.
+
+- **Behavior**: Ascend `tl.dot(lhs, rhs, ...)` can overwrite `lhs` in UB. CUDA Triton leaves `lhs` intact.
+- **Symptom / cost**: numeric mismatch vs Torch on Ascend only; no compile error. One extra GM load per stage is cheaper than keeping a duplicate tile live for the whole kernel.
+
+### Strategy A — GM reload (large tile, reused once between stages)
+
+| Kernel | Exposure | Fix |
+|--------|----------|-----|
+| `recompute_w_u_fwd_kernel_npu` / `recompute_w_u_fwd_kda_kernel_npu` | `u` loop: `b_u = tl.dot(b_A, b_vb, …)` clobbers `b_A`; `w` loop needs pristine `A` | `b_A = tl.load(p_A, …)` before each K-tile `w` dot (also reload each V-tile in `u` loop if needed) |
+| `prepare_wy_repr_bwd_kv_npu` | `k` loop clobbers `b_A`; `v` loop reuses it | Reload `b_A` from GM before the `v` loop |
+
+### Strategy B — pristine copy before first lhs dot (same stage, tight reuse)
+
+| Kernel | Exposure | Fix |
+|--------|----------|-----|
+| `prepare_wy_repr_bwd_kv_npu` | `b_dw` lhs in `b_dA += tl.dot(b_dw, …)`, then rhs in `tl.dot(b_A, b_dw, …)` | `b_dw_c = b_dw + 0.0` **before** first dot; second dot uses `b_dw_c` |
+| same | `b_du` lhs then rhs in V loop | `b_du_c = b_du + 0.0` before first dot |
+| `prepare_wy_repr_bwd_finalize_npu` | `b_dA` lhs in `tl.dot(b_dA_lhs, b_k, …)`; same tile needed as rhs in `tl.dot(tl.trans(b_kb), b_dA_c, …)` | `b_dA_c = b_dA + 0.0` and `b_dA_lhs = b_dA + 0.0` before any dot |
+
+### Copy-ordering rule (applies to all kernels)
+
+- `tile + 0.0` must happen **before** the first `tl.dot` that uses `tile` as lhs — copying after the first dot captures the clobbered UB value, not the original.
+- lhs clobber corrupts the tile for **any** subsequent read (rhs, store, arithmetic), not only a second lhs use.
+
+### Multi-use patterns (each role needs its own pristine copy, all taken before any dot)
+
+| Pattern | Example |
+|---------|---------|
+| lhs → lhs again | `b_k0` in `chunk_o` dv_local; `b_A_42`/`b_A_43` in `solve_tril` 64×64 |
+| lhs → rhs | `b_dw`/`b_du` in `wy_fast` bwd; `b_do` in `chunk_bwd` dAv |
+| lhs → store | `b_Ai_33_c` in `chunk_intra` merge; `b_Ai_22_c` in `solve_tril` |
+| lhs on copy A, then rhs on copy B from same source | `b_Ai22_c2` lhs in `b_Ai20`, `b_Ai22_c3` rhs in `b_Ai32` |
+| lhs across K-slabs (no GM reload) | `b_do` / `b_do_c{,2,3}` in `chunk_delta_h` bwd |
+| lhs in expr₁, same tile lhs again in expr₂ | `b_Akk31`/`b_Akk32` in `b_Ai31` then `b_Ai30` → `b_Akk31_c`/`b_Akk32_c` for second expr |
+
+### Safe patterns (look like reuse but are not exposures)
+
+- **GM reload each iteration**: `b_w`/`b_k` K-segments in `chunk_delta_h` fwd; `b_k` in `prepare_wy_repr_bwd_finalize_a2_npu`; `b_A` per tile in `wy_fast` inner loops.
+- **Fresh load per loop trip**: `b_dAqk`/`b_dAkk` in `chunk_intra` bwd (each `i_j` reloads from GM; halves separated by `tl.debug_barrier()`).
+- **Single lhs use**: `chunk_scaled_dot_kkt` — `b_ks` lhs once per `(s,c)` block.
+
+---
+
+## `tl.dot` lhs clobber — repo-wide case catalog
+
+**Audit scope (2026-08):** only **8 files** under `fla/ops/**/triton_ascend/**` contain `tl.dot` (~143 call sites). All others (layernorm, rotary, gate, fused_recurrent, cumsum, …) are unaffected.
+
+**Verification:** `tests/ops/test_gdn_kernels.py`, `tests/ops/test_solve_tril.py`.
+
+### `chunk_o.py`
+
+File: `fla/ops/common/backends/triton_ascend/chunk_o.py`
+
+| Kernel / site | Pattern | Fix |
+|---------------|---------|-----|
+| `chunk_fwd_kernel_o_npu` | `b_q` lhs for `b_o` dot, then needed for `b_A` dot | `b_q_c = b_q + 0.0` **before** first dot; `b_o` uses `b_q`, `b_A` uses `b_q_c` |
+| `chunk_bwd_kernel_dv_npu` | `b_A` reused across V tiles as lhs | `b_A_pristine = b_A + 0.0`; per V tile: `b_A_i = b_A_pristine + 0.0` |
+| `chunk_bwd_kernel_dv_local_npu` | `b_k0` lhs in `b_A00` and `b_A01` | `b_k0_c = b_k0 + 0.0` before dots; second dot uses `b_k0_c` |
+| `chunk_bwd_dqkwg_npu` | `b_ds` lhs in `b_dq_r += tl.dot(b_ds, b_k_c)`, then lhs of `tl.dot(tl.trans(b_ds_c), b_q_r)` | `b_ds_c = b_ds + 0.0` **before** first `b_ds` dot |
+
+### `chunk_delta_h.py`
+
+File: `fla/ops/common/backends/triton_ascend/chunk_delta_h.py`
+
+| Kernel / site | Pattern | Fix |
+|---------------|---------|-----|
+| `chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu` | `b_w`/`b_k` across K segments | **Safe** — each segment `tl.load`s a new tile from GM |
+| `chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu` | `b_do` lhs across K-slabs (`STATE_V_FIRST` and else) | After gate×scale fold: `b_do_c/b_do_c2/b_do_c3 = b_do + 0.0` before any slab dot; slab1=`b_do`, slab2=`b_do_c`, slab3=`b_do_c2`, slab4=`b_do_c3` |
+| same | `b_dv` updated in-place then subtracted in dh update | `b_dv_pristine = b_dv + 0.0` after dv correction; each slab: `b_dv_i = b_dv_pristine + 0.0` for the subtract dot |
+
+### `chunk_intra.py`
+
+File: `fla/ops/kda/backends/triton_ascend/chunk_intra.py`
+
+| Kernel / site | Pattern | Fix |
+|---------------|---------|-----|
+| `chunk_kda_fwd_kernel_inter_solve_fused_npu` (NC≥3) | `b_qg2`/`b_kg2` lhs twice (Aqk20/Aqk21) | Copies before first dot: `b_qg2_c`, `b_kg2_c` |
+| same (NC≥4) | `b_qg3`/`b_kg3` lhs three times | `b_qg3_c1/c2`, `b_kg3_c1/c2` before any dot |
+| same — inter solve | `b_Ai22` lhs then store; lhs on copy then rhs on another copy | `b_Ai22_c` (store), `b_Ai22_c2` (lhs `b_Ai20`), `b_Ai22_c3` (rhs `b_Ai32`) — all before solve |
+| same — inter solve (NC≥4) | `b_Ai33` lhs/store/lhs roles; `b_Akk31`/`b_Akk32` lhs in both `b_Ai31` and `b_Ai30` | `b_Ai33_c/c2/c3` for store/`b_Ai31`/`b_Ai30` lhs; `b_Akk31_c`/`b_Akk32_c` for second expr in `b_Ai30` |
+| `chunk_kda_bwd_kernel_intra_npu` | Two kernel halves reuse tile names | **Safe** — `tl.debug_barrier()` + GM reload each loop trip |
+
+### `solve_tril.py`
+
+File: `fla/ops/utils/backends/triton_ascend/solve_tril.py`
+
+| Kernel / site | Pattern | Fix |
+|---------------|---------|-----|
+| `merge_16x16_to_32x32_inverse_kernel_npu` | `b_Ai_22` lhs in inner dot of `b_Ai_21`, stored at end | `b_Ai_22_c = b_Ai_22 + 0.0` before solve; store `b_Ai_22_c` |
+| `merge_16x16_to_64x64_inverse_kernel_npu` | `b_Ai_22` lhs in `b_Ai_21`, then rhs in `b_Ai_32` | Outer `b_Ai_32` uses `b_Ai_22_c` not `b_Ai_22` |
+| same | `b_Ai_33_c` rhs in `b_Ai_43`, lhs in `b_Ai_31`, stored | Split: `b_Ai_33_c` (store+rhs), `b_Ai_33_c2` (lhs `b_Ai_31`) |
+| same | `b_Ai_44_c` lhs in `b_Ai_42` and `b_Ai_41` | `b_Ai_44_c2` for second lhs |
+| same | `b_A_42`/`b_A_43` lhs in `b_Ai_42` inner sum and again in `b_Ai_41` | `b_A_42_c`/`b_A_43_c` for `b_Ai_41` dots |
+
+### `chunk_bwd.py` (KDA)
+
+File: `fla/ops/kda/backends/triton_ascend/chunk_bwd.py`
+
+| Kernel / site | Pattern | Fix |
+|---------------|---------|-----|
+| `chunk_kda_bwd_kernel_dAv_npu` | `b_do` lhs in `b_dA`, rhs in `b_dv` | `b_do_c = b_do + 0.0` before first dot |
+| `chunk_kda_bwd_kernel_wy_k_part_npu` | `b_v_new` in V loop | **Safe** — fresh `tl.load` each `i_v` |
+| `chunk_kda_bwd_kernel_wy_dw_part_npu` | `b_dw_c` in inner loop | **Safe** — `tl.load(p_dw_c, …)` each `s_c` trip |
+| `chunk_kda_bwd_kernel_wy_dA_dot_npu` / finalize | single dot per launch | **Safe** |
+
+### `chunk_scaled_dot_kkt.py`
+
+File: `fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py`
+
+- `b_ks` lhs once per `(s,c,k)` accumulation — **no exposure**.
+
+### Audit checklist (for new/changed kernels)
+
+1. `rg 'tl\.dot\(' fla/ops/**/triton_ascend/**` — list all call sites in the kernel.
+2. For each lhs tile: track first lhs dot line; flag any later read (lhs, rhs, store, `+`/`-`).
+3. Confirm every `+ 0.0` copy is **before** the tile's first lhs dot.
+4. Prefer **GM reload** when the tile is large and reused once between stages; prefer **`+ 0.0`** when multiple disposable lhs copies are needed in tight sequence (block merges, K-slabs).
+5. Re-run `tests/ops/test_gdn_kernels.py` + any op-specific kernel tests.
+
+### Upstream
+
+lhs clobber is a Triton-Ascend backend limitation (UB capacity / in-place matmul), not intentional API. Durable fix: compiler preserves lhs or emits a diagnostic on post-dot read. Track via Triton-Ascend / Ascend backend issue tracker.

--- a/.agents/skills/fla-ascend-performance/references/cases.md
+++ b/.agents/skills/fla-ascend-performance/references/cases.md
@@ -28,3 +28,12 @@ File: `fla/ops/kda/backends/triton_ascend/chunk_bwd.py`
 
 - `chunk_kda_bwd_kernel_dAv_npu` and `chunk_kda_bwd_kernel_wy_v_part_npu` loaded `bos`/`eos` via `.to(tl.int32)` then `(bos * HV + i_hv) * V` — int32 wrap on packed varlen offsets (e.g. HV=32, V=4096 safe `bos` ≈ 16K). Later kernels in the same file already used `tl.int64`.
 - Fix: load `bos`/`eos` as int64; `T = (eos - bos).to(tl.int32)`; non-varlen else-branch `(i_b * T).to(tl.int64)`.
+
+## `wy_fast.py` — Ascend `tl.dot` left-operand clobber
+
+Files: `fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py`, `fla/ops/kda/backends/triton_ascend/wy_fast.py`
+
+- **Behavior**: Ascend `tl.dot(lhs, rhs, ...)` can overwrite `lhs` in UB. CUDA Triton leaves `lhs` intact.
+- **Fwd `recompute_w_u_fwd_kernel_npu`**: load `b_A` once; `u` loop runs `b_u = tl.dot(b_A, b_vb, ...)` over V tiles — each dot clobbers `b_A`; `w` loop still needs pristine `A` for `b_w = tl.dot(b_A, b_kb, ...)`. **Fix**: after the `u` loop, before the `w` loop, reload from GM: `b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)`.
+- **Bwd `prepare_wy_repr_bwd_kv_npu`**: `k` loop uses `tl.dot(b_A, b_dw, ...)` (clobbers `b_A`); `v` loop reuses `b_A` — reload before the `v` loop the same way.
+- **Symptom / cost**: numeric mismatch vs Torch on Ascend only; no compile error. One extra GM load per stage is cheaper than keeping a duplicate tile live for the whole kernel.

--- a/.agents/skills/fla-ascend-performance/references/reference.md
+++ b/.agents/skills/fla-ascend-performance/references/reference.md
@@ -53,6 +53,7 @@ After changing `mem_mult`/tiles, always re-check compile + numeric correctness.
 - **Varlen wrong only on long seqs**: after slicing `chunk_indices`, check for a second global `NT_OFFSET`; on core-grid paths, verify `chunk_offsets` → `(i_n, i_t)` against `cu_seqlens`.
 - **Wrong results only in multi-task core-grid loops**: rebind local base pointers each `task_id`; avoid in-place `ptr +=` across iterations.
 - **Occasional bf16 NaN**: mask before exp, fp32 accum, exp/exp2 scale, solve precision.
+- **`tl.dot` left operand clobbered (Ascend only)**: `tl.dot(lhs, rhs, …)` may mutate `lhs` in UB (CUDA does not). Any later read of that tile — second lhs, rhs, store, or arithmetic — can see corrupted data. Two fixes: **GM reload** between stages (e.g. `wy_fast` u→w on `b_A`) or **`tile + 0.0` before the first lhs dot** when multiple disposable copies are needed in tight sequence. Post-dot `+ 0.0` is invalid. Full per-kernel catalog: [cases.md § tl.dot lhs clobber](cases.md#tldot-lhs-clobber--repo-wide-case-catalog). Symptom: numeric mismatch vs Torch, no compile error. Tests: `test_gdn_kernels.py`, `test_solve_tril.py`.
 - **Correct but slower**: launch count (split inter/intra + host grid chunks), tiny tiles, full-size fp32 scratch, extra layout converts, unsynced fake baselines.
 - **Local pass, full gate NaN**: tail writeback, boundary masks, invalid exp regions, scratch init before read.
 - **Compile-variant explosion**: do not specialize on T; move feature flags to heuristics/constexpr.
@@ -77,7 +78,11 @@ Paths relative to the `flash-linear-attention` repo root. Detailed case notes: [
 - `fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py` — peak tile, BC, UB-safe BK
 - `fla/ops/common/backends/triton_ascend/chunk_delta_h.py` — fwd recurrence, V tiling, bwd `dhu` (see [cases.md](cases.md))
 - `fla/ops/common/backends/triton_ascend/chunk_o.py` — fwd fuse + bwd G_T_CONTIG (see [cases.md](cases.md))
-- `fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py` — different fwd/bwd `mem_mult`; multi-stage bwd
+- `fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py` — multi-stage bwd; **`tl.dot` lhs clobber** (GM reload + copy) — [cases.md](cases.md)
+- `fla/ops/kda/backends/triton_ascend/wy_fast.py` — KDA variant of wy_fast; same clobber patterns
+- `fla/ops/kda/backends/triton_ascend/chunk_intra.py` — inter solve fused; multi-copy block merge — [cases.md](cases.md)
+- `fla/ops/kda/backends/triton_ascend/chunk_bwd.py` — KDA bwd (`dAv`, wy dw/dqkg); `b_do_c` pattern — [cases.md](cases.md)
+- `fla/ops/utils/backends/triton_ascend/solve_tril.py` — blocked triangular solve; 32×32/64×64 merge clobber guards — [cases.md](cases.md)
 - `fla/ops/utils/backends/triton_ascend/cumsum.py` — scalar/vector split and leftover UB budget
 
 ### Split / numerics / varlen

--- a/.agents/skills/fla-ascend-performance/references/reference.md
+++ b/.agents/skills/fla-ascend-performance/references/reference.md
@@ -53,6 +53,7 @@ After changing `mem_mult`/tiles, always re-check compile + numeric correctness.
 - **Varlen wrong only on long seqs**: after slicing `chunk_indices`, check for a second global `NT_OFFSET`; on core-grid paths, verify `chunk_offsets` → `(i_n, i_t)` against `cu_seqlens`.
 - **Wrong results only in multi-task core-grid loops**: rebind local base pointers each `task_id`; avoid in-place `ptr +=` across iterations.
 - **Occasional bf16 NaN**: mask before exp, fp32 accum, exp/exp2 scale, solve precision.
+- **`tl.dot` left operand clobbered (Ascend only)**: `tl.dot(lhs, rhs, ...)` may mutate `lhs` in UB. Reload `lhs` from GM before any second dot that needs the original tile (e.g. `wy_fast.py` fwd u loop then w loop on `b_A`; bwd k loop then v loop). CUDA does not show this; symptom is numeric mismatch vs Torch with no compile failure.
 - **Correct but slower**: launch count (split inter/intra + host grid chunks), tiny tiles, full-size fp32 scratch, extra layout converts, unsynced fake baselines.
 - **Local pass, full gate NaN**: tail writeback, boundary masks, invalid exp regions, scratch init before read.
 - **Compile-variant explosion**: do not specialize on T; move feature flags to heuristics/constexpr.

--- a/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
@@ -722,6 +722,7 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 b_dv *= tl.where(m_t, b_g_ratio, 0)[:, None]
         b_dv += tl.load(p_dv, boundary_check=(0, 1))
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        b_dv_pristine = b_dv + 0.0
 
         # Decay dh once; fold gate*scale into do so K-slabs skip per-slab gating.
         if USE_G:
@@ -747,7 +748,8 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 b_dh1 *= exp2(b_gk_last1[:, None])
         if STATE_V_FIRST:
             b_dh1 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-            b_dh1 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+            b_dv_i = b_dv_pristine + 0.0
+            b_dh1 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
         else:
             b_dh1 += (
                 tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
@@ -766,7 +768,8 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                     b_dh2 *= exp2(b_gk_last2[:, None])
             if STATE_V_FIRST:
                 b_dh2 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dh2 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                b_dv_i = b_dv_pristine + 0.0
+                b_dh2 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh2 += (
                     tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
@@ -785,7 +788,8 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                     b_dh3 *= exp2(b_gk_last3[:, None])
             if STATE_V_FIRST:
                 b_dh3 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dh3 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                b_dv_i = b_dv_pristine + 0.0
+                b_dh3 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh3 += (
                     tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
@@ -804,7 +808,8 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                     b_dh4 *= exp2(b_gk_last4[:, None])
             if STATE_V_FIRST:
                 b_dh4 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dh4 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                b_dv_i = b_dv_pristine + 0.0
+                b_dh4 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh4 += (
                     tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)

--- a/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
@@ -722,6 +722,7 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 b_dv *= tl.where(m_t, b_g_ratio, 0)[:, None]
         b_dv += tl.load(p_dv, boundary_check=(0, 1))
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        b_dv_pristine = b_dv + 0.0
 
         # Decay dh once; fold gate*scale into do so K-slabs skip per-slab gating.
         if USE_G:
@@ -735,6 +736,9 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
             b_do = b_do * (b_g_exp * scale)[:, None]
         else:
             b_do = b_do * scale
+        b_do_c = b_do + 0.0
+        b_do_c2 = b_do + 0.0
+        b_do_c3 = b_do + 0.0
 
         p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (0, i_t * BT), (BK, BT), (0, 1))
         p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (0, i_t * BT), (BK, BT), (0, 1))
@@ -747,7 +751,8 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 b_dh1 *= exp2(b_gk_last1[:, None])
         if STATE_V_FIRST:
             b_dh1 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-            b_dh1 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+            b_dv_i = b_dv_pristine + 0.0
+            b_dh1 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
         else:
             b_dh1 += (
                 tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
@@ -765,11 +770,12 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 else:
                     b_dh2 *= exp2(b_gk_last2[:, None])
             if STATE_V_FIRST:
-                b_dh2 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dh2 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                b_dh2 += tl.dot(tl.trans(b_do_c.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
+                b_dv_i = b_dv_pristine + 0.0
+                b_dh2 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh2 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
+                    tl.dot(b_q.to(b_q.dtype), b_do_c.to(b_q.dtype), allow_tf32=False)
                     - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
                 )
 
@@ -784,11 +790,12 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 else:
                     b_dh3 *= exp2(b_gk_last3[:, None])
             if STATE_V_FIRST:
-                b_dh3 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dh3 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                b_dh3 += tl.dot(tl.trans(b_do_c2.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
+                b_dv_i = b_dv_pristine + 0.0
+                b_dh3 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh3 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
+                    tl.dot(b_q.to(b_q.dtype), b_do_c2.to(b_q.dtype), allow_tf32=False)
                     - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
                 )
 
@@ -803,11 +810,12 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
                 else:
                     b_dh4 *= exp2(b_gk_last4[:, None])
             if STATE_V_FIRST:
-                b_dh4 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dh4 -= tl.dot(tl.trans(b_dv.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                b_dh4 += tl.dot(tl.trans(b_do_c3.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
+                b_dv_i = b_dv_pristine + 0.0
+                b_dh4 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
             else:
                 b_dh4 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
+                    tl.dot(b_q.to(b_q.dtype), b_do_c3.to(b_q.dtype), allow_tf32=False)
                     - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
                 )
 

--- a/fla/ops/common/backends/triton_ascend/chunk_o.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_o.py
@@ -201,8 +201,10 @@ def chunk_fwd_kernel_o_npu(
                 b_o += tl.dot(b_q, tl.trans(b_h))
             else:
                 b_o += tl.dot(b_q, b_h)
+            # Ascend tl.dot clobbers lhs; keep a pristine copy for the A dot.
+            b_q_c = b_q + 0.0
             # [BT, BK] @ [BK, BT] -> [BT, BT]
-            b_A += tl.dot(b_q, b_k)
+            b_A += tl.dot(b_q_c, b_k)
 
         if USE_G:
             # g is transposed to [B, HV, T] in wrapper for contiguous T-load.
@@ -413,12 +415,14 @@ def chunk_bwd_kernel_dv_local_hv1_npu(
     m_t = o_t < T
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
+    b_A_pristine = b_A + 0.0
 
     for i_v in range(tl.cdiv(V, BV)):
         p_do = tl.make_block_ptr(do, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_do = tl.load(p_do, boundary_check=(0, 1))
-        b_dv = tl.dot(b_A.to(b_do.dtype), b_do, allow_tf32=False)
+        b_A_i = b_A_pristine + 0.0
+        b_dv = tl.dot(b_A_i.to(b_do.dtype), b_do, allow_tf32=False)
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -745,11 +749,12 @@ def chunk_bwd_kernel_dqkwg_npu(
             p_k_c = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
             b_k_c = tl.load(p_k_c, boundary_check=(0, 1))
             b_ds = tl.where(m_blk, b_ds, 0).to(b_k_c.dtype)
+            b_ds_c = b_ds + 0.0
             b_dq_r += tl.dot(b_ds, b_k_c, allow_tf32=False)
 
             p_dk_acc = tl.make_block_ptr(dk_f32, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
             b_dk_acc = tl.load(p_dk_acc, boundary_check=(0, 1))
-            b_ds_dk = tl.dot(tl.trans(b_ds), b_q_r, allow_tf32=False)
+            b_ds_dk = tl.dot(tl.trans(b_ds_c), b_q_r, allow_tf32=False)
             if not USE_G and not USE_G_GAMMA:
                 b_ds_dk = b_ds_dk * scale
             b_dk_acc += b_ds_dk

--- a/fla/ops/common/backends/triton_ascend/chunk_o.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_o.py
@@ -196,13 +196,15 @@ def chunk_fwd_kernel_o_npu(
             # [BK, BV]
             b_h = tl.load(p_h, boundary_check=(0, 1))
 
+            # Ascend tl.dot clobbers lhs; copy before the first dot on b_q.
+            b_q_c = b_q + 0.0
             # [BT, BK] @ [BK, BV] -> [BT, BV]
             if STATE_V_FIRST:
                 b_o += tl.dot(b_q, tl.trans(b_h))
             else:
                 b_o += tl.dot(b_q, b_h)
             # [BT, BK] @ [BK, BT] -> [BT, BT]
-            b_A += tl.dot(b_q, b_k)
+            b_A += tl.dot(b_q_c, b_k)
 
         if USE_G:
             # g is transposed to [B, HV, T] in wrapper for contiguous T-load.
@@ -413,12 +415,14 @@ def chunk_bwd_kernel_dv_local_hv1_npu(
     m_t = o_t < T
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
+    b_A_pristine = b_A + 0.0
 
     for i_v in range(tl.cdiv(V, BV)):
         p_do = tl.make_block_ptr(do, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_do = tl.load(p_do, boundary_check=(0, 1))
-        b_dv = tl.dot(b_A.to(b_do.dtype), b_do, allow_tf32=False)
+        b_A_i = b_A_pristine + 0.0
+        b_dv = tl.dot(b_A_i.to(b_do.dtype), b_do, allow_tf32=False)
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -507,8 +511,9 @@ def chunk_bwd_kernel_dv_local_npu(
                 p_q1 = tl.make_block_ptr(q, (K, T), (1, H * K), (i_k * BK, i_tc1), (BK, BC), (0, 1))
                 b_q0 = tl.load(p_q0, boundary_check=(0, 1))
                 b_q1 = tl.load(p_q1, boundary_check=(0, 1))
+                b_k0_c = b_k0 + 0.0
                 b_A00 += tl.dot(b_k0, b_q0, allow_tf32=False) * scale
-                b_A01 += tl.dot(b_k0, b_q1, allow_tf32=False) * scale
+                b_A01 += tl.dot(b_k0_c, b_q1, allow_tf32=False) * scale
                 b_A11 += tl.dot(b_k1, b_q1, allow_tf32=False) * scale
 
             if USE_G or USE_G_GAMMA:
@@ -745,11 +750,12 @@ def chunk_bwd_kernel_dqkwg_npu(
             p_k_c = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
             b_k_c = tl.load(p_k_c, boundary_check=(0, 1))
             b_ds = tl.where(m_blk, b_ds, 0).to(b_k_c.dtype)
+            b_ds_c = b_ds + 0.0
             b_dq_r += tl.dot(b_ds, b_k_c, allow_tf32=False)
 
             p_dk_acc = tl.make_block_ptr(dk_f32, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
             b_dk_acc = tl.load(p_dk_acc, boundary_check=(0, 1))
-            b_ds_dk = tl.dot(tl.trans(b_ds), b_q_r, allow_tf32=False)
+            b_ds_dk = tl.dot(tl.trans(b_ds_c), b_q_r, allow_tf32=False)
             if not USE_G and not USE_G_GAMMA:
                 b_ds_dk = b_ds_dk * scale
             b_dk_acc += b_ds_dk

--- a/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
@@ -178,7 +178,6 @@ def recompute_w_u_fwd_kernel_npu(
         offs_bt = tl.arange(0, BT)[None, :]
         ptr_A = A + (bos * HV + i_h) * BT + offs_t_2d * (HV * BT) + offs_bt * 1
         mask_A = mask_t[:, None]
-        b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
 
         ptr_beta = beta + bos_bh + i_h * T_max + global_offs_t
         b_beta = tl.load(ptr_beta, mask=mask_t, other=0.0).to(tl.float32)
@@ -191,6 +190,8 @@ def recompute_w_u_fwd_kernel_npu(
             b_v = tl.load(ptr_v, mask=mask_v, other=0.0).to(tl.float32)
 
             b_vb = b_v * b_beta[:, None]
+            # Ascend tl.dot may clobber the left operand; reload A each V tile.
+            b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
             b_u = tl.dot(b_A, b_vb, allow_tf32=False)
 
             ptr_u = u + (bos * HV + i_h) * V + offs_t_2d * (HV * V) + offs_v * 1
@@ -214,6 +215,8 @@ def recompute_w_u_fwd_kernel_npu(
             b_kb = b_k * b_beta[:, None]
             if USE_G:
                 b_kb = b_kb * b_g[:, None]
+            # Ascend tl.dot may clobber the left operand; reload A each K tile.
+            b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
             b_w = tl.dot(b_A, b_kb, allow_tf32=False)
 
             ptr_w = w + (bos * HV + i_h) * K + offs_t_2d * (HV * K) + offs_k * 1
@@ -272,7 +275,6 @@ def prepare_wy_repr_bwd_kv_npu(
 
         b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
         b_db = tl.zeros([BT], dtype=tl.float32)
-        b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
         b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
         if USE_G:
@@ -301,8 +303,11 @@ def prepare_wy_repr_bwd_kv_npu(
             else:
                 b_kbg = b_k * b_b[:, None]
             b_dw = tl.load(p_dw, boundary_check=(0, 1)).to(tl.float32)
+            b_dw_c = b_dw + 0.0
             b_dA += tl.dot(b_dw, tl.trans(b_kbg), allow_tf32=False)
-            b_dkbg = tl.dot(b_A, b_dw, allow_tf32=False)
+            # Ascend tl.dot may clobber the left operand; reload A each K tile.
+            b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+            b_dkbg = tl.dot(b_A, b_dw_c, allow_tf32=False)
             if USE_G:
                 b_dk = b_dkbg * (b_g_exp * b_b)[:, None]
                 b_db += tl.sum(b_dkbg * b_k * b_g_exp[:, None], 1)
@@ -324,9 +329,12 @@ def prepare_wy_repr_bwd_kv_npu(
             )
             b_v = tl.load(p_v, boundary_check=(0, 1)).to(tl.float32)
             b_du = tl.load(p_du, boundary_check=(0, 1)).to(tl.float32)
+            b_du_c = b_du + 0.0
             b_vb = b_v * b_b[:, None]
             b_dA += tl.dot(b_du, tl.trans(b_vb), allow_tf32=False)
-            b_dvb = tl.dot(b_A, b_du, allow_tf32=False)
+            # Ascend tl.dot may clobber the left operand; reload A each V tile.
+            b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+            b_dvb = tl.dot(b_A, b_du_c, allow_tf32=False)
             b_dv = b_dvb * b_b[:, None]
             b_db += tl.sum(b_dvb * b_v, 1)
             tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
@@ -512,6 +520,7 @@ def prepare_wy_repr_bwd_finalize_k_npu(
         b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
         b_db = tl.load(p_db, boundary_check=(0,)).to(tl.float32)
         b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
+        b_dA_c = b_dA + 0.0
 
         for i_k in range(tl.cdiv(K, BK)):
             p_k = tl.make_block_ptr(
@@ -522,9 +531,11 @@ def prepare_wy_repr_bwd_finalize_k_npu(
             )
             b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
             b_kb = b_k * b_b[:, None]
-            b_dkb = tl.dot(b_dA, b_k, allow_tf32=False)
+            # Ascend tl.dot clobbers lhs; keep a pristine copy for the rhs dot.
+            b_dA_lhs = b_dA + 0.0
+            b_dkb = tl.dot(b_dA_lhs, b_k, allow_tf32=False)
             b_db += tl.sum(b_dkb * b_k, 1)
-            b_dk = b_dkb * b_b[:, None] + tl.trans(tl.dot(tl.trans(b_kb), b_dA, allow_tf32=False))
+            b_dk = b_dkb * b_b[:, None] + tl.trans(tl.dot(tl.trans(b_kb), b_dA_c, allow_tf32=False))
             b_dk += tl.load(p_dk, boundary_check=(0, 1)).to(tl.float32)
             tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 

--- a/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
@@ -178,7 +178,6 @@ def recompute_w_u_fwd_kernel_npu(
         offs_bt = tl.arange(0, BT)[None, :]
         ptr_A = A + (bos * HV + i_h) * BT + offs_t_2d * (HV * BT) + offs_bt * 1
         mask_A = mask_t[:, None]
-        b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
 
         ptr_beta = beta + bos_bh + i_h * T_max + global_offs_t
         b_beta = tl.load(ptr_beta, mask=mask_t, other=0.0).to(tl.float32)
@@ -191,6 +190,8 @@ def recompute_w_u_fwd_kernel_npu(
             b_v = tl.load(ptr_v, mask=mask_v, other=0.0).to(tl.float32)
 
             b_vb = b_v * b_beta[:, None]
+            # Ascend tl.dot may clobber the left operand; reload A each V tile.
+            b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
             b_u = tl.dot(b_A, b_vb, allow_tf32=False)
 
             ptr_u = u + (bos * HV + i_h) * V + offs_t_2d * (HV * V) + offs_v * 1
@@ -214,6 +215,8 @@ def recompute_w_u_fwd_kernel_npu(
             b_kb = b_k * b_beta[:, None]
             if USE_G:
                 b_kb = b_kb * b_g[:, None]
+            # Ascend tl.dot may clobber the left operand; reload A each K tile.
+            b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
             b_w = tl.dot(b_A, b_kb, allow_tf32=False)
 
             ptr_w = w + (bos * HV + i_h) * K + offs_t_2d * (HV * K) + offs_k * 1
@@ -272,7 +275,6 @@ def prepare_wy_repr_bwd_kv_npu(
 
         b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
         b_db = tl.zeros([BT], dtype=tl.float32)
-        b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
         b_dA = tl.zeros([BT, BT], dtype=tl.float32)
 
         if USE_G:
@@ -302,6 +304,8 @@ def prepare_wy_repr_bwd_kv_npu(
                 b_kbg = b_k * b_b[:, None]
             b_dw = tl.load(p_dw, boundary_check=(0, 1)).to(tl.float32)
             b_dA += tl.dot(b_dw, tl.trans(b_kbg), allow_tf32=False)
+            # Ascend tl.dot may clobber the left operand; reload A each K tile.
+            b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
             b_dkbg = tl.dot(b_A, b_dw, allow_tf32=False)
             if USE_G:
                 b_dk = b_dkbg * (b_g_exp * b_b)[:, None]
@@ -326,6 +330,8 @@ def prepare_wy_repr_bwd_kv_npu(
             b_du = tl.load(p_du, boundary_check=(0, 1)).to(tl.float32)
             b_vb = b_v * b_b[:, None]
             b_dA += tl.dot(b_du, tl.trans(b_vb), allow_tf32=False)
+            # Ascend tl.dot may clobber the left operand; reload A each V tile.
+            b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
             b_dvb = tl.dot(b_A, b_du, allow_tf32=False)
             b_dv = b_dvb * b_b[:, None]
             b_db += tl.sum(b_dvb * b_v, 1)
@@ -512,6 +518,7 @@ def prepare_wy_repr_bwd_finalize_k_npu(
         b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
         b_db = tl.load(p_db, boundary_check=(0,)).to(tl.float32)
         b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
+        b_dA_c = b_dA + 0.0
 
         for i_k in range(tl.cdiv(K, BK)):
             p_k = tl.make_block_ptr(
@@ -522,9 +529,11 @@ def prepare_wy_repr_bwd_finalize_k_npu(
             )
             b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
             b_kb = b_k * b_b[:, None]
-            b_dkb = tl.dot(b_dA, b_k, allow_tf32=False)
+            # Ascend tl.dot clobbers lhs; keep a pristine copy for the rhs dot.
+            b_dA_lhs = b_dA + 0.0
+            b_dkb = tl.dot(b_dA_lhs, b_k, allow_tf32=False)
             b_db += tl.sum(b_dkb * b_k, 1)
-            b_dk = b_dkb * b_b[:, None] + tl.trans(tl.dot(tl.trans(b_kb), b_dA, allow_tf32=False))
+            b_dk = b_dkb * b_b[:, None] + tl.trans(tl.dot(tl.trans(b_kb), b_dA_c, allow_tf32=False))
             b_dk += tl.load(p_dk, boundary_check=(0, 1)).to(tl.float32)
             tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 

--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -91,12 +91,10 @@ def chunk_kda_bwd_kernel_dAv_npu(
     dA += (bos * HV + i_hv) * BT
 
     p_A = tl.make_block_ptr(A + (bos * HV + i_hv) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
-    b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
@@ -106,7 +104,9 @@ def chunk_kda_bwd_kernel_dAv_npu(
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_do = tl.load(p_do, boundary_check=(0, 1))
         b_dA += tl.dot(b_do, b_v, allow_tf32=False)
-        b_dv = tl.dot(b_A.to(b_do.dtype), b_do, allow_tf32=False)
+        b_A_i = tl.load(p_A, boundary_check=(0, 1))
+        b_A_i = tl.where(m_A, b_A_i, 0).to(b_do.dtype)
+        b_dv = tl.dot(b_A_i, b_do, allow_tf32=False)
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
     p_dA = tl.make_block_ptr(dA, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))

--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -91,12 +91,10 @@ def chunk_kda_bwd_kernel_dAv_npu(
     dA += (bos * HV + i_hv) * BT
 
     p_A = tl.make_block_ptr(A + (bos * HV + i_hv) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
-    b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
@@ -105,8 +103,11 @@ def chunk_kda_bwd_kernel_dAv_npu(
         p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         b_v = tl.load(p_v, boundary_check=(0, 1))
         b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do_c = b_do + 0.0
         b_dA += tl.dot(b_do, b_v, allow_tf32=False)
-        b_dv = tl.dot(b_A.to(b_do.dtype), b_do, allow_tf32=False)
+        b_A_i = tl.load(p_A, boundary_check=(0, 1))
+        b_A_i = tl.where(m_A, b_A_i, 0).to(b_do.dtype)
+        b_dv = tl.dot(b_A_i, b_do_c, allow_tf32=False)
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
     p_dA = tl.make_block_ptr(dA, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
@@ -566,6 +567,7 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
         b_gb = b_gk_exp * b_beta_r[:, None]
 
         b_dkgb_r = tl.zeros([BC, BK], dtype=tl.float32)
+        b_dw_r_p = b_dw_r + 0.0
         for s_c in range(n_sub):
             i_tc_c = i_t * BT + s_c * BC
             p_dw_c = tl.make_block_ptr(dw, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
@@ -583,7 +585,8 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
 
             p_dA_acc = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_tc_r, s_c * BC), (BC, BC), (1, 0))
             b_dA_rc = tl.load(p_dA_acc, boundary_check=(0, 1)).to(tl.float32)
-            b_dA_rc += tl.dot(b_dw_r.to(tl.float32), tl.trans(b_kg_c.to(tl.float32)), allow_tf32=False)
+            b_dw_r_c = b_dw_r_p + 0.0
+            b_dA_rc += tl.dot(b_dw_r_c.to(tl.float32), tl.trans(b_kg_c.to(tl.float32)), allow_tf32=False)
             tl.store(p_dA_acc, b_dA_rc.to(p_dA_acc.dtype.element_ty), boundary_check=(0, 1))
 
         p_db_acc = tl.make_block_ptr(db_acc, (T,), (HV,), (i_tc_r,), (BC,), (0,))

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra.py
@@ -383,8 +383,10 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
             b_Aqk20 += tl.dot(b_qg2, b_kgt, allow_tf32=False)
             b_Akk20 += tl.dot(b_kg2, b_kgt, allow_tf32=False)
             b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1))
-            b_Aqk21 += tl.dot(b_qg2, b_kgt, allow_tf32=False)
-            b_Akk21 += tl.dot(b_kg2, b_kgt, allow_tf32=False)
+            b_qg2_c = b_qg2 + 0.0
+            b_kg2_c = b_kg2 + 0.0
+            b_Aqk21 += tl.dot(b_qg2_c, b_kgt, allow_tf32=False)
+            b_Akk21 += tl.dot(b_kg2_c, b_kgt, allow_tf32=False)
 
             if NC >= 4:
                 p_q3 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
@@ -401,11 +403,15 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
                 b_Aqk30 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
                 b_Akk30 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
                 b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1))
-                b_Aqk31 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
-                b_Akk31 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
+                b_qg3_c1 = b_qg3 + 0.0
+                b_kg3_c1 = b_kg3 + 0.0
+                b_Aqk31 += tl.dot(b_qg3_c1, b_kgt, allow_tf32=False)
+                b_Akk31 += tl.dot(b_kg3_c1, b_kgt, allow_tf32=False)
                 b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2))
-                b_Aqk32 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
-                b_Akk32 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
+                b_qg3_c2 = b_qg3 + 0.0
+                b_kg3_c2 = b_kg3 + 0.0
+                b_Aqk32 += tl.dot(b_qg3_c2, b_kgt, allow_tf32=False)
+                b_Akk32 += tl.dot(b_kg3_c2, b_kgt, allow_tf32=False)
 
     p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
     tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
@@ -448,6 +454,12 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (HV * BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
         b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
 
+    b_Ai11_c = b_Ai11 + 0.0
+    if NC >= 3:
+        b_Ai22_c = b_Ai22 + 0.0
+    if NC >= 4:
+        b_Ai33_c = b_Ai33 + 0.0
+
     b_Ai10 = -tl.dot(
         tl.dot(b_Ai11, b_Akk10, allow_tf32=False),
         b_Ai00,
@@ -457,11 +469,11 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     if NC >= 3:
         b_Ai21 = -tl.dot(
             tl.dot(b_Ai22, b_Akk21, allow_tf32=False),
-            b_Ai11,
+            b_Ai11_c,
             allow_tf32=False,
         )
         b_Ai20 = -tl.dot(
-            b_Ai22,
+            b_Ai22_c,
             tl.dot(b_Akk20, b_Ai00, allow_tf32=False) +
             tl.dot(b_Akk21, b_Ai10, allow_tf32=False),
             allow_tf32=False,
@@ -469,17 +481,18 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     if NC >= 4:
         b_Ai32 = -tl.dot(
             tl.dot(b_Ai33, b_Akk32, allow_tf32=False),
-            b_Ai22,
+            b_Ai22_c,
             allow_tf32=False,
         )
         b_Ai31 = -tl.dot(
-            b_Ai33,
-            tl.dot(b_Akk31, b_Ai11, allow_tf32=False) +
+            b_Ai33_c,
+            tl.dot(b_Akk31, b_Ai11_c, allow_tf32=False) +
             tl.dot(b_Akk32, b_Ai21, allow_tf32=False),
             allow_tf32=False,
         )
+        b_Ai33_c2 = b_Ai33_c + 0.0
         b_Ai30 = -tl.dot(
-            b_Ai33,
+            b_Ai33_c2,
             tl.dot(b_Akk30, b_Ai00, allow_tf32=False) +
             tl.dot(b_Akk31, b_Ai10, allow_tf32=False) +
             tl.dot(b_Akk32, b_Ai20, allow_tf32=False),
@@ -492,14 +505,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
 
     tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk11, b_Ai11_c.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     if NC >= 3:
         p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
         p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
         p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0))
         tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk22, b_Ai22_c.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     if NC >= 4:
         p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
         p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
@@ -508,7 +521,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk33, b_Ai33_c.to(Akk.dtype.element_ty), boundary_check=(0, 1))
 
 
 @input_guard

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra.py
@@ -379,12 +379,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
             b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
             b_qg2 = b_q2 * b_gqn2
             b_kg2 = b_k2 * b_gqn2
+            b_qg2_c = b_qg2 + 0.0
+            b_kg2_c = b_kg2 + 0.0
             b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0))
             b_Aqk20 += tl.dot(b_qg2, b_kgt, allow_tf32=False)
             b_Akk20 += tl.dot(b_kg2, b_kgt, allow_tf32=False)
             b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1))
-            b_Aqk21 += tl.dot(b_qg2, b_kgt, allow_tf32=False)
-            b_Akk21 += tl.dot(b_kg2, b_kgt, allow_tf32=False)
+            b_Aqk21 += tl.dot(b_qg2_c, b_kgt, allow_tf32=False)
+            b_Akk21 += tl.dot(b_kg2_c, b_kgt, allow_tf32=False)
 
             if NC >= 4:
                 p_q3 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
@@ -397,15 +399,19 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
                 b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
                 b_qg3 = b_q3 * b_gqn3
                 b_kg3 = b_k3 * b_gqn3
+                b_qg3_c1 = b_qg3 + 0.0
+                b_kg3_c1 = b_kg3 + 0.0
+                b_qg3_c2 = b_qg3 + 0.0
+                b_kg3_c2 = b_kg3 + 0.0
                 b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0))
                 b_Aqk30 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
                 b_Akk30 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
                 b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1))
-                b_Aqk31 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
-                b_Akk31 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
+                b_Aqk31 += tl.dot(b_qg3_c1, b_kgt, allow_tf32=False)
+                b_Akk31 += tl.dot(b_kg3_c1, b_kgt, allow_tf32=False)
                 b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2))
-                b_Aqk32 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
-                b_Akk32 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
+                b_Aqk32 += tl.dot(b_qg3_c2, b_kgt, allow_tf32=False)
+                b_Akk32 += tl.dot(b_kg3_c2, b_kgt, allow_tf32=False)
 
     p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
     tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
@@ -448,6 +454,18 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (HV * BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
         b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
 
+    b_Ai11_c = b_Ai11 + 0.0
+    if NC >= 3:
+        b_Ai22_c = b_Ai22 + 0.0
+        b_Ai22_c2 = b_Ai22 + 0.0
+        b_Ai22_c3 = b_Ai22 + 0.0
+    if NC >= 4:
+        b_Ai33_c = b_Ai33 + 0.0
+        b_Ai33_c2 = b_Ai33 + 0.0
+        b_Ai33_c3 = b_Ai33 + 0.0
+        b_Akk31_c = b_Akk31 + 0.0
+        b_Akk32_c = b_Akk32 + 0.0
+
     b_Ai10 = -tl.dot(
         tl.dot(b_Ai11, b_Akk10, allow_tf32=False),
         b_Ai00,
@@ -457,11 +475,11 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     if NC >= 3:
         b_Ai21 = -tl.dot(
             tl.dot(b_Ai22, b_Akk21, allow_tf32=False),
-            b_Ai11,
+            b_Ai11_c,
             allow_tf32=False,
         )
         b_Ai20 = -tl.dot(
-            b_Ai22,
+            b_Ai22_c2,
             tl.dot(b_Akk20, b_Ai00, allow_tf32=False) +
             tl.dot(b_Akk21, b_Ai10, allow_tf32=False),
             allow_tf32=False,
@@ -469,20 +487,20 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     if NC >= 4:
         b_Ai32 = -tl.dot(
             tl.dot(b_Ai33, b_Akk32, allow_tf32=False),
-            b_Ai22,
+            b_Ai22_c3,
             allow_tf32=False,
         )
         b_Ai31 = -tl.dot(
-            b_Ai33,
-            tl.dot(b_Akk31, b_Ai11, allow_tf32=False) +
+            b_Ai33_c2,
+            tl.dot(b_Akk31, b_Ai11_c, allow_tf32=False) +
             tl.dot(b_Akk32, b_Ai21, allow_tf32=False),
             allow_tf32=False,
         )
         b_Ai30 = -tl.dot(
-            b_Ai33,
+            b_Ai33_c3,
             tl.dot(b_Akk30, b_Ai00, allow_tf32=False) +
-            tl.dot(b_Akk31, b_Ai10, allow_tf32=False) +
-            tl.dot(b_Akk32, b_Ai20, allow_tf32=False),
+            tl.dot(b_Akk31_c, b_Ai10, allow_tf32=False) +
+            tl.dot(b_Akk32_c, b_Ai20, allow_tf32=False),
             allow_tf32=False,
         )
 
@@ -492,14 +510,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
 
     tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk11, b_Ai11_c.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     if NC >= 3:
         p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
         p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
         p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0))
         tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk22, b_Ai22_c.to(Akk.dtype.element_ty), boundary_check=(0, 1))
     if NC >= 4:
         p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
         p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
@@ -508,7 +526,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk33, b_Ai33_c.to(Akk.dtype.element_ty), boundary_check=(0, 1))
 
 
 @input_guard

--- a/fla/ops/kda/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/kda/backends/triton_ascend/wy_fast.py
@@ -187,7 +187,6 @@ def recompute_w_u_fwd_kda_kernel_npu(
         b_b = tl.load(p_b, boundary_check=(0,))
 
         p_A = tl.make_block_ptr(A_ptr, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-        b_A = tl.load(p_A, boundary_check=(0, 1))
 
         last_idx = min(i_t * BT + BT, T) - 1
 
@@ -196,6 +195,8 @@ def recompute_w_u_fwd_kda_kernel_npu(
             p_u = tl.make_block_ptr(u_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             b_v = tl.load(p_v, boundary_check=(0, 1))
             b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
+            # Ascend tl.dot may clobber the left operand; reload A each V tile.
+            b_A = tl.load(p_A, boundary_check=(0, 1))
             b_u = tl.dot(b_A, b_vb, allow_tf32=False)
             tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
 
@@ -226,6 +227,8 @@ def recompute_w_u_fwd_kda_kernel_npu(
                 p_kg = tl.make_block_ptr(kg_ptr, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
                 tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
 
+            # Ascend tl.dot may clobber the left operand; reload A each K tile.
+            b_A = tl.load(p_A, boundary_check=(0, 1))
             b_w = tl.dot(b_A, b_kb.to(b_k.dtype), allow_tf32=False)
             p_w = tl.make_block_ptr(w_ptr, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
             tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))

--- a/fla/ops/utils/backends/triton_ascend/solve_tril.py
+++ b/fla/ops/utils/backends/triton_ascend/solve_tril.py
@@ -136,6 +136,7 @@ def merge_16x16_to_32x32_inverse_kernel_npu(
 
     p_A_21 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
     b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai_22_c = b_Ai_22 + 0.0
     b_Ai_21 = -tl.dot(
         tl.dot(b_Ai_22, b_A_21, input_precision='ieee'),
         b_Ai_11,
@@ -146,7 +147,7 @@ def merge_16x16_to_32x32_inverse_kernel_npu(
     p_Ai_21 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
     p_Ai_22 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
     tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_22, b_Ai_22_c.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
 
 
@@ -231,6 +232,15 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
     b_A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
     b_A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
 
+    b_Ai_22_c = b_Ai_22 + 0.0
+    b_Ai_33_c = b_Ai_33 + 0.0
+    b_Ai_33_c2 = b_Ai_33 + 0.0
+    b_Ai_44_c = b_Ai_44 + 0.0
+    b_Ai_44_c2 = b_Ai_44 + 0.0
+    b_Ai_44_store = b_Ai_44 + 0.0
+    b_A_42_c = b_A_42 + 0.0
+    b_A_43_c = b_A_43 + 0.0
+
     b_Ai_21 = -tl.dot(
         tl.dot(b_Ai_22, b_A_21, input_precision='ieee'),
         b_Ai_11,
@@ -238,31 +248,31 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
     )
     b_Ai_32 = -tl.dot(
         tl.dot(b_Ai_33, b_A_32, input_precision='ieee'),
-        b_Ai_22,
+        b_Ai_22_c,
         input_precision='ieee',
     )
     b_Ai_43 = -tl.dot(
         tl.dot(b_Ai_44, b_A_43, input_precision='ieee'),
-        b_Ai_33,
+        b_Ai_33_c,
         input_precision='ieee',
     )
     b_Ai_31 = -tl.dot(
-        b_Ai_33,
+        b_Ai_33_c2,
         tl.dot(b_A_31, b_Ai_11, input_precision='ieee')
         + tl.dot(b_A_32, b_Ai_21, input_precision='ieee'),
         input_precision='ieee',
     )
     b_Ai_42 = -tl.dot(
-        b_Ai_44,
-        tl.dot(b_A_42, b_Ai_22, input_precision='ieee')
+        b_Ai_44_c,
+        tl.dot(b_A_42, b_Ai_22_c, input_precision='ieee')
         + tl.dot(b_A_43, b_Ai_32, input_precision='ieee'),
         input_precision='ieee',
     )
     b_Ai_41 = -tl.dot(
-        b_Ai_44,
+        b_Ai_44_c2,
         tl.dot(b_A_41, b_Ai_11, input_precision='ieee')
-        + tl.dot(b_A_42, b_Ai_21, input_precision='ieee')
-        + tl.dot(b_A_43, b_Ai_31, input_precision='ieee'),
+        + tl.dot(b_A_42_c, b_Ai_21, input_precision='ieee')
+        + tl.dot(b_A_43_c, b_Ai_31, input_precision='ieee'),
         input_precision='ieee',
     )
 
@@ -277,9 +287,9 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
     p_Ai_42 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0))
     p_Ai_43 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0))
     tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_33, b_Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_44, b_Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_22, b_Ai_22_c.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_33, b_Ai_33_c.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_44, b_Ai_44_store.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_31, b_Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_32, b_Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))

--- a/fla/ops/utils/backends/triton_ascend/solve_tril.py
+++ b/fla/ops/utils/backends/triton_ascend/solve_tril.py
@@ -136,6 +136,7 @@ def merge_16x16_to_32x32_inverse_kernel_npu(
 
     p_A_21 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
     b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai_22_c = b_Ai_22 + 0.0
     b_Ai_21 = -tl.dot(
         tl.dot(b_Ai_22, b_A_21, input_precision='ieee'),
         b_Ai_11,
@@ -146,7 +147,7 @@ def merge_16x16_to_32x32_inverse_kernel_npu(
     p_Ai_21 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0))
     p_Ai_22 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0))
     tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_22, b_Ai_22_c.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
 
 
@@ -231,6 +232,10 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
     b_A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
     b_A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
 
+    b_Ai_22_c = b_Ai_22 + 0.0
+    b_Ai_33_c = b_Ai_33 + 0.0
+    b_Ai_44_c = b_Ai_44 + 0.0
+
     b_Ai_21 = -tl.dot(
         tl.dot(b_Ai_22, b_A_21, input_precision='ieee'),
         b_Ai_11,
@@ -243,23 +248,24 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
     )
     b_Ai_43 = -tl.dot(
         tl.dot(b_Ai_44, b_A_43, input_precision='ieee'),
-        b_Ai_33,
+        b_Ai_33_c,
         input_precision='ieee',
     )
     b_Ai_31 = -tl.dot(
-        b_Ai_33,
+        b_Ai_33_c,
         tl.dot(b_A_31, b_Ai_11, input_precision='ieee')
         + tl.dot(b_A_32, b_Ai_21, input_precision='ieee'),
         input_precision='ieee',
     )
     b_Ai_42 = -tl.dot(
-        b_Ai_44,
-        tl.dot(b_A_42, b_Ai_22, input_precision='ieee')
+        b_Ai_44_c,
+        tl.dot(b_A_42, b_Ai_22_c, input_precision='ieee')
         + tl.dot(b_A_43, b_Ai_32, input_precision='ieee'),
         input_precision='ieee',
     )
+    b_Ai_44_c2 = b_Ai_44_c + 0.0
     b_Ai_41 = -tl.dot(
-        b_Ai_44,
+        b_Ai_44_c2,
         tl.dot(b_A_41, b_Ai_11, input_precision='ieee')
         + tl.dot(b_A_42, b_Ai_21, input_precision='ieee')
         + tl.dot(b_A_43, b_Ai_31, input_precision='ieee'),
@@ -277,9 +283,9 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
     p_Ai_42 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0))
     p_Ai_43 = tl.make_block_ptr(Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0))
     tl.store(p_Ai_11, b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_22, b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_33, b_Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
-    tl.store(p_Ai_44, b_Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_22, b_Ai_22_c.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_33, b_Ai_33_c.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
+    tl.store(p_Ai_44, b_Ai_44_c.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_21, b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_31, b_Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))
     tl.store(p_Ai_32, b_Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding='rtne'), boundary_check=(0, 1))


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->

On Ascend NPU, tl.dot(lhs, rhs, ...) may overwrite the left‑hand operand in‑place (within UB), which differs from CUDA Triton behavior. Reusing the left‑hand operand tile across successive tl.dot calls within the same kernel can cause silent numerical divergence (mismatch against Torch oracle with no compilation errors).
This PR unifies the fix for this issue across multiple triton_ascend kernels and adds Ascend performance skill documentation.
Root cause
The Ascend backend tl.dot clobbers the left‑hand operand. Typical scenarios:
fwd wy_fast: In the u‑loop, b_u = tl.dot(b_A, ...) corrupts b_A, yet the w‑loop still requires the original A
bwd wy_fast: b_A gets clobbered in the k‑loop and is reused in the v‑loop
inter‑chunk solve / chunk_o / chunk_delta_h: One tile participates in multiple dot operations (e.g., b_q is used for both b_o and b_A)
Changes
Two remediation strategies:
Reload from GM: Reload the original tile before subsequent dot operations (wy_fast fwd/bwd, chunk_bwd dAv)
0.0 Keep pristine copy: Make a copy prior to dot to prevent lhs overwriting (chunk_o, chunk_delta_h, solve_tril, chunk_intra)

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->
FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules     tests/ops/utils     tests/ops/test_gdn_kernels.py     tests/ops/test_gdn.py     tests/ops/test_kda.py     tests/ops/test_attnres.py     tests/ops/test_solve_tril.py

hardware: Atlas 800T A3(X86)
<img width="1285" height="264" alt="568417cb2ffb088f682ce03427b80d4d" src="https://github.com/user-attachments/assets/edf5275b-0e0a-4543-800b-7624c4eacee5" />


## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->

None

## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->

None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
