### PR TITLE
[Cache] Memoize kernel config lookups to avoid per-launch file access

### DIFF
--- a/fla/ops/utils/cache.py
+++ b/fla/ops/utils/cache.py
@@ -268,6 +268,31 @@ def read_config_file(config_file: Path) -> dict[str, Any] | None:
     return load_config_file(config_file)
 
 
+@cache
+def load_kernel_config_file(config_file: Path) -> "tuple[dict[str, Any] | None, KernelConfigFile | None]":
+    """Read, parse and validate a kernel config file, memoized by path.
+
+    Returns a ``(raw config dict, validated KernelConfigFile)`` pair, with both set
+    to ``None`` when the file is missing or malformed.
+
+    The existence check and the validation are memoized along with the file contents,
+    so in the steady state a kernel launch performs no filesystem access at all.
+    Without this, every launch whose autotune key misses the in-memory cache would
+    stat the config file (and re-validate its JSON) again, which showed up as
+    thousands of small file operations per second in large multi-rank trainings
+    (see issue #1072).
+
+    ALWAYS mode should bypass the memoization via ``load_kernel_config_file.__wrapped__``
+    so that config file edits are picked up on the next kernel call.
+    """
+    if not config_file.exists():
+        return None, None
+    config_data = read_config_file(config_file)
+    if config_data is None:
+        return None, None
+    return config_data, KernelConfigFile.from_dict(config_file, config_data)
+
+
 def load_cached_config(kernel_name: str, autotune_key: AutotuneKey | None = None) -> dict[str, Any] | None:
     """
     Load cached best config for a kernel from FLA configs directory.
@@ -296,13 +321,10 @@ def load_cached_config(kernel_name: str, autotune_key: AutotuneKey | None = None
     config_dir = get_fla_config_dir()
     config_file = config_dir / f"{kernel_name}.json"
 
-    if not config_file.exists():
-        return None
-
-    config_data = read_config_file(config_file)
-    if config_data is None:
-        return None
-    config = KernelConfigFile.from_dict(config_file, config_data)
+    if FLA_CACHE_MODE is FlaCacheMode.ALWAYS:
+        config_data, config = load_kernel_config_file.__wrapped__(config_file)
+    else:
+        config_data, config = load_kernel_config_file(config_file)
     if config is None:
         return None
 

--- a/tests/ops/test_cache.py
+++ b/tests/ops/test_cache.py
@@ -5,11 +5,14 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+import json
+
 import pytest
 import torch
 import triton
 import triton.language as tl
 
+from fla.ops.utils import cache as cache_mod
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.utils import device
 
@@ -58,3 +61,49 @@ def test_fla_cache_autotune_handles_none_restore_value():
     y2 = torch.full((M,), 7, dtype=torch.int32, device=device)
     _optional_restore_kernel[(triton.cdiv(M, 128),)](None, y2, M)
     assert torch.equal(y2, torch.zeros(M, dtype=torch.int32, device=device))
+
+
+def test_load_cached_config_default_mode(tmp_path, monkeypatch):
+    """DEFAULT mode returns the top-level default_config of the kernel's json file."""
+    monkeypatch.setattr(cache_mod, "FLA_CACHE_MODE", cache_mod.FlaCacheMode.DEFAULT)
+    monkeypatch.setenv("FLA_CONFIG_DIR", str(tmp_path))
+
+    kernel = "cache_test_kernel_default"
+    default_config = {"kwargs": {"BLOCK": 64}, "num_warps": 4, "num_stages": 2, "num_ctas": 1}
+    (tmp_path / f"{kernel}.json").write_text(json.dumps({"default_config": default_config}))
+
+    assert cache_mod.load_cached_config(kernel) == default_config
+
+
+def test_load_kernel_config_file_memoizes_missing_file(tmp_path, monkeypatch):
+    """A missing config file is looked up on disk once, then served from memory.
+
+    Repeated lookups for kernels without a config file previously performed one
+    filesystem stat per kernel launch, which showed up as excessive small-file
+    IO in multi-rank trainings.
+    """
+    monkeypatch.setattr(cache_mod, "FLA_CACHE_MODE", cache_mod.FlaCacheMode.FULL)
+    monkeypatch.setenv("FLA_CONFIG_DIR", str(tmp_path))
+
+    kernel = "cache_test_kernel_missing"
+    assert cache_mod.load_cached_config(kernel) is None
+
+    # outside ALWAYS mode the negative result is memoized, matching the
+    # existing behavior of load_config_file for files created mid-run
+    (tmp_path / f"{kernel}.json").write_text(json.dumps({"default_config": {"kwargs": {}}}))
+    assert cache_mod.load_cached_config(kernel) is None
+
+
+def test_load_cached_config_always_mode_rereads(tmp_path, monkeypatch):
+    """ALWAYS mode picks up config file edits on the next lookup."""
+    monkeypatch.setattr(cache_mod, "FLA_CACHE_MODE", cache_mod.FlaCacheMode.ALWAYS)
+    monkeypatch.setenv("FLA_CONFIG_DIR", str(tmp_path))
+
+    kernel = "cache_test_kernel_always"
+    config_file = tmp_path / f"{kernel}.json"
+
+    config_file.write_text(json.dumps({"default_config": {"kwargs": {"BLOCK": 64}}}))
+    assert cache_mod.load_cached_config(kernel)["kwargs"]["BLOCK"] == 64
+
+    config_file.write_text(json.dumps({"default_config": {"kwargs": {"BLOCK": 128}}}))
+    assert cache_mod.load_cached_config(kernel)["kwargs"]["BLOCK"] == 128


### PR DESCRIPTION
## Summary

Addresses #1072.

With the FLA autotune cache enabled, `load_cached_config` performs a `Path.exists()` stat and re-validates the config JSON on every kernel launch whose autotune key misses the in-memory autotuner cache. In large multi-rank trainings this shows up as thousands of small `open/read/stat` operations per second against the shared node-local disk, and host-side gaps before kernel launches (see the profiling in #1072, where `chunk_gated_delta_rule_fwd_h` roughly doubled its wall time).

This PR routes all lookups through a new memoized `load_kernel_config_file` helper that caches, per path: the existence check, the raw JSON, and the validated `KernelConfigFile`. In the steady state a kernel launch performs no filesystem access at all.

Design notes:

- Missing files are memoized as negative entries. This matches the existing behavior of `load_config_file`, which already caches a missing file as `None` (as documented in `scripts/utils/autotune_export.py`).
- `ALWAYS` mode bypasses the memoization through `__wrapped__` and keeps its re-read-on-every-call debugging contract (edit a config JSON, next kernel call picks it up).
- A side effect worth noting: a malformed config file now logs its validation warning once per process instead of once per launch.

Blast radius: host-side lookup path only, no kernel or numerics changes. The one behavior change is that config files created mid-process are no longer picked up outside `ALWAYS` mode; previously that was already true for file contents (memoized by `load_config_file`) but not for the existence check, so only the narrow case "file did not exist at first lookup, created later in the same process" changes, and `ALWAYS` mode retains the old behavior for that workflow.

## Test plan

- Added three host-side tests to `tests/ops/test_cache.py` (no CUDA required): `DEFAULT` mode returns `default_config`, a missing file is memoized as a negative entry, and `ALWAYS` mode re-reads edits.
- Local machine is CPU-only, so I verified the module logic by loading `fla/ops/utils/cache.py` standalone and running the equivalent scenarios, plus `STRICT` exact match, `STRICT` miss, and the `FULL` mode legacy raw-config fallback, all passing. Patching `Path.exists` with a counter shows 100 repeated lookups for a missing config perform 0 stats after this change (previously 100).
- `find_dependent_tests` flags most of the ops suite (everything imports the cache module), so CI coverage is broad by construction; the directly relevant file is `tests/ops/test_cache.py`.
- `ruff check` clean with the repo config.

## Benchmark / NCU (kernel changes only)

Neutral for kernels themselves; this removes host-side filesystem work from the launch path. I could not reproduce the multi-rank IO saturation from #1072 locally (no GPU cluster), but the stat-count measurement above shows the per-launch filesystem access dropping to zero, which is the mechanism behind the reported IOPS.

## Breaking changes

None intended. See blast radius note above for the one narrow mid-process file-creation case, which `ALWAYS` mode still supports.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable. (New tests added; they are host-side and should pass on any CI runner, but I could not run the triton-importing suite locally.)
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). (Not a kernel change.)
