### PR TITLE
[Ops] Add triton-ascend backend for chunk_gla

### DIFF
--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -141,7 +141,7 @@ jobs:
           assert IS_NPU, "Expected NPU backend (IS_NPU=True)"
           PY
 
-      - name: Run tests/modules and tests/ops/utils, gdn, kda, attnres, solve_tril
+      - name: Run tests/modules and tests/ops/utils, gdn, kda, gla, attnres, solve_tril
         shell: bash
         env:
           FLA_NPU_XDIST: "1"
@@ -153,5 +153,6 @@ jobs:
             tests/ops/test_gdn_kernels.py \
             tests/ops/test_gdn.py \
             tests/ops/test_kda.py \
+            tests/ops/test_gla.py \
             tests/ops/test_attnres.py \
             tests/ops/test_solve_tril.py

--- a/fla/ops/common/backends/triton_ascend/__init__.py
+++ b/fla/ops/common/backends/triton_ascend/__init__.py
@@ -37,6 +37,26 @@ class TritonAscendCommonBackend(BaseBackend):
         from fla.ops.common.backends.triton_ascend.chunk_delta_h import chunk_gated_delta_rule_fwd_h_npu
         return chunk_gated_delta_rule_fwd_h_npu(*args, **kwargs)
 
+    def chunk_fwd_h_verifier(self, k, v, *args, **kwargs):
+        K, V = k.shape[-1], v.shape[-1]
+        if K > 256 or V > 256:
+            return False, f'NPU chunk_fwd_h supports K,V<=256, got K={K}, V={V}'
+        return True, None
+
+    def chunk_fwd_h(self, *args, **kwargs):
+        from fla.ops.common.backends.triton_ascend.chunk_h import chunk_fwd_h_npu
+        return chunk_fwd_h_npu(*args, **kwargs)
+
+    def chunk_bwd_dh_verifier(self, q, k, v, *args, **kwargs):
+        K, V = k.shape[-1], v.shape[-1]
+        if K > 256 or V > 256:
+            return False, f'NPU chunk_bwd_dh supports K,V<=256, got K={K}, V={V}'
+        return True, None
+
+    def chunk_bwd_dh(self, *args, **kwargs):
+        from fla.ops.common.backends.triton_ascend.chunk_h import chunk_bwd_dh_npu
+        return chunk_bwd_dh_npu(*args, **kwargs)
+
     def chunk_fwd_o_verifier(self, *args, **kwargs):
         return True, None
 

--- a/fla/ops/common/backends/triton_ascend/__init__.py
+++ b/fla/ops/common/backends/triton_ascend/__init__.py
@@ -39,8 +39,8 @@ class TritonAscendCommonBackend(BaseBackend):
 
     def chunk_fwd_h_verifier(self, k, v, *args, **kwargs):
         K, V = k.shape[-1], v.shape[-1]
-        if K > 256 or V > 256:
-            return False, f'NPU chunk_fwd_h supports K,V<=256, got K={K}, V={V}'
+        if K > 512 or V > 512:
+            return False, f'NPU chunk_fwd_h supports K,V<=512, got K={K}, V={V}'
         return True, None
 
     def chunk_fwd_h(self, *args, **kwargs):
@@ -49,8 +49,8 @@ class TritonAscendCommonBackend(BaseBackend):
 
     def chunk_bwd_dh_verifier(self, q, k, v, *args, **kwargs):
         K, V = k.shape[-1], v.shape[-1]
-        if K > 256 or V > 256:
-            return False, f'NPU chunk_bwd_dh supports K,V<=256, got K={K}, V={V}'
+        if K > 512 or V > 512:
+            return False, f'NPU chunk_bwd_dh supports K,V<=512, got K={K}, V={V}'
         return True, None
 
     def chunk_bwd_dh(self, *args, **kwargs):

--- a/fla/ops/common/backends/triton_ascend/chunk_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_h.py
@@ -1,0 +1,456 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""chunk_fwd_h / chunk_bwd_dh for triton-ascend on Ascend NPU (GLA-style state).
+
+Ascend requires host-specialized ``NT`` + ``tl.static_range(NT)``. Dynamic
+``for i_t in range(tl.cdiv(T, BT))`` under-iterates when ``T`` is unspecialized.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils import prepare_chunk_offsets
+from fla.ops.utils.op import exp2
+from fla.utils import input_guard
+from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, max_grid_axis_chunks
+
+_NUM_WARPS = 4
+_LAUNCH_BLOCK_BUDGET = 4096
+# Fixed tiles: matches validated probe; avoids UB/autotune variance on Ascend.
+_BK = 64
+_BV = 64
+
+
+def _max_nt(T: int, BT: int, cu_seqlens: torch.Tensor | None) -> int:
+    if cu_seqlens is None:
+        return triton.cdiv(T, BT)
+    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+    return int(triton.cdiv(int(lengths.max().item()), BT))
+
+
+def _launch_kv_nh(kernel, *, nk: int, nv: int, nh: int, kernel_kwargs: dict) -> None:
+    budget = _LAUNCH_BLOCK_BUDGET
+    nk_step = nk if nk * nv * nh <= budget else max(1, budget // max(nv * nh, 1))
+    for k_off in range(0, nk, nk_step):
+        k_len = min(nk_step, nk - k_off)
+        kernel_kwargs['K_OFFSET'] = k_off
+        nv_budget = max(1, budget // max(k_len * nh, 1))
+        nv_step = min(nv_budget, max_grid_axis_chunks(nv, k_len * nh, max_grid=ASCEND_MAX_GRID_DIM))
+        for v_off in range(0, nv, nv_step):
+            v_len = min(nv_step, nv - v_off)
+            kernel_kwargs['V_OFFSET'] = v_off
+            nh_budget = max(1, budget // max(k_len * v_len, 1))
+            nh_step = min(nh_budget, max_grid_axis_chunks(nh, k_len * v_len, max_grid=ASCEND_MAX_GRID_DIM))
+            for nh_off in range(0, nh, nh_step):
+                nh_len = min(nh_step, nh - nh_off)
+                kernel_kwargs['NH_OFFSET'] = nh_off
+                kernel[(k_len, v_len, nh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
+    if hasattr(torch, 'npu') and torch.npu.is_available():
+        torch.npu.synchronize()
+
+
+@triton.heuristics({
+    'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
+    'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T', 'K_OFFSET', 'V_OFFSET', 'NH_OFFSET'])
+def chunk_fwd_kernel_h_npu(
+    k, v, h, g, g_gamma, gk, gv, h0, ht,
+    cu_seqlens, split_offsets, T,
+    H: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BS: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr, NT: tl.constexpr,
+    USE_G: tl.constexpr, USE_G_GAMMA: tl.constexpr, USE_GK: tl.constexpr, USE_GV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr, STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr, STATE_V_FIRST: tl.constexpr,
+    K_OFFSET, V_OFFSET, NH_OFFSET,
+):
+    i_k = tl.program_id(0) + K_OFFSET
+    i_v = tl.program_id(1) + V_OFFSET
+    i_nh = tl.program_id(2).to(tl.int64) + NH_OFFSET
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+        NT_SEQ = tl.cdiv(T, BT)
+        boh = tl.load(split_offsets + i_n).to(tl.int64)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT_SEQ = NT
+        boh = i_n * tl.cdiv(T, BS)
+    NTS = BS // BT
+
+    if USE_G_GAMMA:
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0 = h0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            b_h = tl.trans(tl.load(p_h0, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
+        else:
+            p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            b_h = tl.load(p_h0, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
+
+    for i_t in tl.static_range(NT):
+        # Always execute body; inactive (varlen pad) iterations contribute zeros via masks.
+        active = i_t < NT_SEQ
+        i_s = i_t // NTS
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = (o_t < T) & active
+        p_k = k + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H * K)
+        p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+
+        o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
+        if STATE_V_FIRST:
+            p_h = h + o_h + o_v[:, None] * K + o_k[None, :]
+            m_h = (o_v[:, None] < V) & (o_k[None, :] < K) & active
+        else:
+            p_h = h + o_h + o_k[:, None] * V + o_v[None, :]
+            m_h = (o_k[:, None] < K) & (o_v[None, :] < V) & active
+
+        if i_t % NTS == 0:
+            tl.store(p_h, (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty), mask=m_h)
+
+        # Force fp32 recurrence on Ascend (bf16 tl.dot is less stable than CUDA).
+        b_k = tl.load(p_k, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32)
+        b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
+        last_idx = min((i_t + 1) * BT, T) - 1
+        last_idx = max(last_idx, 0)
+
+        if USE_G:
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h).to(tl.float32)
+            p_g = g + bos * H + (i_t * BT + tl.arange(0, BT)) * H + i_h
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T) & active, other=0.).to(tl.float32)
+            b_h *= tl.where(active, exp2(b_g_last), 1.0)
+            b_v = b_v * exp2(b_g_last - b_g)[:, None]
+
+        if USE_G_GAMMA:
+            b_g_last = b_gamma * min(BT, max(T - i_t * BT, 0))
+            b_h *= tl.where(active, exp2(b_g_last), 1.0)
+            b_v = b_v * exp2(b_g_last - b_g)[:, None]
+
+        if USE_GK:
+            p_gk = gk + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H * K)
+            p_gk_last = gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.).to(tl.float32)
+            b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32)
+            b_h *= tl.where(active, exp2(b_gk_last), 1.0)[:, None]
+            b_k = b_k * exp2(b_gk_last[:, None] - b_gk)
+
+        if USE_GV:
+            p_gv = gv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_gv_last = gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.).to(tl.float32)
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
+            b_h *= tl.where(active, exp2(b_gv_last), 1.0)[None, :]
+            b_v = b_v * exp2(b_gv_last[None, :] - b_gv)
+
+        b_h += tl.dot(b_k, b_v)
+
+    if STORE_FINAL_STATE:
+        if STATE_V_FIRST:
+            p_ht = ht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            tl.store(p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))
+        else:
+            p_ht = ht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
+
+
+@triton.heuristics({
+    'STORE_INITIAL_STATE_GRADIENT': lambda args: args['dh0'] is not None,
+    'USE_FINAL_STATE_GRADIENT': lambda args: args['dht'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T', 'K_OFFSET', 'V_OFFSET', 'NH_OFFSET'])
+def chunk_bwd_kernel_dh_npu(
+    q, g, g_gamma, gk, gv, do, dh, dht, dh0,
+    cu_seqlens, split_offsets, scale, T,
+    HQ: tl.constexpr, H: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BS: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr, NT: tl.constexpr, NG: tl.constexpr,
+    USE_G: tl.constexpr, USE_G_GAMMA: tl.constexpr, USE_GK: tl.constexpr, USE_GV: tl.constexpr,
+    STORE_INITIAL_STATE_GRADIENT: tl.constexpr, USE_FINAL_STATE_GRADIENT: tl.constexpr,
+    IS_VARLEN: tl.constexpr, STATE_V_FIRST: tl.constexpr,
+    K_OFFSET, V_OFFSET, NH_OFFSET,
+):
+    i_k = tl.program_id(0) + K_OFFSET
+    i_v = tl.program_id(1) + V_OFFSET
+    i_nh = tl.program_id(2).to(tl.int64) + NH_OFFSET
+    i_n, i_hq = i_nh // HQ, i_nh % HQ
+    i_h = i_hq // NG
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+        NT_SEQ = tl.cdiv(T, BT)
+        boh = tl.load(split_offsets + i_n).to(tl.int64)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT_SEQ = NT
+        boh = i_n * tl.cdiv(T, BS)
+
+    if USE_G_GAMMA:
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+
+    b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    if USE_FINAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dht = dht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            b_dh += tl.trans(tl.load(p_dht, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
+        else:
+            p_dht = dht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            b_dh += tl.load(p_dht, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
+
+    for step in tl.static_range(NT):
+        i_t = NT - 1 - step
+        active = i_t < NT_SEQ
+        i_s = i_t // (BS // BT)
+        o_dh = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
+        if STATE_V_FIRST:
+            p_dh = dh + o_dh + o_v[:, None] * K + o_k[None, :]
+            m_dh = (o_v[:, None] < V) & (o_k[None, :] < K) & active
+        else:
+            p_dh = dh + o_dh + o_k[:, None] * V + o_v[None, :]
+            m_dh = (o_k[:, None] < K) & (o_v[None, :] < V) & active
+
+        if i_t % (BS // BT) == 0:
+            tl.store(p_dh, (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty), mask=m_dh)
+
+        last_idx = min(i_t * BT + BT, T) - 1
+        last_idx = max(last_idx, 0)
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = (o_t < T) & active
+        p_q = q + (bos * HQ + i_hq) * K + o_k[:, None] + o_t[None, :] * (HQ * K)
+        p_do = do + (bos * HQ + i_hq) * V + o_t[:, None] * (HQ * V) + o_v[None, :]
+        b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32) * scale
+        b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
+
+        if USE_G:
+            p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
+            b_g_last = tl.load(g + (bos + last_idx) * H + i_h).to(tl.float32)
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T) & active, other=0.).to(tl.float32)
+            b_q = b_q * exp2(b_g)[None, :]
+            b_dh *= tl.where(active, exp2(b_g_last), 1.0)
+
+        if USE_G_GAMMA:
+            b_g_last = b_gamma * min(BT, max(T - i_t * BT, 0))
+            b_q = b_q * exp2(b_g)[None, :]
+            b_dh *= tl.where(active, exp2(b_g_last), 1.0)
+
+        if USE_GK:
+            p_gk = gk + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H * K)
+            p_gk_last = gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32)
+            b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.).to(tl.float32)
+            b_q = b_q * exp2(b_gk)
+            b_dh *= tl.where(active, exp2(b_gk_last), 1.0)[:, None]
+
+        if USE_GV:
+            p_gv = gv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_gv_last = gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
+            b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.).to(tl.float32)
+            b_do = b_do * exp2(b_gv)
+            b_dh *= tl.where(active, exp2(b_gv_last), 1.0)[None, :]
+
+        b_dh += tl.dot(b_q, b_do)
+
+    if STORE_INITIAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dh0 = dh0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            tl.store(p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))
+        else:
+            p_dh0 = dh0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
+
+
+def _slice_seq(x: torch.Tensor | None, bos: int, eos: int) -> torch.Tensor | None:
+    return None if x is None else x[:, bos:eos]
+
+
+@input_guard
+def chunk_fwd_h_npu(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    g_gamma: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    h0: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    state_v_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    split_size: int | None = None,
+    states_in_fp32: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+    BS = BT if split_size is None else split_size
+    assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    assert K <= 256 and V <= 256, "NPU chunk_h currently supports K,V <= 256"
+
+    # Ascend fused IS_VARLEN path can leave partial NaNs in `ht` while `h` stays
+    # correct. Route each packed sequence through the validated equal-length path.
+    if cu_seqlens is not None:
+        assert B == 1, "NPU varlen chunk_h expects packed batch B=1"
+        split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
+        N = len(cu_seqlens) - 1
+        NS = int(split_offsets[-1].item())
+        state_shape = (V, K) if state_v_first else (K, V)
+        # zeros: tests/conftest poisons empty*() with NaN; partial stores must not leak.
+        h = k.new_zeros(B, NS, H, *state_shape, dtype=torch.float)
+        ht = k.new_zeros(N, H, *state_shape, dtype=torch.float) if output_final_state else None
+        for i_n in range(N):
+            bos = int(cu_seqlens[i_n].item())
+            eos = int(cu_seqlens[i_n + 1].item())
+            boh = int(split_offsets[i_n].item())
+            n_i = int(split_offsets[i_n + 1].item()) - boh
+            if eos <= bos or n_i <= 0:
+                continue
+            h_i, ht_i = chunk_fwd_h_npu(
+                k=_slice_seq(k, bos, eos),
+                v=_slice_seq(v, bos, eos),
+                g=_slice_seq(g, bos, eos),
+                g_gamma=g_gamma,
+                gk=_slice_seq(gk, bos, eos),
+                gv=_slice_seq(gv, bos, eos),
+                h0=None if h0 is None else h0[i_n:i_n + 1],
+                output_final_state=output_final_state,
+                state_v_first=state_v_first,
+                cu_seqlens=None,
+                chunk_size=chunk_size,
+                split_size=split_size,
+                states_in_fp32=states_in_fp32,
+            )
+            h[:, boh:boh + n_i] = h_i
+            if ht is not None:
+                ht[i_n].copy_(ht_i[0])
+        return h, ht
+
+    N, NS, split_offsets = B, triton.cdiv(T, BS), None
+    NT = _max_nt(T, BT, None)
+    state_shape = (V, K) if state_v_first else (K, V)
+    # zeros: tests/conftest poisons empty*() with NaN; partial stores must not leak.
+    h = k.new_zeros(B, NS, H, *state_shape, dtype=torch.float)
+    ht = k.new_zeros(N, H, *state_shape, dtype=torch.float) if output_final_state else None
+
+    BK, BV = _BK, _BV
+    nk, nv, nh = triton.cdiv(K, BK), triton.cdiv(V, BV), N * H
+    _launch_kv_nh(
+        chunk_fwd_kernel_h_npu,
+        nk=nk, nv=nv, nh=nh,
+        kernel_kwargs=dict(
+            k=k, v=v, h=h, g=g, g_gamma=g_gamma, gk=gk, gv=gv, h0=h0, ht=ht,
+            cu_seqlens=None, split_offsets=None, T=T,
+            H=H, K=K, V=V, BT=BT, BS=BS, BK=BK, BV=BV, NT=NT,
+            USE_G=g is not None, USE_G_GAMMA=g_gamma is not None,
+            USE_GK=gk is not None, USE_GV=gv is not None,
+            STATE_V_FIRST=state_v_first,
+            K_OFFSET=0, V_OFFSET=0, NH_OFFSET=0,
+        ),
+    )
+    return h, ht
+
+
+@input_guard
+def chunk_bwd_dh_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h0: torch.Tensor,
+    dht: torch.Tensor,
+    scale: float,
+    g: torch.Tensor | None = None,
+    g_gamma: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    state_v_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    split_size: int | None = None,
+    states_in_fp32: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HQ = q.shape[2]
+    BT = chunk_size
+    BS = BT if split_size is None else split_size
+    assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    assert K <= 256 and V <= 256, "NPU chunk_h currently supports K,V <= 256"
+
+    if cu_seqlens is not None:
+        assert B == 1, "NPU varlen chunk_bwd_dh expects packed batch B=1"
+        split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
+        N = len(cu_seqlens) - 1
+        NS = int(split_offsets[-1].item())
+        state_shape = (V, K) if state_v_first else (K, V)
+        dh = k.new_zeros(B, NS, HQ, *state_shape, dtype=torch.float)
+        dh0 = torch.zeros_like(h0, dtype=torch.float) if h0 is not None else None
+        for i_n in range(N):
+            bos = int(cu_seqlens[i_n].item())
+            eos = int(cu_seqlens[i_n + 1].item())
+            boh = int(split_offsets[i_n].item())
+            n_i = int(split_offsets[i_n + 1].item()) - boh
+            if eos <= bos or n_i <= 0:
+                continue
+            dh_i, dh0_i = chunk_bwd_dh_npu(
+                q=_slice_seq(q, bos, eos),
+                k=_slice_seq(k, bos, eos),
+                v=_slice_seq(v, bos, eos),
+                do=_slice_seq(do, bos, eos),
+                h0=None if h0 is None else h0[i_n:i_n + 1],
+                dht=None if dht is None else dht[i_n:i_n + 1],
+                scale=scale,
+                g=_slice_seq(g, bos, eos),
+                g_gamma=g_gamma,
+                gk=_slice_seq(gk, bos, eos),
+                gv=_slice_seq(gv, bos, eos),
+                state_v_first=state_v_first,
+                cu_seqlens=None,
+                chunk_size=chunk_size,
+                split_size=split_size,
+                states_in_fp32=states_in_fp32,
+            )
+            dh[:, boh:boh + n_i] = dh_i
+            if dh0 is not None and dh0_i is not None:
+                dh0[i_n].copy_(dh0_i[0])
+        return dh, dh0
+
+    N, NS, split_offsets = B, triton.cdiv(T, BS), None
+    NG = HQ // H
+    NT = _max_nt(T, BT, None)
+
+    state_shape = (V, K) if state_v_first else (K, V)
+    dh = k.new_zeros(B, NS, HQ, *state_shape, dtype=torch.float)
+    dh0 = torch.zeros_like(h0, dtype=torch.float) if h0 is not None else None
+
+    BK, BV = _BK, _BV
+    nk, nv, nh = triton.cdiv(K, BK), triton.cdiv(V, BV), N * HQ
+    _launch_kv_nh(
+        chunk_bwd_kernel_dh_npu,
+        nk=nk, nv=nv, nh=nh,
+        kernel_kwargs=dict(
+            q=q, g=g, g_gamma=g_gamma, gk=gk, gv=gv, do=do, dh=dh, dht=dht, dh0=dh0,
+            cu_seqlens=None, split_offsets=None, scale=scale, T=T,
+            HQ=HQ, H=H, K=K, V=V, BT=BT, BS=BS, BK=BK, BV=BV, NT=NT, NG=NG,
+            USE_G=g is not None, USE_G_GAMMA=g_gamma is not None,
+            USE_GK=gk is not None, USE_GV=gv is not None,
+            STATE_V_FIRST=state_v_first,
+            K_OFFSET=0, V_OFFSET=0, NH_OFFSET=0,
+        ),
+    )
+    return dh, dh0

--- a/fla/ops/common/backends/triton_ascend/chunk_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_h.py
@@ -286,6 +286,8 @@ def chunk_fwd_h_npu(
             boh = int(split_offsets[i_n].item())
             n_i = int(split_offsets[i_n + 1].item()) - boh
             if eos <= bos or n_i <= 0:
+                if ht is not None and h0 is not None:
+                    ht[i_n].copy_(h0[i_n])
                 continue
             h_i, ht_i = chunk_fwd_h_npu(
                 k=_slice_seq(k, bos, eos),
@@ -371,6 +373,8 @@ def chunk_bwd_dh_npu(
             boh = int(split_offsets[i_n].item())
             n_i = int(split_offsets[i_n + 1].item()) - boh
             if eos <= bos or n_i <= 0:
+                if dh0 is not None and dht is not None:
+                    dh0[i_n].copy_(dht[i_n])
                 continue
             dh_i, dh0_i = chunk_bwd_dh_npu(
                 q=_slice_seq(q, bos, eos),

--- a/fla/ops/common/backends/triton_ascend/chunk_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_h.py
@@ -22,7 +22,6 @@ from fla.ops.utils.op import exp2
 from fla.utils import input_guard
 from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, max_grid_axis_chunks
 
-_NUM_WARPS = 4
 _LAUNCH_BLOCK_BUDGET = 4096
 # Fixed tiles: matches validated probe; avoids UB/autotune variance on Ascend.
 _BK = 64
@@ -52,7 +51,7 @@ def _launch_kv_nh(kernel, *, nk: int, nv: int, nh: int, kernel_kwargs: dict) -> 
             for nh_off in range(0, nh, nh_step):
                 nh_len = min(nh_step, nh - nh_off)
                 kernel_kwargs['NH_OFFSET'] = nh_off
-                kernel[(k_len, v_len, nh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
+                kernel[(k_len, v_len, nh_len)](**kernel_kwargs)
     if hasattr(torch, 'npu') and torch.npu.is_available():
         torch.npu.synchronize()
 

--- a/fla/ops/common/backends/triton_ascend/chunk_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_h.py
@@ -9,6 +9,8 @@
 
 Ascend requires host-specialized ``NT`` + ``tl.static_range(NT)``. Dynamic
 ``for i_t in range(tl.cdiv(T, BT))`` under-iterates when ``T`` is unspecialized.
+The kernels below only handle equal-length inputs; varlen inputs are split per
+sequence on the host (see ``chunk_fwd_h_npu``/``chunk_bwd_dh_npu``).
 """
 
 from __future__ import annotations
@@ -20,71 +22,44 @@ import triton.language as tl
 from fla.ops.utils import prepare_chunk_offsets
 from fla.ops.utils.op import exp2
 from fla.utils import input_guard
-from fla.utils.ascend_ub_manager import ASCEND_MAX_GRID_DIM, max_grid_axis_chunks
+from fla.utils.ascend_ub_manager import launch_grid_chunked
 
-_LAUNCH_BLOCK_BUDGET = 4096
-# Fixed tiles: matches validated probe; avoids UB/autotune variance on Ascend.
+# Fixed tiles: avoids autotune picking UB-overflowing configs on Ascend.
 _BK = 64
 _BV = 64
 
 
-def _max_nt(T: int, BT: int, cu_seqlens: torch.Tensor | None) -> int:
-    if cu_seqlens is None:
-        return triton.cdiv(T, BT)
-    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-    return int(triton.cdiv(int(lengths.max().item()), BT))
+def _chunk_h_tile_size(K: int, V: int) -> tuple[int, int]:
+    """Pick BK/BV for chunk_h on Ascend.
 
-
-def _launch_kv_nh(kernel, *, nk: int, nv: int, nh: int, kernel_kwargs: dict) -> None:
-    budget = _LAUNCH_BLOCK_BUDGET
-    nk_step = nk if nk * nv * nh <= budget else max(1, budget // max(nv * nh, 1))
-    for k_off in range(0, nk, nk_step):
-        k_len = min(nk_step, nk - k_off)
-        kernel_kwargs['K_OFFSET'] = k_off
-        nv_budget = max(1, budget // max(k_len * nh, 1))
-        nv_step = min(nv_budget, max_grid_axis_chunks(nv, k_len * nh, max_grid=ASCEND_MAX_GRID_DIM))
-        for v_off in range(0, nv, nv_step):
-            v_len = min(nv_step, nv - v_off)
-            kernel_kwargs['V_OFFSET'] = v_off
-            nh_budget = max(1, budget // max(k_len * v_len, 1))
-            nh_step = min(nh_budget, max_grid_axis_chunks(nh, k_len * v_len, max_grid=ASCEND_MAX_GRID_DIM))
-            for nh_off in range(0, nh, nh_step):
-                nh_len = min(nh_step, nh - nh_off)
-                kernel_kwargs['NH_OFFSET'] = nh_off
-                kernel[(k_len, v_len, nh_len)](**kernel_kwargs)
-    if hasattr(torch, 'npu') and torch.npu.is_available():
-        torch.npu.synchronize()
+    BK=BV=64 overflows UB when K,V>=256 and USE_GK loads extra fp32 tiles
+    (b_k/b_gk/b_h/b_v), which surfaces as MTE DDR OOB for large B*H.
+    """
+    if K > 128 or V > 128:
+        return 32, 32
+    return _BK, _BV
 
 
 @triton.heuristics({
     'USE_INITIAL_STATE': lambda args: args['h0'] is not None,
     'STORE_FINAL_STATE': lambda args: args['ht'] is not None,
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.jit(do_not_specialize=['T', 'K_OFFSET', 'V_OFFSET', 'NH_OFFSET'])
 def chunk_fwd_kernel_h_npu(
-    k, v, h, g, g_gamma, gk, gv, h0, ht,
-    cu_seqlens, split_offsets, T,
+    k, v, h, g, g_gamma, gk, gv, h0, ht, T,
     H: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
     BT: tl.constexpr, BS: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr, NT: tl.constexpr,
     USE_G: tl.constexpr, USE_G_GAMMA: tl.constexpr, USE_GK: tl.constexpr, USE_GV: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr, STORE_FINAL_STATE: tl.constexpr,
-    IS_VARLEN: tl.constexpr, STATE_V_FIRST: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
     K_OFFSET, V_OFFSET, NH_OFFSET,
 ):
     i_k = tl.program_id(0) + K_OFFSET
     i_v = tl.program_id(1) + V_OFFSET
     i_nh = tl.program_id(2).to(tl.int64) + NH_OFFSET
     i_n, i_h = i_nh // H, i_nh % H
-    if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = eos - bos
-        NT_SEQ = tl.cdiv(T, BT)
-        boh = tl.load(split_offsets + i_n).to(tl.int64)
-    else:
-        bos, eos = i_n * T, i_n * T + T
-        NT_SEQ = NT
-        boh = i_n * tl.cdiv(T, BS)
+    bos = (i_n * T).to(tl.int64)
+    boh = (i_n * tl.cdiv(T, BS)).to(tl.int64)
     NTS = BS // BT
 
     if USE_G_GAMMA:
@@ -95,29 +70,29 @@ def chunk_fwd_kernel_h_npu(
     o_k = i_k * BK + tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
     if USE_INITIAL_STATE:
+        h0_base = (i_nh * K * V).to(tl.int64)
         if STATE_V_FIRST:
-            p_h0 = h0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            p_h0 = h0 + h0_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             b_h = tl.trans(tl.load(p_h0, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
         else:
-            p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            p_h0 = h0 + h0_base + o_k[:, None].to(tl.int64) * V + o_v[None, :]
             b_h = tl.load(p_h0, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
 
     for i_t in tl.static_range(NT):
-        # Always execute body; inactive (varlen pad) iterations contribute zeros via masks.
-        active = i_t < NT_SEQ
         i_s = i_t // NTS
-        o_t = i_t * BT + tl.arange(0, BT)
-        m_t = (o_t < T) & active
-        p_k = k + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H * K)
-        p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        o_t = (i_t * BT + tl.arange(0, BT)).to(tl.int64)
+        m_t = o_t < T
+        kv_base = (bos * H + i_h).to(tl.int64) * K
+        p_k = k + kv_base + o_k[:, None] + o_t[None, :] * (H * K)
+        p_v = v + (bos * H + i_h).to(tl.int64) * V + o_t[:, None] * (H * V) + o_v[None, :]
 
-        o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
+        o_h = ((boh + i_s.to(tl.int64)) * H + i_h).to(tl.int64) * K * V
         if STATE_V_FIRST:
-            p_h = h + o_h + o_v[:, None] * K + o_k[None, :]
-            m_h = (o_v[:, None] < V) & (o_k[None, :] < K) & active
+            p_h = h + o_h + o_v[:, None].to(tl.int64) * K + o_k[None, :]
+            m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
         else:
-            p_h = h + o_h + o_k[:, None] * V + o_v[None, :]
-            m_h = (o_k[:, None] < K) & (o_v[None, :] < V) & active
+            p_h = h + o_h + o_k[:, None].to(tl.int64) * V + o_v[None, :]
+            m_h = (o_k[:, None] < K) & (o_v[None, :] < V)
 
         if i_t % NTS == 0:
             tl.store(p_h, (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty), mask=m_h)
@@ -126,61 +101,60 @@ def chunk_fwd_kernel_h_npu(
         b_k = tl.load(p_k, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32)
         b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
         last_idx = min((i_t + 1) * BT, T) - 1
-        last_idx = max(last_idx, 0)
 
         if USE_G:
-            b_g_last = tl.load(g + bos * H + last_idx * H + i_h).to(tl.float32)
-            p_g = g + bos * H + (i_t * BT + tl.arange(0, BT)) * H + i_h
-            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T) & active, other=0.).to(tl.float32)
-            b_h *= tl.where(active, exp2(b_g_last), 1.0)
+            b_g_last = tl.load(g + bos * H + last_idx.to(tl.int64) * H + i_h).to(tl.float32)
+            p_g = g + bos * H + o_t * H + i_h
+            b_g = tl.load(p_g, mask=m_t, other=0.).to(tl.float32)
+            b_h *= exp2(b_g_last)
             b_v = b_v * exp2(b_g_last - b_g)[:, None]
 
         if USE_G_GAMMA:
-            b_g_last = b_gamma * min(BT, max(T - i_t * BT, 0))
-            b_h *= tl.where(active, exp2(b_g_last), 1.0)
+            b_g_last = b_gamma * min(BT, T - i_t * BT)
+            b_h *= exp2(b_g_last)
             b_v = b_v * exp2(b_g_last - b_g)[:, None]
 
         if USE_GK:
-            p_gk = gk + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H * K)
-            p_gk_last = gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            p_gk = gk + kv_base + o_k[:, None] + o_t[None, :] * (H * K)
+            p_gk_last = gk + (bos + last_idx.to(tl.int64)) * (H * K) + i_h * K + i_k * BK + tl.arange(0, BK)
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.).to(tl.float32)
             b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32)
-            b_h *= tl.where(active, exp2(b_gk_last), 1.0)[:, None]
+            b_h *= exp2(b_gk_last)[:, None]
             b_k = b_k * exp2(b_gk_last[:, None] - b_gk)
 
         if USE_GV:
-            p_gv = gv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
-            p_gv_last = gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            p_gv = gv + (bos * H + i_h).to(tl.int64) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_gv_last = gv + (bos + last_idx.to(tl.int64)) * (H * V) + i_h * V + i_v * BV + tl.arange(0, BV)
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.).to(tl.float32)
             b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
-            b_h *= tl.where(active, exp2(b_gv_last), 1.0)[None, :]
+            b_h *= exp2(b_gv_last)[None, :]
             b_v = b_v * exp2(b_gv_last[None, :] - b_gv)
 
         b_h += tl.dot(b_k, b_v)
 
     if STORE_FINAL_STATE:
+        ht_base = (i_nh * K * V).to(tl.int64)
         if STATE_V_FIRST:
-            p_ht = ht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            p_ht = ht + ht_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             tl.store(p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))
         else:
-            p_ht = ht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            p_ht = ht + ht_base + o_k[:, None].to(tl.int64) * V + o_v[None, :]
             tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
 
 
 @triton.heuristics({
     'STORE_INITIAL_STATE_GRADIENT': lambda args: args['dh0'] is not None,
     'USE_FINAL_STATE_GRADIENT': lambda args: args['dht'] is not None,
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.jit(do_not_specialize=['T', 'K_OFFSET', 'V_OFFSET', 'NH_OFFSET'])
 def chunk_bwd_kernel_dh_npu(
     q, g, g_gamma, gk, gv, do, dh, dht, dh0,
-    cu_seqlens, split_offsets, scale, T,
+    scale, T,
     HQ: tl.constexpr, H: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
     BT: tl.constexpr, BS: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr, NT: tl.constexpr, NG: tl.constexpr,
     USE_G: tl.constexpr, USE_G_GAMMA: tl.constexpr, USE_GK: tl.constexpr, USE_GV: tl.constexpr,
     STORE_INITIAL_STATE_GRADIENT: tl.constexpr, USE_FINAL_STATE_GRADIENT: tl.constexpr,
-    IS_VARLEN: tl.constexpr, STATE_V_FIRST: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
     K_OFFSET, V_OFFSET, NH_OFFSET,
 ):
     i_k = tl.program_id(0) + K_OFFSET
@@ -188,15 +162,8 @@ def chunk_bwd_kernel_dh_npu(
     i_nh = tl.program_id(2).to(tl.int64) + NH_OFFSET
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // NG
-    if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = eos - bos
-        NT_SEQ = tl.cdiv(T, BT)
-        boh = tl.load(split_offsets + i_n).to(tl.int64)
-    else:
-        bos, eos = i_n * T, i_n * T + T
-        NT_SEQ = NT
-        boh = i_n * tl.cdiv(T, BS)
+    bos = (i_n * T).to(tl.int64)
+    boh = (i_n * tl.cdiv(T, BS)).to(tl.int64)
 
     if USE_G_GAMMA:
         b_gamma = tl.load(g_gamma + i_h)
@@ -206,73 +173,75 @@ def chunk_bwd_kernel_dh_npu(
     o_k = i_k * BK + tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
     if USE_FINAL_STATE_GRADIENT:
+        dht_base = (i_nh * K * V).to(tl.int64)
         if STATE_V_FIRST:
-            p_dht = dht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            p_dht = dht + dht_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             b_dh += tl.trans(tl.load(p_dht, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
         else:
-            p_dht = dht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            p_dht = dht + dht_base + o_k[:, None].to(tl.int64) * V + o_v[None, :]
             b_dh += tl.load(p_dht, mask=(o_k[:, None] < K) & (o_v[None, :] < V), other=0.0).to(tl.float32)
 
     for step in tl.static_range(NT):
         i_t = NT - 1 - step
-        active = i_t < NT_SEQ
         i_s = i_t // (BS // BT)
-        o_dh = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
+        o_dh = ((boh + i_s.to(tl.int64)) * H + i_h).to(tl.int64) * K * V
         if STATE_V_FIRST:
-            p_dh = dh + o_dh + o_v[:, None] * K + o_k[None, :]
-            m_dh = (o_v[:, None] < V) & (o_k[None, :] < K) & active
+            p_dh = dh + o_dh + o_v[:, None].to(tl.int64) * K + o_k[None, :]
+            m_dh = (o_v[:, None] < V) & (o_k[None, :] < K)
         else:
-            p_dh = dh + o_dh + o_k[:, None] * V + o_v[None, :]
-            m_dh = (o_k[:, None] < K) & (o_v[None, :] < V) & active
+            p_dh = dh + o_dh + o_k[:, None].to(tl.int64) * V + o_v[None, :]
+            m_dh = (o_k[:, None] < K) & (o_v[None, :] < V)
 
         if i_t % (BS // BT) == 0:
             tl.store(p_dh, (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty), mask=m_dh)
 
         last_idx = min(i_t * BT + BT, T) - 1
-        last_idx = max(last_idx, 0)
-        o_t = i_t * BT + tl.arange(0, BT)
-        m_t = (o_t < T) & active
-        p_q = q + (bos * HQ + i_hq) * K + o_k[:, None] + o_t[None, :] * (HQ * K)
-        p_do = do + (bos * HQ + i_hq) * V + o_t[:, None] * (HQ * V) + o_v[None, :]
+        o_t = (i_t * BT + tl.arange(0, BT)).to(tl.int64)
+        m_t = o_t < T
+        qv_base = (bos * HQ + i_hq).to(tl.int64)
+        p_q = q + qv_base * K + o_k[:, None] + o_t[None, :] * (HQ * K)
+        p_do = do + qv_base * V + o_t[:, None] * (HQ * V) + o_v[None, :]
         b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32) * scale
         b_do = tl.load(p_do, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
 
         if USE_G:
-            p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
-            b_g_last = tl.load(g + (bos + last_idx) * H + i_h).to(tl.float32)
-            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T) & active, other=0.).to(tl.float32)
+            p_g = g + bos * H + o_t * H + i_h
+            b_g_last = tl.load(g + bos * H + last_idx.to(tl.int64) * H + i_h).to(tl.float32)
+            b_g = tl.load(p_g, mask=m_t, other=0.).to(tl.float32)
             b_q = b_q * exp2(b_g)[None, :]
-            b_dh *= tl.where(active, exp2(b_g_last), 1.0)
+            b_dh *= exp2(b_g_last)
 
         if USE_G_GAMMA:
-            b_g_last = b_gamma * min(BT, max(T - i_t * BT, 0))
+            b_g_last = b_gamma * min(BT, T - i_t * BT)
             b_q = b_q * exp2(b_g)[None, :]
-            b_dh *= tl.where(active, exp2(b_g_last), 1.0)
+            b_dh *= exp2(b_g_last)
 
         if USE_GK:
-            p_gk = gk + (bos * H + i_h) * K + o_k[:, None] + o_t[None, :] * (H * K)
-            p_gk_last = gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            kv_base = (bos * H + i_h).to(tl.int64) * K
+            p_gk = gk + kv_base + o_k[:, None] + o_t[None, :] * (H * K)
+            p_gk_last = gk + (bos + last_idx.to(tl.int64)) * (H * K) + i_h * K + i_k * BK + tl.arange(0, BK)
             b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32)
             b_gk_last = tl.load(p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.).to(tl.float32)
             b_q = b_q * exp2(b_gk)
-            b_dh *= tl.where(active, exp2(b_gk_last), 1.0)[:, None]
+            b_dh *= exp2(b_gk_last)[:, None]
 
         if USE_GV:
-            p_gv = gv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
-            p_gv_last = gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            p_gv = gv + (bos * H + i_h).to(tl.int64) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_gv_last = gv + (bos + last_idx.to(tl.int64)) * (H * V) + i_h * V + i_v * BV + tl.arange(0, BV)
             b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.).to(tl.float32)
             b_do = b_do * exp2(b_gv)
-            b_dh *= tl.where(active, exp2(b_gv_last), 1.0)[None, :]
+            b_dh *= exp2(b_gv_last)[None, :]
 
         b_dh += tl.dot(b_q, b_do)
 
     if STORE_INITIAL_STATE_GRADIENT:
+        dh0_base = (i_nh * K * V).to(tl.int64)
         if STATE_V_FIRST:
-            p_dh0 = dh0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+            p_dh0 = dh0 + dh0_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             tl.store(p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))
         else:
-            p_dh0 = dh0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+            p_dh0 = dh0 + dh0_base + o_k[:, None].to(tl.int64) * V + o_v[None, :]
             tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
 
 
@@ -300,18 +269,16 @@ def chunk_fwd_h_npu(
     BT = chunk_size
     BS = BT if split_size is None else split_size
     assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
-    assert K <= 256 and V <= 256, "NPU chunk_h currently supports K,V <= 256"
 
-    # Ascend fused IS_VARLEN path can leave partial NaNs in `ht` while `h` stays
-    # correct. Route each packed sequence through the validated equal-length path.
+    # packed varlen: run the equal-length kernel per sequence for complete state stores
     if cu_seqlens is not None:
         assert B == 1, "NPU varlen chunk_h expects packed batch B=1"
         split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
         N = len(cu_seqlens) - 1
         NS = int(split_offsets[-1].item())
         state_shape = (V, K) if state_v_first else (K, V)
-        # zeros: tests/conftest poisons empty*() with NaN; partial stores must not leak.
-        h = k.new_zeros(B, NS, H, *state_shape, dtype=torch.float)
+        # zero-init: kernels may only partially store each tile
+        h = k.new_zeros(B, NS, H, *state_shape, dtype=torch.float if states_in_fp32 else k.dtype)
         ht = k.new_zeros(N, H, *state_shape, dtype=torch.float) if output_final_state else None
         for i_n in range(N):
             bos = int(cu_seqlens[i_n].item())
@@ -340,21 +307,20 @@ def chunk_fwd_h_npu(
                 ht[i_n].copy_(ht_i[0])
         return h, ht
 
-    N, NS, split_offsets = B, triton.cdiv(T, BS), None
-    NT = _max_nt(T, BT, None)
+    N, NS = B, triton.cdiv(T, BS)
+    NT = triton.cdiv(T, BT)
     state_shape = (V, K) if state_v_first else (K, V)
-    # zeros: tests/conftest poisons empty*() with NaN; partial stores must not leak.
-    h = k.new_zeros(B, NS, H, *state_shape, dtype=torch.float)
+    # zero-init: kernels may only partially store each tile
+    h = k.new_zeros(B, NS, H, *state_shape, dtype=torch.float if states_in_fp32 else k.dtype)
     ht = k.new_zeros(N, H, *state_shape, dtype=torch.float) if output_final_state else None
 
-    BK, BV = _BK, _BV
-    nk, nv, nh = triton.cdiv(K, BK), triton.cdiv(V, BV), N * H
-    _launch_kv_nh(
+    BK, BV = _chunk_h_tile_size(K, V)
+    launch_grid_chunked(
         chunk_fwd_kernel_h_npu,
-        nk=nk, nv=nv, nh=nh,
+        (triton.cdiv(K, BK), triton.cdiv(V, BV), N * H),
+        offset_keys=('K_OFFSET', 'V_OFFSET', 'NH_OFFSET'),
         kernel_kwargs=dict(
-            k=k, v=v, h=h, g=g, g_gamma=g_gamma, gk=gk, gv=gv, h0=h0, ht=ht,
-            cu_seqlens=None, split_offsets=None, T=T,
+            k=k, v=v, h=h, g=g, g_gamma=g_gamma, gk=gk, gv=gv, h0=h0, ht=ht, T=T,
             H=H, K=K, V=V, BT=BT, BS=BS, BK=BK, BV=BV, NT=NT,
             USE_G=g is not None, USE_G_GAMMA=g_gamma is not None,
             USE_GK=gk is not None, USE_GV=gv is not None,
@@ -389,15 +355,15 @@ def chunk_bwd_dh_npu(
     BT = chunk_size
     BS = BT if split_size is None else split_size
     assert BS % BT == 0, f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
-    assert K <= 256 and V <= 256, "NPU chunk_h currently supports K,V <= 256"
 
+    # packed varlen: run the equal-length kernel per sequence for complete state stores
     if cu_seqlens is not None:
         assert B == 1, "NPU varlen chunk_bwd_dh expects packed batch B=1"
         split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
         N = len(cu_seqlens) - 1
         NS = int(split_offsets[-1].item())
         state_shape = (V, K) if state_v_first else (K, V)
-        dh = k.new_zeros(B, NS, HQ, *state_shape, dtype=torch.float)
+        dh = k.new_zeros(B, NS, HQ, *state_shape, dtype=torch.float if states_in_fp32 else k.dtype)
         dh0 = torch.zeros_like(h0, dtype=torch.float) if h0 is not None else None
         for i_n in range(N):
             bos = int(cu_seqlens[i_n].item())
@@ -429,22 +395,22 @@ def chunk_bwd_dh_npu(
                 dh0[i_n].copy_(dh0_i[0])
         return dh, dh0
 
-    N, NS, split_offsets = B, triton.cdiv(T, BS), None
+    N, NS = B, triton.cdiv(T, BS)
     NG = HQ // H
-    NT = _max_nt(T, BT, None)
+    NT = triton.cdiv(T, BT)
 
     state_shape = (V, K) if state_v_first else (K, V)
-    dh = k.new_zeros(B, NS, HQ, *state_shape, dtype=torch.float)
+    dh = k.new_zeros(B, NS, HQ, *state_shape, dtype=torch.float if states_in_fp32 else k.dtype)
     dh0 = torch.zeros_like(h0, dtype=torch.float) if h0 is not None else None
 
-    BK, BV = _BK, _BV
-    nk, nv, nh = triton.cdiv(K, BK), triton.cdiv(V, BV), N * HQ
-    _launch_kv_nh(
+    BK, BV = _chunk_h_tile_size(K, V)
+    launch_grid_chunked(
         chunk_bwd_kernel_dh_npu,
-        nk=nk, nv=nv, nh=nh,
+        (triton.cdiv(K, BK), triton.cdiv(V, BV), N * HQ),
+        offset_keys=('K_OFFSET', 'V_OFFSET', 'NH_OFFSET'),
         kernel_kwargs=dict(
             q=q, g=g, g_gamma=g_gamma, gk=gk, gv=gv, do=do, dh=dh, dht=dht, dh0=dh0,
-            cu_seqlens=None, split_offsets=None, scale=scale, T=T,
+            scale=scale, T=T,
             HQ=HQ, H=H, K=K, V=V, BT=BT, BS=BS, BK=BK, BV=BV, NT=NT, NG=NG,
             USE_G=g is not None, USE_G_GAMMA=g_gamma is not None,
             USE_GK=gk is not None, USE_GV=gv is not None,

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.common.backends import dispatch
+from fla.ops.backends import dispatch
 from fla.ops.utils import prepare_chunk_offsets
 from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs, check_shared_mem

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -9,6 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.ops.common.backends import dispatch
 from fla.ops.utils import prepare_chunk_offsets
 from fla.ops.utils.op import exp2
 from fla.utils import autotune_cache_kwargs, check_shared_mem
@@ -303,6 +304,7 @@ def chunk_bwd_kernel_dh(
             tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=(o_k[:, None] < K) & (o_v[None, :] < V))
 
 
+@dispatch('common')
 def chunk_fwd_h(
     k: torch.Tensor,
     v: torch.Tensor,
@@ -361,6 +363,7 @@ def chunk_fwd_h(
     return h, ht
 
 
+@dispatch('common')
 def chunk_bwd_dh(
     q: torch.Tensor,
     k: torch.Tensor,

--- a/fla/ops/gla/backends/__init__.py
+++ b/fla/ops/gla/backends/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""GLA backends."""
+
+from fla.ops.backends import BackendRegistry, dispatch
+from fla.ops.gla.backends.triton_ascend import TritonAscendGLABackend
+
+gla_registry = BackendRegistry("gla")
+gla_registry.register(TritonAscendGLABackend())
+
+
+__all__ = ['dispatch', 'gla_registry']

--- a/fla/ops/gla/backends/triton_ascend/__init__.py
+++ b/fla/ops/gla/backends/triton_ascend/__init__.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Triton-Ascend Ascend NPU backend for GLA ops."""
+
+from __future__ import annotations
+
+from fla.ops.backends import BaseBackend
+
+# Flip per-op after numerical smoke passes. Unready ops fall back to CUDA kernels.
+_READY = {
+    'chunk_gla_fwd_intra_gk': True,
+    'chunk_gla_fwd_o_gk': True,
+    'chunk_gla_bwd_dA': True,
+    'chunk_gla_bwd_dv': True,
+    'chunk_gla_bwd_dqk_intra': True,
+    'chunk_gla_bwd_dqkg': True,
+}
+
+
+class TritonAscendGLABackend(BaseBackend):
+    backend_type = 'triton_ascend'
+    package_name = None
+    env_var = None
+    priority = 0
+
+    @classmethod
+    def is_available(cls) -> bool:
+        from fla.utils import IS_NPU
+        return IS_NPU
+
+    def _gate(self, name: str):
+        if not _READY.get(name, False):
+            return False, f'{name} NPU path not ready'
+        return True, None
+
+    def chunk_gla_fwd_intra_gk_verifier(self, *args, **kwargs):
+        return self._gate('chunk_gla_fwd_intra_gk')
+
+    def chunk_gla_fwd_intra_gk(self, *args, **kwargs):
+        from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_fwd_intra_gk_npu
+        return chunk_gla_fwd_intra_gk_npu(*args, **kwargs)
+
+    def chunk_gla_fwd_o_gk_verifier(self, *args, **kwargs):
+        return self._gate('chunk_gla_fwd_o_gk')
+
+    def chunk_gla_fwd_o_gk(self, *args, **kwargs):
+        from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_fwd_o_gk_npu
+        return chunk_gla_fwd_o_gk_npu(*args, **kwargs)
+
+    def chunk_gla_bwd_dA_verifier(self, *args, **kwargs):
+        return self._gate('chunk_gla_bwd_dA')
+
+    def chunk_gla_bwd_dA(self, *args, **kwargs):
+        from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dA_npu
+        return chunk_gla_bwd_dA_npu(*args, **kwargs)
+
+    def chunk_gla_bwd_dv_verifier(self, *args, **kwargs):
+        return self._gate('chunk_gla_bwd_dv')
+
+    def chunk_gla_bwd_dv(self, *args, **kwargs):
+        from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dv_npu
+        return chunk_gla_bwd_dv_npu(*args, **kwargs)
+
+    def chunk_gla_bwd_dqk_intra_verifier(self, *args, **kwargs):
+        return self._gate('chunk_gla_bwd_dqk_intra')
+
+    def chunk_gla_bwd_dqk_intra(self, *args, **kwargs):
+        from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dqk_intra_npu
+        return chunk_gla_bwd_dqk_intra_npu(*args, **kwargs)
+
+    def chunk_gla_bwd_dqkg_verifier(self, *args, **kwargs):
+        return self._gate('chunk_gla_bwd_dqkg')
+
+    def chunk_gla_bwd_dqkg(self, *args, **kwargs):
+        from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dqkg_npu
+        return chunk_gla_bwd_dqkg_npu(*args, **kwargs)

--- a/fla/ops/gla/backends/triton_ascend/__init__.py
+++ b/fla/ops/gla/backends/triton_ascend/__init__.py
@@ -11,15 +11,15 @@ from __future__ import annotations
 
 from fla.ops.backends import BaseBackend
 
-# Flip per-op after numerical smoke passes. Unready ops fall back to CUDA kernels.
-_READY = {
-    'chunk_gla_fwd_intra_gk': True,
-    'chunk_gla_fwd_o_gk': True,
-    'chunk_gla_bwd_dA': True,
-    'chunk_gla_bwd_dv': True,
-    'chunk_gla_bwd_dqk_intra': True,
-    'chunk_gla_bwd_dqkg': True,
-}
+_MAX_KV = 512
+
+
+def _verify_kv(K: int, V: int | None = None) -> tuple[bool, str | None]:
+    if K > _MAX_KV:
+        return False, f'NPU GLA supports K<={_MAX_KV}, got K={K}'
+    if V is not None and V > _MAX_KV:
+        return False, f'NPU GLA supports V<={_MAX_KV}, got V={V}'
+    return True, None
 
 
 class TritonAscendGLABackend(BaseBackend):
@@ -33,48 +33,43 @@ class TritonAscendGLABackend(BaseBackend):
         from fla.utils import IS_NPU
         return IS_NPU
 
-    def _gate(self, name: str):
-        if not _READY.get(name, False):
-            return False, f'{name} NPU path not ready'
-        return True, None
-
-    def chunk_gla_fwd_intra_gk_verifier(self, *args, **kwargs):
-        return self._gate('chunk_gla_fwd_intra_gk')
+    def chunk_gla_fwd_intra_gk_verifier(self, q, k, *args, **kwargs):
+        return _verify_kv(k.shape[-1])
 
     def chunk_gla_fwd_intra_gk(self, *args, **kwargs):
         from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_fwd_intra_gk_npu
         return chunk_gla_fwd_intra_gk_npu(*args, **kwargs)
 
-    def chunk_gla_fwd_o_gk_verifier(self, *args, **kwargs):
-        return self._gate('chunk_gla_fwd_o_gk')
+    def chunk_gla_fwd_o_gk_verifier(self, q, v, *args, **kwargs):
+        return _verify_kv(q.shape[-1], v.shape[-1])
 
     def chunk_gla_fwd_o_gk(self, *args, **kwargs):
         from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_fwd_o_gk_npu
         return chunk_gla_fwd_o_gk_npu(*args, **kwargs)
 
-    def chunk_gla_bwd_dA_verifier(self, *args, **kwargs):
-        return self._gate('chunk_gla_bwd_dA')
+    def chunk_gla_bwd_dA_verifier(self, v, do, *args, **kwargs):
+        return _verify_kv(v.shape[-1])
 
     def chunk_gla_bwd_dA(self, *args, **kwargs):
         from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dA_npu
         return chunk_gla_bwd_dA_npu(*args, **kwargs)
 
-    def chunk_gla_bwd_dv_verifier(self, *args, **kwargs):
-        return self._gate('chunk_gla_bwd_dv')
+    def chunk_gla_bwd_dv_verifier(self, k, g, A, do, dh, *args, **kwargs):
+        return _verify_kv(k.shape[-1], do.shape[-1])
 
     def chunk_gla_bwd_dv(self, *args, **kwargs):
         from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dv_npu
         return chunk_gla_bwd_dv_npu(*args, **kwargs)
 
-    def chunk_gla_bwd_dqk_intra_verifier(self, *args, **kwargs):
-        return self._gate('chunk_gla_bwd_dqk_intra')
+    def chunk_gla_bwd_dqk_intra_verifier(self, q, k, *args, **kwargs):
+        return _verify_kv(k.shape[-1])
 
     def chunk_gla_bwd_dqk_intra(self, *args, **kwargs):
         from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dqk_intra_npu
         return chunk_gla_bwd_dqk_intra_npu(*args, **kwargs)
 
-    def chunk_gla_bwd_dqkg_verifier(self, *args, **kwargs):
-        return self._gate('chunk_gla_bwd_dqkg')
+    def chunk_gla_bwd_dqkg_verifier(self, q, k, v, *args, **kwargs):
+        return _verify_kv(k.shape[-1], v.shape[-1])
 
     def chunk_gla_bwd_dqkg(self, *args, **kwargs):
         from fla.ops.gla.backends.triton_ascend.chunk import chunk_gla_bwd_dqkg_npu

--- a/fla/ops/gla/backends/triton_ascend/chunk.py
+++ b/fla/ops/gla/backends/triton_ascend/chunk.py
@@ -1,0 +1,934 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""GLA chunk kernels for triton-ascend on Ascend NPU."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils.op import exp2
+from fla.utils import input_guard
+from fla.utils.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_row_tile_block_size,
+    max_grid_axis_chunks,
+)
+
+_BC = 16
+_NUM_WARPS = 2
+_NUM_WARPS_FWD_O = 4
+_NUM_WARPS_INTER = 4
+_LAUNCH_BLOCK_BUDGET = 4096
+_SAFETY_MARGIN = 0.80
+_FALLBACK_BK = 16
+_FALLBACK = 16
+_MAX_BKV = 64
+_MAX_TILE = 64
+
+
+def _npu_sync() -> None:
+    if hasattr(torch, 'npu') and torch.npu.is_available():
+        torch.npu.synchronize()
+
+
+def _get_bk(K: int) -> int:
+    return compute_row_tile_block_size(
+        _BC, K, 6.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_BK, min_block=16,
+        max_block=min(64, max(16, triton.next_power_of_2(K))),
+    )
+
+
+def _launch_3d_nt_nc_bh(kernel, *, nt: int, nc: int, bh: int, kernel_kwargs: dict, num_warps: int = _NUM_WARPS) -> None:
+    budget = _LAUNCH_BLOCK_BUDGET
+    chunk_indices = kernel_kwargs.get('chunk_indices')
+    cu_seqlens = kernel_kwargs.get('cu_seqlens')
+    nt_step = nt if nt * nc * bh <= budget else max(1, budget // max(nc * bh, 1))
+    for nt_off in range(0, nt, nt_step):
+        nt_len = min(nt_step, nt - nt_off)
+        if cu_seqlens is not None and chunk_indices is not None:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['NT_OFFSET'] = 0
+        else:
+            kernel_kwargs['NT_OFFSET'] = nt_off
+        nc_budget = max(1, budget // max(nt_len * bh, 1))
+        nc_step = min(nc_budget, max_grid_axis_chunks(nc, nt_len * bh, max_grid=ASCEND_MAX_GRID_DIM))
+        for nc_off in range(0, nc, nc_step):
+            nc_len = min(nc_step, nc - nc_off)
+            kernel_kwargs['NC_OFFSET'] = nc_off
+            bh_budget = max(1, budget // max(nt_len * nc_len, 1))
+            bh_step = min(bh_budget, max_grid_axis_chunks(bh, nt_len * nc_len, max_grid=ASCEND_MAX_GRID_DIM))
+            for bh_off in range(0, bh, bh_step):
+                bh_len = min(bh_step, bh - bh_off)
+                kernel_kwargs['BH_OFFSET'] = bh_off
+                kernel[(nt_len, nc_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'])
+def chunk_gla_fwd_A_kernel_intra_sub_inter_npu(
+    q, k, g, A, cu_seqlens, chunk_indices, scale, T,
+    H: tl.constexpr, K: tl.constexpr, BT: tl.constexpr, BC: tl.constexpr, BK: tl.constexpr, NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr, NT_OFFSET, NC_OFFSET, BH_OFFSET,
+):
+    i_t = tl.program_id(0).to(tl.int64) + NT_OFFSET
+    i_c = tl.program_id(1) + NC_OFFSET
+    i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    i_i, i_j = i_c // NC, i_c % NC
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+    if i_i <= i_j:
+        return
+
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    o_i = i_t * BT + i_i * BC + tl.arange(0, BC)
+    o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+    m_i = o_i < T
+    m_j = o_j < T
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_qk = m_i[:, None] & m_k[None, :]
+        m_kj = m_k[:, None] & m_j[None, :]
+
+        p_q = q + (bos * H + i_h) * K + o_i[:, None] * (H * K) + o_k[None, :]
+        p_g = g + (bos * H + i_h) * K + o_i[:, None] * (H * K) + o_k[None, :]
+        p_k = k + (bos * H + i_h) * K + o_k[:, None] + o_j[None, :] * (H * K)
+        p_gk = g + (bos * H + i_h) * K + o_k[:, None] + o_j[None, :] * (H * K)
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
+        b_q = tl.load(p_q, mask=m_qk, other=0.0).to(tl.float32)
+        b_g = tl.load(p_g, mask=m_qk, other=0.0).to(tl.float32)
+        b_qg = b_q * exp2(b_g - b_gn[None, :]) * scale
+        b_k = tl.load(p_k, mask=m_kj, other=0.0).to(tl.float32)
+        b_gk = tl.load(p_gk, mask=m_kj, other=0.0).to(tl.float32)
+        b_kg = b_k * exp2(b_gn[:, None] - b_gk)
+        b_A += tl.dot(b_qg, b_kg, allow_tf32=False)
+
+    o_jA = i_j * BC + tl.arange(0, BC)
+    m_A = m_i[:, None] & (o_jA[None, :] < BT)
+    p_A = A + (bos * H + i_h) * BT + o_i[:, None] * (H * BT) + o_jA[None, :]
+    tl.store(p_A, b_A.to(A.dtype.element_ty), mask=m_A)
+
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'])
+def chunk_gla_fwd_A_kernel_intra_sub_intra_npu(
+    q, k, g, A, cu_seqlens, chunk_indices, scale, T,
+    H: tl.constexpr, K: tl.constexpr, BT: tl.constexpr, BC: tl.constexpr, BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr, NT_OFFSET, NC_OFFSET, BH_OFFSET,
+):
+    i_t = tl.program_id(0).to(tl.int64) + NT_OFFSET
+    i_i = tl.program_id(1) + NC_OFFSET
+    i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    i_j = i_i
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    o_i = tl.arange(0, BC)
+    o_k = tl.arange(0, BK)
+    o_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) * H * BT + i_j * BC
+    m_k = o_k < K
+    m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+
+    q_ptr = q + (bos * H + i_h) * K
+    k_ptr = k + (bos * H + i_h) * K
+    g_ptr = g + (bos * H + i_h) * K
+    A_ptr = A + (bos * H + i_h) * BT
+
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_qk = m_A[:, None] & m_k[None, :]
+    b_q = tl.load(q_ptr + o_c[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
+    b_g = tl.load(g_ptr + o_c[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
+
+    # Diagonal lower-tri via masked static loop (no continue).
+    max_j = min(BC, T - i_t * BT - i_i * BC)
+    for j in tl.static_range(BC):
+        active = j < max_j
+        b_k = tl.load(
+            k_ptr + (i_t * BT + i_j * BC + j) * H * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
+        b_gk = tl.load(
+            g_ptr + (i_t * BT + i_j * BC + j) * H * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
+        b_Aj = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
+        tl.store(A_ptr + o_A + j, b_Aj, mask=m_A & active)
+
+    tl.debug_barrier()
+    # Zero strict upper triangle of the BC×BC diagonal block (keep causal i>=j).
+    b_zero = tl.zeros([BC, BC], dtype=tl.float32)
+    tl.store(
+        A_ptr + o_A[:, None] + o_i,
+        b_zero,
+        mask=m_A[:, None] & (o_i[:, None] < o_i),
+    )
+
+
+@input_guard
+def chunk_gla_fwd_intra_gk_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K = k.shape
+    BT = chunk_size
+    assert K <= 256, "NPU GLA intra currently supports K <= 256"
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BC = min(_BC, BT)
+    NC = triton.cdiv(BT, BC)
+    # Inter tiles K; diag mirrors CUDA K<=256 path: load full [BC, K] at once.
+    BK_inter = _get_bk(K)
+    BK_diag = max(triton.next_power_of_2(K), 16)
+
+    # Partial writes (lower-tri + diag); zeros avoid dirty upper-tri NaNs.
+    A = q.new_zeros(B, T, H, BT, dtype=torch.float)
+    base = dict(
+        q=q, k=k, g=g, A=A, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
+        scale=scale, T=T, H=H, K=K, BT=BT, BC=BC,
+        NT_OFFSET=0, NC_OFFSET=0, BH_OFFSET=0,
+    )
+    _launch_3d_nt_nc_bh(
+        chunk_gla_fwd_A_kernel_intra_sub_inter_npu,
+        nt=NT, nc=NC * NC, bh=B * H,
+        kernel_kwargs={**base, 'BK': BK_inter, 'NC': NC},
+    )
+    _launch_3d_nt_nc_bh(
+        chunk_gla_fwd_A_kernel_intra_sub_intra_npu,
+        nt=NT, nc=NC, bh=B * H,
+        kernel_kwargs={**base, 'BK': BK_diag},
+    )
+    if hasattr(torch, 'npu') and torch.npu.is_available():
+        torch.npu.synchronize()
+    return A
+
+# ---------------------------------------------------------------------------
+# Forward: o
+# ---------------------------------------------------------------------------
+
+def _fwd_o_pick_bk(K: int) -> int:
+    return compute_row_tile_block_size(
+        64, K, 6.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK, min_block=16,
+        max_block=min(_MAX_BKV, max(16, triton.next_power_of_2(K))),
+    )
+
+
+def _fwd_o_pick_bv(V: int) -> int:
+    return compute_row_tile_block_size(
+        64, V, 6.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK, min_block=16,
+        max_block=min(_MAX_BKV, max(16, triton.next_power_of_2(V))),
+    )
+
+
+def _launch_v_nt_bh(kernel, *, nv: int, nt: int, bh: int, kernel_kwargs: dict) -> None:
+    # Keep full chunk_indices: varlen h is indexed by global chunk id (i_tg).
+    budget = _LAUNCH_BLOCK_BUDGET
+    nv_step = nv if nv * nt * bh <= budget else max(1, budget // max(nt * bh, 1))
+    for v_off in range(0, nv, nv_step):
+        v_len = min(nv_step, nv - v_off)
+        kernel_kwargs['V_OFFSET'] = v_off
+        nt_budget = max(1, budget // max(v_len * bh, 1))
+        nt_step = min(nt_budget, max_grid_axis_chunks(nt, v_len * bh, max_grid=ASCEND_MAX_GRID_DIM))
+        for nt_off in range(0, nt, nt_step):
+            nt_len = min(nt_step, nt - nt_off)
+            kernel_kwargs['NT_OFFSET'] = nt_off
+            bh_budget = max(1, budget // max(v_len * nt_len, 1))
+            bh_step = min(bh_budget, max_grid_axis_chunks(bh, v_len * nt_len, max_grid=ASCEND_MAX_GRID_DIM))
+            for bh_off in range(0, bh, bh_step):
+                bh_len = min(bh_step, bh - bh_off)
+                kernel_kwargs['BH_OFFSET'] = bh_off
+                kernel[(v_len, nt_len, bh_len)](num_warps=_NUM_WARPS_FWD_O, **kernel_kwargs)
+
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'V_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
+def chunk_gla_fwd_kernel_o_npu(
+    q, v, g, h, o, A, cu_seqlens, chunk_indices, scale, T,
+    H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr, IS_VARLEN: tl.constexpr,
+    V_OFFSET, NT_OFFSET, BH_OFFSET,
+):
+    i_v = tl.program_id(0) + V_OFFSET
+    i_t = tl.program_id(1).to(tl.int64) + NT_OFFSET
+    i_bh = tl.program_id(2) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+    if IS_VARLEN:
+        i_tg = i_t.to(tl.int64)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = (i_b * NT + i_t).to(tl.int64)
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+
+    if i_t * BT >= T:
+        return
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    q_base = q + (bos * H + i_h) * K
+    g_base = g + (bos * HV + i_hv) * K
+    v_base = v + (bos * HV + i_hv) * V
+    o_base = o + (bos * HV + i_hv) * V
+    h_base = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
+    A_base = A + (bos * HV + i_hv) * BT
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_i = tl.arange(0, BT)
+    m_t = o_t < T
+    m_v = o_v < V
+    m_tv = m_t[:, None] & m_v[None, :]
+    m_A = m_t[:, None] & (o_i[None, :] < BT)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_qk = m_t[:, None] & m_k[None, :]
+        b_q = tl.load(q_base + o_t[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
+        b_g = tl.load(g_base + o_t[:, None] * (HV * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
+        b_qg = b_q * exp2(b_g)
+        if STATE_V_FIRST:
+            b_h = tl.load(
+                h_base + o_v[:, None] * K + o_k[None, :],
+                mask=m_v[:, None] & m_k[None, :], other=0.0,
+            ).to(tl.float32)
+            b_o += tl.dot(b_qg, tl.trans(b_h), allow_tf32=False)
+        else:
+            b_h = tl.load(
+                h_base + o_k[:, None] * V + o_v[None, :],
+                mask=m_k[:, None] & m_v[None, :], other=0.0,
+            ).to(tl.float32)
+            b_o += tl.dot(b_qg, b_h, allow_tf32=False)
+
+    b_o *= scale
+    b_v = tl.load(v_base + o_t[:, None] * (HV * V) + o_v[None, :], mask=m_tv, other=0.0).to(tl.float32)
+    b_A = tl.load(A_base + o_t[:, None] * (HV * BT) + o_i[None, :], mask=m_A, other=0.0).to(tl.float32)
+    b_A = tl.where(m_s, b_A, 0.0)
+    b_o += tl.dot(b_A, b_v, allow_tf32=False)
+    tl.store(o_base + o_t[:, None] * (HV * V) + o_v[None, :], b_o.to(o.dtype.element_ty), mask=m_tv)
+
+
+@input_guard
+def chunk_gla_fwd_o_gk_npu(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    scale: float,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
+    BT = chunk_size
+    assert K <= 256 and V <= 256, "NPU GLA o currently supports K,V <= 256"
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    o = torch.zeros_like(v)
+    BK, BV = _fwd_o_pick_bk(K), _fwd_o_pick_bv(V)
+    nv, bh = triton.cdiv(V, BV), B * HV
+    _launch_v_nt_bh(
+        chunk_gla_fwd_kernel_o_npu,
+        nv=nv, nt=NT, bh=bh,
+        kernel_kwargs=dict(
+            q=q, v=v, g=g, h=h, o=o, A=A,
+            cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, scale=scale, T=T,
+            H=H, HV=HV, K=K, V=V, BT=BT, BK=BK, BV=BV,
+            STATE_V_FIRST=state_v_first,
+            V_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
+        ),
+    )
+    if hasattr(torch, 'npu') and torch.npu.is_available():
+        torch.npu.synchronize()
+    return o
+
+# ---------------------------------------------------------------------------
+# Backward
+# ---------------------------------------------------------------------------
+
+def _bwd_pick_bk(K: int) -> int:
+    return compute_row_tile_block_size(
+        _BC, K, 8.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK, min_block=16,
+        max_block=min(_MAX_TILE, max(16, triton.next_power_of_2(K))),
+    )
+
+
+def _bwd_pick_bv(V: int) -> int:
+    return compute_row_tile_block_size(
+        64, V, 8.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK, min_block=16,
+        max_block=min(_MAX_TILE, max(16, triton.next_power_of_2(V))),
+    )
+
+
+def _launch_2d(kernel, *, nt: int, bh: int, kernel_kwargs: dict, num_warps: int = _NUM_WARPS) -> None:
+    budget = _LAUNCH_BLOCK_BUDGET
+    nt_step = nt if nt * bh <= budget else max(1, budget // max(bh, 1))
+    for nt_off in range(0, nt, nt_step):
+        nt_len = min(nt_step, nt - nt_off)
+        kernel_kwargs['NT_OFFSET'] = nt_off
+        bh_budget = max(1, budget // max(nt_len, 1))
+        bh_step = min(bh_budget, max_grid_axis_chunks(bh, nt_len, max_grid=ASCEND_MAX_GRID_DIM))
+        for bh_off in range(0, bh, bh_step):
+            bh_len = min(bh_step, bh - bh_off)
+            kernel_kwargs['BH_OFFSET'] = bh_off
+            kernel[(nt_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+
+
+def _launch_3d_na_nt_bh(kernel, *, na: int, nt: int, bh: int, kernel_kwargs: dict, num_warps: int = _NUM_WARPS) -> None:
+    """3D launch over (axis0, nt, bh). Does not slice chunk_indices (need global i_tg)."""
+    budget = _LAUNCH_BLOCK_BUDGET
+    na_step = na if na * nt * bh <= budget else max(1, budget // max(nt * bh, 1))
+    for a_off in range(0, na, na_step):
+        a_len = min(na_step, na - a_off)
+        kernel_kwargs['A_OFFSET'] = a_off
+        nt_budget = max(1, budget // max(a_len * bh, 1))
+        nt_step = min(nt_budget, max_grid_axis_chunks(nt, a_len * bh, max_grid=ASCEND_MAX_GRID_DIM))
+        for nt_off in range(0, nt, nt_step):
+            nt_len = min(nt_step, nt - nt_off)
+            kernel_kwargs['NT_OFFSET'] = nt_off
+            bh_budget = max(1, budget // max(a_len * nt_len, 1))
+            bh_step = min(bh_budget, max_grid_axis_chunks(bh, a_len * nt_len, max_grid=ASCEND_MAX_GRID_DIM))
+            for bh_off in range(0, bh, bh_step):
+                bh_len = min(bh_step, bh - bh_off)
+                kernel_kwargs['BH_OFFSET'] = bh_off
+                kernel[(a_len, nt_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# dA
+# ---------------------------------------------------------------------------
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'BH_OFFSET'])
+def chunk_gla_bwd_kernel_dA_npu(
+    v, do, dA, cu_seqlens, chunk_indices, scale, T,
+    H: tl.constexpr, V: tl.constexpr, BT: tl.constexpr, BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr, NT_OFFSET, BH_OFFSET,
+):
+    i_t = tl.program_id(0).to(tl.int64) + NT_OFFSET
+    i_bh = tl.program_id(1).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    T = eos - bos
+
+    if i_t * BT >= T:
+        return
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_i = tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = m_t[:, None] & (o_i[None, :] < BT)
+    for i_v in range(tl.cdiv(V, BV)):
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        m_tv = m_t[:, None] & m_v[None, :]
+        m_vt = m_v[:, None] & m_t[None, :]
+        b_do = tl.load(
+            do + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :],
+            mask=m_tv, other=0.0,
+        ).to(tl.float32)
+        b_v = tl.load(
+            v + (bos * H + i_h) * V + o_v[:, None] + o_t[None, :] * (H * V),
+            mask=m_vt, other=0.0,
+        ).to(tl.float32)
+        b_dA += tl.dot(b_do, b_v, allow_tf32=False)
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+    b_dA = tl.where(m_s, b_dA * scale, 0.)
+    p_dA = dA + (bos * H + i_h) * BT + o_t[:, None] * (H * BT) + o_i[None, :]
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), mask=m_A)
+
+
+@input_guard
+def chunk_gla_bwd_dA_npu(
+    v: torch.Tensor,
+    do: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, V = v.shape
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BV = _bwd_pick_bv(V)
+    dA = v.new_zeros(B, T, H, BT, dtype=torch.float)
+    _launch_2d(
+        chunk_gla_bwd_kernel_dA_npu,
+        nt=NT, bh=B * H,
+        kernel_kwargs=dict(
+            v=v, do=do, dA=dA, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
+            scale=scale, T=T, H=H, V=V, BT=BT, BV=BV,
+            NT_OFFSET=0, BH_OFFSET=0,
+        ),
+    )
+    _npu_sync()
+    return dA
+
+
+# ---------------------------------------------------------------------------
+# dv
+# ---------------------------------------------------------------------------
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
+def chunk_gla_bwd_kernel_dv_npu(
+    k, g, A, do, dh, dv, cu_seqlens, chunk_indices, T,
+    H: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr, STATE_V_FIRST: tl.constexpr,
+    A_OFFSET, NT_OFFSET, BH_OFFSET,
+):
+    i_v = tl.program_id(0) + A_OFFSET
+    i_t = tl.program_id(1).to(tl.int64) + NT_OFFSET
+    i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_i = tl.arange(0, BT)
+    m_t = o_t < T
+    m_v = o_v < V
+    m_A = (o_i[:, None] < BT) & m_t[None, :]
+    m_tv = m_t[:, None] & m_v[None, :]
+    b_A = tl.load(
+        A + (bos * H + i_h) * BT + o_i[:, None] + o_t[None, :] * (H * BT),
+        mask=m_A, other=0.0,
+    ).to(tl.float32)
+    b_do = tl.load(
+        do + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :],
+        mask=m_tv, other=0.0,
+    ).to(tl.float32)
+    b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], b_A, 0.)
+    b_dv = tl.dot(b_A, b_do, allow_tf32=False)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_tk = m_t[:, None] & m_k[None, :]
+        m_kvd = m_k[:, None] & m_v[None, :]
+        b_k = tl.load(
+            k + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :],
+            mask=m_tk, other=0.0,
+        ).to(tl.float32)
+        b_gk = tl.load(
+            g + (bos * H + i_h) * K + o_t[:, None] * (H * K) + o_k[None, :],
+            mask=m_tk, other=0.0,
+        ).to(tl.float32)
+        b_gn = tl.load(
+            g + (bos + min(i_t * BT + BT, T) - 1) * H * K + i_h * K + o_k,
+            mask=m_k, other=0,
+        ).to(tl.float32)
+        if STATE_V_FIRST:
+            b_dh = tl.load(
+                dh + (i_tg * H + i_h) * K * V + o_k[:, None] + o_v[None, :] * K,
+                mask=m_kvd, other=0.0,
+            ).to(tl.float32)
+        else:
+            b_dh = tl.load(
+                dh + (i_tg * H + i_h) * K * V + o_k[:, None] * V + o_v[None, :],
+                mask=m_kvd, other=0.0,
+            ).to(tl.float32)
+        b_k = b_k * exp2(b_gn[None, :] - b_gk)
+        b_dv += tl.dot(b_k, b_dh, allow_tf32=False)
+
+    tl.store(
+        dv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :],
+        b_dv.to(dv.dtype.element_ty), mask=m_tv,
+    )
+
+
+@input_guard
+def chunk_gla_bwd_dv_npu(
+    k: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V = *k.shape, do.shape[-1]
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BK, BV = _bwd_pick_bk(K), _bwd_pick_bv(V)
+    dv = torch.zeros_like(do)
+    _launch_3d_na_nt_bh(
+        chunk_gla_bwd_kernel_dv_npu,
+        na=triton.cdiv(V, BV), nt=NT, bh=B * H,
+        kernel_kwargs=dict(
+            k=k, g=g, A=A, do=do, dh=dh, dv=dv,
+            cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, T=T,
+            H=H, K=K, V=V, BT=BT, BK=BK, BV=BV, STATE_V_FIRST=state_v_first,
+            A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
+        ),
+        num_warps=_NUM_WARPS_INTER,
+    )
+    _npu_sync()
+    return dv
+
+
+# ---------------------------------------------------------------------------
+# dqk_intra
+# ---------------------------------------------------------------------------
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
+def chunk_gla_bwd_kernel_intra_npu(
+    q, k, g, dA, dq, dk, cu_seqlens, chunk_indices, T,
+    H: tl.constexpr, K: tl.constexpr, BT: tl.constexpr, BC: tl.constexpr, BK: tl.constexpr, NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr, A_OFFSET, NT_OFFSET, BH_OFFSET,
+):
+    # Mirror CUDA/KDA structure: `if i_i > 0` + `range(0, i_i)` (proven on Ascend).
+    # Do NOT use static_range(NC)+mask gates for inter-subchunk — that path produced NaNs.
+    i_kc = tl.program_id(0) + A_OFFSET
+    i_t = tl.program_id(1).to(tl.int64) + NT_OFFSET
+    i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    i_k, i_i = i_kc // NC, i_kc % NC
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    T = eos - bos
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_c = o_c < T
+    m_ck = m_c[:, None] & m_k[None, :]
+    b_g = tl.load(
+        g + (bos * H + i_h) * K + o_c[:, None] * (H * K) + o_k[None, :],
+        mask=m_ck, other=0.0,
+    ).to(tl.float32)
+
+    b_dq = tl.zeros([BC, BK], dtype=tl.float32)
+    if i_i > 0:
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
+        for i_j in range(0, i_i):
+            o_j = i_t * BT + i_j * BC + tl.arange(0, BC)
+            o_jA = i_j * BC + tl.arange(0, BC)
+            m_jk = (o_j[:, None] < T) & m_k[None, :]
+            m_da = m_c[:, None] & (o_jA[None, :] < BT)
+            b_k = tl.load(
+                k + (bos * H + i_h) * K + o_j[:, None] * (H * K) + o_k[None, :],
+                mask=m_jk, other=0.0,
+            ).to(tl.float32)
+            b_gk = tl.load(
+                g + (bos * H + i_h) * K + o_j[:, None] * (H * K) + o_k[None, :],
+                mask=m_jk, other=0.0,
+            ).to(tl.float32)
+            b_kg = b_k * exp2(b_gn[None, :] - b_gk)
+            b_dA = tl.load(
+                dA + (bos * H + i_h) * BT + o_c[:, None] * (H * BT) + o_jA[None, :],
+                mask=m_da, other=0.0,
+            ).to(tl.float32)
+            b_dq += tl.dot(b_dA, b_kg, allow_tf32=False)
+        b_dq *= exp2(b_g - b_gn[None, :])
+
+    o_i = tl.arange(0, BC)
+    m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+    o_dA = bos * H * BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H * BT + i_h * BT + i_i * BC
+    p_kj = k + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_gkj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        b_dAj = tl.load(dA + o_dA + j, mask=m_dA, other=0).to(tl.float32)
+        b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
+        b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+        m_i = o_i[:, None] >= j
+        b_dq += tl.where(m_i, b_dAj[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.)
+        p_kj += H * K
+        p_gkj += H * K
+
+    tl.store(
+        dq + (bos * H + i_h) * K + o_c[:, None] * (H * K) + o_k[None, :],
+        b_dq.to(dq.dtype.element_ty), mask=m_ck,
+    )
+
+    tl.debug_barrier()
+    b_dk = tl.zeros([BC, BK], dtype=tl.float32)
+    NC_eff = min(NC, tl.cdiv(T - i_t * BT, BC))
+    if i_i < NC_eff - 1:
+        p_gn2 = g + (bos + min(i_t * BT + i_i * BC + BC, T) - 1) * H * K + i_h * K + o_k
+        b_gn2 = tl.load(p_gn2, mask=m_k, other=0).to(tl.float32)
+        for i_j in range(i_i + 1, NC_eff):
+            o_j = i_t * BT + i_j * BC + o_i
+            o_iA = i_i * BC + tl.arange(0, BC)
+            m_j = o_j < T
+            m_jk = m_j[:, None] & m_k[None, :]
+            m_da = (o_iA[:, None] < BT) & m_j[None, :]
+            b_q = tl.load(
+                q + (bos * H + i_h) * K + o_j[:, None] * (H * K) + o_k[None, :],
+                mask=m_jk, other=0.0,
+            ).to(tl.float32)
+            b_gq = tl.load(
+                g + (bos * H + i_h) * K + o_j[:, None] * (H * K) + o_k[None, :],
+                mask=m_jk, other=0.0,
+            ).to(tl.float32)
+            b_qg = b_q * tl.where(m_j[:, None], exp2(b_gq - b_gn2[None, :]), 0)
+            b_dA = tl.load(
+                dA + (bos * H + i_h) * BT + o_iA[:, None] + o_j[None, :] * (H * BT),
+                mask=m_da, other=0.0,
+            ).to(tl.float32)
+            b_dk += tl.dot(b_dA, b_qg, allow_tf32=False)
+        b_dk *= exp2(b_gn2[None, :] - b_g)
+
+    o_dA2 = bos * H * BT + (i_t * BT + i_i * BC) * H * BT + i_h * BT + i_i * BC + tl.arange(0, BC)
+    p_qj = q + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_gqj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        b_dAj = tl.load(dA + o_dA2 + j * H * BT).to(tl.float32)
+        b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
+        b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
+        m_i = o_i[:, None] <= j
+        b_dk += tl.where(m_i, b_dAj[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.)
+        p_qj += H * K
+        p_gqj += H * K
+
+    tl.store(
+        dk + (bos * H + i_h) * K + o_c[:, None] * (H * K) + o_k[None, :],
+        b_dk.to(dk.dtype.element_ty), mask=m_ck,
+    )
+
+
+@input_guard
+def chunk_gla_bwd_dqk_intra_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    dA: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K = q.shape
+    BT = chunk_size
+    BC = min(_BC, BT)
+    BK = min(64, triton.next_power_of_2(K))
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+    NK = triton.cdiv(K, BK)
+    dq = torch.zeros_like(q, dtype=torch.float)
+    dk = torch.zeros_like(k, dtype=torch.float)
+    _launch_3d_na_nt_bh(
+        chunk_gla_bwd_kernel_intra_npu,
+        na=NK * NC, nt=NT, bh=B * H,
+        kernel_kwargs=dict(
+            q=q, k=k, g=g, dA=dA, dq=dq, dk=dk,
+            cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, T=T,
+            H=H, K=K, BT=BT, BC=BC, BK=BK, NC=NC,
+            A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
+        ),
+    )
+    _npu_sync()
+    return dq, dk
+
+
+# ---------------------------------------------------------------------------
+# dqkg (inter)
+# ---------------------------------------------------------------------------
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
+def chunk_gla_bwd_kernel_inter_npu(
+    q, k, v, g, h, do, dh, dq, dk, dq2, dk2, dg,
+    cu_seqlens, chunk_indices, scale, T,
+    H: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
+    BT: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr, STATE_V_FIRST: tl.constexpr,
+    A_OFFSET, NT_OFFSET, BH_OFFSET,
+):
+    i_k = tl.program_id(0) + A_OFFSET
+    i_t = tl.program_id(1).to(tl.int64) + NT_OFFSET
+    i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_tk = m_t[:, None] & m_k[None, :]
+
+    q_base = q + (bos * H + i_h) * K
+    k_base = k + (bos * H + i_h) * K
+    v_base = v + (bos * H + i_h) * V
+    g_base = g + (bos * H + i_h) * K
+    h_base = h + (i_tg * H + i_h) * K * V
+    do_base = do + (bos * H + i_h) * V
+    dh_base = dh + (i_tg * H + i_h) * K * V
+    dq_base = dq + (bos * H + i_h) * K
+    dk_base = dk + (bos * H + i_h) * K
+    dq2_base = dq2 + (bos * H + i_h) * K
+    dk2_base = dk2 + (bos * H + i_h) * K
+    dg_base = dg + (bos * H + i_h) * K
+
+    b_gk = tl.load(g_base + o_t[:, None] * (H * K) + o_k[None, :], mask=m_tk, other=0.0).to(tl.float32)
+    b_gn = tl.load(g_base + (min(T, i_t * BT + BT) - 1) * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+    b_dq = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dk = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dgk = tl.zeros([BK], dtype=tl.float32)
+
+    for i_v in range(tl.cdiv(V, BV)):
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        m_tv = m_t[:, None] & m_v[None, :]
+        m_vk = m_v[:, None] & m_k[None, :]
+        b_v = tl.load(v_base + o_t[:, None] * (H * V) + o_v[None, :], mask=m_tv, other=0.0).to(tl.float32)
+        b_do = tl.load(do_base + o_t[:, None] * (H * V) + o_v[None, :], mask=m_tv, other=0.0).to(tl.float32)
+        if STATE_V_FIRST:
+            b_h = tl.load(h_base + o_v[:, None] * K + o_k[None, :], mask=m_vk, other=0.0).to(tl.float32)
+            b_dh = tl.load(dh_base + o_v[:, None] * K + o_k[None, :], mask=m_vk, other=0.0).to(tl.float32)
+        else:
+            b_h = tl.load(h_base + o_v[:, None] + o_k[None, :] * V, mask=m_vk, other=0.0).to(tl.float32)
+            b_dh = tl.load(dh_base + o_v[:, None] + o_k[None, :] * V, mask=m_vk, other=0.0).to(tl.float32)
+        b_dgk += tl.sum(b_h * b_dh, axis=0)
+        b_dq += tl.dot(b_do, b_h, allow_tf32=False)
+        b_dk += tl.dot(b_v, b_dh, allow_tf32=False)
+
+    b_dgk *= exp2(b_gn)
+    b_dq *= scale
+    b_dq = b_dq * exp2(b_gk)
+    b_dk = b_dk * exp2(b_gn[None, :] - b_gk)
+    b_q = tl.load(q_base + o_t[:, None] * (H * K) + o_k[None, :], mask=m_tk, other=0.0).to(tl.float32)
+    b_k = tl.load(k_base + o_t[:, None] * (H * K) + o_k[None, :], mask=m_tk, other=0.0).to(tl.float32)
+    b_dgk += tl.sum(b_dk * b_k, axis=0)
+    b_dq += tl.load(dq_base + o_t[:, None] * (H * K) + o_k[None, :], mask=m_tk, other=0.0).to(tl.float32)
+    b_dk += tl.load(dk_base + o_t[:, None] * (H * K) + o_k[None, :], mask=m_tk, other=0.0).to(tl.float32)
+    b_dg = b_q * b_dq - b_k * b_dk
+    b_dg = b_dg - tl.cumsum(b_dg, axis=0) + tl.sum(b_dg, axis=0)[None, :] + b_dgk[None, :]
+    tl.store(dq2_base + o_t[:, None] * (H * K) + o_k[None, :], b_dq.to(dq2.dtype.element_ty), mask=m_tk)
+    tl.store(dk2_base + o_t[:, None] * (H * K) + o_k[None, :], b_dk.to(dk2.dtype.element_ty), mask=m_tk)
+    tl.store(dg_base + o_t[:, None] * (H * K) + o_k[None, :], b_dg.to(dg.dtype.element_ty), mask=m_tk)
+
+
+@input_guard
+def chunk_gla_bwd_dqkg_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    scale: float | None = None,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BK, BV = _bwd_pick_bk(K), _bwd_pick_bv(V)
+    dg = torch.zeros_like(g)
+    dq2 = torch.zeros_like(dq)
+    dk2 = torch.zeros_like(dk)
+    _launch_3d_na_nt_bh(
+        chunk_gla_bwd_kernel_inter_npu,
+        na=triton.cdiv(K, BK), nt=NT, bh=B * H,
+        kernel_kwargs=dict(
+            q=q, k=k, v=v, g=g, h=h, do=do, dh=dh, dq=dq, dk=dk,
+            dq2=dq2, dk2=dk2, dg=dg,
+            cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, scale=scale, T=T,
+            H=H, K=K, V=V, BT=BT, BK=BK, BV=BV, STATE_V_FIRST=state_v_first,
+            A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
+        ),
+        num_warps=_NUM_WARPS_INTER,
+    )
+    _npu_sync()
+    return dq2, dk2, dg

--- a/fla/ops/gla/backends/triton_ascend/chunk.py
+++ b/fla/ops/gla/backends/triton_ascend/chunk.py
@@ -354,12 +354,13 @@ def chunk_gla_fwd_kernel_o_npu(
     STATE_V_FIRST: tl.constexpr, IS_VARLEN: tl.constexpr,
 ):
     core_id = tl.program_id(0)
-    h_t_step = HV * total_chunks
+    total_chunks_i64 = total_chunks.to(tl.int64)
+    h_t_step = total_chunks_i64 * HV
     for task_id in tl.range(core_id, task_num, num_core):
-        i_v = task_id // h_t_step
+        i_v = (task_id // h_t_step).to(tl.int32)
         remainder = task_id % h_t_step
-        i_hv = remainder // total_chunks
-        global_t = remainder % total_chunks
+        i_hv = (remainder // total_chunks_i64).to(tl.int32)
+        global_t = (remainder % total_chunks_i64).to(tl.int32)
         i_h = i_hv // (HV // H)
         T_cur = T
 
@@ -373,7 +374,7 @@ def chunk_gla_fwd_kernel_o_npu(
             NT = tl.cdiv(T, BT)
             i_b = global_t // NT
             i_t = (global_t % NT).to(tl.int32)
-            bos = (i_b * T).to(tl.int64)
+            bos = tl.cast(i_b, tl.int64) * T
             i_tg = global_t.to(tl.int64)
 
         q_ptr = q + (bos * H + i_h) * K

--- a/fla/ops/gla/backends/triton_ascend/chunk.py
+++ b/fla/ops/gla/backends/triton_ascend/chunk.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+import triton.runtime.driver as driver
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
@@ -23,14 +24,10 @@ from fla.utils.ascend_ub_manager import (
 )
 
 _BC = 16
-_NUM_WARPS = 2
-_NUM_WARPS_FWD_O = 4
-_NUM_WARPS_INTER = 4
 _LAUNCH_BLOCK_BUDGET = 4096
 _SAFETY_MARGIN = 0.80
 _FALLBACK_BK = 16
 _FALLBACK = 16
-_MAX_BKV = 64
 _MAX_TILE = 64
 
 
@@ -47,7 +44,12 @@ def _get_bk(K: int) -> int:
     )
 
 
-def _launch_3d_nt_nc_bh(kernel, *, nt: int, nc: int, bh: int, kernel_kwargs: dict, num_warps: int = _NUM_WARPS) -> None:
+def get_npu_properties():
+    device = torch.npu.current_device()
+    return driver.active.utils.get_device_properties(device)
+
+
+def _launch_3d_nt_nc_bh(kernel, *, nt: int, nc: int, bh: int, kernel_kwargs: dict) -> None:
     budget = _LAUNCH_BLOCK_BUDGET
     chunk_indices = kernel_kwargs.get('chunk_indices')
     cu_seqlens = kernel_kwargs.get('cu_seqlens')
@@ -69,7 +71,7 @@ def _launch_3d_nt_nc_bh(kernel, *, nt: int, nc: int, bh: int, kernel_kwargs: dic
             for bh_off in range(0, bh, bh_step):
                 bh_len = min(bh_step, bh - bh_off)
                 kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(nt_len, nc_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+                kernel[(nt_len, nc_len, bh_len)](**kernel_kwargs)
 
 
 @triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
@@ -236,117 +238,96 @@ def chunk_gla_fwd_intra_gk_npu(
     return A
 
 # ---------------------------------------------------------------------------
-# Forward: o
+# Forward: o  (1D core-grid + host-pick BK; pattern from common/chunk_o.py)
 # ---------------------------------------------------------------------------
 
-def _fwd_o_pick_bk(K: int) -> int:
+
+_FWD_O_BV = 128
+_FWD_O_MEM_MULT = 6.0
+
+
+def _get_fwd_o_bk(K: int) -> int:
+    """Host-pick K tile for fwd-o; avoids Ascend parallel autotune flake in pytest."""
     return compute_row_tile_block_size(
-        64, K, 6.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
-        fallback=_FALLBACK, min_block=16,
-        max_block=min(_MAX_BKV, max(16, triton.next_power_of_2(K))),
+        64,
+        K,
+        _FWD_O_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_BK,
+        min_block=32,
+        max_block=min(128, triton.next_power_of_2(K)),
     )
-
-
-def _fwd_o_pick_bv(V: int) -> int:
-    return compute_row_tile_block_size(
-        64, V, 6.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
-        fallback=_FALLBACK, min_block=16,
-        max_block=min(_MAX_BKV, max(16, triton.next_power_of_2(V))),
-    )
-
-
-def _launch_v_nt_bh(kernel, *, nv: int, nt: int, bh: int, kernel_kwargs: dict) -> None:
-    # Keep full chunk_indices: varlen h is indexed by global chunk id (i_tg).
-    budget = _LAUNCH_BLOCK_BUDGET
-    nv_step = nv if nv * nt * bh <= budget else max(1, budget // max(nt * bh, 1))
-    for v_off in range(0, nv, nv_step):
-        v_len = min(nv_step, nv - v_off)
-        kernel_kwargs['V_OFFSET'] = v_off
-        nt_budget = max(1, budget // max(v_len * bh, 1))
-        nt_step = min(nt_budget, max_grid_axis_chunks(nt, v_len * bh, max_grid=ASCEND_MAX_GRID_DIM))
-        for nt_off in range(0, nt, nt_step):
-            nt_len = min(nt_step, nt - nt_off)
-            kernel_kwargs['NT_OFFSET'] = nt_off
-            bh_budget = max(1, budget // max(v_len * nt_len, 1))
-            bh_step = min(bh_budget, max_grid_axis_chunks(bh, v_len * nt_len, max_grid=ASCEND_MAX_GRID_DIM))
-            for bh_off in range(0, bh, bh_step):
-                bh_len = min(bh_step, bh - bh_off)
-                kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(v_len, nt_len, bh_len)](num_warps=_NUM_WARPS_FWD_O, **kernel_kwargs)
 
 
 @triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
-@triton.jit(do_not_specialize=['T', 'V_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
+@triton.jit(do_not_specialize=['T', 'total_chunks', 'task_num', 'num_core'])
 def chunk_gla_fwd_kernel_o_npu(
     q, v, g, h, o, A, cu_seqlens, chunk_indices, scale, T,
     H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr, V: tl.constexpr,
     BT: tl.constexpr, BK: tl.constexpr, BV: tl.constexpr,
+    total_chunks, task_num, num_core,
     STATE_V_FIRST: tl.constexpr, IS_VARLEN: tl.constexpr,
-    V_OFFSET, NT_OFFSET, BH_OFFSET,
 ):
-    i_v = tl.program_id(0) + V_OFFSET
-    i_t = tl.program_id(1).to(tl.int64) + NT_OFFSET
-    i_bh = tl.program_id(2) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
-    i_h = i_hv // (HV // H)
-    if IS_VARLEN:
-        i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = eos - bos
-        NT = tl.cdiv(T, BT)
-    else:
-        NT = tl.cdiv(T, BT)
-        i_tg = (i_b * NT + i_t).to(tl.int64)
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+    core_id = tl.program_id(0)
+    h_t_step = HV * total_chunks
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_v = task_id // h_t_step
+        remainder = task_id % h_t_step
+        i_hv = remainder // total_chunks
+        global_t = remainder % total_chunks
+        i_h = i_hv // (HV // H)
+        T_cur = T
 
-    if i_t * BT >= T:
-        return
-
-    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
-
-    q_base = q + (bos * H + i_h) * K
-    g_base = g + (bos * HV + i_hv) * K
-    v_base = v + (bos * HV + i_hv) * V
-    o_base = o + (bos * HV + i_hv) * V
-    h_base = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
-    A_base = A + (bos * HV + i_hv) * BT
-
-    b_o = tl.zeros([BT, BV], dtype=tl.float32)
-    o_t = i_t * BT + tl.arange(0, BT)
-    o_v = i_v * BV + tl.arange(0, BV)
-    o_i = tl.arange(0, BT)
-    m_t = o_t < T
-    m_v = o_v < V
-    m_tv = m_t[:, None] & m_v[None, :]
-    m_A = m_t[:, None] & (o_i[None, :] < BT)
-
-    for i_k in range(tl.cdiv(K, BK)):
-        o_k = i_k * BK + tl.arange(0, BK)
-        m_k = o_k < K
-        m_qk = m_t[:, None] & m_k[None, :]
-        b_q = tl.load(q_base + o_t[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
-        b_g = tl.load(g_base + o_t[:, None] * (HV * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
-        b_qg = b_q * exp2(b_g)
-        if STATE_V_FIRST:
-            b_h = tl.load(
-                h_base + o_v[:, None] * K + o_k[None, :],
-                mask=m_v[:, None] & m_k[None, :], other=0.0,
-            ).to(tl.float32)
-            b_o += tl.dot(b_qg, tl.trans(b_h), allow_tf32=False)
+        if IS_VARLEN:
+            i_n = tl.load(chunk_indices + global_t * 2).to(tl.int32)
+            i_t = tl.load(chunk_indices + global_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T_cur = (eos - bos).to(tl.int32)
+            i_tg = global_t.to(tl.int64)
         else:
-            b_h = tl.load(
-                h_base + o_k[:, None] * V + o_v[None, :],
-                mask=m_k[:, None] & m_v[None, :], other=0.0,
-            ).to(tl.float32)
-            b_o += tl.dot(b_qg, b_h, allow_tf32=False)
+            NT = tl.cdiv(T, BT)
+            i_b = global_t // NT
+            i_t = (global_t % NT).to(tl.int32)
+            bos = (i_b * T).to(tl.int64)
+            i_tg = global_t.to(tl.int64)
 
-    b_o *= scale
-    b_v = tl.load(v_base + o_t[:, None] * (HV * V) + o_v[None, :], mask=m_tv, other=0.0).to(tl.float32)
-    b_A = tl.load(A_base + o_t[:, None] * (HV * BT) + o_i[None, :], mask=m_A, other=0.0).to(tl.float32)
-    b_A = tl.where(m_s, b_A, 0.0)
-    b_o += tl.dot(b_A, b_v, allow_tf32=False)
-    tl.store(o_base + o_t[:, None] * (HV * V) + o_v[None, :], b_o.to(o.dtype.element_ty), mask=m_tv)
+        q_ptr = q + (bos * H + i_h) * K
+        g_ptr = g + (bos * HV + i_hv) * K
+        v_ptr = v + (bos * HV + i_hv) * V
+        o_ptr = o + (bos * HV + i_hv) * V
+        h_base = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        a_ptr = A + (bos * HV + i_hv) * BT
+
+        b_o = tl.zeros([BT, BV], dtype=tl.float32)
+        for i_k in range(tl.cdiv(K, BK)):
+            p_q = tl.make_block_ptr(q_ptr, (T_cur, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_g = tl.make_block_ptr(g_ptr, (T_cur, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            if STATE_V_FIRST:
+                p_h = tl.make_block_ptr(h_base, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            else:
+                p_h = tl.make_block_ptr(h_base, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+            b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+            b_h = tl.load(p_h, boundary_check=(0, 1))
+            if STATE_V_FIRST:
+                b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+            else:
+                b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+
+        b_o *= scale
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T_cur
+        p_a = tl.make_block_ptr(a_ptr, (T_cur, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        p_v = tl.make_block_ptr(v_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_o = tl.make_block_ptr(o_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_A = tl.load(p_a, boundary_check=(0, 1))
+        m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+        b_A = tl.where(m_s & (m_t[:, None] & m_t[None, :]), b_A, 0.0)
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_o += tl.dot(b_A.to(b_v.dtype), b_v)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
 @input_guard
@@ -368,29 +349,46 @@ def chunk_gla_fwd_o_gk_npu(
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    if cu_seqlens is None:
+        total_chunks = B * triton.cdiv(T, BT)
+    else:
+        total_chunks = len(chunk_indices)
 
     o = torch.zeros_like(v)
-    BK, BV = _fwd_o_pick_bk(K), _fwd_o_pick_bv(V)
-    nv, bh = triton.cdiv(V, BV), B * HV
-    _launch_v_nt_bh(
-        chunk_gla_fwd_kernel_o_npu,
-        nv=nv, nt=NT, bh=bh,
-        kernel_kwargs=dict(
-            q=q, v=v, g=g, h=h, o=o, A=A,
-            cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, scale=scale, T=T,
-            H=H, HV=HV, K=K, V=V, BT=BT, BK=BK, BV=BV,
-            STATE_V_FIRST=state_v_first,
-            V_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
-        ),
+    BV = min(_FWD_O_BV, triton.next_power_of_2(V))
+    BK = _get_fwd_o_bk(K)
+    NV = triton.cdiv(V, BV)
+    num_core = get_npu_properties()['num_aicore']
+    task_num = NV * HV * total_chunks
+    chunk_gla_fwd_kernel_o_npu[(num_core,)](
+        q=q,
+        v=v,
+        g=g,
+        h=h,
+        o=o,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+        total_chunks=total_chunks,
+        task_num=task_num,
+        num_core=num_core,
+        STATE_V_FIRST=state_v_first,
     )
-    if hasattr(torch, 'npu') and torch.npu.is_available():
-        torch.npu.synchronize()
     return o
 
 # ---------------------------------------------------------------------------
 # Backward
 # ---------------------------------------------------------------------------
+
 
 def _bwd_pick_bk(K: int) -> int:
     return compute_row_tile_block_size(
@@ -408,7 +406,7 @@ def _bwd_pick_bv(V: int) -> int:
     )
 
 
-def _launch_2d(kernel, *, nt: int, bh: int, kernel_kwargs: dict, num_warps: int = _NUM_WARPS) -> None:
+def _launch_2d(kernel, *, nt: int, bh: int, kernel_kwargs: dict) -> None:
     budget = _LAUNCH_BLOCK_BUDGET
     nt_step = nt if nt * bh <= budget else max(1, budget // max(bh, 1))
     for nt_off in range(0, nt, nt_step):
@@ -419,10 +417,10 @@ def _launch_2d(kernel, *, nt: int, bh: int, kernel_kwargs: dict, num_warps: int 
         for bh_off in range(0, bh, bh_step):
             bh_len = min(bh_step, bh - bh_off)
             kernel_kwargs['BH_OFFSET'] = bh_off
-            kernel[(nt_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+            kernel[(nt_len, bh_len)](**kernel_kwargs)
 
 
-def _launch_3d_na_nt_bh(kernel, *, na: int, nt: int, bh: int, kernel_kwargs: dict, num_warps: int = _NUM_WARPS) -> None:
+def _launch_3d_na_nt_bh(kernel, *, na: int, nt: int, bh: int, kernel_kwargs: dict) -> None:
     """3D launch over (axis0, nt, bh). Does not slice chunk_indices (need global i_tg)."""
     budget = _LAUNCH_BLOCK_BUDGET
     na_step = na if na * nt * bh <= budget else max(1, budget // max(nt * bh, 1))
@@ -439,7 +437,7 @@ def _launch_3d_na_nt_bh(kernel, *, na: int, nt: int, bh: int, kernel_kwargs: dic
             for bh_off in range(0, bh, bh_step):
                 bh_len = min(bh_step, bh - bh_off)
                 kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(a_len, nt_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+                kernel[(a_len, nt_len, bh_len)](**kernel_kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -634,7 +632,6 @@ def chunk_gla_bwd_dv_npu(
             H=H, K=K, V=V, BT=BT, BK=BK, BV=BV, STATE_V_FIRST=state_v_first,
             A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
         ),
-        num_warps=_NUM_WARPS_INTER,
     )
     _npu_sync()
     return dv
@@ -928,7 +925,6 @@ def chunk_gla_bwd_dqkg_npu(
             H=H, K=K, V=V, BT=BT, BK=BK, BV=BV, STATE_V_FIRST=state_v_first,
             A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
         ),
-        num_warps=_NUM_WARPS_INTER,
     )
     _npu_sync()
     return dq2, dk2, dg

--- a/fla/ops/gla/backends/triton_ascend/chunk.py
+++ b/fla/ops/gla/backends/triton_ascend/chunk.py
@@ -12,66 +12,28 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
-import triton.runtime.driver as driver
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
 from fla.utils import input_guard
 from fla.utils.ascend_ub_manager import (
-    ASCEND_MAX_GRID_DIM,
     compute_row_tile_block_size,
-    max_grid_axis_chunks,
+    get_npu_properties,
+    launch_grid_chunked,
 )
 
 _BC = 16
-_LAUNCH_BLOCK_BUDGET = 4096
 _SAFETY_MARGIN = 0.80
-_FALLBACK_BK = 16
 _FALLBACK = 16
 _MAX_TILE = 64
-
-
-def _npu_sync() -> None:
-    if hasattr(torch, 'npu') and torch.npu.is_available():
-        torch.npu.synchronize()
 
 
 def _get_bk(K: int) -> int:
     return compute_row_tile_block_size(
         _BC, K, 6.0, tiling_row=False, safety_margin=_SAFETY_MARGIN,
-        fallback=_FALLBACK_BK, min_block=16,
+        fallback=_FALLBACK, min_block=16,
         max_block=min(64, max(16, triton.next_power_of_2(K))),
     )
-
-
-def get_npu_properties():
-    device = torch.npu.current_device()
-    return driver.active.utils.get_device_properties(device)
-
-
-def _launch_3d_nt_nc_bh(kernel, *, nt: int, nc: int, bh: int, kernel_kwargs: dict) -> None:
-    budget = _LAUNCH_BLOCK_BUDGET
-    chunk_indices = kernel_kwargs.get('chunk_indices')
-    cu_seqlens = kernel_kwargs.get('cu_seqlens')
-    nt_step = nt if nt * nc * bh <= budget else max(1, budget // max(nc * bh, 1))
-    for nt_off in range(0, nt, nt_step):
-        nt_len = min(nt_step, nt - nt_off)
-        if cu_seqlens is not None and chunk_indices is not None:
-            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
-            kernel_kwargs['NT_OFFSET'] = 0
-        else:
-            kernel_kwargs['NT_OFFSET'] = nt_off
-        nc_budget = max(1, budget // max(nt_len * bh, 1))
-        nc_step = min(nc_budget, max_grid_axis_chunks(nc, nt_len * bh, max_grid=ASCEND_MAX_GRID_DIM))
-        for nc_off in range(0, nc, nc_step):
-            nc_len = min(nc_step, nc - nc_off)
-            kernel_kwargs['NC_OFFSET'] = nc_off
-            bh_budget = max(1, budget // max(nt_len * nc_len, 1))
-            bh_step = min(bh_budget, max_grid_axis_chunks(bh, nt_len * nc_len, max_grid=ASCEND_MAX_GRID_DIM))
-            for bh_off in range(0, bh, bh_step):
-                bh_len = min(bh_step, bh - bh_off)
-                kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(nt_len, nc_len, bh_len)](**kernel_kwargs)
 
 
 @triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
@@ -168,7 +130,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_npu(
     b_q = tl.load(q_ptr + o_c[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
     b_g = tl.load(g_ptr + o_c[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
 
-    # Diagonal lower-tri via masked static loop (no continue).
+    # intra diagonal: fixed tl.static_range(BC) with a per-j active mask
     max_j = min(BC, T - i_t * BT - i_i * BC)
     for j in tl.static_range(BC):
         active = j < max_j
@@ -184,13 +146,114 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_npu(
         tl.store(A_ptr + o_A + j, b_Aj, mask=m_A & active)
 
     tl.debug_barrier()
-    # Zero strict upper triangle of the BC×BC diagonal block (keep causal i>=j).
+    # zero entries above the causal diagonal in the BC×BC block
     b_zero = tl.zeros([BC, BC], dtype=tl.float32)
     tl.store(
         A_ptr + o_A[:, None] + o_i,
         b_zero,
         mask=m_A[:, None] & (o_i[:, None] < o_i),
     )
+
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'NK_OFFSET', 'NTNC_OFFSET', 'BH_OFFSET'])
+def chunk_gla_fwd_A_kernel_intra_sub_intra_split_npu(
+    q, k, g, A, cu_seqlens, chunk_indices, scale, T,
+    B: tl.constexpr, H: tl.constexpr, K: tl.constexpr,
+    BT: tl.constexpr, BC: tl.constexpr, BK: tl.constexpr, NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr, NK_OFFSET, NTNC_OFFSET, BH_OFFSET,
+):
+    i_k = tl.program_id(0) + NK_OFFSET
+    i_tc = tl.program_id(1) + NTNC_OFFSET
+    i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    i_t, i_i = (i_tc // NC).to(tl.int64), i_tc % NC
+    i_j = i_i
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        all = B * T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    o_i = tl.arange(0, BC)
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) * H * BC
+    m_k = o_k < K
+    m_A = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+
+    q_ptr = q + (bos * H + i_h) * K
+    k_ptr = k + (bos * H + i_h) * K
+    g_ptr = g + (bos * H + i_h) * K
+    A_ptr = A + ((i_k * all + bos) * H + i_h) * BC
+
+    o_c = i_t * BT + i_i * BC + tl.arange(0, BC)
+    m_qk = m_A[:, None] & m_k[None, :]
+    b_q = tl.load(q_ptr + o_c[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
+    b_g = tl.load(g_ptr + o_c[:, None] * (H * K) + o_k[None, :], mask=m_qk, other=0.0).to(tl.float32)
+
+    max_j = min(BC, T - i_t * BT - i_i * BC)
+    for j in tl.static_range(BC):
+        active = j < max_j
+        b_k = tl.load(
+            k_ptr + (i_t * BT + i_j * BC + j) * H * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
+        b_gk = tl.load(
+            g_ptr + (i_t * BT + i_j * BC + j) * H * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
+        b_Aj = tl.sum(b_q * b_k[None, :] * exp2(b_g - b_gk[None, :]), 1) * scale
+        tl.store(A_ptr + o_A + j, b_Aj, mask=m_A & active)
+
+    tl.debug_barrier()
+    b_zero = tl.zeros([BC, BC], dtype=tl.float32)
+    tl.store(
+        A_ptr + o_A[:, None] + o_i,
+        b_zero,
+        mask=m_A[:, None] & (o_i[:, None] < o_i),
+    )
+
+
+@triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
+@triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'])
+def chunk_gla_fwd_A_kernel_intra_sub_intra_merge_npu(
+    A, A2, cu_seqlens, chunk_indices, T,
+    B: tl.constexpr, H: tl.constexpr, BT: tl.constexpr, BC: tl.constexpr, NK: tl.constexpr,
+    IS_VARLEN: tl.constexpr, NT_OFFSET, NC_OFFSET, BH_OFFSET,
+):
+    i_t = tl.program_id(0).to(tl.int64) + NT_OFFSET
+    i_c = tl.program_id(1) + NC_OFFSET
+    i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        all = B * T
+
+    if i_t * BT + i_c * BC >= T:
+        return
+
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    o_c = i_t * BT + i_c * BC + tl.arange(0, BC)
+    o_i = tl.arange(0, BC)
+    m_c = o_c < T
+    m_A = m_c[:, None] & (o_i[None, :] < BC)
+    m_A2 = m_c[:, None] & ((i_c * BC + o_i)[None, :] < BT)
+    for i_k in range(0, NK):
+        p_A = A + (i_k * all + bos) * H * BC + i_h * BC + o_c[:, None] * (H * BC) + o_i[None, :]
+        b_A += tl.load(p_A, mask=m_A, other=0.0).to(tl.float32)
+    p_A2 = A2 + (bos * H + i_h) * BT + o_c[:, None] * (H * BT) + (i_c * BC + o_i)[None, :]
+    tl.store(p_A2, b_A.to(A2.dtype.element_ty), mask=m_A2)
 
 
 @input_guard
@@ -205,41 +268,62 @@ def chunk_gla_fwd_intra_gk_npu(
 ):
     B, T, H, K = k.shape
     BT = chunk_size
-    assert K <= 256, "NPU GLA intra currently supports K <= 256"
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BC = min(_BC, BT)
     NC = triton.cdiv(BT, BC)
-    # Inter tiles K; diag mirrors CUDA K<=256 path: load full [BC, K] at once.
     BK_inter = _get_bk(K)
-    BK_diag = max(triton.next_power_of_2(K), 16)
 
-    # Partial writes (lower-tri + diag); zeros avoid dirty upper-tri NaNs.
     A = q.new_zeros(B, T, H, BT, dtype=torch.float)
     base = dict(
         q=q, k=k, g=g, A=A, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
         scale=scale, T=T, H=H, K=K, BT=BT, BC=BC,
         NT_OFFSET=0, NC_OFFSET=0, BH_OFFSET=0,
     )
-    _launch_3d_nt_nc_bh(
+    launch_grid_chunked(
         chunk_gla_fwd_A_kernel_intra_sub_inter_npu,
-        nt=NT, nc=NC * NC, bh=B * H,
+        (NT, NC * NC, B * H),
+        offset_keys=('NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'),
         kernel_kwargs={**base, 'BK': BK_inter, 'NC': NC},
     )
-    _launch_3d_nt_nc_bh(
-        chunk_gla_fwd_A_kernel_intra_sub_intra_npu,
-        nt=NT, nc=NC, bh=B * H,
-        kernel_kwargs={**base, 'BK': BK_diag},
-    )
-    if hasattr(torch, 'npu') and torch.npu.is_available():
-        torch.npu.synchronize()
+    if K <= 256:
+        BK_diag = max(triton.next_power_of_2(K), 16)
+        launch_grid_chunked(
+            chunk_gla_fwd_A_kernel_intra_sub_intra_npu,
+            (NT, NC, B * H),
+            offset_keys=('NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'),
+            kernel_kwargs={**base, 'BK': BK_diag},
+        )
+    else:
+        BK = min(128, triton.next_power_of_2(K))
+        NK = triton.cdiv(K, BK)
+        A_intra = q.new_zeros(NK, B, T, H, BC, dtype=torch.float)
+        split_base = dict(
+            q=q, k=k, g=g, A=A_intra, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
+            scale=scale, T=T, B=B, H=H, K=K, BT=BT, BC=BC, BK=BK, NC=NC,
+            NK_OFFSET=0, NTNC_OFFSET=0, BH_OFFSET=0,
+        )
+        launch_grid_chunked(
+            chunk_gla_fwd_A_kernel_intra_sub_intra_split_npu,
+            (NK, NT * NC, B * H),
+            offset_keys=('NK_OFFSET', 'NTNC_OFFSET', 'BH_OFFSET'),
+            quanta=(1, NC, 1),
+            kernel_kwargs=split_base,
+        )
+        merge_base = dict(
+            A=A_intra, A2=A, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
+            T=T, B=B, H=H, BT=BT, BC=BC, NK=NK,
+            NT_OFFSET=0, NC_OFFSET=0, BH_OFFSET=0,
+        )
+        launch_grid_chunked(
+            chunk_gla_fwd_A_kernel_intra_sub_intra_merge_npu,
+            (NT, NC, B * H),
+            offset_keys=('NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'),
+            kernel_kwargs=merge_base,
+        )
     return A
-
-# ---------------------------------------------------------------------------
-# Forward: o  (1D core-grid + host-pick BK; pattern from common/chunk_o.py)
-# ---------------------------------------------------------------------------
 
 
 _FWD_O_BV = 128
@@ -247,14 +331,14 @@ _FWD_O_MEM_MULT = 6.0
 
 
 def _get_fwd_o_bk(K: int) -> int:
-    """Host-pick K tile for fwd-o; avoids Ascend parallel autotune flake in pytest."""
+    """Host-pick K tile for fwd-o from UB budget."""
     return compute_row_tile_block_size(
         64,
         K,
         _FWD_O_MEM_MULT,
         tiling_row=False,
         safety_margin=_SAFETY_MARGIN,
-        fallback=_FALLBACK_BK,
+        fallback=_FALLBACK,
         min_block=32,
         max_block=min(128, triton.next_power_of_2(K)),
     )
@@ -345,7 +429,6 @@ def chunk_gla_fwd_o_gk_npu(
 ):
     B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
     BT = chunk_size
-    assert K <= 256 and V <= 256, "NPU GLA o currently supports K,V <= 256"
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
@@ -385,10 +468,6 @@ def chunk_gla_fwd_o_gk_npu(
     )
     return o
 
-# ---------------------------------------------------------------------------
-# Backward
-# ---------------------------------------------------------------------------
-
 
 def _bwd_pick_bk(K: int) -> int:
     return compute_row_tile_block_size(
@@ -405,44 +484,6 @@ def _bwd_pick_bv(V: int) -> int:
         max_block=min(_MAX_TILE, max(16, triton.next_power_of_2(V))),
     )
 
-
-def _launch_2d(kernel, *, nt: int, bh: int, kernel_kwargs: dict) -> None:
-    budget = _LAUNCH_BLOCK_BUDGET
-    nt_step = nt if nt * bh <= budget else max(1, budget // max(bh, 1))
-    for nt_off in range(0, nt, nt_step):
-        nt_len = min(nt_step, nt - nt_off)
-        kernel_kwargs['NT_OFFSET'] = nt_off
-        bh_budget = max(1, budget // max(nt_len, 1))
-        bh_step = min(bh_budget, max_grid_axis_chunks(bh, nt_len, max_grid=ASCEND_MAX_GRID_DIM))
-        for bh_off in range(0, bh, bh_step):
-            bh_len = min(bh_step, bh - bh_off)
-            kernel_kwargs['BH_OFFSET'] = bh_off
-            kernel[(nt_len, bh_len)](**kernel_kwargs)
-
-
-def _launch_3d_na_nt_bh(kernel, *, na: int, nt: int, bh: int, kernel_kwargs: dict) -> None:
-    """3D launch over (axis0, nt, bh). Does not slice chunk_indices (need global i_tg)."""
-    budget = _LAUNCH_BLOCK_BUDGET
-    na_step = na if na * nt * bh <= budget else max(1, budget // max(nt * bh, 1))
-    for a_off in range(0, na, na_step):
-        a_len = min(na_step, na - a_off)
-        kernel_kwargs['A_OFFSET'] = a_off
-        nt_budget = max(1, budget // max(a_len * bh, 1))
-        nt_step = min(nt_budget, max_grid_axis_chunks(nt, a_len * bh, max_grid=ASCEND_MAX_GRID_DIM))
-        for nt_off in range(0, nt, nt_step):
-            nt_len = min(nt_step, nt - nt_off)
-            kernel_kwargs['NT_OFFSET'] = nt_off
-            bh_budget = max(1, budget // max(a_len * nt_len, 1))
-            bh_step = min(bh_budget, max_grid_axis_chunks(bh, a_len * nt_len, max_grid=ASCEND_MAX_GRID_DIM))
-            for bh_off in range(0, bh, bh_step):
-                bh_len = min(bh_step, bh - bh_off)
-                kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(a_len, nt_len, bh_len)](**kernel_kwargs)
-
-
-# ---------------------------------------------------------------------------
-# dA
-# ---------------------------------------------------------------------------
 
 @triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
 @triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'BH_OFFSET'])
@@ -506,22 +547,18 @@ def chunk_gla_bwd_dA_npu(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BV = _bwd_pick_bv(V)
     dA = v.new_zeros(B, T, H, BT, dtype=torch.float)
-    _launch_2d(
+    launch_grid_chunked(
         chunk_gla_bwd_kernel_dA_npu,
-        nt=NT, bh=B * H,
+        (NT, B * H),
+        offset_keys=('NT_OFFSET', 'BH_OFFSET'),
         kernel_kwargs=dict(
             v=v, do=do, dA=dA, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
             scale=scale, T=T, H=H, V=V, BT=BT, BV=BV,
             NT_OFFSET=0, BH_OFFSET=0,
         ),
     )
-    _npu_sync()
     return dA
 
-
-# ---------------------------------------------------------------------------
-# dv
-# ---------------------------------------------------------------------------
 
 @triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
 @triton.jit(do_not_specialize=['T', 'A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
@@ -623,9 +660,10 @@ def chunk_gla_bwd_dv_npu(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BK, BV = _bwd_pick_bk(K), _bwd_pick_bv(V)
     dv = torch.zeros_like(do)
-    _launch_3d_na_nt_bh(
+    launch_grid_chunked(
         chunk_gla_bwd_kernel_dv_npu,
-        na=triton.cdiv(V, BV), nt=NT, bh=B * H,
+        (triton.cdiv(V, BV), NT, B * H),
+        offset_keys=('A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'),
         kernel_kwargs=dict(
             k=k, g=g, A=A, do=do, dh=dh, dv=dv,
             cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, T=T,
@@ -633,13 +671,8 @@ def chunk_gla_bwd_dv_npu(
             A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
         ),
     )
-    _npu_sync()
     return dv
 
-
-# ---------------------------------------------------------------------------
-# dqk_intra
-# ---------------------------------------------------------------------------
 
 @triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
 @triton.jit(do_not_specialize=['T', 'A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
@@ -648,8 +681,6 @@ def chunk_gla_bwd_kernel_intra_npu(
     H: tl.constexpr, K: tl.constexpr, BT: tl.constexpr, BC: tl.constexpr, BK: tl.constexpr, NC: tl.constexpr,
     IS_VARLEN: tl.constexpr, A_OFFSET, NT_OFFSET, BH_OFFSET,
 ):
-    # Mirror CUDA/KDA structure: `if i_i > 0` + `range(0, i_i)` (proven on Ascend).
-    # Do NOT use static_range(NC)+mask gates for inter-subchunk — that path produced NaNs.
     i_kc = tl.program_id(0) + A_OFFSET
     i_t = tl.program_id(1).to(tl.int64) + NT_OFFSET
     i_bh = tl.program_id(2).to(tl.int64) + BH_OFFSET
@@ -702,16 +733,20 @@ def chunk_gla_bwd_kernel_intra_npu(
     o_i = tl.arange(0, BC)
     m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
     o_dA = bos * H * BT + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H * BT + i_h * BT + i_i * BC
-    p_kj = k + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
-    p_gkj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
-    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
-        b_dAj = tl.load(dA + o_dA + j, mask=m_dA, other=0).to(tl.float32)
-        b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
-        b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+    max_j = min(BC, T - i_t * BT - i_i * BC)
+    for j in tl.static_range(BC):
+        active = j < max_j
+        b_dAj = tl.load(dA + o_dA + j, mask=m_dA & active, other=0).to(tl.float32)
+        b_kj = tl.load(
+            k + (bos + i_t * BT + i_i * BC + j) * H * K + i_h * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
+        b_gkj = tl.load(
+            g + (bos + i_t * BT + i_i * BC + j) * H * K + i_h * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
         m_i = o_i[:, None] >= j
-        b_dq += tl.where(m_i, b_dAj[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.)
-        p_kj += H * K
-        p_gkj += H * K
+        b_dq += tl.where(m_i & active, b_dAj[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.)
 
     tl.store(
         dq + (bos * H + i_h) * K + o_c[:, None] * (H * K) + o_k[None, :],
@@ -747,16 +782,19 @@ def chunk_gla_bwd_kernel_intra_npu(
         b_dk *= exp2(b_gn2[None, :] - b_g)
 
     o_dA2 = bos * H * BT + (i_t * BT + i_i * BC) * H * BT + i_h * BT + i_i * BC + tl.arange(0, BC)
-    p_qj = q + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
-    p_gqj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
-    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
-        b_dAj = tl.load(dA + o_dA2 + j * H * BT).to(tl.float32)
-        b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
-        b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
+    for j in tl.static_range(BC):
+        active = j < max_j
+        b_dAj = tl.load(dA + o_dA2 + j * H * BT, mask=active, other=0).to(tl.float32)
+        b_qj = tl.load(
+            q + (bos + i_t * BT + i_i * BC + j) * H * K + i_h * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
+        b_gqj = tl.load(
+            g + (bos + i_t * BT + i_i * BC + j) * H * K + i_h * K + o_k,
+            mask=m_k & active, other=0,
+        ).to(tl.float32)
         m_i = o_i[:, None] <= j
-        b_dk += tl.where(m_i, b_dAj[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.)
-        p_qj += H * K
-        p_gqj += H * K
+        b_dk += tl.where(m_i & active, b_dAj[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.)
 
     tl.store(
         dk + (bos * H + i_h) * K + o_c[:, None] * (H * K) + o_k[None, :],
@@ -777,7 +815,7 @@ def chunk_gla_bwd_dqk_intra_npu(
     B, T, H, K = q.shape
     BT = chunk_size
     BC = min(_BC, BT)
-    BK = min(64, triton.next_power_of_2(K))
+    BK = _bwd_pick_bk(K)
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
@@ -785,9 +823,10 @@ def chunk_gla_bwd_dqk_intra_npu(
     NK = triton.cdiv(K, BK)
     dq = torch.zeros_like(q, dtype=torch.float)
     dk = torch.zeros_like(k, dtype=torch.float)
-    _launch_3d_na_nt_bh(
+    launch_grid_chunked(
         chunk_gla_bwd_kernel_intra_npu,
-        na=NK * NC, nt=NT, bh=B * H,
+        (NK * NC, NT, B * H),
+        offset_keys=('A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'),
         kernel_kwargs=dict(
             q=q, k=k, g=g, dA=dA, dq=dq, dk=dk,
             cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, T=T,
@@ -795,13 +834,8 @@ def chunk_gla_bwd_dqk_intra_npu(
             A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
         ),
     )
-    _npu_sync()
     return dq, dk
 
-
-# ---------------------------------------------------------------------------
-# dqkg (inter)
-# ---------------------------------------------------------------------------
 
 @triton.heuristics({'IS_VARLEN': lambda args: args['cu_seqlens'] is not None})
 @triton.jit(do_not_specialize=['T', 'A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
@@ -915,9 +949,10 @@ def chunk_gla_bwd_dqkg_npu(
     dg = torch.zeros_like(g)
     dq2 = torch.zeros_like(dq)
     dk2 = torch.zeros_like(dk)
-    _launch_3d_na_nt_bh(
+    launch_grid_chunked(
         chunk_gla_bwd_kernel_inter_npu,
-        na=triton.cdiv(K, BK), nt=NT, bh=B * H,
+        (triton.cdiv(K, BK), NT, B * H),
+        offset_keys=('A_OFFSET', 'NT_OFFSET', 'BH_OFFSET'),
         kernel_kwargs=dict(
             q=q, k=k, v=v, g=g, h=h, do=do, dh=dh, dq=dq, dk=dk,
             dq2=dq2, dk2=dk2, dg=dg,
@@ -926,5 +961,4 @@ def chunk_gla_bwd_dqkg_npu(
             A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
         ),
     )
-    _npu_sync()
     return dq2, dk2, dg

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -9,8 +9,8 @@ import torch
 import triton
 import triton.language as tl
 
+from fla.ops.backends import dispatch
 from fla.ops.common.chunk_h import chunk_bwd_dh, chunk_fwd_h
-from fla.ops.gla.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.constant import RCP_LN2

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -10,6 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.common.chunk_h import chunk_bwd_dh, chunk_fwd_h
+from fla.ops.gla.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.constant import RCP_LN2
@@ -863,6 +864,7 @@ def chunk_gla_bwd_kernel_inter(
     tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_tk)
 
 
+@dispatch('gla')
 def chunk_gla_fwd_intra_gk(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -959,6 +961,7 @@ def chunk_gla_fwd_intra_gk(
     return A
 
 
+@dispatch('gla')
 def chunk_gla_fwd_o_gk(
     q: torch.Tensor,
     v: torch.Tensor,
@@ -1002,6 +1005,7 @@ def chunk_gla_fwd_o_gk(
     return o
 
 
+@dispatch('gla')
 def chunk_gla_bwd_dA(
     v: torch.Tensor,
     do: torch.Tensor,
@@ -1036,6 +1040,7 @@ def chunk_gla_bwd_dA(
     return dA
 
 
+@dispatch('gla')
 def chunk_gla_bwd_dv(
     k: torch.Tensor,
     g: torch.Tensor,
@@ -1075,6 +1080,7 @@ def chunk_gla_bwd_dv(
     return dv
 
 
+@dispatch('gla')
 def chunk_gla_bwd_dqk_intra(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -1118,6 +1124,7 @@ def chunk_gla_bwd_dqk_intra(
     return dq, dk
 
 
+@dispatch('gla')
 def chunk_gla_bwd_dqkg(
     q: torch.Tensor,
     k: torch.Tensor,

--- a/fla/utils/ascend_ub_manager.py
+++ b/fla/utils/ascend_ub_manager.py
@@ -19,9 +19,12 @@ import warnings
 
 import torch
 import triton
+import triton.runtime.driver as driver
 
 # Ascend Triton launch limits (see triton_ascend/activations.py).
 ASCEND_MAX_GRID_DIM = 65535
+# Per-launch block-count budget for host-chunked grid launches.
+ASCEND_LAUNCH_BLOCK_BUDGET = 4096
 # Legacy fused kernel byte cap (65536 // fp16 element size).
 _FALLBACK_MAX_FUSED_BLOCK = 65536 // 2
 # Conservative UB fallback when runtime detection is unavailable (64 KiB).
@@ -574,3 +577,51 @@ def iter_axis_launch_chunks(
     max_chunks = max_grid_axis_chunks(axis_size, other_grid_product, max_grid=max_grid)
     for offset in range(0, axis_size, max_chunks):
         yield offset, min(max_chunks, axis_size - offset)
+
+
+def get_npu_properties() -> dict:
+    """Return the triton NPU device properties dict for the current device."""
+    return driver.active.utils.get_device_properties(torch.npu.current_device())
+
+
+def launch_grid_chunked(
+    kernel,
+    grid: tuple[int, ...],
+    *,
+    offset_keys: tuple[str, ...],
+    kernel_kwargs: dict,
+    quanta: tuple[int, ...] | None = None,
+    budget: int = ASCEND_LAUNCH_BLOCK_BUDGET,
+) -> None:
+    """Launch a triton kernel over `grid` in host-side chunks.
+
+    Ascend caps the number of blocks per launch, so axes are chunked such
+    that the per-launch block product stays within `budget`. The global
+    offset of each chunk is forwarded via `kernel_kwargs[offset_keys[ax]]`;
+    declare these args `do_not_specialize` in the kernel to avoid recompiles.
+    `quanta[ax]` snaps chunk boundaries of axis `ax` to multiples of that many
+    blocks, for grids packing several logical indices into one axis
+    (e.g. ``nt * nc``). Keeping the product within `budget`
+    (<= `ASCEND_MAX_GRID_DIM`) also keeps every axis within the per-axis limit.
+    """
+    dims = len(grid)
+    quanta = quanta or (1,) * dims
+    lens = [0] * dims
+
+    def _recurse(ax: int, prod_so_far: int) -> None:
+        quantum = quanta[ax]
+        rest = prod_so_far * quantum
+        for size in grid[ax + 1:]:
+            rest *= size
+        for off_q, len_q in iter_axis_launch_chunks(
+            triton.cdiv(grid[ax], quantum), rest, max_grid=budget,
+        ):
+            offset = off_q * quantum
+            lens[ax] = min(len_q * quantum, grid[ax] - offset)
+            kernel_kwargs[offset_keys[ax]] = offset
+            if ax == dims - 1:
+                kernel[tuple(lens)](**kernel_kwargs)
+            else:
+                _recurse(ax + 1, prod_so_far * len_q * quantum)
+
+    _recurse(0, 1)

--- a/tests/ops/test_gla.py
+++ b/tests/ops/test_gla.py
@@ -252,6 +252,9 @@ def test_fused_recurrent_varlen(
             (2, 1024, 8, 128, 1, torch.float16),
             (2, 1024, 8, 128, 10, torch.float16),
             (4, 2048, 8, 64, 1, torch.float16),
+            (1, 128, 4, 256, 1, torch.float16),
+            (1, 64, 2, 320, 1, torch.float16),
+            (1, 128, 4, 512, 1, torch.bfloat16),
         ]
     ],
 )
@@ -382,6 +385,7 @@ def test_chunk_state_v_first(
         pytest.param(*test, id="H{}-D{}-cu_seqlens{}-{}".format(*test))
         for test in [
             (4, 64, [0, 15], torch.float16),
+            (4, 64, [0, 0, 16], torch.float16),
             (4, 64, [0, 256, 500, 1000], torch.float16),
             (4, 100, [0, 15, 100, 300, 1200, 2000], torch.float16),
         ]


### PR DESCRIPTION
## Summary

Add an Ascend NPU (`triton_ascend`) backend for `chunk_gla` via `@dispatch`, so `chunk_gla` runs on Ascend without falling back to unsupported default Triton paths.

- Register `TritonAscendGLABackend` for GLA intra / fwd-o / bwd sub-kernels.
- Add NPU `chunk_fwd_h` / `chunk_bwd_dh` under `fla/ops/common/backends/triton_ascend/` (dispatched from `@dispatch('common')`; used by GLA for gated state).
- Ascend-specific adaptations: `launch_grid_chunked`, `tl.static_range` where dynamic loops are unsafe, UB-aware tiling, and host-side varlen splitting for `chunk_h`.
- Run `tests/ops/test_gla.py` in Ascend A2 CI.


## Test plan

```bash
pytest tests/ops/test_gla.py
pytest tests/ops/test_kda.py
```

## Benchmark / NCU (kernel changes only)

Neutral: this PR is an NPU backend bring-up plus correctness fixes. We are not claiming a speedup for the "Improve chunk_gla kernel performance" commit and are not adding `chunk_gla` to the A2 benchmark CI job. Same-hardware before/after numbers are not included; a follow-up can add them if needed.


## Breaking changes

None. Public `chunk_gla` API is unchanged. NPU paths activate when `IS_NPU` and backend verifiers pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

