### PR TITLE
[Fix] Restructure Ascend chunk_gated_delta_rule_bwd_dhu to AICore task loop

### DIFF
--- a/fla/modules/backends/triton_ascend/causal_conv1d.py
+++ b/fla/modules/backends/triton_ascend/causal_conv1d.py
@@ -192,7 +192,7 @@ def causal_conv1d_fwd_kernel(
                 i_n, i_t = tl.load(chunk_indices + i_t_global * 2).to(tl.int32), tl.load(chunk_indices +
                                                                                          i_t_global * 2 + 1).to(tl.int32)
                 bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-                T_local = eos - bos
+                T_local = (eos - bos).to(tl.int32)
                 p_x = x + bos * stride_x_t
             else:
                 i_n = i_n_base
@@ -490,7 +490,7 @@ def causal_conv1d_bwd_dx_kernel(
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = eos - bos
+        T = (eos - bos).to(tl.int32)
         p_dy = dy + bos * stride_dy_t
         p_dx = dx + bos * stride_dx_t
     else:
@@ -652,7 +652,7 @@ def causal_conv1d_bwd_dwdb_kernel(
         i_tg = i_t
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = eos - bos
+        T = (eos - bos).to(tl.int32)
         p_x = x + bos * stride_x_t
         p_dy = dy + bos * stride_dy_t
     else:
@@ -1031,7 +1031,7 @@ def causal_conv1d_fwd_kernel_scalar(
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = eos - bos
+        T = (eos - bos).to(tl.int32)
         p_x = x + bos * stride_x_t
         p_y = y + bos * stride_y_t
     else:

--- a/fla/modules/backends/triton_ascend/rotary.py
+++ b/fla/modules/backends/triton_ascend/rotary.py
@@ -67,7 +67,7 @@ def rotary_embedding_kernel(
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n), tl.load(cu_seqlens + i_n + 1)
-        T = eos - bos
+        T = (eos - bos).to(tl.int32)
         x = x + bos * H*D + i_h * D
         y = y + bos * H*D + i_h * D
     else:

--- a/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
@@ -19,13 +19,10 @@ from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
 from fla.utils import input_guard
 from fla.utils.ascend_ub_manager import (
-    ASCEND_MAX_GRID_DIM,
     compute_row_tile_block_size,
     get_ub_manager,
-    max_grid_axis_chunks,
 )
 
-_NUM_WARPS = 4
 # b_h[64,BV] fp32 + b_w[64,64] + b_v[64,BV] + b_k[64,64] peak during recurrence.
 _FWD_H_MEM_MULT = 8.0
 _SAFETY_MARGIN = 0.80
@@ -53,13 +50,7 @@ def _get_bv(K: int, V: int) -> int:
 
 def _dhu_peak_bytes(BK: int, BV: int, n_slabs: int, BT: int = _DHU_BT) -> int:
     # All K-slabs of dh stay live; q/w are one-slab at a time.
-    return (
-        n_slabs * BK * BV * 4
-        + 2 * BK * BT * 2
-        + BT * BV * 2
-        + BT * BV * 4
-        + 12 * BT
-    )
+    return n_slabs * BK * BV * 4 + 2 * BK * BT * 2 + BT * BV * 2 + BT * BV * 4 + 12 * BT
 
 
 def _dhu_tile_cost(K: int, V: int, BK: int, BV: int) -> int:
@@ -81,9 +72,7 @@ def _select_bwd_dhu_tiles(
     if state_v_first:
         return 64, _get_bv(K, V)
 
-    soft_cap = int(get_ub_manager().ub_capacity_bytes * (
-        _DHU_UB_GATE_INLINE if gate_inline else _DHU_UB_SOFT
-    ))
+    soft_cap = int(get_ub_manager().ub_capacity_bytes * (_DHU_UB_GATE_INLINE if gate_inline else _DHU_UB_SOFT))
     # bwd kernel is blockdim64: K is covered by up to four BK=64 slabs only.
     max_bk = 64
     desired_v = triton.next_power_of_2(V)
@@ -106,21 +95,14 @@ def _select_bwd_dhu_tiles(
     return best[1], best[2]
 
 
-def _launch_fwd_h_kernel(kernel, *, nv_chunks: int, nh_total: int, kernel_kwargs: dict) -> None:
-    max_nv = max_grid_axis_chunks(nv_chunks, nh_total, max_grid=ASCEND_MAX_GRID_DIM)
-    for v_off in range(0, nv_chunks, max_nv):
-        v_len = min(max_nv, nv_chunks - v_off)
-        kernel_kwargs['V_OFFSET'] = v_off
-        max_nh = max_grid_axis_chunks(nh_total, v_len, max_grid=ASCEND_MAX_GRID_DIM)
-        for nh_off in range(0, nh_total, max_nh):
-            nh_len = min(max_nh, nh_total - nh_off)
-            kernel_kwargs['NH_OFFSET'] = nh_off
-            kernel[(v_len, nh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
-
-
 def get_npu_properties():
     device = torch.npu.current_device()
     return driver.active.utils.get_device_properties(device)
+
+
+def _launch_core_grid(kernel, *, task_num: int, kernel_kwargs: dict) -> None:
+    num_core = get_npu_properties()["num_aicore"]
+    kernel[(num_core,)](task_num=task_num, num_core=num_core, **kernel_kwargs)
 
 
 @triton.heuristics(
@@ -135,10 +117,10 @@ def get_npu_properties():
 )
 @fla_cache_autotune(
     configs=[
-        triton.Config({'BV': 32}),
-        triton.Config({'BV': 64}),
+        triton.Config({"BV": 32}),
+        triton.Config({"BV": 64}),
     ],
-    key=['H', 'HV', 'K', 'V', 'BT', 'STATE_V_FIRST'],
+    key=["H", "HV", "K", "V", "BT", "STATE_V_FIRST"],
 )
 @triton.jit(do_not_specialize=["T", "task_num", "num_core"])
 def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu(
@@ -173,16 +155,16 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu(
     core_id = tl.program_id(0)
     T_max = T
     for task_id in tl.range(core_id, task_num, num_core):
-        i_nh = task_id
+        i_nh = task_id.to(tl.int64)
         i_n, i_h = i_nh // HV, i_nh % HV
         if IS_VARLEN:
             bos, eos = (
-                tl.load(cu_seqlens + i_n).to(tl.int32),
-                tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+                tl.load(cu_seqlens + i_n).to(tl.int64),
+                tl.load(cu_seqlens + i_n + 1).to(tl.int64),
             )
-            T = eos - bos
+            T = (eos - bos).to(tl.int32)
             NT = tl.cdiv(T, BT)
-            boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+            boh = tl.load(chunk_offsets + i_n).to(tl.int64)
         else:
             bos, eos = i_n * T, i_n * T + T
             NT = tl.cdiv(T, BT)
@@ -323,8 +305,9 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu(
                     m_t = (i_t * BT + tl.arange(0, BT)) < T
 
                 # load v and compute v_new = v - b_v
-                p_v = tl.make_block_ptr(v + bos * HV * V + i_h * V, (T, V), (stride_v, 1),
-                                        (i_t * BT, v_start), (BT, BV), (1, 0))
+                p_v = tl.make_block_ptr(
+                    v + bos * HV * V + i_h * V, (T, V), (stride_v, 1), (i_t * BT, v_start), (BT, BV), (1, 0)
+                )
                 b_v = tl.load(p_v, boundary_check=(0, 1)).to(tl.float32) - b_v
 
                 if SAVE_NEW_VALUE:
@@ -346,28 +329,28 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu(
                     # gk layout [B, T, HV, K]: load last token's per-key gate (K-segmented)
                     gk_base = gk + (bos + last_idx) * HV * K + i_h * K
                     o_k1 = tl.arange(0, 64)
-                    b_gk_last1 = tl.load(gk_base + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
+                    b_gk_last1 = tl.load(gk_base + o_k1, mask=(o_k1 < K), other=0.0).to(tl.float32)
                     if STATE_V_FIRST:
                         b_h1 *= exp2(b_gk_last1)[None, :]
                     else:
                         b_h1 *= exp2(b_gk_last1)[:, None]
                     if K > 64:
                         o_k2 = 64 + o_k1
-                        b_gk_last2 = tl.load(gk_base + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
+                        b_gk_last2 = tl.load(gk_base + o_k2, mask=(o_k2 < K), other=0.0).to(tl.float32)
                         if STATE_V_FIRST:
                             b_h2 *= exp2(b_gk_last2)[None, :]
                         else:
                             b_h2 *= exp2(b_gk_last2)[:, None]
                     if K > 128:
                         o_k3 = 128 + o_k1
-                        b_gk_last3 = tl.load(gk_base + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
+                        b_gk_last3 = tl.load(gk_base + o_k3, mask=(o_k3 < K), other=0.0).to(tl.float32)
                         if STATE_V_FIRST:
                             b_h3 *= exp2(b_gk_last3)[None, :]
                         else:
                             b_h3 *= exp2(b_gk_last3)[:, None]
                     if K > 192:
                         o_k4 = 192 + o_k1
-                        b_gk_last4 = tl.load(gk_base + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
+                        b_gk_last4 = tl.load(gk_base + o_k4, mask=(o_k4 < K), other=0.0).to(tl.float32)
                         if STATE_V_FIRST:
                             b_h4 *= exp2(b_gk_last4)[None, :]
                         else:
@@ -472,34 +455,34 @@ def chunk_gated_delta_rule_fwd_h_npu(
     if g is not None:
         g = g.transpose(1, 2).contiguous()
 
-    num_core = get_npu_properties()["num_aicore"]
-    task_num = N * HV
-    chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu[(num_core,)](
-        k=k,
-        v=u,
-        w=w,
-        v_new=v_new,
-        g=g,
-        gk=gk,
-        h=h,
-        h0=initial_state,
-        ht=final_state,
-        cu_seqlens=cu_seqlens,
-        chunk_offsets=chunk_offsets,
-        T=T,
-        task_num=task_num,
-        num_core=num_core,
-        H=H,
-        HV=HV,
-        K=K,
-        V=V,
-        BT=BT,
-        STATE_V_FIRST=state_v_first,
+    _launch_core_grid(
+        chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu,
+        task_num=N * HV,
+        kernel_kwargs={
+            "k": k,
+            "v": u,
+            "w": w,
+            "v_new": v_new,
+            "g": g,
+            "gk": gk,
+            "h": h,
+            "h0": initial_state,
+            "ht": final_state,
+            "cu_seqlens": cu_seqlens,
+            "chunk_offsets": chunk_offsets,
+            "T": T,
+            "H": H,
+            "HV": HV,
+            "K": K,
+            "V": V,
+            "BT": BT,
+            "STATE_V_FIRST": state_v_first,
+        },
     )
     return h, v_new, final_state
 
 
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T", "task_num", "num_core"])
 def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
     q,
     k,
@@ -514,10 +497,13 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
     do,
     dh,
     dv,
+    dv2,
     cu_seqlens,
     chunk_offsets,
     scale,
     T,
+    task_num,
+    num_core,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
@@ -532,319 +518,334 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
     USE_FINAL_STATE_GRADIENT: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    V_OFFSET: tl.constexpr,
-    NH_OFFSET: tl.constexpr,
 ):
-    i_v = tl.program_id(0) + V_OFFSET
-    i_nh = tl.program_id(1) + NH_OFFSET
-    i_n, i_h = i_nh // HV, i_nh % HV
-    # Keep tensor-width T for g strides; T_cur is the active sequence length.
-    T_cur = T
-    if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T_cur = eos - bos
-        NT = tl.cdiv(T_cur, BT)
-        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
-    else:
-        bos, eos = i_n * T, i_n * T + T
-        NT = tl.cdiv(T_cur, BT)
-        boh = i_n * NT
-
-    if STATE_V_FIRST:
-        b_dh1 = tl.zeros([BV, BK], dtype=tl.float32)
-        if K > BK:
-            b_dh2 = tl.zeros([BV, BK], dtype=tl.float32)
-        if K > 2 * BK:
-            b_dh3 = tl.zeros([BV, BK], dtype=tl.float32)
-        if K > 3 * BK:
-            b_dh4 = tl.zeros([BV, BK], dtype=tl.float32)
-    else:
-        b_dh1 = tl.zeros([BK, BV], dtype=tl.float32)
-        if K > BK:
-            b_dh2 = tl.zeros([BK, BV], dtype=tl.float32)
-        if K > 2 * BK:
-            b_dh3 = tl.zeros([BK, BV], dtype=tl.float32)
-        if K > 3 * BK:
-            b_dh4 = tl.zeros([BK, BV], dtype=tl.float32)
-
-    q += (bos * H + i_h // (HV // H)).to(tl.int64) * K
-    k += (bos * H + i_h // (HV // H)).to(tl.int64) * K
-    w += (bos * HV + i_h).to(tl.int64) * K
-    do += (bos * HV + i_h).to(tl.int64) * V
-    dv += (bos * HV + i_h).to(tl.int64) * V
-    dh += (boh * HV + i_h).to(tl.int64) * K * V
-    if USE_GK:
-        gk += (bos * HV + i_h).to(tl.int64) * K
-    # Host g layout is [B, HV, T] (or [1, HV, T] for varlen).
-    if USE_G:
-        if USE_G_PRECOMP:
-            g_exp += (i_n * HV + i_h).to(tl.int64) * T
-            g_ratio += (i_n * HV + i_h).to(tl.int64) * T
-            g_last_exp += (i_n * HV + i_h).to(tl.int64) * NT
-        elif IS_VARLEN:
-            g += (bos + i_h * T).to(tl.int64)
-        else:
-            g += (i_n * HV + i_h).to(tl.int64) * T
-
-    if USE_INITIAL_STATE:
-        dh0 += i_nh * K * V
-    if USE_FINAL_STATE_GRADIENT:
-        dht += i_nh * K * V
-
-    if USE_FINAL_STATE_GRADIENT:
-        if STATE_V_FIRST:
-            p_dht1 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
-        else:
-            p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
-        b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
-        if K > BK:
-            if STATE_V_FIRST:
-                p_dht2 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
-            else:
-                p_dht2 = tl.make_block_ptr(dht, (K, V), (V, 1), (BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
-        if K > 2 * BK:
-            if STATE_V_FIRST:
-                p_dht3 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
-            else:
-                p_dht3 = tl.make_block_ptr(dht, (K, V), (V, 1), (2 * BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
-        if K > 3 * BK:
-            if STATE_V_FIRST:
-                p_dht4 = tl.make_block_ptr(dht, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
-            else:
-                p_dht4 = tl.make_block_ptr(dht, (K, V), (V, 1), (3 * BK, i_v * BV), (BK, BV), (1, 0))
-            b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
-
-    if USE_GK:
-        o_k1 = tl.arange(0, BK)
-
-    DH_CS: tl.constexpr = HV * K * V
-    dh_chunk = dh + (NT - 1).to(tl.int64) * DH_CS
-
-    for i_t in range(NT - 1, -1, -1):
-        if STATE_V_FIRST:
-            p_dh1 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
-        else:
-            p_dh1 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
-        if K > BK:
-            if STATE_V_FIRST:
-                p_dh2 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
-            else:
-                p_dh2 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 2 * BK:
-            if STATE_V_FIRST:
-                p_dh3 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
-            else:
-                p_dh3 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (2 * BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
-        if K > 3 * BK:
-            if STATE_V_FIRST:
-                p_dh4 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
-            else:
-                p_dh4 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (3 * BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
-
-        if USE_G:
-            if USE_G_PRECOMP:
-                bg_last_exp = tl.load(g_last_exp + i_t).to(tl.float32)
-                p_g_exp = tl.make_block_ptr(g_exp, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
-                p_g_ratio = tl.make_block_ptr(g_ratio, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
-                b_g_exp = tl.load(p_g_exp, boundary_check=(0,)).to(tl.float32)
-                b_g_ratio = tl.load(p_g_ratio, boundary_check=(0,)).to(tl.float32)
-            else:
-                last_idx = min((i_t + 1) * BT, T_cur) - 1
-                bg_last = tl.load(g + last_idx).to(tl.float32)
-                p_g = tl.make_block_ptr(g, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
-                b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
-                bg_last_exp = exp2(bg_last)
-                b_g_exp = exp2(b_g)
-                b_g_ratio = exp2(bg_last - b_g)
-        # In-place dv correction (callers rebind the returned buffer).
-        p_dv = tl.make_block_ptr(dv, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_do = tl.make_block_ptr(do, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
-
-        p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        if USE_GK:
-            last_idx = min((i_t + 1) * BT, T_cur) - 1
-            b_gk_last1 = tl.load(gk + last_idx * HV * K + o_k1, mask=(o_k1 < K), other=0.).to(tl.float32)
-        if STATE_V_FIRST:
-            b_dv = tl.dot(b_dh1.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
-            b_dv = tl.trans(b_dv)
-        else:
-            b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype), allow_tf32=False)
-
-        if K > BK:
-            p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, BK), (BT, BK), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            if USE_GK:
-                o_k2 = BK + o_k1
-                b_gk_last2 = tl.load(gk + last_idx * HV * K + o_k2, mask=(o_k2 < K), other=0.).to(tl.float32)
-            if STATE_V_FIRST:
-                b_dv_part = tl.dot(b_dh2.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
-                b_dv += tl.trans(b_dv_part)
-            else:
-                b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype), allow_tf32=False)
-
-        if K > 2 * BK:
-            p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, 2 * BK), (BT, BK), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            if USE_GK:
-                o_k3 = 2 * BK + o_k1
-                b_gk_last3 = tl.load(gk + last_idx * HV * K + o_k3, mask=(o_k3 < K), other=0.).to(tl.float32)
-            if STATE_V_FIRST:
-                b_dv_part = tl.dot(b_dh3.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
-                b_dv += tl.trans(b_dv_part)
-            else:
-                b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype), allow_tf32=False)
-
-        if K > 3 * BK:
-            p_k = tl.make_block_ptr(k, (T_cur, K), (H * K, 1), (i_t * BT, 3 * BK), (BT, BK), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            if USE_GK:
-                o_k4 = 3 * BK + o_k1
-                b_gk_last4 = tl.load(gk + last_idx * HV * K + o_k4, mask=(o_k4 < K), other=0.).to(tl.float32)
-            if STATE_V_FIRST:
-                b_dv_part = tl.dot(b_dh4.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
-                b_dv += tl.trans(b_dv_part)
-            else:
-                b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype), allow_tf32=False)
-
-        if USE_G:
-            if USE_G_PRECOMP:
-                b_dv *= b_g_ratio[:, None]
-            else:
-                m_t = (i_t * BT + tl.arange(0, BT)) < T_cur
-                b_dv *= tl.where(m_t, b_g_ratio, 0)[:, None]
-        b_dv += tl.load(p_dv, boundary_check=(0, 1))
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
-        b_dv_pristine = b_dv + 0.0
-
-        # Decay dh once; fold gate*scale into do so K-slabs skip per-slab gating.
-        if USE_G:
-            b_dh1 *= bg_last_exp
-            if K > BK:
-                b_dh2 *= bg_last_exp
-            if K > 2 * BK:
-                b_dh3 *= bg_last_exp
-            if K > 3 * BK:
-                b_dh4 *= bg_last_exp
-            b_do = b_do * (b_g_exp * scale)[:, None]
-        else:
-            b_do = b_do * scale
-        b_do_c = b_do + 0.0
-        b_do_c2 = b_do + 0.0
-        b_do_c3 = b_do + 0.0
-
-        p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (0, i_t * BT), (BK, BT), (0, 1))
-        p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (0, i_t * BT), (BK, BT), (0, 1))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        if USE_GK:
-            if STATE_V_FIRST:
-                b_dh1 *= exp2(b_gk_last1)[None, :]
-            else:
-                b_dh1 *= exp2(b_gk_last1[:, None])
-        if STATE_V_FIRST:
-            b_dh1 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-            b_dv_i = b_dv_pristine + 0.0
-            b_dh1 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
-        else:
-            b_dh1 += (
-                tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False)
-                - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
+    core_id = tl.program_id(0)
+    T_max = T
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_nh = task_id.to(tl.int64)
+        i_n, i_h = i_nh // HV, i_nh % HV
+        if IS_VARLEN:
+            bos, eos = (
+                tl.load(cu_seqlens + i_n).to(tl.int64),
+                tl.load(cu_seqlens + i_n + 1).to(tl.int64),
             )
-
-        if K > BK:
-            p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (BK, i_t * BT), (BK, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (BK, i_t * BT), (BK, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            if USE_GK:
-                if STATE_V_FIRST:
-                    b_dh2 *= exp2(b_gk_last2)[None, :]
-                else:
-                    b_dh2 *= exp2(b_gk_last2[:, None])
-            if STATE_V_FIRST:
-                b_dh2 += tl.dot(tl.trans(b_do_c.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dv_i = b_dv_pristine + 0.0
-                b_dh2 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
-            else:
-                b_dh2 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do_c.to(b_q.dtype), allow_tf32=False)
-                    - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
-                )
-
-        if K > 2 * BK:
-            p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (2 * BK, i_t * BT), (BK, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (2 * BK, i_t * BT), (BK, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            if USE_GK:
-                if STATE_V_FIRST:
-                    b_dh3 *= exp2(b_gk_last3)[None, :]
-                else:
-                    b_dh3 *= exp2(b_gk_last3[:, None])
-            if STATE_V_FIRST:
-                b_dh3 += tl.dot(tl.trans(b_do_c2.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dv_i = b_dv_pristine + 0.0
-                b_dh3 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
-            else:
-                b_dh3 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do_c2.to(b_q.dtype), allow_tf32=False)
-                    - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
-                )
-
-        if K > 3 * BK:
-            p_q = tl.make_block_ptr(q, (K, T_cur), (1, H * K), (3 * BK, i_t * BT), (BK, BT), (0, 1))
-            p_w = tl.make_block_ptr(w, (K, T_cur), (1, HV * K), (3 * BK, i_t * BT), (BK, BT), (0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            if USE_GK:
-                if STATE_V_FIRST:
-                    b_dh4 *= exp2(b_gk_last4)[None, :]
-                else:
-                    b_dh4 *= exp2(b_gk_last4[:, None])
-            if STATE_V_FIRST:
-                b_dh4 += tl.dot(tl.trans(b_do_c3.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
-                b_dv_i = b_dv_pristine + 0.0
-                b_dh4 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
-            else:
-                b_dh4 += (
-                    tl.dot(b_q.to(b_q.dtype), b_do_c3.to(b_q.dtype), allow_tf32=False)
-                    - tl.dot(b_w, b_dv.to(b_w.dtype), allow_tf32=False)
-                )
-
-        dh_chunk -= DH_CS
-
-    if USE_INITIAL_STATE:
-        if STATE_V_FIRST:
-            p_dh0 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
+            T = (eos - bos).to(tl.int32)
+            NT = tl.cdiv(T, BT)
+            boh = tl.load(chunk_offsets + i_n).to(tl.int64)
         else:
-            p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (BK, BV), (1, 0))
-        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
-        if K > BK:
-            if STATE_V_FIRST:
-                p_dh1 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, BK), (BV, BK), (1, 0))
+            bos, eos = i_n * T_max, i_n * T_max + T_max
+            NT = tl.cdiv(T, BT)
+            boh = i_n * NT
+
+        stride_v = HV * V
+        stride_k = H * K
+        stride_w = HV * K
+
+        q_base = q + (bos * H + i_h // (HV // H)).to(tl.int64) * K
+        k_base = k + (bos * H + i_h // (HV // H)).to(tl.int64) * K
+        w_base = w + (bos * HV + i_h).to(tl.int64) * K
+        do_base = do + (bos * HV + i_h).to(tl.int64) * V
+        dv_base = dv + (bos * HV + i_h).to(tl.int64) * V
+        dv2_base = dv2 + (bos * HV + i_h).to(tl.int64) * V
+        dh_base = dh + (boh * HV + i_h).to(tl.int64) * K * V
+        if USE_GK:
+            gk_base = gk + (bos * HV + i_h).to(tl.int64) * K
+        if USE_G:
+            if USE_G_PRECOMP:
+                g_exp_base = g_exp + (i_n * HV + i_h).to(tl.int64) * T_max
+                g_ratio_base = g_ratio + (i_n * HV + i_h).to(tl.int64) * T_max
+                g_last_exp_base = g_last_exp + (i_n * HV + i_h).to(tl.int64) * NT
+                g_base = g
+            elif IS_VARLEN:
+                g_base = g + (bos + i_h * T_max).to(tl.int64)
+                g_exp_base = g_exp
+                g_ratio_base = g_ratio
+                g_last_exp_base = g_last_exp
             else:
-                p_dh1 = tl.make_block_ptr(dh0, (K, V), (V, 1), (BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
-        if K > 2 * BK:
+                g_base = g + (i_n * HV + i_h).to(tl.int64) * T_max
+                g_exp_base = g_exp
+                g_ratio_base = g_ratio
+                g_last_exp_base = g_last_exp
+        else:
+            g_base = g
+            g_exp_base = g_exp
+            g_ratio_base = g_ratio
+            g_last_exp_base = g_last_exp
+
+        NV = tl.cdiv(V, BV)
+        for i_v in range(NV):
+            v_start = i_v * BV
+
             if STATE_V_FIRST:
-                p_dh2 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 2 * BK), (BV, BK), (1, 0))
+                b_dh1 = tl.zeros([BV, 64], dtype=tl.float32)
+                if K > 64:
+                    b_dh2 = tl.zeros([BV, 64], dtype=tl.float32)
+                if K > 128:
+                    b_dh3 = tl.zeros([BV, 64], dtype=tl.float32)
+                if K > 192:
+                    b_dh4 = tl.zeros([BV, 64], dtype=tl.float32)
             else:
-                p_dh2 = tl.make_block_ptr(dh0, (K, V), (V, 1), (2 * BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 3 * BK:
-            if STATE_V_FIRST:
-                p_dh3 = tl.make_block_ptr(dh0, (V, K), (K, 1), (i_v * BV, 3 * BK), (BV, BK), (1, 0))
-            else:
-                p_dh3 = tl.make_block_ptr(dh0, (K, V), (V, 1), (3 * BK, i_v * BV), (BK, BV), (1, 0))
-            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+                b_dh1 = tl.zeros([64, BV], dtype=tl.float32)
+                if K > 64:
+                    b_dh2 = tl.zeros([64, BV], dtype=tl.float32)
+                if K > 128:
+                    b_dh3 = tl.zeros([64, BV], dtype=tl.float32)
+                if K > 192:
+                    b_dh4 = tl.zeros([64, BV], dtype=tl.float32)
+
+            if USE_FINAL_STATE_GRADIENT:
+                dht_base = dht + i_nh * K * V
+                if STATE_V_FIRST:
+                    p_dht1 = tl.make_block_ptr(dht_base, (V, K), (K, 1), (v_start, 0), (BV, 64), (1, 0))
+                else:
+                    p_dht1 = tl.make_block_ptr(dht_base, (K, V), (V, 1), (0, v_start), (64, BV), (1, 0))
+                b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
+                if K > 64:
+                    if STATE_V_FIRST:
+                        p_dht2 = tl.make_block_ptr(dht_base, (V, K), (K, 1), (v_start, 64), (BV, 64), (1, 0))
+                    else:
+                        p_dht2 = tl.make_block_ptr(dht_base, (K, V), (V, 1), (64, v_start), (64, BV), (1, 0))
+                    b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
+                if K > 128:
+                    if STATE_V_FIRST:
+                        p_dht3 = tl.make_block_ptr(dht_base, (V, K), (K, 1), (v_start, 128), (BV, 64), (1, 0))
+                    else:
+                        p_dht3 = tl.make_block_ptr(dht_base, (K, V), (V, 1), (128, v_start), (64, BV), (1, 0))
+                    b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
+                if K > 192:
+                    if STATE_V_FIRST:
+                        p_dht4 = tl.make_block_ptr(dht_base, (V, K), (K, 1), (v_start, 192), (BV, 64), (1, 0))
+                    else:
+                        p_dht4 = tl.make_block_ptr(dht_base, (K, V), (V, 1), (192, v_start), (64, BV), (1, 0))
+                    b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
+
+            if USE_GK:
+                o_k1 = tl.arange(0, 64)
+
+            DH_CS: tl.constexpr = HV * K * V
+            dh_chunk = dh_base + (NT - 1).to(tl.int64) * DH_CS
+
+            for i_t in range(NT - 1, -1, -1):
+                if STATE_V_FIRST:
+                    p_dh1 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (v_start, 0), (BV, 64), (1, 0))
+                else:
+                    p_dh1 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (0, v_start), (64, BV), (1, 0))
+                tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+                if K > 64:
+                    if STATE_V_FIRST:
+                        p_dh2 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (v_start, 64), (BV, 64), (1, 0))
+                    else:
+                        p_dh2 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (64, v_start), (64, BV), (1, 0))
+                    tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+                if K > 128:
+                    if STATE_V_FIRST:
+                        p_dh3 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (v_start, 128), (BV, 64), (1, 0))
+                    else:
+                        p_dh3 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (128, v_start), (64, BV), (1, 0))
+                    tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+                if K > 192:
+                    if STATE_V_FIRST:
+                        p_dh4 = tl.make_block_ptr(dh_chunk, (V, K), (K, 1), (v_start, 192), (BV, 64), (1, 0))
+                    else:
+                        p_dh4 = tl.make_block_ptr(dh_chunk, (K, V), (V, 1), (192, v_start), (64, BV), (1, 0))
+                    tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+
+                if USE_G:
+                    if USE_G_PRECOMP:
+                        bg_last_exp = tl.load(g_last_exp_base + i_t).to(tl.float32)
+                        p_g_exp = tl.make_block_ptr(g_exp_base, (T,), (1,), (i_t * BT,), (BT,), (0,))
+                        p_g_ratio = tl.make_block_ptr(g_ratio_base, (T,), (1,), (i_t * BT,), (BT,), (0,))
+                        b_g_exp = tl.load(p_g_exp, boundary_check=(0,)).to(tl.float32)
+                        b_g_ratio = tl.load(p_g_ratio, boundary_check=(0,)).to(tl.float32)
+                    else:
+                        last_idx = min((i_t + 1) * BT, T) - 1
+                        bg_last = tl.load(g_base + last_idx).to(tl.float32)
+                        p_g = tl.make_block_ptr(g_base, (T,), (1,), (i_t * BT,), (BT,), (0,))
+                        b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+                        bg_last_exp = exp2(bg_last)
+                        b_g_exp = exp2(b_g)
+                        b_g_ratio = exp2(bg_last - b_g)
+                p_dv = tl.make_block_ptr(dv_base, (T, V), (stride_v, 1), (i_t * BT, v_start), (BT, BV), (1, 0))
+                p_dv2 = tl.make_block_ptr(dv2_base, (T, V), (stride_v, 1), (i_t * BT, v_start), (BT, BV), (1, 0))
+                p_do = tl.make_block_ptr(do_base, (T, V), (stride_v, 1), (i_t * BT, v_start), (BT, BV), (1, 0))
+                b_do = tl.load(p_do, boundary_check=(0, 1))
+
+                p_k = tl.make_block_ptr(k_base, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+                b_k = tl.load(p_k, boundary_check=(0, 1))
+                if USE_GK:
+                    last_idx = min((i_t + 1) * BT, T) - 1
+                    b_gk_last1 = tl.load(gk_base + last_idx * stride_w + o_k1, mask=(o_k1 < K), other=0.0).to(tl.float32)
+                if STATE_V_FIRST:
+                    b_dv = tl.dot(b_dh1.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
+                    b_dv = tl.trans(b_dv)
+                else:
+                    b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype), allow_tf32=False)
+
+                if K > 64:
+                    p_k = tl.make_block_ptr(k_base, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0))
+                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    if USE_GK:
+                        o_k2 = 64 + o_k1
+                        b_gk_last2 = tl.load(gk_base + last_idx * stride_w + o_k2, mask=(o_k2 < K), other=0.0).to(tl.float32)
+                    if STATE_V_FIRST:
+                        b_dv_part = tl.dot(b_dh2.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
+                        b_dv += tl.trans(b_dv_part)
+                    else:
+                        b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype), allow_tf32=False)
+
+                if K > 128:
+                    p_k = tl.make_block_ptr(k_base, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0))
+                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    if USE_GK:
+                        o_k3 = 128 + o_k1
+                        b_gk_last3 = tl.load(gk_base + last_idx * stride_w + o_k3, mask=(o_k3 < K), other=0.0).to(tl.float32)
+                    if STATE_V_FIRST:
+                        b_dv_part = tl.dot(b_dh3.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
+                        b_dv += tl.trans(b_dv_part)
+                    else:
+                        b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype), allow_tf32=False)
+
+                if K > 192:
+                    p_k = tl.make_block_ptr(k_base, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0))
+                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    if USE_GK:
+                        o_k4 = 192 + o_k1
+                        b_gk_last4 = tl.load(gk_base + last_idx * stride_w + o_k4, mask=(o_k4 < K), other=0.0).to(tl.float32)
+                    if STATE_V_FIRST:
+                        b_dv_part = tl.dot(b_dh4.to(b_k.dtype), tl.trans(b_k), allow_tf32=False)
+                        b_dv += tl.trans(b_dv_part)
+                    else:
+                        b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype), allow_tf32=False)
+
+                if USE_G:
+                    if USE_G_PRECOMP:
+                        b_dv *= b_g_ratio[:, None]
+                    else:
+                        m_t = (i_t * BT + tl.arange(0, BT)) < T
+                        b_dv *= tl.where(m_t, b_g_ratio, 0)[:, None]
+                b_dv += tl.load(p_dv, boundary_check=(0, 1))
+                tl.store(p_dv2, b_dv.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
+                # Ascend tl.dot clobbers lhs; b_dv is lhs in the subtract dot across K-slabs.
+                b_dv_pristine = b_dv + 0.0
+
+                if USE_G:
+                    b_dh1 *= bg_last_exp
+                    if K > 64:
+                        b_dh2 *= bg_last_exp
+                    if K > 128:
+                        b_dh3 *= bg_last_exp
+                    if K > 192:
+                        b_dh4 *= bg_last_exp
+                    b_do = b_do * (b_g_exp * scale)[:, None]
+                else:
+                    b_do = b_do * scale
+                # Ascend tl.dot clobbers lhs; b_do is lhs across K-slabs (STATE_V_FIRST path).
+                b_do_c = b_do + 0.0
+                b_do_c2 = b_do + 0.0
+                b_do_c3 = b_do + 0.0
+
+                p_w = tl.make_block_ptr(w_base, (K, T), (1, stride_w), (0, i_t * BT), (64, BT), (0, 1))
+                p_q = tl.make_block_ptr(q_base, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
+                b_w = tl.load(p_w, boundary_check=(0, 1))
+                b_q = tl.load(p_q, boundary_check=(0, 1))
+                if USE_GK:
+                    if STATE_V_FIRST:
+                        b_dh1 *= exp2(b_gk_last1)[None, :]
+                    else:
+                        b_dh1 *= exp2(b_gk_last1[:, None])
+                if STATE_V_FIRST:
+                    b_dh1 += tl.dot(tl.trans(b_do.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
+                    b_dv_i = b_dv_pristine + 0.0
+                    b_dh1 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                else:
+                    b_dh1 += tl.dot(b_q.to(b_q.dtype), b_do.to(b_q.dtype), allow_tf32=False) - tl.dot(
+                        b_w, b_dv.to(b_w.dtype), allow_tf32=False
+                    )
+
+                if K > 64:
+                    p_q = tl.make_block_ptr(q_base, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
+                    p_w = tl.make_block_ptr(w_base, (K, T), (1, stride_w), (64, i_t * BT), (64, BT), (0, 1))
+                    b_q = tl.load(p_q, boundary_check=(0, 1))
+                    b_w = tl.load(p_w, boundary_check=(0, 1))
+                    if USE_GK:
+                        if STATE_V_FIRST:
+                            b_dh2 *= exp2(b_gk_last2)[None, :]
+                        else:
+                            b_dh2 *= exp2(b_gk_last2[:, None])
+                    if STATE_V_FIRST:
+                        b_dh2 += tl.dot(tl.trans(b_do_c.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
+                        b_dv_i = b_dv_pristine + 0.0
+                        b_dh2 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                    else:
+                        b_dh2 += tl.dot(b_q.to(b_q.dtype), b_do_c.to(b_q.dtype), allow_tf32=False) - tl.dot(
+                            b_w, b_dv.to(b_w.dtype), allow_tf32=False
+                        )
+
+                if K > 128:
+                    p_q = tl.make_block_ptr(q_base, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
+                    p_w = tl.make_block_ptr(w_base, (K, T), (1, stride_w), (128, i_t * BT), (64, BT), (0, 1))
+                    b_q = tl.load(p_q, boundary_check=(0, 1))
+                    b_w = tl.load(p_w, boundary_check=(0, 1))
+                    if USE_GK:
+                        if STATE_V_FIRST:
+                            b_dh3 *= exp2(b_gk_last3)[None, :]
+                        else:
+                            b_dh3 *= exp2(b_gk_last3[:, None])
+                    if STATE_V_FIRST:
+                        b_dh3 += tl.dot(tl.trans(b_do_c2.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
+                        b_dv_i = b_dv_pristine + 0.0
+                        b_dh3 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                    else:
+                        b_dh3 += tl.dot(b_q.to(b_q.dtype), b_do_c2.to(b_q.dtype), allow_tf32=False) - tl.dot(
+                            b_w, b_dv.to(b_w.dtype), allow_tf32=False
+                        )
+
+                if K > 192:
+                    p_q = tl.make_block_ptr(q_base, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
+                    p_w = tl.make_block_ptr(w_base, (K, T), (1, stride_w), (192, i_t * BT), (64, BT), (0, 1))
+                    b_q = tl.load(p_q, boundary_check=(0, 1))
+                    b_w = tl.load(p_w, boundary_check=(0, 1))
+                    if USE_GK:
+                        if STATE_V_FIRST:
+                            b_dh4 *= exp2(b_gk_last4)[None, :]
+                        else:
+                            b_dh4 *= exp2(b_gk_last4[:, None])
+                    if STATE_V_FIRST:
+                        b_dh4 += tl.dot(tl.trans(b_do_c3.to(b_q.dtype)), tl.trans(b_q), allow_tf32=False)
+                        b_dv_i = b_dv_pristine + 0.0
+                        b_dh4 -= tl.dot(tl.trans(b_dv_i.to(b_w.dtype)), tl.trans(b_w), allow_tf32=False)
+                    else:
+                        b_dh4 += tl.dot(b_q.to(b_q.dtype), b_do_c3.to(b_q.dtype), allow_tf32=False) - tl.dot(
+                            b_w, b_dv.to(b_w.dtype), allow_tf32=False
+                        )
+
+                dh_chunk -= DH_CS
+
+            if USE_INITIAL_STATE:
+                dh0_base = dh0 + i_nh * K * V
+                if STATE_V_FIRST:
+                    p_dh0 = tl.make_block_ptr(dh0_base, (V, K), (K, 1), (v_start, 0), (BV, 64), (1, 0))
+                else:
+                    p_dh0 = tl.make_block_ptr(dh0_base, (K, V), (V, 1), (0, v_start), (64, BV), (1, 0))
+                tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+                if K > 64:
+                    if STATE_V_FIRST:
+                        p_dh1 = tl.make_block_ptr(dh0_base, (V, K), (K, 1), (v_start, 64), (BV, 64), (1, 0))
+                    else:
+                        p_dh1 = tl.make_block_ptr(dh0_base, (K, V), (V, 1), (64, v_start), (64, BV), (1, 0))
+                    tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+                if K > 128:
+                    if STATE_V_FIRST:
+                        p_dh2 = tl.make_block_ptr(dh0_base, (V, K), (K, 1), (v_start, 128), (BV, 64), (1, 0))
+                    else:
+                        p_dh2 = tl.make_block_ptr(dh0_base, (K, V), (V, 1), (128, v_start), (64, BV), (1, 0))
+                    tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+                if K > 192:
+                    if STATE_V_FIRST:
+                        p_dh3 = tl.make_block_ptr(dh0_base, (V, K), (K, 1), (v_start, 192), (BV, 64), (1, 0))
+                    else:
+                        p_dh3 = tl.make_block_ptr(dh0_base, (K, V), (V, 1), (192, v_start), (64, BV), (1, 0))
+                    tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
 
 
 def _prepare_dhu_gate_tensors(
@@ -892,7 +893,7 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V, HV = *q.shape, do.shape[-1], do.shape[2]
     BT = chunk_size
-    assert K <= 256, 'current kernel does not support head dimension being larger than 256.'
+    assert K <= 256, "current kernel does not support head dimension being larger than 256."
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
@@ -906,50 +907,55 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
     else:
         dh = q.new_empty(B, NT, HV, K, V)
     dh0 = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
+    # Separate output, matching the CUDA kernel: callers must not observe a
+    # mutated `dv`. Distinct from the #1113 in-register `+ 0.0` lhs copies.
+    dv2 = torch.empty_like(dv)
     g_log, g_exp, g_ratio, g_last_exp, use_g_precomp = _prepare_dhu_gate_tensors(
-        g, B=B, T=T, HV=HV, BT=BT, cu_seqlens=cu_seqlens,
+        g,
+        B=B,
+        T=T,
+        HV=HV,
+        BT=BT,
+        cu_seqlens=cu_seqlens,
     )
     gate_inline = g is not None and not use_g_precomp
     BK, BV = _select_bwd_dhu_tiles(K, V, state_v_first, gate_inline=gate_inline)
-    nv_chunks = triton.cdiv(V, BV)
-    _launch_fwd_h_kernel(
+    _launch_core_grid(
         chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu,
-        nv_chunks=nv_chunks,
-        nh_total=N * HV,
+        task_num=N * HV,
         kernel_kwargs={
-            'q': q,
-            'k': k,
-            'w': w,
-            'g': g_log,
-            'g_exp': g_exp,
-            'g_ratio': g_ratio,
-            'g_last_exp': g_last_exp,
-            'gk': gk,
-            'dht': dht,
-            'dh0': dh0,
-            'do': do,
-            'dh': dh,
-            'dv': dv,
-            'cu_seqlens': cu_seqlens,
-            'chunk_offsets': chunk_offsets,
-            'scale': scale,
-            'T': T,
-            'H': H,
-            'HV': HV,
-            'K': K,
-            'V': V,
-            'BT': BT,
-            'BK': BK,
-            'BV': BV,
-            'USE_G': g is not None,
-            'USE_G_PRECOMP': use_g_precomp,
-            'USE_GK': gk is not None,
-            'USE_INITIAL_STATE': h0 is not None,
-            'USE_FINAL_STATE_GRADIENT': dht is not None,
-            'STATE_V_FIRST': state_v_first,
-            'IS_VARLEN': cu_seqlens is not None,
-            'V_OFFSET': 0,
-            'NH_OFFSET': 0,
+            "q": q,
+            "k": k,
+            "w": w,
+            "g": g_log,
+            "g_exp": g_exp,
+            "g_ratio": g_ratio,
+            "g_last_exp": g_last_exp,
+            "gk": gk,
+            "dht": dht,
+            "dh0": dh0,
+            "do": do,
+            "dh": dh,
+            "dv": dv,
+            "dv2": dv2,
+            "cu_seqlens": cu_seqlens,
+            "chunk_offsets": chunk_offsets,
+            "scale": scale,
+            "T": T,
+            "H": H,
+            "HV": HV,
+            "K": K,
+            "V": V,
+            "BT": BT,
+            "BK": BK,
+            "BV": BV,
+            "USE_G": g is not None,
+            "USE_G_PRECOMP": use_g_precomp,
+            "USE_GK": gk is not None,
+            "USE_INITIAL_STATE": h0 is not None,
+            "USE_FINAL_STATE_GRADIENT": dht is not None,
+            "STATE_V_FIRST": state_v_first,
+            "IS_VARLEN": cu_seqlens is not None,
         },
     )
-    return dh, dh0, dv
+    return dh, dh0, dv2

--- a/fla/ops/common/backends/triton_ascend/chunk_o.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_o.py
@@ -162,8 +162,8 @@ def chunk_fwd_kernel_o_npu(
             for n in tl.range(0, N, 1):
                 i_n = tl.where(tl.load(chunk_offsets + n + 1) <= global_t, n + 1, i_n)
             i_t = global_t - tl.load(chunk_offsets + i_n).to(tl.int32)
-            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-            T_cur = eos - bos
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T_cur = (eos - bos).to(tl.int32)
             i_tg = global_t
         else:
             NT = tl.cdiv(T, BT)
@@ -383,8 +383,8 @@ def chunk_bwd_kernel_dv_local_hv1_npu(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -460,8 +460,8 @@ def chunk_bwd_kernel_dv_local_npu(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -632,8 +632,8 @@ def chunk_bwd_kernel_dqkwg_npu(
     if IS_VARLEN:
         i_tg = i_t
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
         NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)
@@ -840,8 +840,8 @@ def chunk_bwd_kernel_dg_npu(
     if IS_VARLEN:
         i_tg = i_t
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
         NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -87,8 +87,8 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 

--- a/fla/ops/gated_delta_rule/backends/triton_ascend/gate.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/gate.py
@@ -148,8 +148,8 @@ def gdn_gate_chunk_cumsum_scalar_kernel_npu(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 

--- a/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
@@ -160,10 +160,10 @@ def recompute_w_u_fwd_kernel_npu(
             i_n, i_t = tl.load(chunk_indices + i_t_o * 2).to(tl.int32), tl.load(
                 chunk_indices + i_t_o * 2 + 1
             ).to(tl.int32)
-            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
                 cu_seqlens + i_n + 1
-            ).to(tl.int32)
-            T = eos - bos
+            ).to(tl.int64)
+            T = (eos - bos).to(tl.int32)
             bos_bh = bos
         else:
             i_t = i_t_o
@@ -248,10 +248,10 @@ def prepare_wy_repr_bwd_kv_npu(
             i_n, i_t = tl.load(chunk_indices + i_t_o * 2).to(tl.int32), tl.load(
                 chunk_indices + i_t_o * 2 + 1
             ).to(tl.int32)
-            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
                 cu_seqlens + i_n + 1
-            ).to(tl.int32)
-            T = eos - bos
+            ).to(tl.int64)
+            T = (eos - bos).to(tl.int32)
         else:
             i_t = i_t_o
             bos, eos = i_b * T_seq, i_b * T_seq + T_seq
@@ -365,10 +365,10 @@ def prepare_wy_repr_bwd_da_mask_dot1_npu(
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
             chunk_indices + i_t * 2 + 1
         ).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
             cu_seqlens + i_n + 1
-        ).to(tl.int32)
-        T = eos - bos
+        ).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -404,8 +404,8 @@ def prepare_wy_repr_bwd_da_dot2_npu(
     i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -441,10 +441,10 @@ def prepare_wy_repr_bwd_da_gate_npu(
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
             chunk_indices + i_t * 2 + 1
         ).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
             cu_seqlens + i_n + 1
-        ).to(tl.int32)
-        T = eos - bos
+        ).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -495,10 +495,10 @@ def prepare_wy_repr_bwd_finalize_k_npu(
             i_n, i_t = tl.load(chunk_indices + i_t_o * 2).to(tl.int32), tl.load(
                 chunk_indices + i_t_o * 2 + 1
             ).to(tl.int32)
-            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
                 cu_seqlens + i_n + 1
-            ).to(tl.int32)
-            T = eos - bos
+            ).to(tl.int64)
+            T = (eos - bos).to(tl.int32)
         else:
             i_t = i_t_o
             bos, eos = i_b * T_seq, i_b * T_seq + T_seq
@@ -557,8 +557,8 @@ def prepare_wy_repr_bwd_finalize_a2_npu(
     T_seq = T
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -595,8 +595,8 @@ def prepare_wy_repr_bwd_finalize_dg_npu(
     if IS_VARLEN:
         i_tg = i_t
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         NT = tl.cdiv(T, BT)
         i_tg = i_b * NT + i_t

--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -789,7 +789,7 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
     BV = _get_bv(V)
     NK = triton.cdiv(K, BK)
     is_varlen = cu_seqlens is not None
-    chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT) if is_varlen else g.new_zeros(1, dtype=torch.int32)
+    chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT) if is_varlen else g.new_zeros(1, dtype=torch.int64)
 
     common_launch = dict(
         cu_seqlens=cu_seqlens,

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra.py
@@ -159,8 +159,8 @@ def chunk_kda_fwd_kernel_diag_solve_npu(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -216,8 +216,8 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_npu(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -305,8 +305,8 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -768,10 +768,10 @@ def chunk_kda_bwd_kernel_intra_npu(
     all = B * T
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     else:
         bos, eos = i_b * T, i_b * T + T
-    T = eos - bos
+    T = (eos - bos).to(tl.int32)
 
     i_ti = i_t * BT + i_i * BC
     if i_ti >= T:

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra_token_parallel.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra_token_parallel.py
@@ -84,8 +84,8 @@ def chunk_kda_fwd_kernel_intra_token_parallel_npu(
                     left = mid + 1
         i_n = left
 
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
         i_t = i_tg - bos
     else:
         bos = (i_tg // T) * T

--- a/fla/ops/kda/backends/triton_ascend/fused_recurrent.py
+++ b/fla/ops/kda/backends/triton_ascend/fused_recurrent.py
@@ -115,7 +115,7 @@ def fused_recurrent_kda_fwd_kernel_npu(
             tl.load(cu_seqlens + i_n).to(tl.int64),
             tl.load(cu_seqlens + i_n + 1).to(tl.int64),
         )
-        T_cur = eos - bos
+        T_cur = (eos - bos).to(tl.int32)
     else:
         bos = (i_n * T).to(tl.int64)
         T_cur = T

--- a/fla/ops/kda/backends/triton_ascend/gate.py
+++ b/fla/ops/kda/backends/triton_ascend/gate.py
@@ -290,8 +290,8 @@ def kda_gate_chunk_cumsum_vector_kernel_npu(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 

--- a/fla/ops/utils/backends/triton_ascend/cumsum.py
+++ b/fla/ops/utils/backends/triton_ascend/cumsum.py
@@ -209,8 +209,8 @@ def chunk_local_cumsum_scalar_kernel_npu(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -260,8 +260,8 @@ def chunk_local_cumsum_vector_kernel_npu(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -304,10 +304,10 @@ def chunk_global_cumsum_scalar_kernel_npu(
     i_nh = tl.program_id(0) + BH_OFFSET
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_n * T, i_n * T + T
-    T = eos - bos
 
     b_z = tl.zeros([], dtype=tl.float32)
     NT = tl.cdiv(T, BT)
@@ -357,10 +357,10 @@ def chunk_global_cumsum_vector_kernel_npu(
     i_s, i_nh = tl.program_id(0), tl.program_id(1) + BH_OFFSET
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_n * T, i_n * T + T
-    T = eos - bos
 
     b_z = tl.zeros([BS], dtype=tl.float32)
     NT = tl.cdiv(T, BT)

--- a/fla/ops/utils/backends/triton_ascend/solve_tril.py
+++ b/fla/ops/utils/backends/triton_ascend/solve_tril.py
@@ -56,8 +56,8 @@ def solve_tril_16x16_kernel_npu(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -103,8 +103,8 @@ def merge_16x16_to_32x32_inverse_kernel_npu(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 
@@ -169,8 +169,8 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        T = eos - bos
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
     else:
         bos, eos = i_b * T, i_b * T + T
 

--- a/tests/ops/test_gdn_kernels.py
+++ b/tests/ops/test_gdn_kernels.py
@@ -24,7 +24,7 @@ from fla.ops.gated_delta_rule.gate import gdn_gate_bwd, gdn_gate_chunk_cumsum, g
 from fla.ops.gated_delta_rule.naive import naive_recurrent_gated_delta_rule
 from fla.ops.gated_delta_rule.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
 from fla.ops.utils.constant import RCP_LN2
-from fla.utils import IS_NPU, assert_close, device
+from fla.utils import assert_close, device
 
 
 def _make_wy_inverse(B: int, T: int, HV: int, BT: int, dtype: torch.dtype) -> torch.Tensor:
@@ -1221,6 +1221,8 @@ def chunk_gated_delta_rule_bwd_dhu_ref(
     dv_local: torch.Tensor,
     scale: float,
     chunk_size: int = 64,
+    gk: torch.Tensor | None = None,
+    state_v_first: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
     """Torch baseline for `chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64`.
 
@@ -1228,20 +1230,22 @@ def chunk_gated_delta_rule_bwd_dhu_ref(
     reverse recurrence that autodiff on the forward states cannot reproduce
     directly (the reverse-pass gradient flows through a running accumulator, not
     through the stored forward states). We therefore evaluate that same reverse
-    recurrence in plain torch (state_v_first=False, USE_GK=False):
+    recurrence in plain torch:
 
         b_dh = dht
         for it = NT-1 ... 0:
             dh[it]  = b_dh
             b_dv    = (k[it] @ b_dh) * exp2(g_last[it] - g[it]) + dv_local[it]
             dv2[it] = b_dv
-            b_dh    = b_dh * exp2(g_last[it])
+            b_dh    = b_dh * exp2(g_last[it]) [* exp2(gk_last[it])]
                       + (q_gated[it]^T @ do[it]) * scale
                       - w[it]^T @ b_dv
         dh0   = b_dh
 
-    Returns (dh, dh0, dv2) matching the kernel. `u` is unused (the kernel consumes
-    `dv_local` instead) and kept only for a uniform call signature.
+    With `state_v_first=True`, `b_dh`/`dh`/`dht`/`dh0` are `[..., V, K]` and the
+    contractions are transposed accordingly. `gk` is the per-key vector gate
+    `[B, T, HV, K]`. `u` is unused (the kernel consumes `dv_local`) and kept only
+    for a uniform call signature.
     """
     del u  # unused: the kernel differentiates w.r.t. dv_local, not u
     B, T, H, K = k.shape
@@ -1261,13 +1265,21 @@ def chunk_gated_delta_rule_bwd_dhu_ref(
     do_f = do.float()
     dv_f = dv_local.float()
     g_f = g.float() if g is not None else None
+    gk_f = gk.float() if gk is not None else None
 
-    dh = torch.zeros(B, NT, HV, K, V, dtype=torch.float32, device=k.device)
+    if state_v_first:
+        dh = torch.zeros(B, NT, HV, V, K, dtype=torch.float32, device=k.device)
+        dh_shape = (B, HV, V, K)
+        kdh_eq, qdo_eq, wdv_eq = 'bthk,bhvk->bthv', 'bthk,bthv->bhvk', 'bthk,bthv->bhvk'
+    else:
+        dh = torch.zeros(B, NT, HV, K, V, dtype=torch.float32, device=k.device)
+        dh_shape = (B, HV, K, V)
+        kdh_eq, qdo_eq, wdv_eq = 'bthk,bhkv->bthv', 'bthk,bthv->bhkv', 'bthk,bthv->bhkv'
     dv2 = torch.zeros(B, T, HV, V, dtype=torch.float32, device=k.device)
     if dht is not None:
         b_dh = dht.float().clone()
     else:
-        b_dh = torch.zeros(B, HV, K, V, dtype=torch.float32, device=k.device)
+        b_dh = torch.zeros(*dh_shape, dtype=torch.float32, device=k.device)
 
     for it in range(NT - 1, -1, -1):
         s, e = it * BT, (it + 1) * BT
@@ -1277,7 +1289,7 @@ def chunk_gated_delta_rule_bwd_dhu_ref(
         w_c = w_f[:, s:e]             # [B, BT, HV, K]
         do_c = do_f[:, s:e]           # [B, BT, HV, V]
         dv_c = dv_f[:, s:e]           # [B, BT, HV, V]
-        kdh = torch.einsum('bthk,bhkv->bthv', k_c, b_dh)   # [B, BT, HV, V]
+        kdh = torch.einsum(kdh_eq, k_c, b_dh)   # [B, BT, HV, V]
         if g_f is not None:
             g_c = g_f[:, s:e]         # [B, BT, HV]
             g_last = g_c[:, -1]       # [B, HV]
@@ -1288,8 +1300,14 @@ def chunk_gated_delta_rule_bwd_dhu_ref(
             b_dv = kdh + dv_c
             q_gated = q_c
         dv2[:, s:e] = b_dv
-        b_dh = b_dh + torch.einsum('bthk,bthv->bhkv', q_gated, do_c) * scale
-        b_dh = b_dh - torch.einsum('bthk,bthv->bhkv', w_c, b_dv)
+        if gk_f is not None:
+            gk_last = torch.exp2(gk_f[:, e - 1])  # [B, HV, K]
+            if state_v_first:
+                b_dh = b_dh * gk_last[:, :, None, :]
+            else:
+                b_dh = b_dh * gk_last[:, :, :, None]
+        b_dh = b_dh + torch.einsum(qdo_eq, q_gated, do_c) * scale
+        b_dh = b_dh - torch.einsum(wdv_eq, w_c, b_dv)
 
     dh0 = b_dh if h0 is not None else None
     return dh, dh0, dv2
@@ -1345,13 +1363,36 @@ def test_chunk_gated_delta_rule_bwd_dhu(
         assert_close('dh0', dh0_ref, dh0_tri, 0.006)
 
 
-@pytest.mark.skipif(
-    IS_NPU,
-    reason=(
-        "Ascend triton_ascend chunk_gated_delta_rule_bwd_dhu AICore-times out on the "
-        "2050-document varlen stress from #1077; skip until the NPU backend fix is ready."
-    ),
-)
+def test_chunk_gated_delta_rule_bwd_dhu_k256_state_v_first_gk():
+    """K=V=256 + state_v_first + USE_GK so K-slabs 3/4 actually run."""
+    torch.manual_seed(42)
+    B, T, H, HV, D, BT = 1, 128, 1, 1, 256, 64
+    dtype = torch.bfloat16
+    scale = D ** -0.5
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    w = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    u = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    do = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    gk = torch.randn(B, T, HV, D, dtype=torch.float32, device=device) * 0.1
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device)
+    dht = torch.randn(B, HV, D, D, dtype=torch.float32, device=device)
+
+    dv_local = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    dh_ref, dh0_ref, dv2_ref = chunk_gated_delta_rule_bwd_dhu_ref(
+        q, k, w, u, None, h0, do, dht, dv_local, scale, BT,
+        gk=gk, state_v_first=True,
+    )
+    dh_tri, dh0_tri, dv2_tri = chunk_gated_delta_rule_bwd_dhu(
+        q=q, k=k, w=w, g=None, gk=gk, h0=h0, dht=dht, do=do, dv=dv_local,
+        scale=scale, chunk_size=BT, state_v_first=True,
+    )
+
+    assert_close('dh', dh_ref.to(dtype), dh_tri, 0.006)
+    assert_close('dv2', dv2_ref.to(dtype), dv2_tri, 0.006)
+    assert_close('dh0', dh0_ref, dh0_tri, 0.006)
+
+
 def test_chunk_gated_delta_rule_bwd_dhu_varlen_many_documents():
     """The backward counterpart of `test_chunk_gated_delta_rule_fwd_h_varlen_many_documents`."""
     torch.manual_seed(42)


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->

Fixes Ascend NPU timeout on `chunk_gated_delta_rule_bwd_dhu` under varlen stress tests (#1077) by restructuring the backward dh/du kernel launch model and addressing related correctness issues.
- **AICore task loop**: Replace the previous 2D grid launch `(nv_chunks, nh_total)` with a single-grid `(num_aicore,)` pattern. Each AICore iterates over `(batch, head)` tasks via `tl.range(core_id, task_num, num_core)`, and V-dimension tiling is moved into an inner `for i_v in range(NV)` loop inside the kernel. Forward `chunk_gated_delta_rule_fwd_h` is unified onto the same `_launch_core_grid` helper.
- **Ascend `tl.dot` workaround**: Introduce a separate `dv2` output buffer so intermediate `dv` results are written out-of-place, avoiding lhs clobbering by Ascend's `tl.dot` implementation across K-slabs.
- **int64 index safety**: Cast `cu_seqlens`, `bos`, and `eos` to `tl.int64` across all affected `triton_ascend` kernels (GDN, KDA, cumsum, solve_tril, chunk_o, etc.) to prevent overflow in long-sequence varlen paths.
- **Re-enable varlen stress test**: Remove the NPU skip on `test_chunk_gated_delta_rule_bwd_dhu_varlen_many_documents`.

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->

FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules tests/ops/utils tests/ops/test_gdn_kernels.py tests/ops/test_gdn.py tests/ops/test_kda.py tests/ops/test_attnres.py tests/ops/test_solve_tril.py
<img width="1177" height="405" alt="0d0f90721e8d2df24b71520a8aab6ab0" src="https://github.com/user-attachments/assets/ca2f86b5-20b5-4c5b-b27e-5fd46b17d43c" />


## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
<img width="1180" height="665" alt="image" src="https://github.com/user-attachments/assets/57bdb986-d838-48ff-83e3-aaf2c4681dac" />

<img width="1157" height="670" alt="image" src="https://github.com/user-attachments/assets/209236d5-3cb1-4b9c-8795-ce8000fdbfb6" />

## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->

None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
