### PR TITLE
[Perf] Optimize Ascend causal_conv1d with 1D core-grid and constexpr DMA split

### DIFF
--- a/.agents/skills/fla-ascend-performance/SKILL.md
+++ b/.agents/skills/fla-ascend-performance/SKILL.md
@@ -4,15 +4,18 @@ description: >
   Guidelines for Ascend NPU kernel / Triton-Ascend backend performance work in the FLA repo.
   Covers profiling with torch_npu, PipeUtilization/MemoryUB CSV analysis, Cube/Vector/MTE/UB
   bottleneck diagnosis, and kernel optimization (UB tiling, grid splits, fusion/split, varlen,
-  G_T_CONTIG gate loading, correctness gates, tl.dot left-operand clobber). NPU kernels must not use num_warps/num_stages.
-  Per-kernel tl.dot clobber catalog: references/cases.md.
+  G_T_CONTIG gate loading, constexpr DMA-path split / TAIL_MODE, extract_slice, MTE OOB,
+  int32 address overflow, tl.cast vs constexpr .to, make_block_ptr int32 offsets,
+  correctness gates, tl.dot left-operand clobber). NPU kernels must not use num_warps/num_stages.
+  Per-kernel catalog: references/cases.md (incl. causal_conv1d core-grid).
   Use when working on NPU profiling, kernel_details/op_statistic, aic_metrics,
-  fla triton_ascend backends, g transpose stride-1, UB overflow, grid limits, tl.dot reuse, or Ascend performance.
+  fla triton_ascend backends (ops or modules), g transpose stride-1, UB overflow,
+  dual-path DCE, grid limits, int64 pointer math, tl.dot reuse, or Ascend performance.
 ---
 
 # FLA Ascend NPU: Profiling → Bottlenecks → Optimization
 
-Use this skill for Ascend operator performance work under `fla/ops/**/triton_ascend/**`.
+Use this skill for Ascend operator performance work on all files under any `triton_ascend` directory (`**/triton_ascend/**`).
 
 Multi-round iteration discipline (frozen tests, task contract, when to stop): **`fla-optimization-loop`**. MR packaging: **`fla-mr-readiness`**.
 
@@ -109,7 +112,8 @@ python scripts/analyze_profile.py path/to/*_profiling_* --kernel-filter <substr>
 | High UB bw under MemoryUB, low vec/mac | UB bandwidth saturated | Larger tiles / more fusion |
 | Low target Ratio, many tiny ops | Unfused / fallback | Fix dispatch and fusion first |
 | Two kernels share `o` + high MTE | Intermediate writeback | Fuse producer/consumer if UB fits; else keep split |
-| Frequent host grid chunking | Launch / grid-product overhead | Prefer 1D `num_aicore` core-grid + flat `task_id` |
+| Frequent host grid chunking | Launch / grid-product overhead | Prefer 1D core-grid (`num_aicore` Cube / `num_vectorcore` Vector) + flat `task_id` |
+| Low `aiv_vec_ratio` (~0.75) while MemoryUB is *not* saturated; larger tiles UB-overflow | Dual DMA paths live in UB | Runtime `block_ptr` vs masked load: host-split with `tl.constexpr` so each launch DCE's the other ([cases.md § causal_conv1d](references/cases.md#causal_conv1dpy--1d-core-grid--constexpr-dma-split)) |
 
 Colloquial “CUDA utilization” → read **Cube/MAC** (`aic_mac_ratio`). Host UB model complements the profiler — see [reference.md](references/reference.md).
 
@@ -134,15 +138,22 @@ Change only levers that match the bottleneck; one hypothesis per round. Before t
 - **Gate `g` along T (critical on Ascend)**: if `g` is `[B, T, HV]`, host `g.transpose(1, 2).contiguous()` and load via `G_T_CONTIG` + stride-1 `g_ptr` (see [g-contiguous-loading.md](references/g-contiguous-loading.md)). Stride-`HV` gathers in bwd hot loops can be **10×–35× slower** than contiguous loads; HV==1 needs no transpose. Match fwd pointer math; keep `T_seq` before varlen overwrites `T`.
 - Distinct shapes (e.g. `HV==1`, layout flags) get separate paths — no expensive hot-loop branches.
 - Grid product cap `ASCEND_MAX_GRID_DIM=65535`: host-split with `iter_axis_launch_chunks`, pass `*_OFFSET`; after varlen slicing, zero the matching offset — never slice and also add a global offset. UB and grid are independent constraints.
-- **1D core-grid** (prefer when there are many independent tiles and multi-axis grids need host chunking): launch `grid=(num_aicore,)` from `driver.active.utils.get_device_properties(device)["num_aicore"]`, flatten work into `task_num`, and schedule with `for task_id in tl.range(core_id, task_num, num_core)`. Decode `task_id` → tile indices inside the kernel. One launch, no `ASCEND_MAX_GRID_DIM` host loop, better load balance when `task_num` is irregular (varlen chunks × heads × V tiles). Keep `do_not_specialize` on `T` / `task_num` / `num_core` / dynamic extents.
+- **1D core-grid** (prefer when there are many independent tiles and multi-axis grids need host chunking): flatten work into `task_num` and schedule with `for task_id in tl.range(core_id, task_num, num_core)` (or `range(pid, total_tasks, num_programs)`). Decode `task_id` → tile indices inside the kernel. One launch, no `ASCEND_MAX_GRID_DIM` host loop, better load balance when `task_num` is irregular. Keep `do_not_specialize` on `T` / `task_num` / `num_core` / dynamic extents.
+- **Match core count to the bound pipe**: Cube-bound → `grid=(num_aicore,)` via `get_device_properties()["num_aicore"]`. Vector-bound (conv, layernorm, rotary) → `get_multiprocessor_count` (`num_vectorcore` on NPU; A2 is 48 vector vs 24 Cube). Launching a Vector kernel on `num_aicore` leaves half the vector cores idle.
 - In a core-grid task loop, **rebind local pointers each iteration** (`q_ptr = q + …`); do not accumulate with in-place `ptr +=` across tasks — Ascend Triton can mis-compile that pattern.
-- **int64 before multiply on runtime indices**: with `do_not_specialize` on `T`, values like `NT = cdiv(T, BT)` are runtime int32. `(NT - 1) * DH_CS` or `i_t * HV * K * V` can wrap past 2³¹ before `.to(tl.int64)` (e.g. K=V=128, HV=64 overflows at T>131K). Cast the index first: `(NT - 1).to(tl.int64) * DH_CS`, not `((NT - 1) * DH_CS).to(tl.int64)`.
-- **Varlen `cu_seqlens` → int64 for pointer math**: host `cu_seqlens` is `torch.long` (int64). Loading with `.to(tl.int32)` then computing `(bos * HV + i_hv) * V` overflows int32 well before `bos` hits 2³¹ (e.g. HV=32, V=4096 → safe `bos` ≈ 16K tokens). Pattern: `bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64); T = (eos - bos).to(tl.int32)`. Non-varlen else-branch: `(i_b * T).to(tl.int64)`. Alternative (when `T_cur` only needs int32): load `bos`/`eos` as int32 but cast before multiply — `(bos * HV + i_h).to(tl.int64) * K`. Never rely on post-multiply `.to(tl.int64)`.
+- **int64 before multiply on runtime indices**: program IDs and grid-derived values (`i_t`, `i_b`, `NT = cdiv(T, BT)`) are runtime int32 or narrower. `do_not_specialize` on `T` makes `NT` runtime, but `i_t * stride` also wraps when `T` is specialized (packed conv: `i_t * BT` then `offset * D`). `(NT - 1) * DH_CS` wraps past 2³¹ before a trailing `.to(tl.int64)`. Example: DH_CS=`HV*K*V`, K=V=128, HV=64, BT=64 → overflow at NT>2048 (T>131K). Packed `offset * D`: T>2³¹/D (D=4096 → T>524K). Cast the index first with `tl.cast` (not `.to` on specialized ints): `tl.cast(i_t, tl.int64) * BT`, `tl.cast(i_b, tl.int64) * T`, `tl.cast(B, tl.int64) * T`, `tl.cast(NT - 1, tl.int64) * DH_CS`. Kernel args `B`/`T` are constexpr — `B.to(tl.int64)` is `AttributeError("'constexpr' object has no attribute 'to'")`; `i_t`/`i_b` can fold to constexpr when NT=1. `tl.load(...).to(tl.int64)` on `cu_seqlens` is fine. Never `(i_b * T).to(tl.int64)` or `((NT - 1) * DH_CS).to(tl.int64)`.
+- **`make_block_ptr` offsets stay int32**: Triton rejects int64 `offsets/block_shape`. Flattened pointer math (`bos * D`, `t0 * D`, `i_b * stride`) uses int64; pass `i_t * BT` (int32) as the block row offset. Do not feed `t0` into `make_block_ptr`. Case: [causal_conv1d](references/cases.md#causal_conv1dpy--1d-core-grid--constexpr-dma-split).
+- **Varlen `cu_seqlens` → int64 for pointer math**: host dtype is often `torch.long`, but tests also pass `int32`; load as `tl.int64` either way. Loading `.to(tl.int32)` then `(bos * HV + i_hv) * V` overflows well before `bos` hits 2³¹ (HV=32, V=4096 → safe `bos` ≈ 16K). Pattern: `bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64); T_cur = (eos - bos).to(tl.int32)`. Non-varlen: `bos = tl.cast(i_b, tl.int64) * T` (CUDA/repo often writes `(i_b * T).to(tl.int64)`, which still wraps if `i_b * T` exceeds 2³¹). Alternative when `T_cur` only needs int32: load `bos` as int32 but cast **the index** before the large stride — `tl.cast(bos, tl.int64) * HV + i_h` then `* K`. `(bos * HV + i_h).to(tl.int64) * K` only fixes `* K`/`* V` (HV is small); `bos * HV` itself can still wrap.
 - Reductions / recurrence / grads use fp32 accum, cast on store; sensitive solves: `input_precision='ieee'` / `allow_tf32=False`; mask before exp on gated paths; keep a consistent `exp`/`exp2` base.
 - **Ascend `tl.dot` clobbers the left operand**: on NPU, `tl.dot(lhs, rhs, …)` may overwrite `lhs` in UB (CUDA Triton does not). Any later read of that tile (second lhs, rhs, store) sees corrupted data unless you reload from GM or copy with `tile + 0.0` **before** the first lhs dot. Full per-kernel catalog: [cases.md § tl.dot lhs clobber](references/cases.md#tldot-lhs-clobber--repo-wide-case-catalog). Symptom: silent numeric drift vs Torch oracle with no compile error.
 - **Audit checklist for new/changed kernels**: (1) `rg 'tl\.dot\(' fla/ops/**/triton_ascend/**` — only 8 op files use `tl.dot`; (2) for each lhs tile, flag lhs→lhs, lhs→rhs/store, or post-dot copy; (3) prefer GM reload for one reuse between stages, `+ 0.0` for tight multi-dot sequences; (4) re-run `tests/ops/test_gdn_kernels.py` + op-specific kernel tests.
 - **Upstream**: lhs clobber is a Triton-Ascend backend limitation (UB capacity / in-place matmul), not intentional API. Durable fix belongs in the compiler (preserve lhs or emit a diagnostic on post-dot read). Track via the Triton-Ascend / Ascend backend issue tracker.
 - For separable gate differences, compute `exp2(gs)[:, None] / exp2(gc)[None, :]` instead of `exp2(gs[:, None] - gc[None, :])` to replace a matrix of exponentials with two vectors. Verify numerics on the target compiler; multiplying by `exp2(-gc)` can produce materially different Ascend results.
+- **Constexpr-split mutually exclusive DMA paths** (critical on Ascend): a runtime `if is_tail_chunk` that chooses `make_block_ptr` vs masked `tl.load` keeps **both** paths live in UB. Peak UB ≈ sum of both; Vector cannot saturate even when MemoryUB bandwidth is free; larger tiles then fail compile. Host-split the last tile into a second launch with `tl.constexpr TAIL_MODE` (`0` = never tail / block_ptr only, `1` = always masked, `2` = runtime for varlen / `NT==1`) so each compile DCE's the unused path. Case: [causal_conv1d](references/cases.md#causal_conv1dpy--1d-core-grid--constexpr-dma-split).
+- **MTE DMA past packed allocation**: `make_block_ptr` whose block end overshoots packed `B*T` rows faults MTE (`DDR address out of range`). Use masked load/store on the last chunk, or the constexpr split above so bulk never overshoots. Halo windows (`BT+W-1`) overshoot even sooner — count the halo in the tail predicate.
+- **Do not OR a constexpr optional-pointer flag with a runtime check**: `if USE_INITIAL_STATE or i_t*BT < W` still lowers the else and compiles `initial_state + …` when the pointer is `None`. Nest: `if not FLAG: … elif runtime: … else: …`.
+- **`tl.extract_slice` / `tl.insert_slice`**: sliding-window taps without extra GM loads (causal conv). Some triton-ascend versions expose them only via `triton.language.extra.cann.extension` — shim onto `tl` if missing. Preloading every tap tile overflows UB; load inside the `static_range` or one `BT+W-1` window + slice.
+- **Weight `[D, W]` → host `transpose(0,1).contiguous()` to `[W, D]`** for stride-1 channel `block_ptr` (same idea as G_T_CONTIG). Odd `D` that cannot be tiled with a power-of-two `BD` that divides `D` and `BD>=16` falls back to the legacy multi-axis path.
 
 ### Fusion, compile, varlen
 
@@ -167,7 +178,7 @@ Each round, in order:
 5. Synchronized benchmark (latency/throughput, fwd and fwd+bwd); re-profile with the same `aic_metrics` and confirm Duration/pipe/UB move as expected.
 6. Metrics unchanged → reclassify bottleneck or switch metrics; do not pile unrelated changes.
 
-Prefer: `tests/ops/test_gdn_kernels.py`, `tests/ops/test_solve_tril.py`, `tests/utils/test_ascend_ub_manager.py`, `python -m benchmarks.ops.verify --op <op> --base <ref>` (`--gate-k` is a quick signal only).
+Prefer: `tests/ops/test_gdn_kernels.py`, `tests/ops/test_solve_tril.py`, `tests/modules/test_conv.py` (causal_conv1d), `tests/utils/test_ascend_ub_manager.py`, `python -m benchmarks.ops.verify --op <op> --base <ref>` (`--gate-k` is a quick signal only).
 
 ### Round summary template
 
@@ -188,13 +199,16 @@ Generalizable fixes discovered during optimization belong in this skill (`SKILL.
 - [ ] No `num_warps` / `num_stages` in Ascend kernel launches, autotune configs, or wrappers
 - [ ] Backend registration, lazy import, public signatures correct
 - [ ] Peak live tiles estimated; tiles from shared helpers + safety margin
-- [ ] Grid ≤ 65535 **or** 1D core-grid (`num_aicore`); host-split offsets not double-counted with varlen; task-loop pointers rebound each iteration
+- [ ] Grid ≤ 65535 **or** 1D core-grid (`num_aicore` Cube / `num_vectorcore` Vector); host-split offsets not double-counted with varlen; task-loop pointers rebound each iteration
+- [ ] Runtime `block_ptr` vs masked DMA: constexpr-split so bulk DCE's the unused path; tail DMA does not overshoot packed `B*T` (include halo)
+- [ ] Optional-pointer constexpr flags are nested, not `or`-ed with runtime checks (None ptr must not compile)
 - [ ] Block pointers contiguous innermost; **gate `g` uses G_T_CONTIG** when `[B,T,HV]` (see [g-contiguous-loading.md](references/g-contiguous-loading.md)); tail `boundary_check`
 - [ ] fp32 accum consistent with output/exp base; fusion worth the complexity (no gratuitous `ACCUMULATE_OUTPUT` writeback when UB allows)
 - [ ] Reused `tl.dot` left-hand tiles: GM reload or `tile + 0.0` **before** first lhs dot (post-dot copy invalid); see [cases.md § tl.dot catalog](references/cases.md#tldot-lhs-clobber--repo-wide-case-catalog)
 - [ ] fwd/bwd/varlen/layout branches covered; no unwritten regions under NaN poisoning
-- [ ] Runtime chunk indices (`NT`, `i_t`, …) cast to `tl.int64` **before** stride multiply when `T` is `do_not_specialize`
-- [ ] Varlen `bos`/`eos` from `cu_seqlens` loaded as `tl.int64` (or `.to(tl.int64)` before `(bos * HV + …) * stride`); `T_cur = (eos - bos).to(tl.int32)` only
+- [ ] Runtime indices (`NT`, `i_t`, `i_b`, `B`, program IDs) via `tl.cast(..., tl.int64)` **before** stride / `BT` / `D` multiply — including packed `offset * D`. Not gated on `do_not_specialize`. Do not call `.to(tl.int64)` on specialized kernel args (`constexpr` has no `.to`)
+- [ ] Varlen `bos`/`eos` from `cu_seqlens` loaded as `tl.int64`; `T_cur = (eos - bos).to(tl.int32)` only; non-varlen `tl.cast(i_b, tl.int64) * T`
+- [ ] `make_block_ptr` offsets/block_shape stay int32 (`i_t * BT`); int64 is only for flattened `ptr + offset * stride`
 - [ ] Optional-arg paths exercised (e.g. `use_g` True/False with `g=None` reference) when PR touches gated and ungated paths
 - [ ] Did not weaken tests/tolerances/benchmarks for “wins”; synced bench + re-profile on target NPU
 - [ ] Round summary includes pipe/UB metrics (template above)
@@ -208,6 +222,11 @@ Generalizable fixes discovered during optimization belong in this skill (`SKILL.
 - Loosening tolerances, dropping cases, or editing benchmarks to fake speedups
 - Adding or keeping `num_warps` / `num_stages` on Ascend paths (unsupported; not a tuning lever)
 - Hiding unsupported triton-ascend ops without documenting workarounds
+- Leaving a runtime `is_tail_chunk` (or similar) between `block_ptr` and masked DMA — both stay in UB
+- Launching a Vector-bound kernel on `num_aicore` (half the vector cores idle on A2)
+- `if CONSTEXPR_FLAG or runtime:` around an optional pointer — else still compiles when the ptr is None
+- `B.to(tl.int64)` / `i_t.to(tl.int64)` on specialized or folded constexpr ints (`constexpr` has no `.to`); use `tl.cast`
+- Passing int64 `t0` as `make_block_ptr` offsets (`offsets/block_shape` must be int32)
 
 ## Related files
 
@@ -215,4 +234,6 @@ Generalizable fixes discovered during optimization belong in this skill (`SKILL.
 - Metrics, failure modes, code index: [references/reference.md](references/reference.md)
 - Past kernel case notes: [references/cases.md](references/cases.md)
 - **Gate `g` stride-1 loading (G_T_CONTIG)**: [g-contiguous-loading.md](references/g-contiguous-loading.md)
+- **causal_conv1d 1D core-grid + constexpr DMA split**: [cases.md § causal_conv1d](references/cases.md#causal_conv1dpy--1d-core-grid--constexpr-dma-split)
+- Ascend-specific traps (DMA dual-path UB, None-ptr compile, `constexpr` `.to`, int64 `block_ptr` offsets): [TRAPS.md](references/TRAPS.md)
 - Ad-hoc workload output dir: `npu_prof/` (new collection must use the generic scripts)

--- a/.agents/skills/fla-ascend-performance/references/TRAPS.md
+++ b/.agents/skills/fla-ascend-performance/references/TRAPS.md
@@ -1,0 +1,35 @@
+# Ascend Triton traps
+
+Silent-bug and compile/UB traps specific to Triton-Ascend. General FLA measurement traps stay in `fla-optimization-loop/references/TRAPS.md`. Case notes: [cases.md](cases.md).
+
+Each entry: **Fact / Why / How to apply**.
+
+---
+
+## Runtime DMA-path `if` keeps both sides in UB
+
+**Fact:** A runtime `if is_tail_chunk:` that chooses `make_block_ptr` vs masked `tl.load` does **not** DCE the unused path on Triton-Ascend. Peak UB is the sum of both; Vector stays ~0.75 occupied; larger tiles fail compile even when MemoryUB bandwidth is free.
+
+**Why:** The compiler treats the predicate as data-dependent, so both DMA sequences stay in the live set. Halo windows (`BT+W-1`) make the tail path even larger. The same class of bug: `if CONSTEXPR_FLAG or runtime:` around an optional pointer still compiles `ptr + …` when `ptr is None`.
+
+**How to apply:** Host-split the last tile into a second launch with a `tl.constexpr` mode (never / always / runtime-for-varlen). Nest constexpr optional-pointer flags; do not OR them with runtime checks. See [cases.md § causal_conv1d](cases.md#causal_conv1dpy--1d-core-grid--constexpr-dma-split).
+
+---
+
+## `constexpr` has no `.to()` — use `tl.cast` for address math
+
+**Fact:** Specialized kernel args (`B`, `T`) and program IDs that fold (e.g. `i_t` when `NT==1`) are `constexpr`. `x.to(tl.int64)` is `AttributeError("'constexpr' object has no attribute 'to'")` at compile. CUDA kernels often write `i_t.to(tl.int64)` because those indices stay runtime there.
+
+**Why:** Ascend specializes more integers than CUDA. `tl.cast(x, tl.int64)` works on constexpr and runtime ints; `.to()` only exists on tensor / load results.
+
+**How to apply:** `t0 = tl.cast(i_t, tl.int64) * BT`, `bos = tl.cast(i_b, tl.int64) * T`, `tl.cast(B, tl.int64) * T`. Keep `tl.load(cu_seqlens + i_n).to(tl.int64)`. Never `(i_b * T).to(tl.int64)`.
+
+---
+
+## Int64 `make_block_ptr` offsets fail compile
+
+**Fact:** `make_block_ptr` rejects int64 `offsets` / `block_shape` (`Block pointers only support 32 bit offsets/block_shape`). Feeding `t0 = tl.cast(i_t, tl.int64) * BT` as the row offset breaks compile after the overflow fix.
+
+**Why:** Block-pointer metadata is int32 by design. Flattened `ptr + offset * stride` is the path that needs int64.
+
+**How to apply:** Keep `t0` (int64) for `x + bos * D + t0 * D`. Pass `i_t * BT` (int32) to `make_block_ptr`. See [cases.md § causal_conv1d](cases.md#causal_conv1dpy--1d-core-grid--constexpr-dma-split).

--- a/.agents/skills/fla-ascend-performance/references/cases.md
+++ b/.agents/skills/fla-ascend-performance/references/cases.md
@@ -2,6 +2,51 @@
 
 Experience notes from past kernel work. Read the current code before applying — numbers are not immutable hardware constants. Paths are relative to the `flash-linear-attention` repo root.
 
+## `causal_conv1d.py` — 1D core-grid + constexpr DMA split
+
+File: `fla/modules/backends/triton_ascend/causal_conv1d.py`
+
+Packed training path (contiguous `[B,T,D]`, no `initial_state` / `dht`, `D` divisible by a `BD>=16` tile) uses 1D core-grid kernels. Odd `D` (e.g. 200), strided layout, and cache-state paths stay on the legacy multi-axis kernels.
+
+### Fast-path shape
+
+- Public weight is `[D, W]`; host `transpose(0, 1).contiguous()` → `[W, D]` so `block_ptr` is stride-1 along D.
+- Grid: `get_multiprocessor_count` → `num_vectorcore` (Vector-bound, Cube=0). A2: 48 vector vs 24 Cube.
+- Fwd: preferred `BD=256` (exact divisor of D), `BT<=32`. Fuse bias / silu / residual. If activation is silu/swish, also store pre-silu `y_linear` (extra MTE3, skips a second full fwd in bwd). Stash on the pre-rearrange `x` as `_fla_causal_conv_y_linear`.
+- Bwd: `BT<=64` bf16/fp16, `BT<=32` fp32 (fp32 live tiles ~200KB > 192KB UB). `BD` 64 if `cdiv(D,64)*NUM_CHKS > NUM_CORES/2` else 32. No-state path: one `BT+W-1` `dy` load + `extract_slice` per tap; `insert_slice` into `b_dw`.
+- `tl.extract_slice` / `insert_slice`: shim from `triton.language.extra.cann.extension` when `tl` lacks them. Intra-loop `x` loads — preloading every tap overflows UB.
+- Constexpr vs runtime on optional ptrs: nest `if not USE_INITIAL_STATE: … elif i_t*BT >= W: … else: …`. OR-ing still compiles `initial_state + …` when the pointer is None.
+- Tail DMA: packed-row end `bos + i_t*BT + BT` (bwd halo: `+ W-1`) must not exceed `B*T`, else MTE `DDR address out of range`. Masked load/store on that chunk.
+- Address math: `t0 = tl.cast(i_t, tl.int64) * BT` and `bos = tl.cast(i_b, tl.int64) * T` for flattened `offset * D` (int32 wrap at T>2³¹/D; D=4096 → T>524K). Use `tl.cast`, not `.to` — specialized `B`/`T` are constexpr (`B.to(tl.int64)` fails compile). `make_block_ptr` offsets stay int32 (`i_t * BT`); do not pass `t0`. Tail check: `tl.cast(B, tl.int64) * T`.
+
+### Constexpr `TAIL_MODE` split (the perf win)
+
+Bwd used a **runtime** `is_tail_chunk` to pick `make_block_ptr` vs masked DMA. Triton-Ascend keeps **both** paths live in UB → peak UB ≈ sum of both; Vector stuck at `aiv_vec_ratio≈0.76` even though MemoryUB R/W ~32/22 GB/s was not saturated. Larger tiles (`BT=128` / `BD=128`) fail compile (`req ~390KB > 192KB`).
+
+Packed `NT>1`: two launches so each compile DCE's the unused path.
+
+| Launch | `TAIL_MODE` | Coverage | DMA |
+|--------|-------------|----------|-----|
+| bulk | `0` | `i_t = 0..NT-2` (`num_chks=B*(NT-1)`, `nt_stride=NT-1`, `i_t_offset=0`) | `block_ptr` only |
+| tail | `1` | last T-chunk (`num_chks=B`, `nt_stride=1`, `i_t_offset=NT-1`) | masked only |
+| varlen / `NT==1` | `2` | all tasks | runtime predicate |
+
+`NT_STRIDE` / `I_T_OFFSET` decode `i_chk` → `(i_b, i_t)` without a runtime tail flag in the bulk kernel.
+
+### Measured (Ascend 910, 48 vector / 24 Cube, bf16 silu bias, no residual/state)
+
+Synced median fwdbwd, vs core-grid **before** the split:
+
+| Shape | before | after |
+|-------|--------|-------|
+| B1 T8192 D4096 W4 | 1.536 ms | **1.371 ms** |
+| B1 T2048 D4096 W4 | 0.689 ms | 0.590 ms |
+| B1 T2048 D1024 W4 | 0.540 ms | 0.457 ms |
+
+Pipe (T8192 D4096): bwd 916µs (65%, vec=0.756, mte2=0.216) → bulk **759µs vec=0.948** + tail 23µs. Fwd ~350µs unchanged (vec≈0.64, still per-tap masked `x` loads). Host transpose + `dw`/`db` ReduceSum ~10%. Gate: `tests/modules/test_conv.py -k "not cuda"`.
+
+Open: fwd window+`extract_slice` (same pattern as no-state bwd); host ReduceSum of per-chunk `dw`/`db`.
+
 ## `chunk_delta_h.py` — bwd `dhu`
 
 File: `fla/ops/common/backends/triton_ascend/chunk_delta_h.py`
@@ -29,7 +74,7 @@ File: `fla/ops/common/backends/triton_ascend/chunk_o.py`
 File: `fla/ops/kda/backends/triton_ascend/chunk_bwd.py`
 
 - `chunk_kda_bwd_kernel_dAv_npu` and `chunk_kda_bwd_kernel_wy_v_part_npu` loaded `bos`/`eos` via `.to(tl.int32)` then `(bos * HV + i_hv) * V` — int32 wrap on packed varlen offsets (e.g. HV=32, V=4096 safe `bos` ≈ 16K). Later kernels in the same file already used `tl.int64`.
-- Fix: load `bos`/`eos` as int64; `T = (eos - bos).to(tl.int32)`; non-varlen else-branch `(i_b * T).to(tl.int64)`.
+- Fix: load `bos`/`eos` as int64; `T = (eos - bos).to(tl.int32)`; non-varlen else-branch `tl.cast(i_b, tl.int64) * T` (CUDA often writes `(i_b * T).to(tl.int64)`, which still wraps if `i_b * T` exceeds 2³¹; `.to` also fails if `i_b` is constexpr).
 
 ## `wy_fast.py` — Ascend `tl.dot` left-operand clobber
 

--- a/.agents/skills/fla-ascend-performance/references/reference.md
+++ b/.agents/skills/fla-ascend-performance/references/reference.md
@@ -48,8 +48,10 @@ After changing `mem_mult`/tiles, always re-check compile + numeric correctness.
 
 ## Common failures and fixes
 
-- **UB overflow**: fewer concurrent fp32 tiles; smaller BK/BV; split kernels; avoid accidental large broadcasts.
-- **Grid limit**: host-split axes + offsets, **or** switch to 1D core-grid (`num_aicore` × flat `task_num`); do not only grow tiles.
+- **UB overflow**: fewer concurrent fp32 tiles; smaller BK/BV; split kernels; avoid accidental large broadcasts. Also check for a **runtime** `block_ptr` vs masked-DMA branch — both paths stay live; constexpr-split (see [cases.md § causal_conv1d](cases.md#causal_conv1dpy--1d-core-grid--constexpr-dma-split)).
+- **Grid limit**: host-split axes + offsets, **or** switch to 1D core-grid; Cube-bound → `num_aicore`, Vector-bound → `num_vectorcore` / `get_multiprocessor_count`. Do not only grow tiles.
+- **MTE `DDR address out of range`**: `make_block_ptr` block end past packed `B*T` rows (or `BT+W-1` halo). Masked tail DMA, or constexpr-split so bulk never overshoots.
+- **Compile of `None` pointer arithmetic**: `if CONSTEXPR_FLAG or runtime:` still lowers the else. Nest the constexpr flag in its own `if`/`elif`.
 - **Varlen wrong only on long seqs**: after slicing `chunk_indices`, check for a second global `NT_OFFSET`; on core-grid paths, verify `chunk_offsets` → `(i_n, i_t)` against `cu_seqlens`.
 - **Wrong results only in multi-task core-grid loops**: rebind local base pointers each `task_id`; avoid in-place `ptr +=` across iterations.
 - **Occasional bf16 NaN**: mask before exp, fp32 accum, exp/exp2 scale, solve precision.
@@ -58,7 +60,8 @@ After changing `mem_mult`/tiles, always re-check compile + numeric correctness.
 - **Local pass, full gate NaN**: tail writeback, boundary masks, invalid exp regions, scratch init before read.
 - **Compile-variant explosion**: do not specialize on T; move feature flags to heuristics/constexpr.
 - **`num_warps` / `num_stages` on NPU**: unsupported by Ascend Triton — remove from launches/autotune; never use as an optimization knob.
-- **int32 chunk-address overflow**: `NT = cdiv(T, BT)` under `do_not_specialize` is int32; `(NT-1)*HV*K*V` wraps before `.to(tl.int64)` on long context (K=V=128, HV=64 → T>131K). Fix: `(NT-1).to(tl.int64)*DH_CS` (same rule for any runtime `i_t`/offset × stride).
+- **int32 chunk-address overflow**: `NT = cdiv(T, BT)` under `do_not_specialize` is int32; `(NT-1)*HV*K*V` wraps before `.to(tl.int64)` on long context (K=V=128, HV=64, BT=64 → T>131K). Same class without `do_not_specialize`: packed conv `i_t * BT` then `offset * D` (D=4096 → T>524K). Fix: `tl.cast(i_t, tl.int64)*BT`, `tl.cast(i_b, tl.int64)*T`, `tl.cast(NT-1, tl.int64)*DH_CS` — never post-multiply `.to(tl.int64)`, never `B.to(tl.int64)` on specialized args.
+- **`constexpr` has no `.to()` / int64 `make_block_ptr` offsets**: specialized `B`/`T` (and folded `i_t` when NT=1) fail `x.to(tl.int64)` at compile. Use `tl.cast(x, tl.int64)`. Block-pointer `offsets/block_shape` must stay int32 — keep `t0` for flattened `* D` only.
 - **Ungated path untested**: kernel tests that always pass `g` miss `g=None` regressions (in-place `dv`, scale folds, tiling). Parametrize `use_g` on the existing test + `g=None` reference branch — no new CI file required.
 - **Unsupported triton-ascend ops**: work around in-kernel; list every unsupported op in the round summary so follow-ups can track compiler gaps.
 
@@ -84,6 +87,7 @@ Paths relative to the `flash-linear-attention` repo root. Detailed case notes: [
 - `fla/ops/kda/backends/triton_ascend/chunk_bwd.py` — KDA bwd (`dAv`, wy dw/dqkg); `b_do_c` pattern — [cases.md](cases.md)
 - `fla/ops/utils/backends/triton_ascend/solve_tril.py` — blocked triangular solve; 32×32/64×64 merge clobber guards — [cases.md](cases.md)
 - `fla/ops/utils/backends/triton_ascend/cumsum.py` — scalar/vector split and leftover UB budget
+- `fla/modules/backends/triton_ascend/causal_conv1d.py` — 1D core-grid conv; Vector `num_vectorcore`; constexpr `TAIL_MODE` DMA split; `extract_slice` — [cases.md](cases.md)
 
 ### Split / numerics / varlen
 
@@ -94,6 +98,7 @@ Paths relative to the `flash-linear-attention` repo root. Detailed case notes: [
 ### Tests and benchmarks
 
 - `tests/ops/test_gdn_kernels.py` — per-kernel oracle
+- `tests/modules/test_conv.py` — causal_conv1d (NPU: `-k "not cuda"`)
 - `tests/utils/test_ascend_ub_manager.py` — tiling/grid boundaries
 - `tests/conftest.py` — NaN memory poisoning
 - `benchmarks/ops/verify.py` — correctness-gated benchmark (do not claim wins with `--no-gate`)

--- a/fla/modules/backends/triton_ascend/causal_conv1d.py
+++ b/fla/modules/backends/triton_ascend/causal_conv1d.py
@@ -13,7 +13,516 @@ import triton.language as tl
 from einops import rearrange
 
 from fla.ops.utils import prepare_chunk_indices
-from fla.utils import input_guard
+from fla.utils import get_multiprocessor_count, input_guard
+
+# triton-ascend exposes extract_slice/insert_slice via cann.extension on some versions.
+try:
+    from triton.language.extra.cann.extension import extract_slice, insert_slice
+
+    if not hasattr(tl, 'extract_slice'):
+        tl.extract_slice = extract_slice
+    if not hasattr(tl, 'insert_slice'):
+        tl.insert_slice = insert_slice
+except ImportError:
+    pass
+
+
+def _select_coregrid_bd(D: int, preferred: int) -> int | None:
+    """Largest power-of-2 BD <= preferred that exactly divides D.
+
+    Core-grid kernels need channel tiles on exact D boundaries;
+    odd widths (e.g. D=200) fall back to the legacy path.
+    """
+    bd = min(preferred, triton.next_power_of_2(max(D, 1)))
+    while bd > 8 and (bd > D or D % bd != 0):
+        bd //= 2
+    if bd > D or D % bd != 0:
+        return None
+    return bd
+
+
+@triton.heuristics({
+    'HAS_WEIGHT': lambda args: args['weight'] is not None,
+    'HAS_BIAS': lambda args: args['bias'] is not None,
+    'HAS_RESIDUAL': lambda args: args['residual'] is not None,
+    'HAS_Y_LINEAR': lambda args: args['y_linear'] is not None,
+    'USE_INITIAL_STATE': lambda args: args['initial_state'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit
+def causal_conv1d_fwd_coregrid_kernel(
+    x,
+    y,
+    y_linear,
+    weight,
+    bias,
+    residual,
+    cu_seqlens,
+    initial_state,
+    chunk_indices,
+    B,
+    T,
+    D: tl.constexpr,
+    W: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_Y_LINEAR: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NUM_CHKS: tl.int32,
+    NUM_BLKS_D: tl.int32,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+
+    total_tasks = NUM_BLKS_D * NUM_CHKS
+
+    for task_id in range(pid, total_tasks, num_programs):
+        i_d = task_id % NUM_BLKS_D
+        i_chk = task_id // NUM_BLKS_D
+
+        if IS_VARLEN:
+            i_n = tl.load(chunk_indices + i_chk * 2).to(tl.int32)
+            i_t = tl.load(chunk_indices + i_chk * 2 + 1).to(tl.int32)
+            bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+            eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T_len = eos - bos
+        else:
+            NT_per_seq = tl.cdiv(T, BT)
+            i_b = i_chk // NT_per_seq
+            i_t = i_chk % NT_per_seq
+            i_n = i_b
+            bos = tl.cast(i_b, tl.int64) * T
+            eos = bos + T
+            T_len = T
+
+        t0 = tl.cast(i_t, tl.int64) * BT
+        o_d = i_d * BD + tl.arange(0, BD)
+        m_d = o_d < D
+
+        # tail-of-allocation guard: packed-row block end must not exceed B*T,
+        # else MTE DMA touches unmapped pages.
+        is_tail_chunk = (bos + t0 + BT) > (tl.cast(B, tl.int64) * T)
+
+        if HAS_WEIGHT:
+            # host layout is [W, D] (contiguous along D), so the block load is stride-1.
+            p_w = tl.make_block_ptr(weight, (W, D), (D, 1), (0, i_d * BD), (W, BD), (1, 0))
+            b_w = tl.load(p_w)
+
+        b_y = tl.zeros((BT, BD), dtype=tl.float32)
+        yi_offset_1 = o_d[None, :]
+
+        # split the constexpr flag from the runtime `i_t * BT >= W` check.
+        # triton-ascend still lowers the else if they are or-ed, and would compile
+        # `initial_state + ...` when the pointer is None.
+        if not USE_INITIAL_STATE:
+            for i_w in tl.static_range(-W + 1, 1):
+                yi_offset_0 = t0 + i_w + tl.arange(0, BT)[:, None]
+                mask = (yi_offset_0 < T_len) & (yi_offset_1 < D) & (yi_offset_0 >= 0)
+                # intra-loop load: preloading overflows UB under certain tiling.
+                b_yi = tl.load(x + bos * D + yi_offset_0 * D + yi_offset_1, mask=mask, other=0.).to(tl.float32)
+                if HAS_WEIGHT:
+                    b_yi *= tl.extract_slice(b_w, [i_w + W - 1, 0], [1, BD], [1, 1])
+                b_y += b_yi
+        elif t0 >= W:
+            for i_w in tl.static_range(-W + 1, 1):
+                yi_offset_0 = t0 + i_w + tl.arange(0, BT)[:, None]
+                mask = (yi_offset_0 < T_len) & (yi_offset_1 < D) & (yi_offset_0 >= 0)
+                b_yi = tl.load(x + bos * D + yi_offset_0 * D + yi_offset_1, mask=mask, other=0.).to(tl.float32)
+                if HAS_WEIGHT:
+                    b_yi *= tl.extract_slice(b_w, [i_w + W - 1, 0], [1, BD], [1, 1])
+                b_y += b_yi
+        else:
+            o_t = t0 + tl.arange(0, BT)
+            for i_w in tl.static_range(-W + 1, 1):
+                o_x = o_t + i_w
+                m_x = ((o_x >= 0) & (o_x < T_len))[:, None] & m_d
+                m_c = ((o_x + W >= 0) & (o_x < 0))[:, None] & m_d
+                b_yi = tl.load(x + bos * D + o_x[:, None] * D + o_d, mask=m_x, other=0).to(tl.float32)
+                b_yi += tl.load(
+                    initial_state + tl.cast(i_n, tl.int64) * D * W + o_d * W + (o_x + W)[:, None],
+                    mask=m_c,
+                    other=0,
+                ).to(tl.float32)
+                if HAS_WEIGHT:
+                    b_yi *= tl.extract_slice(b_w, [i_w + W - 1, 0], [1, BD], [1, 1])
+                b_y += b_yi
+
+        if HAS_BIAS:
+            b_y += tl.load(bias + o_d, mask=m_d).to(tl.float32)
+
+        # pre-silu linear y for bwd: extra MTE3 store, avoids a second full fwd launch.
+        if HAS_Y_LINEAR:
+            if is_tail_chunk:
+                o_t_yl = t0 + tl.arange(0, BT)
+                m_t_yl = (o_t_yl >= 0) & (o_t_yl < T_len)
+                b_yl_cast = tl.cast(b_y, dtype=y_linear.dtype.element_ty, fp_downcast_rounding='rtne')
+                tl.store(
+                    y_linear + bos * D + o_t_yl[:, None] * D + o_d[None, :],
+                    b_yl_cast,
+                    mask=m_t_yl[:, None] & m_d[None, :],
+                )
+            else:
+                p_yl = tl.make_block_ptr(
+                    y_linear + bos * D, (T_len, D), (D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0),
+                )
+                tl.store(
+                    p_yl,
+                    tl.cast(b_y, dtype=p_yl.dtype.element_ty, fp_downcast_rounding='rtne'),
+                    boundary_check=(0, 1),
+                )
+
+        if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+            b_y = b_y * tl.sigmoid(b_y)
+
+        if HAS_RESIDUAL:
+            if is_tail_chunk:
+                o_t_r = t0 + tl.arange(0, BT)
+                m_t_r = (o_t_r >= 0) & (o_t_r < T_len)
+                b_residual = tl.load(
+                    residual + bos * D + o_t_r[:, None] * D + o_d[None, :],
+                    mask=m_t_r[:, None] & m_d[None, :],
+                    other=0.,
+                )
+            else:
+                p_residual = tl.make_block_ptr(
+                    residual + bos * D, (T_len, D), (D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0),
+                )
+                b_residual = tl.load(p_residual, boundary_check=(0, 1))
+            b_y += b_residual
+
+        if is_tail_chunk:
+            o_t_y = t0 + tl.arange(0, BT)
+            m_t_y = (o_t_y >= 0) & (o_t_y < T_len)
+            b_y_cast = tl.cast(b_y, dtype=y.dtype.element_ty, fp_downcast_rounding='rtne')
+            tl.store(
+                y + bos * D + o_t_y[:, None] * D + o_d[None, :],
+                b_y_cast,
+                mask=m_t_y[:, None] & m_d[None, :],
+            )
+        else:
+            p_y = tl.make_block_ptr(y + bos * D, (T_len, D), (D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
+            tl.store(
+                p_y,
+                tl.cast(b_y, dtype=p_y.dtype.element_ty, fp_downcast_rounding='rtne'),
+                boundary_check=(0, 1),
+            )
+
+
+@triton.heuristics({
+    'HAS_WEIGHT': lambda args: args['dw'] is not None,
+    'HAS_BIAS': lambda args: args['db'] is not None,
+    'USE_INITIAL_STATE': lambda args: args['dh0'] is not None,
+    'USE_FINAL_STATE': lambda args: args['dht'] is not None,
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit
+def causal_conv1d_bwd_coregrid_kernel(
+    x,
+    y,
+    weight,
+    initial_state,
+    dh0,
+    dht,
+    dy,
+    dx,
+    dw,
+    db,
+    cu_seqlens,
+    chunk_indices,
+    B,
+    T,
+    D: tl.constexpr,
+    W: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    USE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NUM_BLKS_D: tl.int32,
+    NUM_CHKS: tl.int32,
+    NT_STRIDE: tl.int32,
+    I_T_OFFSET: tl.int32,
+    TAIL_MODE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+
+    # packed [B, T, D] row count; tail DMA past B*T faults MTE ("DDR address out of range").
+    # TAIL_MODE: 0 = never (block_ptr bulk), 1 = always (masked), 2 = runtime (varlen / NT==1).
+    total_rows = tl.cast(B, tl.int64) * T
+    total_tasks = NUM_BLKS_D * NUM_CHKS
+
+    for task_id in range(pid, total_tasks, num_programs):
+        i_d = task_id % NUM_BLKS_D
+        i_chk = task_id // NUM_BLKS_D
+
+        if IS_VARLEN:
+            i_tg = tl.cast(i_chk, tl.int64)
+            i_n = tl.load(chunk_indices + i_chk * 2).to(tl.int32)
+            i_t = tl.load(chunk_indices + i_chk * 2 + 1).to(tl.int32)
+            bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+            eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T_len = eos - bos
+        else:
+            NT_per_seq = tl.cdiv(T, BT)
+            i_b = i_chk // NT_STRIDE
+            i_t = i_chk % NT_STRIDE + I_T_OFFSET
+            i_tg = tl.cast(i_b, tl.int64) * NT_per_seq + tl.cast(i_t, tl.int64)
+            i_n = i_b
+            bos = tl.cast(i_b, tl.int64) * T
+            eos = bos + T
+            T_len = T
+
+        t0 = tl.cast(i_t, tl.int64) * BT
+        o_d = i_d * BD + tl.arange(0, BD)
+        m_d = o_d < D
+        if TAIL_MODE == 0:
+            is_tail_chunk = False
+        elif TAIL_MODE == 1:
+            is_tail_chunk = True
+        else:
+            is_tail_chunk = (bos + t0 + BT + W - 1) > total_rows
+
+        if HAS_WEIGHT:
+            if is_tail_chunk:
+                o_t_x = t0 + tl.arange(0, BT)
+                m_t_x = (o_t_x >= 0) & (o_t_x < T_len)
+                b_x = tl.load(
+                    x + bos * D + o_t_x[:, None] * D + o_d[None, :],
+                    mask=m_t_x[:, None] & m_d[None, :],
+                    other=0,
+                )
+            else:
+                p_x = tl.make_block_ptr(x + bos * D, (T_len, D), (D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
+                b_x = tl.load(p_x, boundary_check=(0, 1))
+            p_w = tl.make_block_ptr(weight, (W, D), (D, 1), (0, i_d * BD), (W, BD), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1), padding_option='zero')
+
+        b_dx = tl.zeros((BT, BD), dtype=tl.float32)
+        if HAS_BIAS:
+            b_db = tl.zeros((BD,), dtype=tl.float32)
+
+        # no-state: one BT+W-1 load + extract_slice; cache paths use per-tap loads.
+        if not USE_FINAL_STATE and not USE_INITIAL_STATE:
+            b_dw = tl.zeros((W, BD), dtype=tl.float32)
+
+            if is_tail_chunk:
+                o_t_full = t0 + tl.arange(0, BT + W - 1)
+                m_t_full = (o_t_full >= 0) & (o_t_full < T_len)
+                b_dy = tl.load(
+                    dy + bos * D + o_t_full[:, None] * D + o_d[None, :],
+                    mask=m_t_full[:, None] & m_d[None, :],
+                    other=0.,
+                ).to(tl.float32)
+                if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                    b_y = tl.load(
+                        y + bos * D + o_t_full[:, None] * D + o_d[None, :],
+                        mask=m_t_full[:, None] & m_d[None, :],
+                        other=0.,
+                    ).to(tl.float32)
+            else:
+                p_dy = tl.make_block_ptr(
+                    dy + bos * D, (T_len, D), (D, 1), (i_t * BT, i_d * BD), (BT + W - 1, BD), (1, 0),
+                )
+                b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+                if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                    p_y = tl.make_block_ptr(
+                        y + bos * D, (T_len, D), (D, 1), (i_t * BT, i_d * BD), (BT + W - 1, BD), (1, 0),
+                    )
+                    b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
+
+            if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                b_ys = tl.sigmoid(b_y)
+                b_dy = b_dy * b_ys * (1 + b_y * (1 - b_ys))
+
+            for i_w in tl.static_range(0, W):
+                b_dy_sub = tl.extract_slice(b_dy, [i_w, 0], [BT, BD], [1, 1])
+                b_wdy = b_dy_sub
+                if HAS_WEIGHT:
+                    b_wdy = b_wdy * tl.extract_slice(b_w, [W - i_w - 1, 0], [1, BD], [1, 1])
+                    b_dw_sub = tl.sum(b_dy_sub * b_x, 0)
+                    b_dw = tl.insert_slice(b_dw, b_dw_sub[None, :], [W - i_w - 1, 0], [1, BD], [1, 1])
+                if HAS_BIAS and i_w == 0:
+                    b_db += tl.sum(b_dy_sub, 0)
+                b_dx += b_wdy
+
+            p_dw = tl.make_block_ptr(dw + i_tg * W * D, (W, D), (D, 1), (0, i_d * BD), (W, BD), (1, 0))
+            tl.store(p_dw, b_dw.to(dw.dtype.element_ty))
+        elif t0 >= W:
+            for i_w in tl.static_range(0, W):
+                if is_tail_chunk:
+                    o_t_iw = t0 + i_w + tl.arange(0, BT)
+                    m_t_iw = (o_t_iw >= 0) & (o_t_iw < T_len)
+                    b_dy = tl.load(
+                        dy + bos * D + o_t_iw[:, None] * D + o_d[None, :],
+                        mask=m_t_iw[:, None] & m_d[None, :],
+                        other=0.,
+                    ).to(tl.float32)
+                    if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                        b_y = tl.load(
+                            y + bos * D + o_t_iw[:, None] * D + o_d[None, :],
+                            mask=m_t_iw[:, None] & m_d[None, :],
+                            other=0.,
+                        ).to(tl.float32)
+                        b_ys = tl.sigmoid(b_y)
+                        b_dy = b_dy * b_ys * (1 + b_y * (1 - b_ys))
+                else:
+                    p_dy = tl.make_block_ptr(
+                        dy + bos * D, (T_len, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0),
+                    )
+                    b_dy = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+                    if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                        p_y = tl.make_block_ptr(
+                            y + bos * D, (T_len, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0),
+                        )
+                        b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
+                        b_ys = tl.sigmoid(b_y)
+                        b_dy = b_dy * b_ys * (1 + b_y * (1 - b_ys))
+                b_wdy = b_dy
+                if HAS_WEIGHT:
+                    b_wdy = b_wdy * tl.extract_slice(b_w, [W - i_w - 1, 0], [1, BD], [1, 1])
+                    b_dw = tl.sum(b_dy * b_x, 0)
+                    tl.store(dw + i_tg * W * D + (W - i_w - 1) * D + o_d, b_dw.to(dw.dtype.element_ty), mask=m_d)
+                if HAS_BIAS and i_w == 0:
+                    b_db += tl.sum(b_dy, 0)
+                b_dx += b_wdy
+        else:
+            o_t = t0 + tl.arange(0, BT)
+            for i_w in tl.static_range(0, W):
+                if is_tail_chunk:
+                    o_t_iw = t0 + i_w + tl.arange(0, BT)
+                    m_t_iw = (o_t_iw >= 0) & (o_t_iw < T_len)
+                    b_dy_shift = tl.load(
+                        dy + bos * D + o_t_iw[:, None] * D + o_d[None, :],
+                        mask=m_t_iw[:, None] & m_d[None, :],
+                        other=0.,
+                    ).to(tl.float32)
+                    if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                        b_y = tl.load(
+                            y + bos * D + o_t_iw[:, None] * D + o_d[None, :],
+                            mask=m_t_iw[:, None] & m_d[None, :],
+                            other=0.,
+                        ).to(tl.float32)
+                        b_ys = tl.sigmoid(b_y)
+                        b_dy_shift = b_dy_shift * b_ys * (1 + b_y * (1 - b_ys))
+                else:
+                    p_dy = tl.make_block_ptr(
+                        dy + bos * D, (T_len, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0),
+                    )
+                    b_dy_shift = tl.load(p_dy, boundary_check=(0, 1)).to(tl.float32)
+                    if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                        p_y = tl.make_block_ptr(
+                            y + bos * D, (T_len, D), (D, 1), (i_t * BT + i_w, i_d * BD), (BT, BD), (1, 0),
+                        )
+                        b_y = tl.load(p_y, boundary_check=(0, 1)).to(tl.float32)
+                        b_ys = tl.sigmoid(b_y)
+                        b_dy_shift = b_dy_shift * b_ys * (1 + b_y * (1 - b_ys))
+                if HAS_WEIGHT:
+                    b_dw = tl.sum(b_dy_shift * b_x, 0)
+                    if USE_INITIAL_STATE:
+                        mask_head_rows = o_t < i_w
+                        b_dy_head = tl.load(
+                            dy + bos * D + o_t[:, None] * D + o_d,
+                            mask=(mask_head_rows[:, None] & m_d[None, :]),
+                            other=0.,
+                        ).to(tl.float32)
+                        if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                            b_y_head = tl.load(
+                                y + bos * D + o_t[:, None] * D + o_d,
+                                mask=(mask_head_rows[:, None] & m_d[None, :]),
+                                other=0.,
+                            ).to(tl.float32)
+                            b_ys_head = tl.sigmoid(b_y_head)
+                            b_dy_head = b_dy_head * b_ys_head * (1 + b_y_head * (1 - b_ys_head))
+                        o_c = W - i_w + o_t
+                        mask_c = mask_head_rows & (o_c >= 1) & (o_c < W)
+                        b_xc = tl.load(
+                            initial_state + tl.cast(i_n, tl.int64) * D * W + o_d[None, :] * W + o_c[:, None],
+                            mask=(mask_c[:, None] & m_d[None, :]),
+                            other=0.,
+                        ).to(tl.float32)
+                        b_dw += tl.sum(b_dy_head * b_xc, 0)
+                    tl.store(dw + i_tg * W * D + (W - i_w - 1) * D + o_d, b_dw.to(dw.dtype.element_ty), mask=m_d)
+
+                if HAS_BIAS and i_w == 0:
+                    b_db += tl.sum(b_dy_shift, 0)
+                if HAS_WEIGHT:
+                    b_wdy = b_dy_shift * tl.extract_slice(b_w, [W - i_w - 1, 0], [1, BD], [1, 1])
+                else:
+                    b_wdy = b_dy_shift
+                b_dx += b_wdy
+
+            if USE_INITIAL_STATE:
+                for i_w in tl.static_range(1, W):
+                    # dh0[i_w] = sum_{t=0}^{i_w-1} dy0[t] * w[i_w-1-t];
+                    # load dy0 row-by-row to avoid overflowing UB with a [BT, BD] preload.
+                    b_dh0_s = tl.zeros((BD,), dtype=tl.float32)
+                    for i_t2 in tl.static_range(0, W - 1):
+                        if i_t2 < i_w:
+                            dy0_row = tl.load(
+                                dy + bos * D + (t0 + i_t2) * D + o_d, mask=m_d, other=0.,
+                            ).to(tl.float32)
+                            if ACTIVATION == 'swish' or ACTIVATION == 'silu':
+                                y0_row = tl.load(
+                                    y + bos * D + (t0 + i_t2) * D + o_d, mask=m_d, other=0.,
+                                ).to(tl.float32)
+                                y0_s = tl.sigmoid(y0_row)
+                                dy0_row = dy0_row * y0_s * (1 + y0_row * (1 - y0_s))
+                            if HAS_WEIGHT:
+                                w_row = tl.extract_slice(b_w, [i_w - 1 - i_t2, 0], [1, BD], [1, 1])
+                                b_dh0_s += tl.sum(dy0_row[None, :] * w_row, 0).to(tl.float32)
+                            else:
+                                b_dh0_s += dy0_row
+                    tl.store(
+                        dh0 + tl.cast(i_t, tl.int64) * tl.cast(B, tl.int64) * D * W +
+                        tl.cast(i_n, tl.int64) * D * W + o_d * W + i_w,
+                        b_dh0_s.to(dh0.dtype.element_ty, fp_downcast_rounding='rtne'),
+                        mask=m_d,
+                    )
+
+        if HAS_BIAS:
+            b_db = tl.cast(b_db, dtype=db.dtype.element_ty, fp_downcast_rounding='rtne')
+            tl.store(db + i_tg * D + o_d, b_db, mask=m_d)
+
+        if USE_FINAL_STATE:
+            if t0 + BT >= T_len - W:
+                # final_state[b, d, w] = x[b, T_len-W+w, d] for w in [0, W),
+                # so dx[t] += dht[b, d, t-(T_len-W)] for t in [T_len-W, T_len).
+                row_arange = tl.arange(0, BT)
+                for i_w in tl.static_range(0, W):
+                    target_row = T_len - W + i_w
+                    local_row = target_row - t0
+                    in_chunk = (local_row >= 0) & (local_row < BT) & (target_row >= 0) & (target_row < T_len)
+                    b_dht_row = tl.load(dht + tl.cast(i_n, tl.int64) * D * W + o_d *
+                                        W + i_w, mask=m_d, other=0.).to(tl.float32)
+                    row_match = (row_arange == local_row) & in_chunk
+                    b_dx += tl.where(row_match[:, None] & m_d[None, :], b_dht_row[None, :], 0.)
+
+        if is_tail_chunk:
+            o_t_dx = t0 + tl.arange(0, BT)
+            m_t_dx = (o_t_dx >= 0) & (o_t_dx < T_len)
+            b_dx_cast = tl.cast(b_dx, dtype=dx.dtype.element_ty, fp_downcast_rounding='rtne')
+            tl.store(
+                dx + bos * D + o_t_dx[:, None] * D + o_d[None, :],
+                b_dx_cast,
+                mask=m_t_dx[:, None] & m_d[None, :],
+            )
+        else:
+            p_dx = tl.make_block_ptr(dx + bos * D, (T_len, D), (D, 1), (i_t * BT, i_d * BD), (BT, BD), (1, 0))
+            tl.store(
+                p_dx,
+                tl.cast(b_dx, dtype=p_dx.dtype.element_ty, fp_downcast_rounding='rtne'),
+                boundary_check=(0, 1),
+            )
+
 
 # Ascend Triton rejects grids whose product exceeds 65535 (see fla/modules/token_shift.py).
 _NPU_MAX_TRITON_GRID = 65535
@@ -175,7 +684,8 @@ def causal_conv1d_fwd_kernel(
         i_n_base = tl.load(chunk_indices + i_t_base * MAX_NT_PER_BLOCK * 2).to(tl.int32)
     else:
         i_n_base = i_b
-        bos_base, eos_base = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+        bos_base = tl.cast(i_b, tl.int64) * T
+        eos_base = bos_base + T
 
     o_d = i_d * BD + tl.arange(0, BD)
     o_w = tl.arange(0, BW)
@@ -199,10 +709,11 @@ def causal_conv1d_fwd_kernel(
                 i_t = i_t_global
                 bos, eos = bos_base, eos_base
                 T_local = T
-                p_x = x + i_b * stride_x_n
+                p_x = x + tl.cast(i_b, tl.int64) * stride_x_n
 
+            t0 = tl.cast(i_t, tl.int64) * BT
             b_y = tl.zeros((BT, BD), dtype=tl.float32)
-            if not USE_INITIAL_STATE or i_t * BT >= W:
+            if not USE_INITIAL_STATE or t0 >= W:
                 for i_w in tl.static_range(W):
                     p_yi = tl.make_block_ptr(p_x, (T_local, D), (stride_x_t, stride_x_d),
                                              (i_t * BT + i_w - W + 1, i_d * BD), (BT, BD), (1, 0))
@@ -211,7 +722,7 @@ def causal_conv1d_fwd_kernel(
                         b_yi *= tl.sum(b_w * (o_w == i_w), 1)
                     b_y += b_yi
             else:
-                o_t = i_t * BT + tl.arange(0, BT)
+                o_t = t0 + tl.arange(0, BT)
                 for i_w in tl.static_range(W):
                     o_x = o_t + i_w - W + 1
                     # Explicit 2D ([None, :]) indexing throughout: triton-ascend miscompiles
@@ -229,7 +740,7 @@ def causal_conv1d_fwd_kernel(
                     # lowered even when initial_state is None -- without the guard it would
                     # dereference None at compile time (AttributeError on None.type).
                     if USE_INITIAL_STATE:
-                        b_yi += tl.load(initial_state + i_n * D * W + o_d[None, :] * W + (o_x + W)
+                        b_yi += tl.load(initial_state + tl.cast(i_n, tl.int64) * D * W + o_d[None, :] * W + (o_x + W)
                                         [:, None], mask=m_c, other=0).to(tl.float32)
                     if HAS_WEIGHT:
                         b_yi *= tl.sum(b_w * (o_w == i_w), 1)[None, :]
@@ -503,7 +1014,7 @@ def causal_conv1d_bwd_dx_kernel(
     o_w = tl.arange(0, BW) + W - BW
     m_d = o_d < D
     m_w = o_w >= 0
-    o_t = i_t * BT + tl.arange(0, BT)
+    o_t = tl.cast(i_t, tl.int64) * BT + tl.arange(0, BT)
     m_t = (o_t >= 0) & (o_t < T)
 
     if HAS_WEIGHT:
@@ -524,13 +1035,13 @@ def causal_conv1d_bwd_dx_kernel(
             b_dx += b_dy
 
     if USE_FINAL_STATE:
-        if i_t * BT + BT >= T - W:
+        if tl.cast(i_t, tl.int64) * BT + BT >= T - W:
             start_tok = T - (W - 1)
-            offset = i_t * BT + tl.arange(0, BT)
+            offset = o_t
             tok_idx = offset - start_tok
             mask = (offset >= start_tok) & (offset < T)
             w_idx = 1 + tok_idx
-            dht_off = i_n * D * W + o_d[None, :] * W + w_idx[:, None]
+            dht_off = tl.cast(i_n, tl.int64) * D * W + o_d[None, :] * W + w_idx[:, None]
             b_dht = tl.load(dht + dht_off, mask=mask[:, None] & m_d[None, :], other=0.).to(tl.float32)
             b_dx += b_dht
 
@@ -649,7 +1160,7 @@ def causal_conv1d_bwd_dwdb_kernel(
     # dw/db-only backward: weight/bias gradient partials (dx is handled separately).
     i_d, i_t, i_b = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     if IS_VARLEN:
-        i_tg = i_t
+        i_tg = tl.cast(i_t, tl.int64)
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
@@ -657,13 +1168,13 @@ def causal_conv1d_bwd_dwdb_kernel(
         p_dy = dy + bos * stride_dy_t
     else:
         i_t = i_t + CHUNK_OFFSET
-        i_tg = i_b * NT + i_t
+        i_tg = tl.cast(i_b, tl.int64) * NT + tl.cast(i_t, tl.int64)
         i_n = i_b
         p_x = x + tl.cast(i_b, tl.int64) * stride_x_n
         p_dy = dy + tl.cast(i_b, tl.int64) * stride_dy_n
 
     o_d = i_d * BD + tl.arange(0, BD)
-    o_t = i_t * BT + tl.arange(0, BT)
+    o_t = tl.cast(i_t, tl.int64) * BT + tl.arange(0, BT)
     m_d = o_d < D
     m_t = (o_t >= 0) & (o_t < T)
 
@@ -698,7 +1209,7 @@ def causal_conv1d_bwd_dwdb_kernel(
                 o_c = W - i_w + o_t
                 mask_c = (mask_head_rows & (o_c >= 1) & (o_c < W))
                 b_xc = tl.load(
-                    initial_state + i_n * D * W + o_d[None, :] * W + o_c[:, None],
+                    initial_state + tl.cast(i_n, tl.int64) * D * W + o_d[None, :] * W + o_c[:, None],
                     mask=(mask_c[:, None] & m_d[None, :]),
                     other=0.0,
                 ).to(tl.float32)
@@ -817,7 +1328,7 @@ def compute_dh0_kernel(
     IS_VARLEN: tl.constexpr,
     CHUNK_OFFSET: tl.constexpr,
 ):
-    i_d, i_n = tl.program_id(0), tl.program_id(1) + CHUNK_OFFSET
+    i_d, i_n = tl.program_id(0), tl.cast(tl.program_id(1) + CHUNK_OFFSET, tl.int64)
 
     if IS_VARLEN:
         bos = tl.load(cu_seqlens + i_n).to(tl.int64)
@@ -826,7 +1337,7 @@ def compute_dh0_kernel(
         dy_base = dy + bos * stride_dy_t
     else:
         seq_len = T
-        dy_base = dy + tl.cast(i_n, tl.int64) * stride_dy_n
+        dy_base = dy + i_n * stride_dy_n
 
     o_d = i_d * BD + tl.arange(0, BD)
     m_d = o_d < D
@@ -845,7 +1356,7 @@ def compute_dh0_kernel(
                     if IS_VARLEN:
                         p_y = y + bos * stride_y_t + t * stride_y_t + o_d * stride_y_d
                     else:
-                        p_y = y + tl.cast(i_n, tl.int64) * stride_y_n + t * stride_y_t + o_d * stride_y_d
+                        p_y = y + i_n * stride_y_n + t * stride_y_t + o_d * stride_y_d
                     b_y = tl.load(p_y, mask=m_t, other=0).to(tl.float32)
                     b_ys = tl.sigmoid(b_y)
                     b_dy = b_dy * b_ys * (1 + b_y * (1 - b_ys))
@@ -879,7 +1390,7 @@ def causal_conv1d_states_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     CHUNK_OFFSET: tl.constexpr,
 ):
-    i_d, i_n = tl.program_id(0), tl.program_id(1) + CHUNK_OFFSET
+    i_d, i_n = tl.program_id(0), tl.cast(tl.program_id(1) + CHUNK_OFFSET, tl.int64)
 
     o_d = i_d * BD + tl.arange(0, BD)
     m_d = o_d < D
@@ -891,11 +1402,11 @@ def causal_conv1d_states_fwd_kernel(
         p_x = x + bos * stride_x_t
     else:
         seq_len = T
-        p_x = x + tl.cast(i_n, tl.int64) * stride_x_n
+        p_x = x + i_n * stride_x_n
 
     o_w = W - BW + tl.arange(0, BW)
     m_w = o_w >= 0
-    o_t = seq_len - BW + tl.arange(0, BW)
+    o_t = tl.cast(seq_len, tl.int64) - BW + tl.arange(0, BW)
     m_t = (o_t >= 0) & (o_t < seq_len)
 
     b_x = tl.load(
@@ -915,7 +1426,7 @@ def causal_conv1d_states_fwd_kernel(
             ).to(tl.float32)
             b_x += b_cache
 
-    p_final = final_state + tl.cast(i_n, tl.int64) * D * W + o_d[:, None] * W + o_w[None, :]
+    p_final = final_state + i_n * D * W + o_d[:, None] * W + o_w[None, :]
     tl.store(p_final, tl.trans(b_x).to(final_state.dtype.element_ty), mask=m_d[:, None] & m_w[None, :])
 
 
@@ -941,7 +1452,7 @@ def causal_conv1d_update_kernel(
     HAS_BIAS: tl.constexpr,
     CHUNK_OFFSET: tl.constexpr,
 ):
-    i_d, i_n = tl.program_id(0), tl.program_id(1) + CHUNK_OFFSET
+    i_d, i_n = tl.program_id(0), tl.cast(tl.program_id(1) + CHUNK_OFFSET, tl.int64)
 
     o_d = i_d * BD + tl.arange(0, BD)
     m_d = o_d < D
@@ -1037,7 +1548,7 @@ def causal_conv1d_fwd_kernel_scalar(
     else:
         i_n = i_b
         i_t = i_t + CHUNK_OFFSET
-        bos = (i_b * T).to(tl.int64)
+        bos = tl.cast(i_b, tl.int64) * T
         p_x = x + tl.cast(i_b, tl.int64) * stride_x_n
         p_y = y + tl.cast(i_b, tl.int64) * stride_y_n
 
@@ -1049,7 +1560,7 @@ def causal_conv1d_fwd_kernel_scalar(
     if HAS_WEIGHT:
         b_w = tl.load(weight + o_d[:, None] * W + o_w, mask=m_d[:, None] & m_w, other=0).to(tl.float32)
 
-    o_t = i_t * BT + tl.arange(0, BT)
+    o_t = tl.cast(i_t, tl.int64) * BT + tl.arange(0, BT)
     m_t = (o_t >= 0) & (o_t < T)
     b_y = tl.zeros((BT, BD), dtype=tl.float32)
 
@@ -1065,7 +1576,7 @@ def causal_conv1d_fwd_kernel_scalar(
         if USE_INITIAL_STATE:
             m_c = ((o_x + W >= 0) & (o_x < 0))[:, None] & m_d[None, :]
             b_yi += tl.load(
-                initial_state + i_n * D * W + o_d[None, :] * W + (o_x + W)[:, None],
+                initial_state + tl.cast(i_n, tl.int64) * D * W + o_d[None, :] * W + (o_x + W)[:, None],
                 mask=m_c,
                 other=0,
             ).to(tl.float32)
@@ -1220,6 +1731,168 @@ def _launch_fwd_core(
     return y
 
 
+def _launch_fwd_coregrid(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    residual: torch.Tensor | None,
+    activation: str | None,
+    cu_seqlens: torch.Tensor | None,
+    cu_seqlens_cpu: torch.Tensor | None,
+    save_linear: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """1D core-grid forward. Public weight is [D, W]; load as contiguous [W, D].
+
+    If ``save_linear``, also store pre-silu conv+bias (no residual) for bwd.
+    """
+    B, T, D = x.shape
+    W = weight.shape[1]
+    weight_wd = weight.transpose(0, 1).contiguous()
+    NUM_CORES = get_multiprocessor_count(x.device.index)
+    BD = _select_coregrid_bd(D, 256)
+    if BD is None:
+        raise RuntimeError(f'coregrid fwd: no aligned BD for D={D}')
+    BT = min(32, triton.next_power_of_2(triton.cdiv(max(16, B * T), NUM_CORES)))
+    NUM_BLKS_D = triton.cdiv(D, BD)
+    if cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT, cu_seqlens_cpu=cu_seqlens_cpu)
+        NUM_CHKS = len(chunk_indices)
+    else:
+        chunk_indices = None
+        NUM_CHKS = triton.cdiv(T, BT) * B
+    y = torch.empty_like(x)
+    y_linear = torch.empty_like(x) if save_linear else None
+    causal_conv1d_fwd_coregrid_kernel[(NUM_CORES,)](
+        x=x,
+        y=y,
+        y_linear=y_linear,
+        weight=weight_wd,
+        bias=bias,
+        residual=residual,
+        cu_seqlens=cu_seqlens,
+        initial_state=None,
+        chunk_indices=chunk_indices,
+        B=B,
+        T=T,
+        D=D,
+        W=W,
+        BT=BT,
+        BD=BD,
+        ACTIVATION=activation,
+        NUM_CHKS=NUM_CHKS,
+        NUM_BLKS_D=NUM_BLKS_D,
+    )
+    return y, y_linear
+
+
+def _launch_bwd_coregrid(
+    x: torch.Tensor,
+    dy: torch.Tensor,
+    weight: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    residual: torch.Tensor | None,
+    activation: str | None,
+    cu_seqlens: torch.Tensor | None,
+    cu_seqlens_cpu: torch.Tensor | None,
+    y_linear: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    """Unified 1D core-grid backward. Public weight is [D, W]; load as contiguous [W, D]."""
+    B, T, D = x.shape
+    W = weight.shape[1] if weight is not None else None
+    weight_wd = weight.transpose(0, 1).contiguous() if weight is not None else None
+    NUM_CORES = get_multiprocessor_count(x.device.index)
+    # BT=64 halves dw/db partials on mid shapes.
+    # fp32 live tiles overflow UB (200KB > 192KB); bf16/fp16 (the training path) fit.
+    bt_cap = 32 if x.dtype == torch.float32 else 64
+    BT = min(bt_cap, triton.next_power_of_2(triton.cdiv(max(16, B * T), NUM_CORES)))
+    if cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT, cu_seqlens_cpu=cu_seqlens_cpu)
+        NUM_CHKS = len(chunk_indices)
+        NT = len(chunk_indices)
+    else:
+        chunk_indices = None
+        NT = triton.cdiv(T, BT)
+        NUM_CHKS = NT * B
+    has_parallelism = triton.cdiv(D, 64) * NUM_CHKS > NUM_CORES // 2
+    preferred = 64 if has_parallelism else 32
+    BD = _select_coregrid_bd(D, preferred)
+    if BD is None:
+        raise RuntimeError(f'coregrid bwd: no aligned BD for D={D}')
+    NUM_BLKS_D = triton.cdiv(D, BD)
+
+    if y_linear is None and activation is not None:
+        y_linear, _ = _launch_fwd_coregrid(
+            x, weight, bias, None,
+            activation=None,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_cpu=cu_seqlens_cpu,
+        )
+    dx = torch.empty_like(x)
+    dw = weight.new_empty(B * NT, W, D, dtype=torch.float) if weight is not None else None
+    db = bias.new_empty(B * NT, *bias.shape, dtype=torch.float) if bias is not None else None
+    dr = dy if residual is not None else None
+
+    def _invoke(num_chks: int, nt_stride: int, i_t_offset: int, tail_mode: int) -> None:
+        causal_conv1d_bwd_coregrid_kernel[(NUM_CORES,)](
+            x=x,
+            y=y_linear,
+            weight=weight_wd,
+            initial_state=None,
+            dh0=None,
+            dht=None,
+            dy=dy,
+            dx=dx,
+            dw=dw,
+            db=db,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            B=B,
+            T=T,
+            D=D,
+            W=W,
+            BT=BT,
+            BD=BD,
+            ACTIVATION=activation,
+            NUM_BLKS_D=NUM_BLKS_D,
+            NUM_CHKS=num_chks,
+            NT_STRIDE=nt_stride,
+            I_T_OFFSET=i_t_offset,
+            TAIL_MODE=tail_mode,
+        )
+
+    # packed NT>1: constexpr-split the last T-chunk so the bulk kernel DCE's the masked DMA path.
+    if cu_seqlens is None and NT > 1:
+        _invoke(num_chks=B * (NT - 1), nt_stride=NT - 1, i_t_offset=0, tail_mode=0)
+        _invoke(num_chks=B, nt_stride=1, i_t_offset=NT - 1, tail_mode=1)
+    else:
+        _invoke(num_chks=NUM_CHKS, nt_stride=max(NT, 1), i_t_offset=0, tail_mode=2)
+    if weight is not None:
+        dw = dw.sum(0).to(weight).transpose(0, 1)
+    if bias is not None:
+        db = db.sum(0).to(bias)
+    return dx, dw, db, dr
+
+
+def _can_use_coregrid(
+    x: torch.Tensor,
+    residual: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    dht: torch.Tensor | None = None,
+    layout_fallback: bool = False,
+) -> bool:
+    """Whether the 1D core-grid kernels can run for this layout and channel width."""
+    if layout_fallback or initial_state is not None or dht is not None:
+        return False
+    if not x.is_contiguous() or x.stride(-1) != 1:
+        return False
+    if residual is not None and (not residual.is_contiguous() or residual.stride(-1) != 1):
+        return False
+    D = x.shape[-1]
+    # need a usable channel tile (legacy path covers odd D like 200).
+    bd = _select_coregrid_bd(D, 64)
+    return bd is not None and bd >= 16
+
+
 @input_guard(no_guard_contiguous=['x'])
 def causal_conv1d_fwd_npu(
     x: torch.Tensor,
@@ -1235,10 +1908,31 @@ def causal_conv1d_fwd_npu(
     BT: int = 64,
     layout_fallback: bool = False,
 ):
-    del layout_fallback
     shape = x.shape
+    # bwd reads the stashed y_linear from the pre-rearrange tensor.
+    x_saved = x
     if x.shape[-1] != weight.shape[0]:
         x = rearrange(x, 'b t ... -> b t (...)')
+    # 1D core-grid fast path (large BD + extract_slice).
+    if _can_use_coregrid(x, residual, initial_state, layout_fallback=layout_fallback):
+        save_linear = activation in ('swish', 'silu')
+        y, y_linear = _launch_fwd_coregrid(
+            x, weight, bias, residual, activation, cu_seqlens, cu_seqlens_cpu,
+            save_linear=save_linear,
+        )
+        if y_linear is not None:
+            x_saved._fla_causal_conv_y_linear = y_linear
+        final_state = None
+        if output_final_state:
+            final_state = causal_conv1d_update_states_npu(
+                x=x,
+                state_len=weight.shape[1],
+                initial_state=initial_state,
+                cu_seqlens=cu_seqlens,
+            )
+        return y.view(shape), final_state
+
+    del layout_fallback
     B, T, D = x.shape[0], x.shape[1], weight.shape[0]
     W = weight.shape[1]
 
@@ -1286,10 +1980,25 @@ def causal_conv1d_bwd_npu(
     BT: int = 64,
     layout_fallback: bool = False,
 ):
-    del layout_fallback
     shape = x.shape
-    if x.shape[-1] != weight.shape[0]:
+    y_linear = getattr(x, '_fla_causal_conv_y_linear', None)
+    if y_linear is not None:
+        del x._fla_causal_conv_y_linear
+    if weight is not None and x.shape[-1] != weight.shape[0]:
         x = rearrange(x, 'b t ... -> b t (...)')
+        if y_linear is not None and y_linear.shape != x.shape:
+            y_linear = rearrange(y_linear, 'b t ... -> b t (...)')
+    if _can_use_coregrid(x, residual, initial_state, dht=dht, layout_fallback=layout_fallback):
+        # core-grid assumes packed BTD; cheap-copy strided dy from cat/split views.
+        if dy is not None and not dy.is_contiguous():
+            dy = dy.contiguous()
+        dx, dw, db, dr = _launch_bwd_coregrid(
+            x, dy, weight, bias, residual, activation, cu_seqlens, cu_seqlens_cpu,
+            y_linear=y_linear,
+        )
+        return dx.view(shape), dw, db, dr, None
+
+    del layout_fallback
     B, T, D = x.shape
     W = weight.shape[1] if weight is not None else None
 


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->

Packed training path for Ascend `causal_conv1d` (contiguous `[B, T, D]`, no `initial_state`/`dht`, `D` divisible by a `BD >= 16` tile) now uses 1D Vector core-grid kernels instead of the legacy multi-axis launch.
The main win is splitting bulk vs tail DMA with a `tl.constexpr TAIL_MODE`. A runtime `is_tail_chunk` that chose `make_block_ptr` vs masked load kept **both** paths live in UB on Triton-Ascend, so peak UB was their sum, Vector stuck around `aiv_vec_ratio ≈ 0.76`, and larger tiles failed compile. Packed `NT > 1` now launches twice (`TAIL_MODE=0` block_ptr-only bulk, `TAIL_MODE=1` masked-only last chunk) so each compile DCE's the unused path. Varlen / `NT==1` keep `TAIL_MODE=2`.
Other fast-path details:
- Launch on `num_vectorcore` (`get_multiprocessor_count`; 48 vector vs 24 Cube on A2), not `num_aicore`
- Host-transpose weight `[D, W] → [W, D]` for stride-1 channel `block_ptr`
- Fuse bias / silu / residual; stash pre-silu `y_linear` on `x` to skip a second full fwd in bwd
- No-state bwd: one `BT+W-1` `dy` load + `extract_slice` / `insert_slice` per tap
- Masked tail DMA so `make_block_ptr` does not overshoot packed `B*T` (MTE `DDR address out of range`); nest constexpr optional-pointer flags instead of `or`-ing with runtime checks

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->

FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules/test_conv.py
hardware: Atlas 800T A3(X86)
<img width="1322" height="342" alt="image" src="https://github.com/user-attachments/assets/fc227061-6d7d-4510-8631-020b7a4ab628" />


## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
<img width="907" height="1052" alt="image" src="https://github.com/user-attachments/assets/966b5070-526b-4ac6-9c6a-2469d82519a9" />


## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->
None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
