### PR TITLE
[KDA] Warn on kwargs silently dropped by chunk_kda and fused_recurrent_kda

### DIFF
--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -18,7 +18,7 @@ from fla.ops.cp import FLACPContext
 from fla.ops.kda.chunk_bwd import chunk_kda_bwd
 from fla.ops.kda.chunk_fwd import chunk_kda_fwd
 from fla.ops.utils.index import prepare_chunk_indices
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard, warn_unconsumed_kwargs
 
 
 class ChunkKDAFunction(torch.autograd.Function):
@@ -390,6 +390,8 @@ def chunk_kda(
     chunk_size = kwargs.pop("chunk_size", 64)
     if chunk_size not in (32, 64):
         raise ValueError(f"`chunk_size` must be either 32 or 64 for KDA, got {chunk_size}.")
+
+    warn_unconsumed_kwargs('chunk_kda', kwargs, consumed=('A_log', 'dt_bias'))
 
     if safe_gate and use_gate_in_kernel:
         if lower_bound is None:

--- a/fla/ops/kda/fused_recurrent.py
+++ b/fla/ops/kda/fused_recurrent.py
@@ -16,7 +16,7 @@ import triton.language as tl
 from fla.ops.backends import dispatch
 from fla.ops.utils.op import exp
 from fla.ops.utils.softplus import softplus
-from fla.utils import input_guard
+from fla.utils import input_guard, warn_unconsumed_kwargs
 
 
 @triton.heuristics(
@@ -448,6 +448,8 @@ def fused_recurrent_kda(
             stacklevel=2,
         )
         state_v_first = kwargs.pop('transpose_state_layout')
+
+    warn_unconsumed_kwargs('fused_recurrent_kda', kwargs)
 
     if cu_seqlens is not None:
         if q.shape[0] != 1:

--- a/fla/utils/__init__.py
+++ b/fla/utils/__init__.py
@@ -30,6 +30,7 @@ from ._decorators import (  # noqa: F401
     input_guard,
     require_version,
     tensor_cache,
+    warn_unconsumed_kwargs,
 )
 from ._device import (  # noqa: F401
     IS_AMD,

--- a/fla/utils/_decorators.py
+++ b/fla/utils/_decorators.py
@@ -329,6 +329,42 @@ def deprecate_kwarg(
     return wrapper
 
 
+def warn_unconsumed_kwargs(
+    func_name: str,
+    kwargs: dict[str, Any],
+    consumed: tuple[str, ...] = (),
+) -> None:
+    """
+    Warn about keyword arguments that a public entry point accepted but will not use.
+
+    Public ops keep a trailing ``**kwargs`` so that backend-specific arguments can flow
+    through the dispatch layer. The downside is that a misspelled argument, or a flag
+    only known to a newer release, is silently dropped instead of raising, which can
+    silently change numerics (see fla-org/flash-linear-attention#1119).
+
+    Call this after all known keys have been popped from ``kwargs``. Keys listed in
+    ``consumed`` are treated as used even if still present.
+
+    Args:
+        func_name (`str`):
+            Name of the calling entry point, used in the warning message.
+        kwargs (`dict[str, Any]`):
+            The remaining ``**kwargs`` of the entry point.
+        consumed (`tuple[str, ...]`, *optional*):
+            Keys that are read from ``kwargs`` without being popped.
+    """
+    unconsumed = sorted(k for k in kwargs if k not in consumed)
+    if unconsumed:
+        warnings.warn(
+            f"`{func_name}` received unexpected keyword arguments {unconsumed}, which will be ignored. "
+            f"This usually means an argument name is misspelled, or that the argument requires a newer "
+            f"version of flash-linear-attention than the one installed. "
+            f"If the argument controls kernel semantics, ignoring it may silently change the results.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
 def checkpoint(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -6,6 +6,7 @@
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
 import importlib.util
+import warnings
 
 import pytest
 import torch
@@ -94,6 +95,28 @@ def test_chunk_invalid_chunk_size():
 
     with pytest.raises(ValueError, match=r"`chunk_size` must be either 32 or 64"):
         chunk_kda(q, k, v, g, beta, chunk_size=16)
+
+
+def test_unconsumed_kwargs_warning():
+    B, T, H, D = 1, 64, 1, 64
+    q = torch.randn(B, T, H, D, dtype=torch.float, device=device)
+    k = torch.randn(B, T, H, D, dtype=torch.float, device=device)
+    v = torch.randn(B, T, H, D, dtype=torch.float, device=device)
+    g = F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float, device=device))
+    beta = torch.randn(B, T, H, dtype=torch.float, device=device).sigmoid()
+
+    # arguments unknown to the installed version are reported instead of being silently dropped
+    with pytest.warns(UserWarning, match=r"unexpected keyword arguments \['use_beta_sigmoid'\]"):
+        chunk_kda(q, k, v, g, beta, use_beta_sigmoid=True)
+    with pytest.warns(UserWarning, match=r"unexpected keyword arguments \['use_beta_sigmoid'\]"):
+        fused_recurrent_kda(q, k, v, g, beta, use_beta_sigmoid=True)
+
+    # calls without stray keyword arguments stay silent
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        chunk_kda(q, k, v, g, beta)
+        fused_recurrent_kda(q, k, v, g, beta)
+    assert not any("unexpected keyword arguments" in str(w.message) for w in caught)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #1119.

`chunk_kda` and `fused_recurrent_kda` keep a trailing `**kwargs` so backend-specific arguments can flow through the dispatch layer, but that means a misspelled argument, or a flag only known to a newer release, is silently discarded instead of raising. As reported in #1119, Kimi K3's modeling code passes `use_beta_sigmoid_in_kernel=True`, and on fla 0.5.0 (which predates the flag) the sigmoid was never applied: wrong recurrences, no error, no warning.

This PR adds a shared `warn_unconsumed_kwargs` helper to `fla.utils` and calls it from both public KDA entry points after all known keys have been popped. Any leftover key now raises a `UserWarning` naming the ignored arguments and pointing at a likely version mismatch.

Design notes:

- A warning rather than a `TypeError`, because the dispatch layer legitimately lets unknown keys fall through to the default implementation when a specialized backend rejects a call (e.g. the FlashKDA path), and a hard error would break that fallback.
- Documented pass-through keys stay silent: `A_log`, `dt_bias`, `chunk_size`, and the deprecated `transpose_state_layout` (which keeps its existing `DeprecationWarning`).
- The helper is generic on purpose; if this shape looks right, follow-up PRs can wire it into the other op families that share the same bare `**kwargs` pattern (gdn2, gated_delta_rule, gla, rwkv7, etc.).

Blast radius: no numerical or API changes. The only observable difference is a new `UserWarning` on calls that pass arguments the installed version does not consume, which previously did nothing.

## Test plan

- Added `test_unconsumed_kwargs_warning` to `tests/ops/test_kda.py`: asserts the warning fires for an unknown kwarg on both entry points, and that clean calls (including the documented pass-through keys) stay silent.
- `python scripts/find_dependent_tests.py fla/ops/kda/chunk.py fla/ops/kda/fused_recurrent.py fla/utils/_decorators.py` selects `tests/ops/test_kda.py`, `tests/ops/test_intracard_cache.py`, `tests/models/test_modeling_kda.py`, `tests/context_parallel/test_cp_kda.py`, and the layer/hybrid suites.
- Local machine is CPU-only (no triton), so the kernel-path tests need CI hardware. Verified locally: helper logic exercised directly (warns on unknown keys, sorted key list in message, silent when consumed or empty), `ruff check` clean with the repo config, and all touched files byte-compile.

## Benchmark / NCU (kernel changes only)

Neutral, no kernel changes. The helper is a set difference over an almost always empty dict, executed once per entry-point call on the host.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable. (New behavior is covered by the added test; dependent GPU tests need CI, no GPU available locally.)
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). (Not a kernel change.)
