### PR TITLE
[Rodimus] Fix TypeError from stale head_first argument in chunk path

### DIFF
--- a/fla/layers/rodimus.py
+++ b/fla/layers/rodimus.py
@@ -28,7 +28,7 @@ from fla.layers.utils import (
 )
 from fla.modules import RMSNorm, RotaryEmbedding, ShortConvolution
 from fla.modules.layernorm_gated import RMSNormGated
-from fla.ops.gla import chunk_gla, fused_chunk_gla, fused_recurrent_gla
+from fla.ops.gla import chunk_gla, fused_recurrent_gla
 
 if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
@@ -97,7 +97,7 @@ class RodimusAttention(nn.Module):
         self.residual_in_fp32 = residual_in_fp32
         self.layer_idx = layer_idx
 
-        assert mode in ['chunk', 'fused_recurrent', 'fused_chunk'], f"Not supported mode `{mode}`."
+        assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
 
         self.gate_proj = nn.Linear(self.hidden_size, self.d_inner, bias=False)
         self.up_proj = nn.Linear(self.hidden_size, self.d_inner, bias=False)
@@ -195,17 +195,6 @@ class RodimusAttention(nn.Module):
                 output_final_state=use_cache,
                 state_v_first=True,
                 cu_seqlens=cu_seqlens,
-                head_first=False,
-            )
-        elif mode == 'fused_chunk':
-            o, recurrent_state = fused_chunk_gla(
-                q=q,
-                k=k,
-                v=v,
-                g=rt_gate_log,
-                initial_state=recurrent_state,
-                output_final_state=use_cache,
-                head_first=False,
             )
         elif mode == 'chunk':
             q, k, rt_gate_log = map(lambda x: x.to(v.dtype), (q, k, rt_gate_log))
@@ -218,7 +207,6 @@ class RodimusAttention(nn.Module):
                 output_final_state=use_cache,
                 state_v_first=True,
                 cu_seqlens=cu_seqlens,
-                head_first=False,
             )
         else:
             raise NotImplementedError(f"Not supported mode `{mode}`.")


### PR DESCRIPTION
## Summary

`chunk_gla` dropped its `head_first` parameter in the repo-wide cleanup (4a7a9f4c), but `RodimusAttention` still passes `head_first=False`. The layer defaults to `mode='chunk'` and only falls back to `fused_recurrent` for single-token decode, so any Rodimus forward with more than one token currently raises `TypeError` at the `chunk_gla` call. The Rodimus model tests cover exactly this shape (T=1024), but CI selects tests from changed files and the GLA cleanup never touched the Rodimus files, which is how the stale call site survived.

Changes:

- Drop `head_first=False` from the `chunk_gla` call (the crash) and from the `fused_recurrent_gla` call, where a bare `**kwargs` was silently swallowing it (the same failure class as #1119).
- Remove the `fused_chunk` mode from the allowed set. `fused_chunk_gla` is a permanent `NotImplementedError` stub, so the mode could be selected at construction time but always failed at runtime. Its branch also never passed `state_v_first=True`, so had it ever worked it would have used a different state layout than the other two paths.

Blast radius: Rodimus only. The chunk path goes from crashing to working; no numerics change anywhere else. No checkpoint or state-dict impact.

## Test plan

- `tests/models/test_modeling_rodimus.py` exercises the fixed path directly (forward/backward at T=1024 and generation at T=2000), and this PR touches `fla/layers/rodimus.py`, so CI will select it: `python scripts/find_dependent_tests.py fla/layers/rodimus.py` returns `tests/models/test_modeling_rodimus.py`, `tests/models/test_hybrid_attention.py`, `tests/layers/test_attn_varlen_pack_layout.py`, `tests/layers/test_layer_cache_layer_idx.py`.
- No GPU available locally; verified the fix statically against the current `chunk_gla` / `fused_recurrent_gla` signatures, plus `ruff check` and byte-compilation.

## Benchmark / NCU (kernel changes only)

Neutral, no kernel changes.

## Breaking changes

Constructing `RodimusAttention` (or a `RodimusConfig`) with `attn_mode='fused_chunk'` now fails the mode assert at construction time instead of raising `NotImplementedError` on the first forward call. No working configuration is affected since the mode never ran. If you would rather keep the mode accepted and failing at runtime, I am happy to drop that part and keep only the `head_first` fix.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable. (Existing Rodimus model tests cover the fixed path; they need CI hardware.)
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). (Not a kernel change.)
