### PR TITLE
[Perf] Tune GDN chunked forward for Intel XPU

### DIFF
--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -14,6 +14,7 @@ from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
 from fla.utils import (
+    IS_INTEL,
     IS_NVIDIA_BLACKWELL,
     IS_NVIDIA_HOPPER,
     autotune_cache_kwargs,
@@ -25,7 +26,14 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
 # TODO: Triton mainline fixes a Blackwell tl.dot recurrence race.
 # Keep this kernel on num_warps=2 for Blackwell until Triton 3.8 is released
 # and we re-validate the wider config space.
-GATED_DELTA_RULE_FWD_H_NUM_WARPS = [2] if IS_NVIDIA_BLACKWELL else [2, 4]
+# Intel needs more warps than NVIDIA here: 8 warps is ~1.5x faster than the best
+# config reachable under the [2, 4] cap.
+if IS_NVIDIA_BLACKWELL:
+    GATED_DELTA_RULE_FWD_H_NUM_WARPS = [2]
+elif IS_INTEL:
+    GATED_DELTA_RULE_FWD_H_NUM_WARPS = [2, 4, 8, 16]
+else:
+    GATED_DELTA_RULE_FWD_H_NUM_WARPS = [2, 4]
 
 
 @triton.heuristics({

--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -14,6 +14,7 @@ from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
 from fla.utils import (
+    IS_INTEL,
     IS_NVIDIA_HOPPER,
     TRITON_ABOVE_3_4_0,
     TRITON_ABOVE_3_7_1,
@@ -24,6 +25,22 @@ from fla.utils import (
 BKV_LIST = [64, 128] if check_shared_mem() else ([32, 64] if check_shared_mem('ada') else [32])
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
 
+# Upstream pairs each tile size with a single warp count, which is tuned for NVIDIA.
+# On Intel that pairing is off by a factor of two: BK=BV=64 is fastest at 8 warps but is
+# only offered at 4, so the autotuner falls back to the 32x32 config and leaves ~2.2x on
+# the table. Widen the space there instead of changing the defaults for other vendors.
+_O_CONFIGS = [
+    triton.Config({'BK': 128, 'BV': 128}, num_warps=8, num_stages=3),
+    triton.Config({'BK': 64, 'BV': 64}, num_warps=4, num_stages=3),
+    triton.Config({'BK': 32, 'BV': 32}, num_warps=2, num_stages=3),
+]
+if IS_INTEL:
+    _O_CONFIGS += [
+        triton.Config({'BK': BK, 'BV': BV}, num_warps=w, num_stages=2)
+        for BK, BV in [(128, 64), (64, 64), (64, 32), (32, 64), (32, 32)]
+        for w in (4, 8)
+    ]
+
 
 @triton.heuristics({
     'USE_G': lambda args: args['g'] is not None,
@@ -31,11 +48,7 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @fla_cache_autotune(
-    configs=[
-        triton.Config({'BK': 128, 'BV': 128}, num_warps=8, num_stages=3),
-        triton.Config({'BK': 64, 'BV': 64}, num_warps=4, num_stages=3),
-        triton.Config({'BK': 32, 'BV': 32}, num_warps=2, num_stages=3),
-    ],
+    configs=_O_CONFIGS,
     key=['H', 'HV', 'K', 'V', 'BT', 'STATE_V_FIRST'],
     **autotune_cache_kwargs,
 )

--- a/fla/ops/gated_delta_rule/chunk_fwd.py
+++ b/fla/ops/gated_delta_rule/chunk_fwd.py
@@ -15,7 +15,7 @@ from fla.ops.gated_delta_rule.wy_fast import recompute_w_u_fwd
 from fla.ops.utils import prepare_chunk_indices, solve_tril
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
-from fla.utils import IS_TF32_SUPPORTED, autotune_cache_kwargs
+from fla.utils import IS_INTEL, IS_TF32_SUPPORTED, autotune_cache_kwargs
 
 if IS_TF32_SUPPORTED:
     SOLVE_TRIL_DOT_PRECISION = tl.constexpr('tf32')
@@ -375,7 +375,10 @@ def chunk_gated_delta_rule_fwd_intra(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
 
-    if BT == 64:
+    # The fused kernel keeps ten [BC, BC] fp32 accumulators live across the K loop.
+    # That fits NVIDIA's register file but spills on Intel GPUs, where the unfused
+    # two-kernel path measures 2.3-3.0x faster despite the extra HBM round-trip.
+    if BT == 64 and not IS_INTEL:
         # Step 1: fused kkt + solve_tril
         BC = 16
         NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
@@ -395,7 +398,7 @@ def chunk_gated_delta_rule_fwd_intra(
             BC=BC,
         )
     else:
-        # Step 1: mathematically equivalent unfused kkt + solve_tril for non-64 chunks
+        # Step 1: mathematically equivalent unfused kkt + solve_tril
         A = chunk_scaled_dot_kkt_fwd(
             k=k,
             g=g,

--- a/fla/ops/gated_delta_rule/wy_fast.py
+++ b/fla/ops/gated_delta_rule/wy_fast.py
@@ -13,13 +13,17 @@ from fla.ops.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
-from fla.utils import IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
+from fla.utils import IS_INTEL, IS_NVIDIA_BLACKWELL, autotune_cache_kwargs, check_shared_mem
 
 # Blackwell can select unstable Triton configs for prepare_wy_repr_bwd_kernel
 # during autotuning (see #913). Restrict it to the config that has been
 # validated on B200 until the wider config space is re-validated.
 PREPARE_WY_REPR_BWD_NUM_WARPS = [2] if IS_NVIDIA_BLACKWELL else [2, 4]
 PREPARE_WY_REPR_BWD_NUM_STAGES = [4] if IS_NVIDIA_BLACKWELL else [2, 3, 4]
+
+# Intel keeps scaling past the warp counts NVIDIA prefers: 16 warps is ~1.3x faster
+# than 8 for recompute_w_u.
+RECOMPUTE_W_U_NUM_WARPS = [2, 4, 8, 16] if IS_INTEL else [2, 4, 8]
 
 
 @triton.heuristics({
@@ -29,7 +33,7 @@ PREPARE_WY_REPR_BWD_NUM_STAGES = [4] if IS_NVIDIA_BLACKWELL else [2, 3, 4]
 @fla_cache_autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4, 8]
+        for num_warps in RECOMPUTE_W_U_NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
     key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],


### PR DESCRIPTION
## Summary

Four Intel-XPU-scoped changes to the gated delta rule chunked forward. Three widen
autotune config spaces; one selects a different (already existing) code path. No math is
changed, and every change is gated on `IS_INTEL`, so NVIDIA / AMD / Ascend behaviour is
bit-identical and their autotune spaces are untouched.

## Test plan

Hardware: Intel Arc Pro B70 Graphics (256 XVEs), Level-Zero V2 driver 1.15.38646+6,
torch 2.13.0+xpu, triton-xpu 3.7.2, bf16. No NVIDIA GPU available to me, but the changed
branches are unreachable on non-Intel devices.

Dependent tests identified with
`python scripts/find_dependent_tests.py fla/ops/gated_delta_rule/chunk_fwd.py fla/ops/gated_delta_rule/wy_fast.py fla/ops/common/chunk_o.py fla/ops/common/chunk_delta_h.py`.

Run so far:

    pytest tests/ops/test_gdn_kernels.py -q
    -> 55 passed

    pytest tests/ops/test_gdn.py -q -k "chunk and not varlen"
    -> 24 passed, 22 skipped

    pytest tests/ops/test_delta.py tests/ops/test_simple_gla.py tests/ops/test_gdn2.py -q
    -> 55 passed, run truncated at 59% by my local 90-minute cap

No test file, reference implementation, or `naive.py` was modified.

## Benchmark / NCU (kernel changes only)

Shape: `B=1, T=8192, H=32, K=128, V=128`, dtype bf16, per call, same hardware before/after.

| Kernel | Speedup |
|---|---:|
| fused `kkt_solve` -> `chunk_scaled_dot_kkt_fwd` + `solve_tril` | 2.94x |
| `chunk_fwd_kernel_o` | 2.23x |
| `chunk_gated_delta_rule_fwd_kernel_h_blockdim64` | 1.50x |
| `recompute_w_u_fwd_kernel` | 1.30x |
| `l2norm_fwd_kernel` (x2) | neutral |
| **`chunk_gated_delta_rule` forward, total** | **2.02x** |

`chunk_gated_delta_rule_fwd_intra` across shapes (bf16):

| Shape | Speedup |
|---|---:|
| B1 T2048 H32 D128 | 2.10x |
| B1 T8192 H32 D128 | 2.05x |
| B1 T16384 H32 D128 | 1.99x |
| B4 T8192 H32 D128 | 2.04x |

Varlen (`cu_seqlens`), same hardware, `chunk_gated_delta_rule` forward, bf16, H=32,
K=V=128. "before" measured from a clean `git worktree` at `a341a193` (unmodified `main`),
pinned to the same physical GPU via `ZE_AFFINITY_MASK`:

| Workload | nseq | Total T | Speedup |
|---|---:|---:|---:|
| uniform 4x2048 | 4 | 8192 | 1.57x |
| ragged 8k (4096/2048/1024/512/384/128) | 6 | 8192 | 1.58x |
| ragged 16k (8192/4096/2048/1024/700/324) | 6 | 16384 | 1.56x |
| many short (32x256) | 32 | 8192 | 1.58x |

Output checksums are identical before and after on all four varlen workloads.

End to end, Qwen3.5-9B prefill, batch 1, bf16, single GPU:

| Context | Speedup |
|---|---:|
| 512 | 1.11x |
| 2048 | 1.08x |
| 8192 | 1.08x |

Decode is unchanged — it is bound by
streaming the 18 GB of bf16 weights, and GDN is under 1% of a decode step.

## Breaking changes

None. All four changes are behind `IS_INTEL` and are unreachable on other backends. The
Intel path selected in change 1 is an existing, already-tested code path, and changes 2-4
only add configurations to autotune spaces.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).