### PR TITLE
[GDN] Key the fused GDN-2 WY/dqkg backward autotuner on K and V

### DIFF
--- a/fla/ops/gdn2/chunk_bwd.py
+++ b/fla/ops/gdn2/chunk_bwd.py
@@ -60,7 +60,7 @@ NUM_WARPS_WY = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
         for num_stages in [2, 3, 4]
         if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
     ],
-    key=['BT', 'STATE_V_FIRST'],
+    key=['BT', 'K', 'V', 'STATE_V_FIRST'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/tests/ops/test_gdn2.py
+++ b/tests/ops/test_gdn2.py
@@ -472,3 +472,43 @@ def test_layer(num_heads, num_v_heads, use_short_conv):
         if p.requires_grad:
             assert p.grad is not None, f"{name}.grad is None"
             assert torch.isfinite(p.grad).all(), f"{name}.grad has non-finite values"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_chunk_bwd_autotune_key_covers_head_dims():
+    """The fused WY/dqkg backward must autotune each (K, V) geometry separately.
+
+    The kernel autotunes over BK/BV tile configs, whose relative performance
+    depends on the head dimensions K and V. Backwards through two different
+    (K, V) geometries at the same chunk size must therefore leave two distinct
+    autotuner cache entries; if K/V are missing from the autotune key, the
+    second geometry cache-hits on the first geometry's winner and runs a
+    config that was never measured for its shape.
+    """
+    import fla.ops.gdn2.chunk_bwd as chunk_bwd_mod
+
+    # The module symbol is Heuristics(Autotuner(JITFunction)); walk .fn down to
+    # the Autotuner, which owns the config cache.
+    tuner = chunk_bwd_mod.chunk_gdn2_bwd_kernel_wy_dqkg_fused
+    for _ in range(3):
+        if hasattr(tuner, 'cache'):
+            break
+        tuner = tuner.fn
+    assert hasattr(tuner, 'cache'), "could not locate the Autotuner on the fused kernel"
+
+    saved = dict(tuner.cache)
+    tuner.cache.clear()
+    try:
+        for K, V in [(32, 64), (64, 128)]:
+            q, k, v, g, b, w, _, _ = _rand_inputs(1, 256, 2, K, V, torch.bfloat16)
+            for t in (q, k, v, g, b, w):
+                t.requires_grad_(True)
+            o, _ = chunk_gdn2(q=q, k=k, v=v, g=g, b=b, w=w, use_qk_l2norm_in_kernel=True)
+            o.sum().backward()
+        assert len(tuner.cache) == 2, (
+            f"expected one autotune cache entry per (K, V) geometry, got {len(tuner.cache)}; "
+            f"the autotune key must include K and V"
+        )
+    finally:
+        tuner.cache.clear()
+        tuner.cache.update(saved)


### PR DESCRIPTION
## Summary

`chunk_gdn2_bwd_kernel_wy_dqkg_fused` autotunes over `BK`/`BV` tile configs
(plus `num_warps`/`num_stages`), but its autotune key was
`['BT', 'STATE_V_FIRST']` — `K` and `V`, the head dimensions that bound the
tiles and determine each config's occupancy, were not part of the key.

Consequently the first `(K, V)` geometry that reaches the kernel in a process
tunes it for every other geometry sharing `BT`: a model with `K=64, V=128`
heads running after a `K=128, V=256` warmup silently inherits the larger
geometry's winning config instead of tuning for its own. We hit this while
benchmarking GDN-2 at multiple head geometries — back-to-back shapes in one
process reproduced with the first shape's config, skewing every subsequent
measurement until each geometry was quarantined into its own process with a
fresh Triton cache.

This PR adds `K` and `V` to the key, matching the sibling kernels in
`fla/ops/gdn2/wy_fast.py` (which key on
`['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN']`), and adds a regression
test. Only this kernel in `fla/ops/gdn2/` sweeps `BK`/`BV` while omitting
`K`/`V` from its key.

Cost: one extra autotune sweep per distinct `(K, V)` geometry, on first
encounter only; results are cached as before. Single-geometry runs (the
common case) see no change.

## Test plan

New in `tests/ops/test_gdn2.py`:

- `test_chunk_bwd_autotune_key_covers_head_dims` — backwards through two
  `(K, V)` geometries at the same chunk size must leave two distinct
  autotuner cache entries. Fails on `main` (the second geometry cache-hits on
  the first's winner), passes on this branch.
  Verified on H200: 1 failed on the base commit, 1 passed on this branch, same environment, with the key line as the only tree difference.

Dependent tests (`python scripts/find_dependent_tests.py fla/ops/gdn2/chunk_bwd.py`):

- `tests/ops/test_gdn2.py` — 29 passed (full suite, incl. the new test)
- `tests/layers/test_attn_varlen_pack_layout.py` — 13 passed, 2 skipped

Local test environment:
- GPU: NVIDIA H200, driver 570.195.03
- Python: 3.12.3
- torch: 2.14.0.dev20260707+cu126
- triton: 3.8.0

## Benchmark / NCU

Neutral for single-geometry processes: the key change does not alter which
config wins for a geometry tuned on its own — it only ensures each geometry
is tuned at all.

For multi-geometry processes it removes a measurable penalty. On H200
(bf16, T=32768 packed varlen in 32 documents, chunk 64, medians of 30 iters),
the per-geometry winners genuinely differ (`BK64/BV32/warps4/stages4` at
K=64/V=128 vs `BK64/BV64/warps4/stages4` at K=128/V=256), and running
K=64/V=128/H=32 on the config leaked from a K=128/V=256 warmup (what `main`
does today) costs (the leaked run's tuner cache confirms it selected K128/V256's winner, `BK64/BV64/warps4/stages4`, instead of the geometry's own `BK64/BV32`):

| K64/V128/H32, fused kernel | tuned for itself | on leaked K128/V256 winner |
|---|---|---|
| wy_dqkg median | 2.774 ms | 3.111 ms (**+12.2%**) |
| full bwd median | 8.689 ms | 9.030 ms (+3.9%) |

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
