### PR TITLE
[Perf] Accelerate KDA training with TileLang

### DIFF
--- a/fla/ops/kda/backends/tilelang/__init__.py
+++ b/fla/ops/kda/backends/tilelang/__init__.py
@@ -12,9 +12,17 @@ from __future__ import annotations
 import torch
 
 from fla.ops.backends import BaseBackend
-from fla.utils import find_spec_cached, has_usable_nvcc
+from fla.utils import check_shared_mem, find_spec_cached, has_usable_nvcc
 
 _TILELANG_AVAILABLE = find_spec_cached("tilelang") is not None
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 << (x - 1).bit_length()
+
+
+def _tile_extent(dim: int, const_tiling: int) -> int:
+    return min(max(_next_power_of_2(dim), 16), const_tiling)
 
 
 class KDATileLangBackend(BaseBackend):
@@ -26,6 +34,161 @@ class KDATileLangBackend(BaseBackend):
     @classmethod
     def is_available(cls) -> bool:
         return _TILELANG_AVAILABLE and has_usable_nvcc()
+
+    def chunk_kda_verifier(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float | None = None,
+        initial_state: torch.Tensor | None = None,
+        output_final_state: bool = False,
+        use_qk_l2norm_in_kernel: bool = False,
+        use_gate_in_kernel: bool = False,
+        use_beta_sigmoid_in_kernel: bool = False,
+        allow_neg_eigval: bool = False,
+        safe_gate: bool = False,
+        lower_bound: float | None = None,
+        disable_recompute: bool = False,
+        return_intermediate_states: bool = False,
+        state_v_first: bool = False,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_cpu: torch.LongTensor | None = None,
+        cp_context=None,
+        **kwargs,
+    ) -> tuple[bool, str | None]:
+        if not torch.is_grad_enabled():
+            return False, "TileLang KDA public backend currently targets autograd training only"
+        if kwargs.keys() - {"chunk_size"}:
+            return False, f"TileLang KDA public backend does not support kwargs {sorted(kwargs.keys())}"
+        chunk_size = kwargs.get("chunk_size", 64)
+        if use_qk_l2norm_in_kernel:
+            return False, "TileLang KDA public backend currently supports use_qk_l2norm_in_kernel=False only"
+        if use_gate_in_kernel:
+            return False, "TileLang KDA public backend currently supports pre-gated KDA only"
+        if use_beta_sigmoid_in_kernel:
+            return False, "TileLang KDA public backend currently supports post-sigmoid beta only"
+        if allow_neg_eigval:
+            return False, "TileLang KDA public backend does not support allow_neg_eigval=True"
+        if safe_gate:
+            return False, "TileLang KDA public backend currently supports safe_gate=False only"
+        if disable_recompute:
+            return False, "TileLang KDA public backend currently supports disable_recompute=False only"
+        if return_intermediate_states:
+            return False, "TileLang KDA public backend does not support return_intermediate_states"
+        if state_v_first:
+            return False, "TileLang KDA public backend currently supports state_v_first=False only"
+        if cu_seqlens is not None or cu_seqlens_cpu is not None:
+            return False, "TileLang KDA public backend currently supports dense fixed-length sequences only"
+        if cp_context is not None:
+            return False, "TileLang KDA public backend does not support context parallel"
+        if chunk_size != 32:
+            return False, f"TileLang KDA public backend supports chunk_size=32 for the measured BF16 bucket, got {chunk_size}"
+        tensors = {"q": q, "k": k, "v": v, "g": g, "beta": beta}
+        if not all(getattr(tensor, "is_cuda", False) for tensor in tensors.values()):
+            return False, "TileLang KDA public backend requires CUDA tensors"
+        for name, tensor in tensors.items():
+            is_contiguous = getattr(tensor, "is_contiguous", None)
+            if is_contiguous is not None and not is_contiguous():
+                return False, f"TileLang KDA public backend requires {name} to be contiguous"
+        if q.dtype != torch.bfloat16:
+            return False, f"TileLang KDA public backend requires q dtype torch.bfloat16, got {q.dtype}"
+        for name in ("k", "v"):
+            if tensors[name].dtype != q.dtype:
+                return False, (
+                    f"TileLang KDA public backend requires {name} dtype {tensors[name].dtype} "
+                    f"to match q dtype {q.dtype}"
+                )
+        if g.dtype != torch.float32:
+            return False, f"TileLang KDA public backend requires g dtype torch.float32, got {g.dtype}"
+        if beta.dtype != torch.bfloat16:
+            return False, f"TileLang KDA public backend requires beta dtype torch.bfloat16, got {beta.dtype}"
+        if len(q.shape) != 4 or len(k.shape) != 4 or len(v.shape) != 4 or len(g.shape) != 4:
+            return False, "TileLang KDA public backend requires q, k, v, and g to be 4D tensors"
+        if q.shape != k.shape:
+            return False, f"TileLang KDA public backend requires q and k to share shape, got {q.shape} vs {k.shape}"
+
+        B, T, H, K = q.shape
+        HV, V = v.shape[2], v.shape[-1]
+        if K != 128 or V != 128:
+            return False, f"TileLang KDA public backend supports the measured K=V=128 bucket, got K={K}, V={V}"
+        if T % chunk_size != 0:
+            return False, (
+                f"TileLang KDA public backend requires dense sequence length T={T} to be divisible by "
+                f"chunk_size={chunk_size}; fall back to Triton"
+            )
+        if HV % H != 0:
+            return False, f"TileLang KDA public backend requires HV={HV} to be divisible by H={H} for GVA"
+        if v.shape != (B, T, HV, V):
+            return False, f"TileLang KDA public backend requires v shape {(B, T, HV, V)}, got {v.shape}"
+        if g.shape != (B, T, HV, K):
+            return False, f"TileLang KDA public backend requires g shape {(B, T, HV, K)}, got {g.shape}"
+        if beta.shape != (B, T, HV):
+            return False, f"TileLang KDA public backend requires beta shape {(B, T, HV)}, got {beta.shape}"
+        if initial_state is not None:
+            if initial_state.dtype != torch.float32:
+                return False, "TileLang KDA public backend requires initial_state dtype torch.float32"
+            is_contiguous = getattr(initial_state, "is_contiguous", None)
+            if is_contiguous is not None and not is_contiguous():
+                return False, "TileLang KDA public backend requires initial_state to be contiguous"
+            if initial_state.shape != (B, HV, K, V):
+                return False, (
+                    f"TileLang KDA public backend requires initial_state shape {(B, HV, K, V)}, "
+                    f"got {initial_state.shape}"
+                )
+        return True, None
+
+    def chunk_kda(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float | None = None,
+        initial_state: torch.Tensor | None = None,
+        output_final_state: bool = False,
+        use_qk_l2norm_in_kernel: bool = False,
+        use_gate_in_kernel: bool = False,
+        use_beta_sigmoid_in_kernel: bool = False,
+        allow_neg_eigval: bool = False,
+        safe_gate: bool = False,
+        lower_bound: float | None = None,
+        disable_recompute: bool = False,
+        return_intermediate_states: bool = False,
+        state_v_first: bool = False,
+        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens_cpu: torch.LongTensor | None = None,
+        cp_context=None,
+        **kwargs,
+    ):
+        from fla.ops.kda.chunk import chunk_kda
+        return chunk_kda.__wrapped__.__wrapped__(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            use_gate_in_kernel=use_gate_in_kernel,
+            use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
+            allow_neg_eigval=allow_neg_eigval,
+            safe_gate=safe_gate,
+            lower_bound=lower_bound,
+            disable_recompute=disable_recompute,
+            return_intermediate_states=return_intermediate_states,
+            state_v_first=state_v_first,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_cpu=cu_seqlens_cpu,
+            cp_context=cp_context,
+            _tilelang_helpers=True,
+            **kwargs,
+        )
 
     def chunk_kda_bwd_wy_dqkg_fused_verifier(
         self,
@@ -46,10 +209,84 @@ class KDATileLangBackend(BaseBackend):
         chunk_size: int = 64,
         chunk_indices: torch.LongTensor | None = None,
     ) -> tuple[bool, str | None]:
-        if v.shape[2] != k.shape[2]:
+        if any(getattr(tensor, "requires_grad", False) for tensor in (q, k, v, v_new, g, beta, A, h, do, dh, dv)):
             return False, (
-                "TileLang backend does not support GQA (v has more heads than k); "
-                "use repeat_interleave on k/q to match v's head count, or fall back to Triton"
+                "TileLang KDA backend is limited to manual fused-backward calls; "
+                "use the guarded public chunk_kda backend for autograd TileLang routing"
+            )
+        data_tensors = {
+            "q": q,
+            "k": k,
+            "v": v,
+            "v_new": v_new,
+            "A": A,
+            "h": h,
+            "do": do,
+            "dh": dh,
+            "dv": dv,
+        }
+        aux_tensors = {"g": g, "beta": beta}
+        if not all(getattr(tensor, "is_cuda", False) for tensor in (*data_tensors.values(), *aux_tensors.values())):
+            return False, "TileLang KDA backend requires CUDA tensors"
+        if q.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            return False, f"TileLang KDA backend does not support dtype {q.dtype}; fall back to Triton"
+        if g.dtype != torch.float32:
+            return False, f"TileLang KDA backend requires g dtype torch.float32, got {g.dtype}; fall back to Triton"
+        if beta.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            return False, f"TileLang KDA backend does not support beta dtype {beta.dtype}; fall back to Triton"
+        for name, tensor in data_tensors.items():
+            if tensor.dtype != q.dtype:
+                return False, f"TileLang KDA backend requires {name} dtype {tensor.dtype} to match q dtype {q.dtype}"
+        for name, tensor in {**data_tensors, **aux_tensors}.items():
+            is_contiguous = getattr(tensor, "is_contiguous", None)
+            if is_contiguous is not None and not is_contiguous():
+                return False, f"TileLang KDA backend requires {name} to be contiguous"
+        if len(q.shape) != 4 or len(k.shape) != 4 or len(v.shape) != 4:
+            return False, "TileLang KDA backend requires q, k, and v to be 4D tensors"
+        if q.shape != k.shape:
+            return False, f"TileLang KDA backend requires q and k to have the same shape, got {q.shape} vs {k.shape}"
+        if chunk_size not in (32, 64):
+            return False, f"TileLang KDA backend supports chunk_size 32 or 64, got {chunk_size}"
+        if cu_seqlens is not None or chunk_indices is not None:
+            return False, "TileLang KDA backend currently supports dense fixed-length sequences only; fall back to Triton"
+
+        B, T, H, K = q.shape
+        HV, V = v.shape[2], v.shape[-1]
+        if T % chunk_size != 0:
+            return False, (
+                f"TileLang KDA backend requires dense sequence length T={T} to be divisible by "
+                f"chunk_size={chunk_size}; fall back to Triton"
+            )
+        if HV % H != 0:
+            return False, (
+                f"TileLang KDA backend requires num_v_heads (HV={HV}) to be divisible by "
+                f"num_qk_heads (H={H}); HV % H must be 0 for GVA"
+            )
+        tensor_idx = getattr(getattr(q, "device", None), "index", 0) or 0
+        const_tiling = 64 if check_shared_mem(tensor_idx=tensor_idx) else 32
+        BK = _tile_extent(K, const_tiling)
+        BV = _tile_extent(V, const_tiling)
+        if K % BK != 0:
+            return False, f"TileLang KDA backend requires K={K} to be divisible by its BK tile {BK}; fall back to Triton"
+        if V % BV != 0:
+            return False, f"TileLang KDA backend requires V={V} to be divisible by its BV tile {BV}; fall back to Triton"
+        if v_new.shape != v.shape or do.shape != v.shape or dv.shape != v.shape:
+            return False, (
+                "TileLang KDA backend requires v, v_new, do, and dv to share shape "
+                f"{v.shape}; got v_new={v_new.shape}, do={do.shape}, dv={dv.shape}"
+            )
+        if g.shape != (B, T, HV, K):
+            return False, f"TileLang KDA backend requires g shape {(B, T, HV, K)}, got {g.shape}"
+        if beta.shape != (B, T, HV):
+            return False, f"TileLang KDA backend requires beta shape {(B, T, HV)}, got {beta.shape}"
+        if A.shape != (B, T, HV, chunk_size):
+            return False, f"TileLang KDA backend requires A shape {(B, T, HV, chunk_size)}, got {A.shape}"
+        state_shape = (V, K) if state_v_first else (K, V)
+        expected_state_shape = (B, T // chunk_size, HV, *state_shape)
+        if h.shape != expected_state_shape or dh.shape != expected_state_shape:
+            return False, (
+                f"TileLang KDA backend requires h/dh shape {expected_state_shape}, "
+                f"got h={h.shape}, dh={dh.shape}"
             )
         return True, None
 

--- a/fla/ops/kda/backends/tilelang/chunk_bwd_dav.py
+++ b/fla/ops/kda/backends/tilelang/chunk_bwd_dav.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""TileLang implementation of dense chunk_kda_bwd_dAv."""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from fla.utils import check_shared_mem
+
+_DTYPE_NAMES = {torch.float16: 'float16', torch.bfloat16: 'bfloat16', torch.float32: 'float32'}
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 << (x - 1).bit_length()
+
+
+def _tile_extent(dim: int, const_tiling: int) -> int:
+    return min(max(_next_power_of_2(dim), 16), const_tiling)
+
+
+def _check_cuda_contiguous_supported(name: str, tensor: torch.Tensor) -> None:
+    if not tensor.is_cuda:
+        raise ValueError(f"KDA TileLang dAv backend requires {name} to be a CUDA tensor")
+    if tensor.dtype not in _DTYPE_NAMES:
+        raise ValueError(f"KDA TileLang dAv backend does not support {name} dtype {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"KDA TileLang dAv backend requires {name} to be contiguous")
+
+
+@tilelang.jit(pass_configs={
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+})
+def _build_kda_bwd_dav_kernel(B, H, HV, K, V, BT, BV, dtype_str, num_warps=4):
+    dtype_map = {'float16': T.float16, 'bfloat16': T.bfloat16, 'float32': T.float32}
+    dtype = dtype_map[dtype_str]
+    NV = tilelang.cdiv(V, BV)
+    threads = num_warps * 32
+
+    _B, _H, _HV, _K, _V = B, H, HV, K, V
+    _BT, _BV, _NV = BT, BV, NV
+    _dtype = dtype
+    _threads = threads
+
+    T_d = T.dynamic("T")
+
+    qk_s = (_B, T_d, _H, _K)
+    v_s = (_B, T_d, _HV, _V)
+    A_s = (_B, T_d, _HV, _BT)
+
+    @T.prim_func
+    def kernel(
+        q: T.Tensor(qk_s, _dtype),
+        k: T.Tensor(qk_s, _dtype),
+        v: T.Tensor(v_s, _dtype),
+        A: T.Tensor(A_s, _dtype),
+        do: T.Tensor(v_s, _dtype),
+        dv: T.Tensor(v_s, _dtype),
+        dA: T.Tensor(A_s, T.float32),
+        scale: T.float32,
+    ):
+        with T.Kernel(T.ceildiv(T_d, _BT), _B * _HV, threads=_threads) as (i_t, i_bh):
+            i_b = i_bh // _HV
+            i_hv = i_bh % _HV
+            t_s = i_t * _BT
+
+            s_A_raw = T.alloc_shared((_BT, _BT), _dtype)
+            s_A_t = T.alloc_shared((_BT, _BT), _dtype)
+            T.copy(A[i_b, t_s:t_s + _BT, i_hv, 0:_BT], s_A_raw)
+            for i, j in T.Parallel(_BT, _BT):
+                s_A_t[i, j] = T.if_then_else(i <= j, s_A_raw[j, i], T.cast(0, _dtype))
+
+            b_dA = T.alloc_fragment((_BT, _BT), T.float32)
+            T.clear(b_dA)
+            s_do = T.alloc_shared((_BT, _BV), _dtype)
+            s_v = T.alloc_shared((_BT, _BV), _dtype)
+            b_dv = T.alloc_fragment((_BT, _BV), T.float32)
+
+            for i_v in T.serial(_NV):
+                v_off = i_v * _BV
+                T.copy(do[i_b, t_s:t_s + _BT, i_hv, v_off:v_off + _BV], s_do)
+                T.copy(v[i_b, t_s:t_s + _BT, i_hv, v_off:v_off + _BV], s_v)
+
+                T.gemm(s_do, s_v, b_dA, transpose_B=True)
+
+                T.clear(b_dv)
+                T.gemm(s_A_t, s_do, b_dv)
+                for i, j in T.Parallel(_BT, _BV):
+                    dv[i_b, t_s + i, i_hv, v_off + j] = T.cast(b_dv[i, j], _dtype)
+
+            for i, j in T.Parallel(_BT, _BT):
+                dA[i_b, t_s + i, i_hv, j] = T.if_then_else(i >= j, b_dA[i, j] * scale, 0.0)
+
+    return kernel
+
+
+def chunk_kda_bwd_dAv_tilelang(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    A: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if A is None:
+        raise ValueError("KDA TileLang dAv backend requires A")
+    if cu_seqlens is not None or chunk_indices is not None:
+        raise ValueError("KDA TileLang dAv backend currently supports dense fixed-length sequences only")
+    if chunk_size not in (32, 64):
+        raise ValueError(f"KDA TileLang dAv backend supports chunk_size 32 or 64, got {chunk_size}")
+    for name, tensor in {"q": q, "k": k, "v": v, "do": do, "A": A}.items():
+        _check_cuda_contiguous_supported(name, tensor)
+    if q.dtype != k.dtype:
+        raise ValueError(f"KDA TileLang dAv backend requires k dtype {k.dtype} to match q dtype {q.dtype}")
+    for name, tensor in {"v": v, "do": do, "A": A}.items():
+        if tensor.dtype != q.dtype:
+            raise ValueError(f"KDA TileLang dAv backend requires {name} dtype {tensor.dtype} to match q dtype {q.dtype}")
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4 or do.ndim != 4:
+        raise ValueError("KDA TileLang dAv backend requires q, k, v, and do to be 4D tensors")
+    if q.shape != k.shape:
+        raise ValueError(f"KDA TileLang dAv backend requires q and k to share shape, got {q.shape} vs {k.shape}")
+
+    B, T_seq, H, K = q.shape
+    HV, V = v.shape[2], v.shape[-1]
+    if do.shape != v.shape:
+        raise ValueError(f"KDA TileLang dAv backend requires do shape {v.shape}, got {do.shape}")
+    if A.shape != (B, T_seq, HV, chunk_size):
+        raise ValueError(f"KDA TileLang dAv backend requires A shape {(B, T_seq, HV, chunk_size)}, got {A.shape}")
+    if T_seq % chunk_size != 0:
+        raise ValueError(
+            f"KDA TileLang dAv backend requires T={T_seq} to be divisible by chunk_size={chunk_size}"
+        )
+    if HV % H != 0:
+        raise ValueError(f"KDA TileLang dAv backend requires HV={HV} to be divisible by H={H} for GVA")
+
+    const_tiling = 64 if check_shared_mem(tensor_idx=q.device.index or 0) else 32
+    BV = _tile_extent(V, const_tiling)
+    if V % BV != 0:
+        raise ValueError(f"KDA TileLang dAv backend requires V={V} to be divisible by its BV tile {BV}")
+    if scale is None:
+        scale = K ** -0.5
+
+    dA = torch.empty(B, T_seq, HV, chunk_size, dtype=torch.float32, device=v.device)
+    dv = torch.empty_like(do)
+    dtype_str = _DTYPE_NAMES[q.dtype]
+    num_warps = 4
+
+    kernel = _build_kda_bwd_dav_kernel(B, H, HV, K, V, chunk_size, BV, dtype_str, num_warps=num_warps)
+    kernel(q, k, v, A, do, dv, dA, scale)
+    return dA, dv

--- a/fla/ops/kda/backends/tilelang/chunk_bwd_dqkg.py
+++ b/fla/ops/kda/backends/tilelang/chunk_bwd_dqkg.py
@@ -9,8 +9,8 @@
 
 Ported from the Triton kernel in fla/ops/kda/chunk_bwd.py.
 Key structural differences from the common chunk_bwd_dqkwg kernel:
-  - K-loop is INTERNAL (no NK grid dimension): grid is (NT, B*H) or (NT, H) for varlen
-  - Gate g is 2D: (B, T, H, K), not (B, T, H)
+  - K-loop is INTERNAL (no NK grid dimension): grid is (NT, B*HV)
+  - Gate g is 2D: (B, T, HV, K), not (B, T, HV)
   - Extra inputs: v_new, beta, A (attention matrix)
   - Extra outputs: dv2, db, dA
   - dgk is per-K accumulator (BK,), not scalar
@@ -22,10 +22,28 @@ Key structural differences from the common chunk_bwd_dqkwg kernel:
 import tilelang
 import tilelang.language as T
 import torch
-import triton
 
-from fla.ops.utils import prepare_chunk_indices
 from fla.utils import check_shared_mem
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 << (x - 1).bit_length()
+
+
+def _tile_extent(dim: int, const_tiling: int) -> int:
+    return min(max(_next_power_of_2(dim), 16), const_tiling)
+
+
+_DTYPE_NAMES = {torch.float16: 'float16', torch.bfloat16: 'bfloat16', torch.float32: 'float32'}
+
+
+def _check_cuda_contiguous_supported(name: str, tensor: torch.Tensor) -> None:
+    if not tensor.is_cuda:
+        raise ValueError(f"KDA TileLang backend requires {name} to be a CUDA tensor")
+    if tensor.dtype not in _DTYPE_NAMES:
+        raise ValueError(f"KDA TileLang backend does not support {name} dtype {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"KDA TileLang backend requires {name} to be contiguous")
 
 
 @tilelang.jit(pass_configs={
@@ -33,68 +51,71 @@ from fla.utils import check_shared_mem
     tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
 })
 def _build_kda_bwd_kernel(
-    B, H, K, V, BT, BK, BV,
+    B, H, HV, K, V, BT, BK, BV,
     hD1, hD2,
-    dtype_str,
-    STATE_V_FIRST, IS_VARLEN=False,
+    dtype_str, beta_dtype_str,
+    STATE_V_FIRST,
     num_warps=4,
 ):
     dtype_map = {'float16': T.float16, 'bfloat16': T.bfloat16, 'float32': T.float32}
     dtype = dtype_map[dtype_str]
+    beta_dtype = dtype_map[beta_dtype_str]
     NK = tilelang.cdiv(K, BK)
     NV = tilelang.cdiv(V, BV)
     threads = num_warps * 32
     tile_hD1, tile_hD2 = (BV, BK) if STATE_V_FIRST else (BK, BV)
 
-    # Rebind to underscore-prefixed locals for closure capture
-    _B, _H, _K, _V = B, H, K, V
+    # rebind to underscore-prefixed locals for closure capture
+    _B, _H, _HV, _K, _V = B, H, HV, K, V
+    _G = HV // H
     _BT, _BK, _BV, _NK, _NV = BT, BK, BV, NK, NV
     _hD1, _hD2, _thD1, _thD2 = hD1, hD2, tile_hD1, tile_hD2
     _dtype = dtype
+    _beta_dtype = beta_dtype
     _threads = threads
     _TS = STATE_V_FIRST
-    _VAR = IS_VARLEN
 
-    T_d, NT_d, total_h_d, N_seqs_d = T.dynamic("T, NT, total_h, N_seqs")
+    T_d, total_h_d = T.dynamic("T, total_h")
 
     qk_s = (_B, T_d, _H, _K)
-    v_s = (_B, T_d, _H, _V)
-    g_s = (_B, T_d, _H, _K)       # 2D gate: per-K dimension
-    beta_s = (_B, T_d, _H)
-    A_s = (_B, T_d, _H, _BT)      # attention matrix: (B, T, H, BT)
+    dqk_s = (_B, T_d, _HV, _K)
+    v_s = (_B, T_d, _HV, _V)
+    g_s = (_B, T_d, _HV, _K)       # 2D gate: per-K dimension
+    beta_s = (_B, T_d, _HV)
+    A_s = (_B, T_d, _HV, _BT)      # attention matrix: (B, T, HV, BT)
     h_s = (total_h_d, _hD1, _hD2)
-    db_s = (_B, T_d, _H)
-    dA_s = (_B, T_d, _H, _BT)
+    db_s = (_B, T_d, _HV)
+    dA_s = (_B, T_d, _HV, _BT)
 
     @T.macro
     def kernel_body(q, k, v, v_new, g, beta, A, h, do, dh, dq, dk, dv, dv2, dg, db, dA, scale,
-                    i_b, i_h, t_s, T_seq, i_t_local, h_idx):
-        # ========== 1. Load beta and A for this chunk ==========
+                    i_b, i_hv, t_s, T_seq, i_t_local, h_idx):
+        i_h = i_hv // _G
+        # load beta and A for this chunk
         s_beta = T.alloc_shared((_BT,), T.float32)
-        T.copy(beta[i_b, t_s:t_s + _BT, i_h], s_beta, disable_tma=True)
-        # Zero OOB positions for varlen safety
+        T.copy(beta[i_b, t_s:t_s + _BT, i_hv], s_beta, disable_tma=True)
+        # zero boundary positions outside the active sequence span
         for _i in T.Parallel(_BT):
             if (i_t_local * _BT + _i) >= T_seq:
                 s_beta[_i] = 0.0
 
-        # A in Triton is loaded transposed: b_A[bt, t] = A[i_b, t_s+t, i_h, bt]
-        # Load, transpose, and zero OOB rows/cols for varlen safety
+        # load A as Triton does, transposed: b_A[bt, t] = A[i_b, t_s+t, i_hv, bt]
+        # load, transpose, and zero boundary rows/cols outside the active sequence span
         s_A = T.alloc_shared((_BT, _BT), _dtype)
-        T.copy(A[i_b, t_s:t_s + _BT, i_h, 0:_BT], s_A)
+        T.copy(A[i_b, t_s:t_s + _BT, i_hv, 0:_BT], s_A)
         f_A_tmp = T.alloc_fragment((_BT, _BT), _dtype)
         for _i, _j in T.Parallel(_BT, _BT):
             valid = ((i_t_local * _BT + _i) < T_seq) & ((i_t_local * _BT + _j) < T_seq)
             f_A_tmp[_i, _j] = T.if_then_else(valid, s_A[_j, _i], T.cast(0, _dtype))
         T.copy(f_A_tmp, s_A)
 
-        # ========== 2. Init dA, db accumulators ==========
+        # initialize dA and db accumulators
         b_dA = T.alloc_fragment((_BT, _BT), T.float32)
         T.clear(b_dA)
         b_db = T.alloc_fragment((_BT,), T.float32)
         T.clear(b_db)
 
-        # ========== 3. Pre-K V-loop (dA_v contribution, dv2, db_v) ==========
-        # These computations are K-independent: dA += dv@v^T, dv2 = A@dv*beta, db += sum((A@dv)*v)
+        # run K-independent V work: dA += dv@v^T, dv2 = A@dv*beta, db += sum((A@dv)*v)
         s_dv_pre = T.alloc_shared((_BT, _BV), _dtype)
         s_v_orig = T.alloc_shared((_BT, _BV), _dtype)
         b_dvb = T.alloc_fragment((_BT, _BV), T.float32)
@@ -105,8 +126,8 @@ def _build_kda_bwd_kernel(
         for i_v in T.serial(_NV):
             v_off = i_v * _BV
 
-            T.copy(dv[i_b, t_s:t_s + _BT, i_h, v_off:v_off + _BV], s_dv_pre)
-            T.copy(v[i_b, t_s:t_s + _BT, i_h, v_off:v_off + _BV], s_v_orig)
+            T.copy(dv[i_b, t_s:t_s + _BT, i_hv, v_off:v_off + _BV], s_dv_pre)
+            T.copy(v[i_b, t_s:t_s + _BT, i_hv, v_off:v_off + _BV], s_v_orig)
 
             # b_dA += dv @ v^T (BT, BT)
             T.gemm(s_dv_pre, s_v_orig, b_dA, transpose_B=True)
@@ -115,12 +136,12 @@ def _build_kda_bwd_kernel(
             T.clear(b_dvb)
             T.gemm(s_A, s_dv_pre, b_dvb)
 
-            # Store dv2 = dvb * beta[:, None]
+            # store dv2 = dvb * beta[:, None]
             for _i, _j in T.Parallel(_BT, _BV):
                 s_dv2[_i, _j] = T.cast(b_dvb[_i, _j] * s_beta[_i], _dtype)
             for _i, _j in T.Parallel(_BT, _BV):
                 if (i_t_local * _BT + _i) < T_seq:
-                    dv2[i_b, t_s + _i, i_h, v_off + _j] = s_dv2[_i, _j]
+                    dv2[i_b, t_s + _i, i_hv, v_off + _j] = s_dv2[_i, _j]
 
             # db += sum(dvb * v, dim=1)
             for _i, _j in T.Parallel(_BT, _BV):
@@ -129,11 +150,11 @@ def _build_kda_bwd_kernel(
             for _i in T.Parallel(_BT):
                 b_db[_i] = b_db[_i] + f_dvv_row[_i]
 
-        # ========== 4. K-loop ==========
+        # run the K loop
         for i_k in T.serial(_NK):
             k_off = i_k * _BK
 
-            # Load k, g for this K-block (zero OOB rows for varlen cross-row safety)
+            # load k and g for this K-block, zeroing boundary rows outside the active sequence span
             s_k = T.alloc_shared((_BT, _BK), _dtype)
             T.copy(k[i_b, t_s:t_s + _BT, i_h, k_off:k_off + _BK], s_k)
             for _i, _j in T.Parallel(_BT, _BK):
@@ -141,7 +162,7 @@ def _build_kda_bwd_kernel(
                     s_k[_i, _j] = T.cast(0, _dtype)
 
             s_g = T.alloc_shared((_BT, _BK), T.float32)
-            T.copy(g[i_b, t_s:t_s + _BT, i_h, k_off:k_off + _BK], s_g)
+            T.copy(g[i_b, t_s:t_s + _BT, i_hv, k_off:k_off + _BK], s_g)
             for _i, _j in T.Parallel(_BT, _BK):
                 if (i_t_local * _BT + _i) >= T_seq:
                     s_g[_i, _j] = 0.0
@@ -152,7 +173,7 @@ def _build_kda_bwd_kernel(
             for _j in T.Parallel(_BK):
                 s_gn[_j] = s_g[last_pos, _j]
 
-            # Per-K accumulators
+            # per-K accumulators
             b_dq = T.alloc_fragment((_BT, _BK), T.float32)
             b_dk = T.alloc_fragment((_BT, _BK), T.float32)
             b_dw = T.alloc_fragment((_BT, _BK), T.float32)
@@ -161,12 +182,12 @@ def _build_kda_bwd_kernel(
             T.clear(b_dw)
 
             # dgk: per-K accumulator for sum(h*dh, axis=0) -- shape (BK,)
-            # Use shared memory (avoid 1D fragment/reducer issues)
+            # use shared memory to avoid 1D fragment/reducer issues
             s_dgk = T.alloc_shared((_BK,), T.float32)
             for _j in T.Parallel(_BK):
                 s_dgk[_j] = 0.0
 
-            # ========== 4a. V-loop (dq, dk, dw, dgk) ==========
+            # run the V loop for dq, dk, dw, and dgk
             s_v_new = T.alloc_shared((_BT, _BV), _dtype)
             s_do = T.alloc_shared((_BT, _BV), _dtype)
             s_h = T.alloc_shared((_thD1, _thD2), _dtype)
@@ -180,8 +201,8 @@ def _build_kda_bwd_kernel(
             for i_v in T.serial(_NV):
                 v_off = i_v * _BV
 
-                T.copy(v_new[i_b, t_s:t_s + _BT, i_h, v_off:v_off + _BV], s_v_new)
-                T.copy(do[i_b, t_s:t_s + _BT, i_h, v_off:v_off + _BV], s_do)
+                T.copy(v_new[i_b, t_s:t_s + _BT, i_hv, v_off:v_off + _BV], s_v_new)
+                T.copy(do[i_b, t_s:t_s + _BT, i_hv, v_off:v_off + _BV], s_do)
 
                 if _TS:
                     T.copy(h[h_idx, v_off:v_off + _BV, k_off:k_off + _BK], s_h)
@@ -190,7 +211,7 @@ def _build_kda_bwd_kernel(
                     T.copy(h[h_idx, k_off:k_off + _BK, v_off:v_off + _BV], s_h)
                     T.copy(dh[h_idx, k_off:k_off + _BK, v_off:v_off + _BV], s_dh)
 
-                # GEMMs first (consume s_h/s_dh before any alloc might reuse their memory)
+                # consume s_h and s_dh before another allocation can reuse their memory
                 # b_dq += do @ h, b_dk += v_new @ dh
                 if _TS:
                     T.gemm(s_do, s_h, b_dq)
@@ -200,7 +221,7 @@ def _build_kda_bwd_kernel(
                     T.gemm(s_v_new, s_dh, b_dk, transpose_B=True)
 
                 # b_dw += dv @ h (dv feeds into dw → cross-row dA/dkgb, needs OOB mask)
-                T.copy(dv[i_b, t_s:t_s + _BT, i_h, v_off:v_off + _BV], s_dv_tile)
+                T.copy(dv[i_b, t_s:t_s + _BT, i_hv, v_off:v_off + _BV], s_dv_tile)
 
                 if _TS:
                     T.gemm(s_dv_tile, s_h, b_dw)
@@ -224,7 +245,7 @@ def _build_kda_bwd_kernel(
                     for _j in T.Parallel(_BK):
                         s_dgk[_j] = s_dgk[_j] + f_hdh_k_ts[_j]
 
-            # ========== 4b. Gate dq, dk ==========
+            # apply gate factors to dq and dk
             # b_dq = b_dq * exp2(g) * scale
             s_dq = T.alloc_shared((_BT, _BK), T.float32)
             T.copy(b_dq, s_dq)
@@ -241,7 +262,7 @@ def _build_kda_bwd_kernel(
                     s_dk[_i, _j] * T.exp2(s_gn[_j] - s_g[_i, _j]),
                     0.0)
 
-            # ========== 4c. kg = k * exp2(g), dgk *= exp2(gn) ==========
+            # compute kg = k * exp2(g) and scale dgk by exp2(gn)
             s_kg = T.alloc_shared((_BT, _BK), _dtype)
             for _i, _j in T.Parallel(_BT, _BK):
                 s_kg[_i, _j] = T.cast(T.cast(s_k[_i, _j], T.float32) * T.exp2(s_g[_i, _j]), _dtype)
@@ -249,21 +270,21 @@ def _build_kda_bwd_kernel(
             for _j in T.Parallel(_BK):
                 s_dgk[_j] = s_dgk[_j] * T.exp2(s_gn[_j])
 
-            # ========== 4d. dw = -dw ==========
+            # negate dw
             s_dw = T.alloc_shared((_BT, _BK), _dtype)
             T.copy(b_dw, s_dw)
             for _i, _j in T.Parallel(_BT, _BK):
                 s_dw[_i, _j] = T.cast(-T.cast(s_dw[_i, _j], T.float32), _dtype)
 
-            # ========== 4e. dA += dw @ kg^T ==========
+            # accumulate dA += dw @ kg^T
             T.gemm(s_dw, s_kg, b_dA, transpose_B=True)
 
-            # ========== 4f. dkgb = A @ dw ==========
+            # compute dkgb = A @ dw
             b_dkgb = T.alloc_fragment((_BT, _BK), T.float32)
             T.clear(b_dkgb)
             T.gemm(s_A, s_dw, b_dkgb)
 
-            # ========== 4g. db += sum(dkgb * kg, dim=1) ==========
+            # accumulate db += sum(dkgb * kg, dim=1)
             f_dkgb_kg = T.alloc_fragment((_BT, _BK), T.float32)
             for _i, _j in T.Parallel(_BT, _BK):
                 f_dkgb_kg[_i, _j] = b_dkgb[_i, _j] * T.cast(s_kg[_i, _j], T.float32)
@@ -272,11 +293,11 @@ def _build_kda_bwd_kernel(
             for _i in T.Parallel(_BT):
                 b_db[_i] = b_db[_i] + f_db_row[_i]
 
-            # ========== 4h. dgk += col_sum(k * dk) ==========
+            # accumulate dgk += col_sum(k * dk)
             f_kdk = T.alloc_fragment((_BT, _BK), T.float32)
             for _i, _j in T.Parallel(_BT, _BK):
                 f_kdk[_i, _j] = T.cast(s_k[_i, _j], T.float32) * s_dk[_i, _j]
-            # Column sum of kdk -> (BK,) via transpose then row-reduce
+            # column-sum kdk into (BK,) via transpose then row-reduce
             f_kdk_t = T.alloc_fragment((_BK, _BT), T.float32)
             for _i, _j in T.Parallel(_BK, _BT):
                 f_kdk_t[_i, _j] = f_kdk[_j, _i]
@@ -287,7 +308,7 @@ def _build_kda_bwd_kernel(
             for _j in T.Parallel(_BK):
                 s_dgk[_j] = s_dgk[_j] + s_kdk_col[_j]
 
-            # ========== 4i. dg = q*dq - kdk + m_last*dgk + kg*dkgb*beta ==========
+            # compute dg = q*dq - kdk + m_last*dgk + kg*dkgb*beta
             s_dg_out = T.alloc_shared((_BT, _BK), T.float32)
             m_last_pos = T.max(0, T.min(_BT, T_seq - i_t_local * _BT) - 1)
             for _i, _j in T.Parallel(_BT, _BK):
@@ -296,22 +317,22 @@ def _build_kda_bwd_kernel(
                 beta_term = T.cast(s_kg[_i, _j], T.float32) * b_dkgb[_i, _j] * s_beta[_i]
                 s_dg_out[_i, _j] = q_dq - f_kdk[_i, _j] + last_term + beta_term
 
-            # ========== 4j. dk += dkgb * gb where gb = exp2(g) * beta ==========
+            # accumulate dk += dkgb * gb where gb = exp2(g) * beta
             for _i, _j in T.Parallel(_BT, _BK):
                 s_dk[_i, _j] = s_dk[_i, _j] + b_dkgb[_i, _j] * T.exp2(s_g[_i, _j]) * s_beta[_i]
 
-            # ========== 4k. Store dq, dk, dg for this K-block ==========
+            # store dq, dk, and dg for this K-block
             for _i, _j in T.Parallel(_BT, _BK):
                 if (i_t_local * _BT + _i) < T_seq:
-                    dq[i_b, t_s + _i, i_h, k_off + _j] = s_dq[_i, _j]
+                    dq[i_b, t_s + _i, i_hv, k_off + _j] = s_dq[_i, _j]
             for _i, _j in T.Parallel(_BT, _BK):
                 if (i_t_local * _BT + _i) < T_seq:
-                    dk[i_b, t_s + _i, i_h, k_off + _j] = s_dk[_i, _j]
+                    dk[i_b, t_s + _i, i_hv, k_off + _j] = s_dk[_i, _j]
             for _i, _j in T.Parallel(_BT, _BK):
                 if (i_t_local * _BT + _i) < T_seq:
-                    dg[i_b, t_s + _i, i_h, k_off + _j] = s_dg_out[_i, _j]
+                    dg[i_b, t_s + _i, i_hv, k_off + _j] = s_dg_out[_i, _j]
 
-        # ========== 5. dA post-processing ==========
+        # post-process dA
         # m_A = (i > j) & valid
         # b_dA = where(m_A, b_dA * beta[j], 0)
         # b_dA = b_dA @ A
@@ -321,7 +342,7 @@ def _build_kda_bwd_kernel(
         s_dA = T.alloc_shared((_BT, _BT), T.float32)
         T.copy(b_dA, s_dA)
 
-        # Apply causal mask and beta weighting
+        # apply causal mask and beta weighting
         for _i, _j in T.Parallel(_BT, _BT):
             m_valid = ((i_t_local * _BT + _i) < T_seq) & ((i_t_local * _BT + _j) < T_seq)
             m_upper = (_i > _j) & m_valid
@@ -337,7 +358,7 @@ def _build_kda_bwd_kernel(
         T.gemm(s_dA_dtype, s_A, b_dA2)
 
         # dA = A @ dA
-        # Reuse s_dA_dtype for the second cast
+        # reuse s_dA_dtype for the second cast
         for _i, _j in T.Parallel(_BT, _BT):
             s_dA_dtype[_i, _j] = T.cast(b_dA2[_i, _j], _dtype)
 
@@ -345,7 +366,7 @@ def _build_kda_bwd_kernel(
         T.clear(b_dA3)
         T.gemm(s_A, s_dA_dtype, b_dA3)
 
-        # Apply mask and negate, reuse s_dA buffer
+        # apply mask and negate, reusing s_dA
         for _i, _j in T.Parallel(_BT, _BT):
             m_valid = ((i_t_local * _BT + _i) < T_seq) & ((i_t_local * _BT + _j) < T_seq)
             m_upper = (_i > _j) & m_valid
@@ -353,65 +374,36 @@ def _build_kda_bwd_kernel(
 
         for _i, _j in T.Parallel(_BT, _BT):
             if (i_t_local * _BT + _i) < T_seq:
-                dA[i_b, t_s + _i, i_h, _j] = s_dA[_i, _j]
+                dA[i_b, t_s + _i, i_hv, _j] = s_dA[_i, _j]
 
-        # ========== 6. Store db ==========
+        # store db
         for _i in T.Parallel(_BT):
             if (i_t_local * _BT + _i) < T_seq:
-                db[i_b, t_s + _i, i_h] = b_db[_i]
+                db[i_b, t_s + _i, i_hv] = b_db[_i]
 
-    # ========== Kernel entry points ==========
-    if _VAR:
-        @T.prim_func
-        def kernel(
-            q: T.Tensor(qk_s, _dtype), k: T.Tensor(qk_s, _dtype),
-            v: T.Tensor(v_s, _dtype), v_new: T.Tensor(v_s, _dtype),
-            g: T.Tensor(g_s, T.float32), beta: T.Tensor(beta_s, T.float32),
-            A: T.Tensor(A_s, _dtype),
-            h: T.Tensor(h_s, _dtype), do: T.Tensor(v_s, _dtype),
-            dh: T.Tensor(h_s, _dtype),
-            dq: T.Tensor(qk_s, T.float32), dk: T.Tensor(qk_s, T.float32),
-            dv: T.Tensor(v_s, _dtype), dv2: T.Tensor(v_s, _dtype),
-            dg: T.Tensor(g_s, T.float32), db: T.Tensor(db_s, T.float32),
-            dA: T.Tensor(dA_s, T.float32),
-            cu_seqlens: T.Tensor((N_seqs_d,), T.int32),
-            chunk_indices: T.Tensor((NT_d, 2), T.int32),
-            scale: T.float32,
-        ):
-            with T.Kernel(NT_d, _H, threads=_threads) as (i_t, i_h):
-                i_n = chunk_indices[i_t, 0]
-                i_t_local = chunk_indices[i_t, 1]
-                bos = cu_seqlens[i_n]
-                T_seq = cu_seqlens[i_n + 1] - bos
-                h_idx = i_t * _H + i_h
-                t_s = bos + i_t_local * _BT
-                kernel_body(q, k, v, v_new, g, beta, A, h, do, dh,
-                            dq, dk, dv, dv2, dg, db, dA,
-                            scale, 0, i_h, t_s, T_seq, i_t_local, h_idx)
-    else:
-        @T.prim_func
-        def kernel(
-            q: T.Tensor(qk_s, _dtype), k: T.Tensor(qk_s, _dtype),
-            v: T.Tensor(v_s, _dtype), v_new: T.Tensor(v_s, _dtype),
-            g: T.Tensor(g_s, T.float32), beta: T.Tensor(beta_s, T.float32),
-            A: T.Tensor(A_s, _dtype),
-            h: T.Tensor(h_s, _dtype), do: T.Tensor(v_s, _dtype),
-            dh: T.Tensor(h_s, _dtype),
-            dq: T.Tensor(qk_s, T.float32), dk: T.Tensor(qk_s, T.float32),
-            dv: T.Tensor(v_s, _dtype), dv2: T.Tensor(v_s, _dtype),
-            dg: T.Tensor(g_s, T.float32), db: T.Tensor(db_s, T.float32),
-            dA: T.Tensor(dA_s, T.float32),
-            scale: T.float32,
-        ):
-            with T.Kernel(T.ceildiv(T_d, _BT), _B * _H, threads=_threads) as (i_t, i_bh):
-                i_b = i_bh // _H
-                i_h = i_bh % _H
-                NT_local = T.ceildiv(T_d, _BT)
-                h_idx = (i_b * NT_local + i_t) * _H + i_h
-                t_s = i_t * _BT
-                kernel_body(q, k, v, v_new, g, beta, A, h, do, dh,
-                            dq, dk, dv, dv2, dg, db, dA,
-                            scale, i_b, i_h, t_s, T_d, i_t, h_idx)
+    @T.prim_func
+    def kernel(
+        q: T.Tensor(qk_s, _dtype), k: T.Tensor(qk_s, _dtype),
+        v: T.Tensor(v_s, _dtype), v_new: T.Tensor(v_s, _dtype),
+        g: T.Tensor(g_s, T.float32), beta: T.Tensor(beta_s, _beta_dtype),
+        A: T.Tensor(A_s, _dtype),
+        h: T.Tensor(h_s, _dtype), do: T.Tensor(v_s, _dtype),
+        dh: T.Tensor(h_s, _dtype),
+        dq: T.Tensor(dqk_s, T.float32), dk: T.Tensor(dqk_s, T.float32),
+        dv: T.Tensor(v_s, _dtype), dv2: T.Tensor(v_s, _dtype),
+        dg: T.Tensor(g_s, T.float32), db: T.Tensor(db_s, T.float32),
+        dA: T.Tensor(dA_s, T.float32),
+        scale: T.float32,
+    ):
+        with T.Kernel(T.ceildiv(T_d, _BT), _B * _HV, threads=_threads) as (i_t, i_bh):
+            i_b = i_bh // _HV
+            i_hv = i_bh % _HV
+            NT_local = T.ceildiv(T_d, _BT)
+            h_idx = (i_b * NT_local + i_t) * _HV + i_hv
+            t_s = i_t * _BT
+            kernel_body(q, k, v, v_new, g, beta, A, h, do, dh,
+                        dq, dk, dv, dv2, dg, db, dA,
+                        scale, i_b, i_hv, t_s, T_d, i_t, h_idx)
 
     return kernel
 
@@ -421,22 +413,70 @@ def chunk_kda_bwd_wy_dqkg_fused_tilelang(
     scale=None, cu_seqlens=None, chunk_size=64,
     chunk_indices=None, state_v_first=False,
 ):
-    B, _, H, K, V = *k.shape, v.shape[-1]
-    BT = chunk_size
-    # Ensure float32 inputs match kernel signature
-    g = g.float()
-    beta = beta.float()
-    if chunk_indices is None and cu_seqlens is not None:
-        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    IS_VARLEN = cu_seqlens is not None
+    data_tensors = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "v_new": v_new,
+        "A": A,
+        "h": h,
+        "do": do,
+        "dh": dh,
+        "dv": dv,
+    }
+    aux_tensors = {"g": g, "beta": beta}
+    for name, tensor in {**data_tensors, **aux_tensors}.items():
+        _check_cuda_contiguous_supported(name, tensor)
+    if g.dtype != torch.float32:
+        raise ValueError(f"KDA TileLang backend requires g dtype torch.float32, got {g.dtype}")
+    for name, tensor in data_tensors.items():
+        if tensor.dtype != q.dtype:
+            raise ValueError(f"KDA TileLang backend requires {name} dtype {tensor.dtype} to match q dtype {q.dtype}")
 
-    CONST_TILING = 64 if check_shared_mem() else 32
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("KDA TileLang backend requires q, k, and v to be 4D tensors")
+    if q.shape != k.shape:
+        raise ValueError(f"KDA TileLang backend requires q and k to have the same shape, got {q.shape} vs {k.shape}")
+    if chunk_size not in (32, 64):
+        raise ValueError(f"KDA TileLang backend supports chunk_size 32 or 64, got {chunk_size}")
+
+    B, T, H, K = q.shape
+    HV, V = v.shape[2], v.shape[-1]
+    if HV % H != 0:
+        raise ValueError(f"num_v_heads (HV={HV}) must be divisible by num_qk_heads (H={H}) for KDA TileLang GVA")
+    BT = chunk_size
+    if cu_seqlens is not None or chunk_indices is not None:
+        raise ValueError("KDA TileLang backend currently supports dense fixed-length sequences only")
+    if T % BT != 0:
+        raise ValueError(f"KDA TileLang backend requires dense sequence length T={T} to be divisible by chunk_size={BT}")
+    if v_new.shape != v.shape or do.shape != v.shape or dv.shape != v.shape:
+        raise ValueError(
+            "KDA TileLang backend requires v, v_new, do, and dv to share shape "
+            f"{v.shape}; got v_new={v_new.shape}, do={do.shape}, dv={dv.shape}"
+        )
+    if g.shape != (B, T, HV, K):
+        raise ValueError(f"KDA TileLang backend requires g shape {(B, T, HV, K)}, got {g.shape}")
+    if beta.shape != (B, T, HV):
+        raise ValueError(f"KDA TileLang backend requires beta shape {(B, T, HV)}, got {beta.shape}")
+    if A.shape != (B, T, HV, BT):
+        raise ValueError(f"KDA TileLang backend requires A shape {(B, T, HV, BT)}, got {A.shape}")
+    state_shape = (V, K) if state_v_first else (K, V)
+    expected_state_shape = (B, T // BT, HV, *state_shape)
+    if h.shape != expected_state_shape or dh.shape != expected_state_shape:
+        raise ValueError(
+            f"KDA TileLang backend requires h/dh shape {expected_state_shape}, "
+            f"got h={h.shape}, dh={dh.shape}"
+        )
+    # ensure float32 gate input matches the kernel signature
+    g = g.float()
+
+    CONST_TILING = 64 if check_shared_mem(tensor_idx=q.device.index or 0) else 32
     if scale is None:
         scale = K ** -0.5
 
-    # Outputs
-    dq = torch.empty_like(q, dtype=torch.float)
-    dk = torch.empty_like(k, dtype=torch.float)
+    # allocate outputs
+    dq = torch.empty(B, T, HV, K, dtype=torch.float, device=q.device)
+    dk = torch.empty(B, T, HV, K, dtype=torch.float, device=k.device)
     dv2 = torch.empty_like(v)
     dg = torch.empty_like(g, dtype=torch.float)
     db = torch.empty_like(beta, dtype=torch.float)
@@ -445,27 +485,27 @@ def chunk_kda_bwd_wy_dqkg_fused_tilelang(
     h_flat = h.reshape(-1, h.shape[-2], h.shape[-1])
     dh_flat = dh.reshape(-1, dh.shape[-2], dh.shape[-1])
     hD1, hD2 = h_flat.shape[-2], h_flat.shape[-1]
-    dtype_str = {torch.float16: 'float16', torch.bfloat16: 'bfloat16', torch.float32: 'float32'}[q.dtype]
+    dtype_str = _DTYPE_NAMES[q.dtype]
+    beta_dtype_str = _DTYPE_NAMES[beta.dtype]
 
-    # Static tiling config
-    BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
-    BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
+    # static tiling config
+    BK = _tile_extent(K, CONST_TILING)
+    BV = _tile_extent(V, CONST_TILING)
+    if K % BK != 0:
+        raise ValueError(f"KDA TileLang backend requires K={K} to be divisible by its BK tile {BK}")
+    if V % BV != 0:
+        raise ValueError(f"KDA TileLang backend requires V={V} to be divisible by its BV tile {BV}")
     num_warps = 8 if K <= 64 else 4
 
     kernel = _build_kda_bwd_kernel(
-        B, H, K, V, BT, BK, BV,
-        hD1, hD2, dtype_str,
-        state_v_first, IS_VARLEN,
+        B, H, HV, K, V, BT, BK, BV,
+        hD1, hD2, dtype_str, beta_dtype_str,
+        state_v_first,
         num_warps=num_warps,
     )
 
-    if IS_VARLEN:
-        kernel(q, k, v, v_new, g, beta, A, h_flat, do, dh_flat,
-               dq, dk, dv, dv2, dg, db, dA,
-               cu_seqlens.int(), chunk_indices.int(), scale)
-    else:
-        kernel(q, k, v, v_new, g, beta, A, h_flat, do, dh_flat,
-               dq, dk, dv, dv2, dg, db, dA, scale)
+    kernel(q, k, v, v_new, g, beta, A, h_flat, do, dh_flat,
+           dq, dk, dv, dv2, dg, db, dA, scale)
 
     dv = dv2
     return dq, dk, dv, db, dg, dA

--- a/fla/ops/kda/backends/tilelang/chunk_bwd_intra.py
+++ b/fla/ops/kda/backends/tilelang/chunk_bwd_intra.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""TileLang implementation of dense KDA intra-chunk backward."""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+_DTYPE_NAMES = {torch.float16: 'float16', torch.bfloat16: 'bfloat16', torch.float32: 'float32'}
+
+
+@tilelang.jit(pass_configs={
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+})
+def _build_kda_bwd_intra_kernel(
+    B,
+    H,
+    HV,
+    K,
+    BT,
+    BC,
+    BK,
+    dtype_str,
+    beta_dtype_str,
+    num_warps=2,
+):
+    dtype_map = {'float16': T.float16, 'bfloat16': T.bfloat16, 'float32': T.float32}
+    dtype = dtype_map[dtype_str]
+    beta_dtype = dtype_map[beta_dtype_str]
+    threads = num_warps * 32
+    NC = tilelang.cdiv(BT, BC)
+    NK = tilelang.cdiv(K, BK)
+
+    _B, _H, _HV, _K = B, H, HV, K
+    _G = HV // H
+    _BT, _BC, _BK, _NC, _NK = BT, BC, BK, NC, NK
+    _dtype = dtype
+    _beta_dtype = beta_dtype
+    _threads = threads
+
+    T_d = T.dynamic("T")
+
+    qk_s = (_B, T_d, _H, _K)
+    hvk_s = (_B, T_d, _HV, _K)
+    beta_s = (_B, T_d, _HV)
+    dA_s = (_B, T_d, _HV, _BT)
+    db2_s = (_NK, _B, T_d, _HV)
+
+    @T.prim_func
+    def kernel(
+        q: T.Tensor(qk_s, _dtype),
+        k: T.Tensor(qk_s, _dtype),
+        g: T.Tensor(hvk_s, T.float32),
+        beta: T.Tensor(beta_s, _beta_dtype),
+        dAqk: T.Tensor(dA_s, T.float32),
+        dAkk: T.Tensor(dA_s, T.float32),
+        dq: T.Tensor(hvk_s, T.float32),
+        dq2: T.Tensor(hvk_s, T.float32),
+        dk: T.Tensor(hvk_s, T.float32),
+        dk2: T.Tensor(hvk_s, T.float32),
+        dg: T.Tensor(hvk_s, T.float32),
+        dg2: T.Tensor(hvk_s, T.float32),
+        db: T.Tensor(db2_s, T.float32),
+    ):
+        with T.Kernel(_NK * _NC, T.ceildiv(T_d, _BT), _B * _HV, threads=_threads) as (i_kc, i_t, i_bh):
+            i_b = i_bh // _HV
+            i_hv = i_bh % _HV
+            i_h = i_hv // _G
+            i_k = i_kc // _NC
+            i_i = i_kc % _NC
+            t_s = i_t * _BT
+            t_i = t_s + i_i * _BC
+            k_s = i_k * _BK
+
+            b_g = T.alloc_shared((_BC, _BK), T.float32)
+            b_q = T.alloc_shared((_BC, _BK), _dtype)
+            b_k = T.alloc_shared((_BC, _BK), _dtype)
+            b_beta = T.alloc_shared((_BC,), T.float32)
+
+            T.copy(g[i_b, t_i:t_i + _BC, i_hv, k_s:k_s + _BK], b_g)
+            T.copy(q[i_b, t_i:t_i + _BC, i_h, k_s:k_s + _BK], b_q)
+            T.copy(k[i_b, t_i:t_i + _BC, i_h, k_s:k_s + _BK], b_k)
+            T.copy(beta[i_b, t_i:t_i + _BC, i_hv], b_beta, disable_tma=True)
+
+            b_dq2 = T.alloc_fragment((_BC, _BK), T.float32)
+            b_dk2 = T.alloc_fragment((_BC, _BK), T.float32)
+            b_dkt = T.alloc_fragment((_BC, _BK), T.float32)
+            T.clear(b_dq2)
+            T.clear(b_dk2)
+            T.clear(b_dkt)
+
+            s_dAqk = T.alloc_shared((_BC, _BC), T.float32)
+            s_dAkk = T.alloc_shared((_BC, _BC), T.float32)
+            s_kg = T.alloc_shared((_BC, _BK), T.float32)
+
+            if i_i > 0:
+                s_gn = T.alloc_shared((_BK,), T.float32)
+                T.copy(g[i_b, t_i, i_hv, k_s:k_s + _BK], s_gn, disable_tma=True)
+                for i_j in T.serial(0, _NC):
+                    if i_j < i_i:
+                        t_j = t_s + i_j * _BC
+                        s_kj = T.alloc_shared((_BC, _BK), _dtype)
+                        s_gj = T.alloc_shared((_BC, _BK), T.float32)
+                        T.copy(k[i_b, t_j:t_j + _BC, i_h, k_s:k_s + _BK], s_kj)
+                        T.copy(g[i_b, t_j:t_j + _BC, i_hv, k_s:k_s + _BK], s_gj)
+                        for ii, kk in T.Parallel(_BC, _BK):
+                            s_kg[ii, kk] = T.cast(s_kj[ii, kk], T.float32) * T.exp2(s_gn[kk] - s_gj[ii, kk])
+                        T.copy(dAqk[i_b, t_i:t_i + _BC, i_hv, i_j * _BC:i_j * _BC + _BC], s_dAqk)
+                        T.copy(dAkk[i_b, t_i:t_i + _BC, i_hv, i_j * _BC:i_j * _BC + _BC], s_dAkk)
+                        T.gemm(s_dAqk, s_kg, b_dq2)
+                        T.gemm(s_dAkk, s_kg, b_dk2)
+                for ii, kk in T.Parallel(_BC, _BK):
+                    factor = T.exp2(b_g[ii, kk] - s_gn[kk])
+                    b_dq2[ii, kk] = b_dq2[ii, kk] * factor
+                    b_dk2[ii, kk] = b_dk2[ii, kk] * factor
+
+            for j in T.serial(0, _BC):
+                s_kj = T.alloc_shared((_BK,), T.float32)
+                s_gj = T.alloc_shared((_BK,), T.float32)
+                s_dAqk_j = T.alloc_shared((_BC,), T.float32)
+                s_dAkk_j = T.alloc_shared((_BC,), T.float32)
+                T.copy(k[i_b, t_i + j, i_h, k_s:k_s + _BK], s_kj, disable_tma=True)
+                T.copy(g[i_b, t_i + j, i_hv, k_s:k_s + _BK], s_gj, disable_tma=True)
+                T.copy(dAqk[i_b, t_i:t_i + _BC, i_hv, i_i * _BC + j], s_dAqk_j, disable_tma=True)
+                T.copy(dAkk[i_b, t_i:t_i + _BC, i_hv, i_i * _BC + j], s_dAkk_j, disable_tma=True)
+                for ii, kk in T.Parallel(_BC, _BK):
+                    if ii >= j:
+                        factor = T.exp2(b_g[ii, kk] - s_gj[kk]) * T.cast(s_kj[kk], T.float32)
+                        b_dq2[ii, kk] = b_dq2[ii, kk] + s_dAqk_j[ii] * factor
+                        b_dk2[ii, kk] = b_dk2[ii, kk] + s_dAkk_j[ii] * factor
+
+            f_db_prod = T.alloc_fragment((_BC, _BK), T.float32)
+            for ii, kk in T.Parallel(_BC, _BK):
+                f_db_prod[ii, kk] = b_dk2[ii, kk] * T.cast(b_k[ii, kk], T.float32)
+            b_db = T.alloc_fragment((_BC,), T.float32)
+            T.reduce_sum(f_db_prod, b_db, dim=1)
+            for ii, kk in T.Parallel(_BC, _BK):
+                b_dk2[ii, kk] = b_dk2[ii, kk] * b_beta[ii]
+
+            b_dg2 = T.alloc_fragment((_BC, _BK), T.float32)
+            for ii, kk in T.Parallel(_BC, _BK):
+                b_dg2[ii, kk] = T.cast(b_q[ii, kk], T.float32) * b_dq2[ii, kk]
+                b_dq2[ii, kk] = b_dq2[ii, kk] + dq[i_b, t_i + ii, i_hv, k_s + kk]
+                dq2[i_b, t_i + ii, i_hv, k_s + kk] = b_dq2[ii, kk]
+            for ii in T.Parallel(_BC):
+                db[i_k, i_b, t_i + ii, i_hv] = b_db[ii]
+
+            if i_i < _NC - 1:
+                s_gn2 = T.alloc_shared((_BK,), T.float32)
+                T.copy(g[i_b, t_i + _BC - 1, i_hv, k_s:k_s + _BK], s_gn2, disable_tma=True)
+                for i_j in T.serial(0, _NC):
+                    if i_j > i_i:
+                        t_j = t_s + i_j * _BC
+                        s_qj = T.alloc_shared((_BC, _BK), T.float32)
+                        s_kbgj = T.alloc_shared((_BC, _BK), T.float32)
+                        s_gj = T.alloc_shared((_BC, _BK), T.float32)
+                        s_bj = T.alloc_shared((_BC,), T.float32)
+                        T.copy(g[i_b, t_j:t_j + _BC, i_hv, k_s:k_s + _BK], s_gj)
+                        T.copy(beta[i_b, t_j:t_j + _BC, i_hv], s_bj, disable_tma=True)
+                        for jj, kk in T.Parallel(_BC, _BK):
+                            g_factor = T.exp2(s_gj[jj, kk] - s_gn2[kk])
+                            s_qj[jj, kk] = T.cast(q[i_b, t_j + jj, i_h, k_s + kk], T.float32) * g_factor
+                            s_kbgj[jj, kk] = T.cast(k[i_b, t_j + jj, i_h, k_s + kk], T.float32) * s_bj[jj] * g_factor
+                        for ii, jj in T.Parallel(_BC, _BC):
+                            s_dAqk[ii, jj] = dAqk[i_b, t_j + jj, i_hv, i_i * _BC + ii]
+                            s_dAkk[ii, jj] = dAkk[i_b, t_j + jj, i_hv, i_i * _BC + ii]
+                        T.gemm(s_dAqk, s_qj, b_dkt)
+                        T.gemm(s_dAkk, s_kbgj, b_dkt)
+                for ii, kk in T.Parallel(_BC, _BK):
+                    b_dkt[ii, kk] = b_dkt[ii, kk] * T.exp2(s_gn2[kk] - b_g[ii, kk])
+
+            for j in T.serial(0, _BC):
+                s_qj = T.alloc_shared((_BK,), T.float32)
+                s_kbj = T.alloc_shared((_BK,), T.float32)
+                s_gj = T.alloc_shared((_BK,), T.float32)
+                s_dAqk_j = T.alloc_shared((_BC,), T.float32)
+                s_dAkk_j = T.alloc_shared((_BC,), T.float32)
+                beta_j = T.alloc_var(T.float32)
+                beta_j = T.cast(beta[i_b, t_i + j, i_hv], T.float32)
+                for kk in T.Parallel(_BK):
+                    s_qj[kk] = T.cast(q[i_b, t_i + j, i_h, k_s + kk], T.float32)
+                    s_kbj[kk] = T.cast(k[i_b, t_i + j, i_h, k_s + kk], T.float32) * beta_j
+                    s_gj[kk] = g[i_b, t_i + j, i_hv, k_s + kk]
+                for ii in T.Parallel(_BC):
+                    s_dAqk_j[ii] = dAqk[i_b, t_i + j, i_hv, i_i * _BC + ii]
+                    s_dAkk_j[ii] = dAkk[i_b, t_i + j, i_hv, i_i * _BC + ii]
+                for ii, kk in T.Parallel(_BC, _BK):
+                    if ii <= j:
+                        factor = T.exp2(s_gj[kk] - b_g[ii, kk])
+                        b_dkt[ii, kk] = b_dkt[ii, kk] + s_dAqk_j[ii] * s_qj[kk] * factor
+                        b_dkt[ii, kk] = b_dkt[ii, kk] + s_dAkk_j[ii] * s_kbj[kk] * factor
+
+            for ii, kk in T.Parallel(_BC, _BK):
+                b_dg2[ii, kk] = b_dg2[ii, kk] + (b_dk2[ii, kk] - b_dkt[ii, kk]) * T.cast(b_k[ii, kk], T.float32)
+                b_dg2[ii, kk] = b_dg2[ii, kk] + dg[i_b, t_i + ii, i_hv, k_s + kk]
+                b_dk2[ii, kk] = b_dk2[ii, kk] + dk[i_b, t_i + ii, i_hv, k_s + kk] + b_dkt[ii, kk]
+                dk2[i_b, t_i + ii, i_hv, k_s + kk] = b_dk2[ii, kk]
+                dg2[i_b, t_i + ii, i_hv, k_s + kk] = b_dg2[ii, kk]
+
+    return kernel
+
+
+def chunk_kda_bwd_intra_tilelang(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    dAqk: torch.Tensor,
+    dAkk: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    db: torch.Tensor,
+    dg: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    safe_gate: bool = False,
+):
+    if safe_gate:
+        raise ValueError("KDA TileLang bwd_intra currently supports safe_gate=False only")
+    if cu_seqlens is not None or chunk_indices is not None:
+        raise ValueError("KDA TileLang bwd_intra currently supports dense fixed-length sequences only")
+    if chunk_size not in (32, 64):
+        raise ValueError(f"KDA TileLang bwd_intra supports chunk_size 32 or 64, got {chunk_size}")
+    if q.ndim != 4 or k.ndim != 4 or g.ndim != 4:
+        raise ValueError("KDA TileLang bwd_intra requires q, k, and g to be 4D tensors")
+    if q.shape != k.shape:
+        raise ValueError(f"KDA TileLang bwd_intra requires q and k to share shape, got {q.shape} vs {k.shape}")
+    B, T_seq, H, K = q.shape
+    HV = g.shape[2]
+    if K not in (64, 128):
+        raise ValueError(f"KDA TileLang bwd_intra supports K=64 or 128, got {K}")
+    if T_seq % chunk_size != 0:
+        raise ValueError(f"KDA TileLang bwd_intra requires T={T_seq} to be divisible by chunk_size={chunk_size}")
+    if HV % H != 0:
+        raise ValueError(f"KDA TileLang bwd_intra requires HV={HV} to be divisible by H={H}")
+    if g.shape != (B, T_seq, HV, K):
+        raise ValueError(f"KDA TileLang bwd_intra requires g shape {(B, T_seq, HV, K)}, got {g.shape}")
+    if beta.shape != (B, T_seq, HV) or db.shape != (B, T_seq, HV):
+        raise ValueError(f"KDA TileLang bwd_intra requires beta/db shape {(B, T_seq, HV)}, got {beta.shape}/{db.shape}")
+    if dAqk.shape != (B, T_seq, HV, chunk_size) or dAkk.shape != (B, T_seq, HV, chunk_size):
+        raise ValueError(
+            f"KDA TileLang bwd_intra requires dAqk/dAkk shape {(B, T_seq, HV, chunk_size)}, "
+            f"got {dAqk.shape}/{dAkk.shape}"
+        )
+    if dq.shape != (B, T_seq, HV, K) or dk.shape != (B, T_seq, HV, K) or dg.shape != (B, T_seq, HV, K):
+        raise ValueError(f"KDA TileLang bwd_intra requires dq/dk/dg shape {(B, T_seq, HV, K)}")
+    for name, tensor in {
+        "q": q, "k": k, "g": g, "beta": beta, "dAqk": dAqk, "dAkk": dAkk,
+        "dq": dq, "dk": dk, "db": db, "dg": dg,
+    }.items():
+        if not tensor.is_cuda:
+            raise ValueError(f"KDA TileLang bwd_intra requires {name} to be a CUDA tensor")
+        if not tensor.is_contiguous():
+            raise ValueError(f"KDA TileLang bwd_intra requires {name} to be contiguous")
+    if q.dtype not in _DTYPE_NAMES:
+        raise ValueError(f"KDA TileLang bwd_intra does not support q dtype {q.dtype}")
+    if k.dtype != q.dtype:
+        raise ValueError(f"KDA TileLang bwd_intra requires k dtype {k.dtype} to match q dtype {q.dtype}")
+    if beta.dtype not in _DTYPE_NAMES:
+        raise ValueError(f"KDA TileLang bwd_intra does not support beta dtype {beta.dtype}")
+    for name, tensor in {"g": g, "dAqk": dAqk, "dAkk": dAkk, "dq": dq, "dk": dk, "db": db, "dg": dg}.items():
+        if tensor.dtype != torch.float32:
+            raise ValueError(f"KDA TileLang bwd_intra requires {name} dtype torch.float32, got {tensor.dtype}")
+
+    BC = 16
+    BK = 32
+    NK = K // BK
+    dq2 = torch.empty_like(dq)
+    dk2 = torch.empty_like(dk)
+    dg2 = torch.empty_like(dg)
+    db2 = torch.empty(NK, B, T_seq, HV, dtype=torch.float32, device=beta.device)
+    dtype_str = _DTYPE_NAMES[q.dtype]
+    beta_dtype_str = _DTYPE_NAMES[beta.dtype]
+
+    kernel = _build_kda_bwd_intra_kernel(
+        B,
+        H,
+        HV,
+        K,
+        chunk_size,
+        BC,
+        BK,
+        dtype_str,
+        beta_dtype_str,
+        num_warps=2,
+    )
+    kernel(q, k, g, beta, dAqk, dAkk, dq, dq2, dk, dk2, dg, dg2, db2)
+    db = db2.sum(0).add_(db)
+    return dq2, dk2, db, dg2

--- a/fla/ops/kda/backends/tilelang/chunk_fwd_intra.py
+++ b/fla/ops/kda/backends/tilelang/chunk_fwd_intra.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""TileLang implementation of dense KDA intra-chunk forward diagonal blocks."""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from fla.ops.kda.chunk_intra import chunk_kda_fwd_kernel_inter_solve_fused
+from fla.ops.kda.wy_fast import recompute_w_u_fwd
+from fla.utils import check_shared_mem
+
+_DTYPE_NAMES = {torch.float16: 'float16', torch.bfloat16: 'bfloat16', torch.float32: 'float32'}
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 << (x - 1).bit_length()
+
+
+def _tile_extent(dim: int, const_tiling: int) -> int:
+    return min(max(_next_power_of_2(dim), 16), const_tiling)
+
+
+def _check_cuda_contiguous_supported(name: str, tensor: torch.Tensor, dtype_required: torch.dtype | None = None) -> None:
+    if not tensor.is_cuda:
+        raise ValueError(f"KDA TileLang fwd_intra backend requires {name} to be a CUDA tensor")
+    if dtype_required is not None and tensor.dtype != dtype_required:
+        raise ValueError(f"KDA TileLang fwd_intra backend requires {name} dtype {dtype_required}, got {tensor.dtype}")
+    if dtype_required is None and tensor.dtype not in _DTYPE_NAMES:
+        raise ValueError(f"KDA TileLang fwd_intra backend does not support {name} dtype {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"KDA TileLang fwd_intra backend requires {name} to be contiguous")
+
+
+@tilelang.jit(pass_configs={
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+})
+def _build_kda_fwd_intra_diag_kernel(
+    B,
+    H,
+    HV,
+    K,
+    BT,
+    BC,
+    BK,
+    dtype_str,
+    beta_dtype_str,
+    num_warps=2,
+):
+    dtype_map = {'float16': T.float16, 'bfloat16': T.bfloat16, 'float32': T.float32}
+    dtype = dtype_map[dtype_str]
+    beta_dtype = dtype_map[beta_dtype_str]
+    threads = num_warps * 32
+    NC = tilelang.cdiv(BT, BC)
+    NK = tilelang.cdiv(K, BK)
+
+    _B, _H, _HV, _K = B, H, HV, K
+    _G = HV // H
+    _BT, _BC, _BK, _NC, _NK = BT, BC, BK, NC, NK
+    _dtype = dtype
+    _beta_dtype = beta_dtype
+    _threads = threads
+
+    T_d = T.dynamic("T")
+
+    qk_s = (_B, T_d, _H, _K)
+    hvk_s = (_B, T_d, _HV, _K)
+    beta_s = (_B, T_d, _HV)
+    A_s = (_B, T_d, _HV, _BT)
+    Akkd_s = (_B, T_d, _HV, _BC)
+
+    @T.prim_func
+    def kernel(
+        q: T.Tensor(qk_s, _dtype),
+        k: T.Tensor(qk_s, _dtype),
+        g: T.Tensor(hvk_s, T.float32),
+        beta: T.Tensor(beta_s, _beta_dtype),
+        Aqk: T.Tensor(A_s, _dtype),
+        Akkd: T.Tensor(Akkd_s, T.float32),
+        scale: T.float32,
+    ):
+        with T.Kernel(T.ceildiv(T_d, _BT), _NC, _B * _HV, threads=_threads) as (i_t, i_i, i_bh):
+            i_b = i_bh // _HV
+            i_hv = i_bh % _HV
+            i_h = i_hv // _G
+            t_s = i_t * _BT
+            t_i = t_s + i_i * _BC
+
+            b_Aqk = T.alloc_fragment((_BC, _BC), T.float32)
+            b_Akk = T.alloc_fragment((_BC, _BC), T.float32)
+            T.clear(b_Aqk)
+            T.clear(b_Akk)
+
+            s_qg = T.alloc_shared((_BC, _BK), _dtype)
+            s_kg = T.alloc_shared((_BC, _BK), _dtype)
+            s_kbg = T.alloc_shared((_BC, _BK), _dtype)
+            s_gn = T.alloc_shared((_BK,), T.float32)
+            s_beta = T.alloc_shared((_BC,), T.float32)
+
+            T.copy(beta[i_b, t_i:t_i + _BC, i_hv], s_beta, disable_tma=True)
+
+            for i_k in T.serial(_NK):
+                k_s = i_k * _BK
+                T.copy(g[i_b, t_i + _BC // 2, i_hv, k_s:k_s + _BK], s_gn, disable_tma=True)
+                for i, j in T.Parallel(_BC, _BK):
+                    gi = g[i_b, t_i + i, i_hv, k_s + j]
+                    q_scale = T.exp2(gi - s_gn[j])
+                    k_scale = T.exp2(s_gn[j] - gi)
+                    q_val = T.cast(q[i_b, t_i + i, i_h, k_s + j], T.float32)
+                    k_val = T.cast(k[i_b, t_i + i, i_h, k_s + j], T.float32)
+                    s_qg[i, j] = T.cast(q_val * q_scale, _dtype)
+                    s_kg[i, j] = T.cast(k_val * k_scale, _dtype)
+                    s_kbg[i, j] = T.cast(k_val * T.cast(s_beta[i], T.float32) * q_scale, _dtype)
+
+                T.gemm(s_qg, s_kg, b_Aqk, transpose_B=True)
+                T.gemm(s_kbg, s_kg, b_Akk, transpose_B=True)
+
+            s_Akk = T.alloc_shared((_BC, _BC), T.float32)
+            s_Ai = T.alloc_shared((_BC, _BC), T.float32)
+            for i, j in T.Parallel(_BC, _BC):
+                Aqk[i_b, t_i + i, i_hv, i_i * _BC + j] = T.cast(
+                    T.if_then_else(i >= j, b_Aqk[i, j] * scale, 0.0),
+                    _dtype,
+                )
+                raw_akk = T.if_then_else(i > j, b_Akk[i, j], 0.0)
+                s_Akk[i, j] = raw_akk
+                s_Ai[i, j] = -raw_akk
+
+            for row in T.serial(2, _BC):
+                for j in T.serial(_BC):
+                    acc = T.alloc_var(T.float32)
+                    acc = T.if_then_else(j < row, -s_Akk[row, j], 0.0)
+                    for p in T.serial(_BC):
+                        row_p = T.if_then_else(p < row, -s_Akk[row, p], 0.0)
+                        acc += row_p * s_Ai[p, j]
+                    s_Ai[row, j] = T.if_then_else(j < row, acc, 0.0)
+
+            for i, j in T.Parallel(_BC, _BC):
+                Akkd[i_b, t_i + i, i_hv, j] = T.if_then_else(i == j, 1.0, s_Ai[i, j])
+
+    return kernel
+
+
+def chunk_kda_fwd_intra_tilelang(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    safe_gate: bool = False,
+    disable_recompute: bool = False,
+):
+    if gk is None or beta is None:
+        raise ValueError("KDA TileLang fwd_intra backend requires gk and beta")
+    if safe_gate:
+        raise ValueError("KDA TileLang fwd_intra backend currently supports safe_gate=False only")
+    if disable_recompute:
+        raise ValueError("KDA TileLang fwd_intra backend currently supports disable_recompute=False only")
+    if cu_seqlens is not None or chunk_indices is not None:
+        raise ValueError("KDA TileLang fwd_intra backend currently supports dense fixed-length sequences only")
+    if chunk_size not in (32, 64):
+        raise ValueError(f"KDA TileLang fwd_intra backend supports chunk_size 32 or 64, got {chunk_size}")
+    for name, tensor in {"q": q, "k": k, "v": v, "beta": beta}.items():
+        _check_cuda_contiguous_supported(name, tensor)
+    _check_cuda_contiguous_supported("gk", gk, dtype_required=torch.float32)
+    if q.dtype != k.dtype or q.dtype != v.dtype:
+        raise ValueError(f"KDA TileLang fwd_intra backend requires q/k/v to share dtype, got {q.dtype}/{k.dtype}/{v.dtype}")
+    if beta.dtype not in _DTYPE_NAMES:
+        raise ValueError(f"KDA TileLang fwd_intra backend does not support beta dtype {beta.dtype}")
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4 or gk.ndim != 4:
+        raise ValueError("KDA TileLang fwd_intra backend requires q, k, v, and gk to be 4D tensors")
+    if q.shape != k.shape:
+        raise ValueError(f"KDA TileLang fwd_intra backend requires q and k to share shape, got {q.shape} vs {k.shape}")
+
+    B, T_seq, H, K = q.shape
+    HV, V = v.shape[2], v.shape[-1]
+    BT = chunk_size
+    BC = 16
+    if K not in (64, 128):
+        raise ValueError(f"KDA TileLang fwd_intra backend supports K=64 or 128, got {K}")
+    if T_seq % BT != 0:
+        raise ValueError(f"KDA TileLang fwd_intra backend requires T={T_seq} to be divisible by chunk_size={BT}")
+    if HV % H != 0:
+        raise ValueError(f"KDA TileLang fwd_intra backend requires HV={HV} to be divisible by H={H} for GVA")
+    if v.shape != (B, T_seq, HV, V):
+        raise ValueError(f"KDA TileLang fwd_intra backend requires v shape {(B, T_seq, HV, V)}, got {v.shape}")
+    if gk.shape != (B, T_seq, HV, K):
+        raise ValueError(f"KDA TileLang fwd_intra backend requires gk shape {(B, T_seq, HV, K)}, got {gk.shape}")
+    if beta.shape != (B, T_seq, HV):
+        raise ValueError(f"KDA TileLang fwd_intra backend requires beta shape {(B, T_seq, HV)}, got {beta.shape}")
+    if scale is None:
+        scale = K ** -0.5
+
+    const_tiling = 64 if check_shared_mem(tensor_idx=q.device.index or 0) else 32
+    BK = _tile_extent(K, const_tiling)
+    if K % BK != 0:
+        raise ValueError(f"KDA TileLang fwd_intra backend requires K={K} to be divisible by its BK tile {BK}")
+
+    NT = triton_cdiv(T_seq, BT)
+    NC = triton_cdiv(BT, BC)
+    Aqk = torch.empty(B, T_seq, HV, BT, device=q.device, dtype=q.dtype)
+    Akk = torch.zeros(B, T_seq, HV, BT, device=q.device, dtype=q.dtype)
+    Akkd = torch.empty(B, T_seq, HV, BC, device=q.device, dtype=torch.float32)
+
+    dtype_str = _DTYPE_NAMES[q.dtype]
+    beta_dtype_str = _DTYPE_NAMES[beta.dtype]
+    kernel = _build_kda_fwd_intra_diag_kernel(
+        B,
+        H,
+        HV,
+        K,
+        BT,
+        BC,
+        BK,
+        dtype_str,
+        beta_dtype_str,
+        num_warps=2,
+    )
+    kernel(q, k, gk, beta, Aqk, Akkd, scale)
+
+    grid = (NT, B * HV)
+    chunk_kda_fwd_kernel_inter_solve_fused[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akkd=Akkd,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=None,
+        chunk_indices=None,
+        T=T_seq,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+        NC=NC,
+        USE_SAFE_GATE=True,
+    )
+    w, u, qg, kg = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=Akk,
+        q=None,
+        gk=gk,
+        cu_seqlens=None,
+        chunk_indices=None,
+    )
+    return w, u, qg, kg, Aqk, Akk
+
+
+def triton_cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -50,6 +50,7 @@ class ChunkKDAFunction(torch.autograd.Function):
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         cp_context: FLACPContext | None = None,
+        use_tilelang_helpers: bool = False,
     ):
         # Apply l2norm
         q_rstd, k_rstd = None, None
@@ -93,6 +94,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             return_intermediate_states=return_intermediate_states,
             cp_context=cp_context,
             state_v_first=state_v_first,
+            use_tilelang_helpers=use_tilelang_helpers,
         )
 
         if return_intermediate_states:
@@ -116,6 +118,7 @@ class ChunkKDAFunction(torch.autograd.Function):
         ctx.disable_recompute = disable_recompute
         ctx.cp_context = cp_context
         ctx.state_v_first = state_v_first
+        ctx.use_tilelang_helpers = use_tilelang_helpers
         return o.type_as(q), final_state
 
     @staticmethod
@@ -162,6 +165,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             kg=kg,
             v_new=v_new,
             h=h,
+            use_tilelang_helpers=ctx.use_tilelang_helpers,
         )
         if ctx.use_qk_l2norm_in_kernel:
             dq = l2norm_bwd(q, q_rstd, dq)
@@ -170,11 +174,10 @@ class ChunkKDAFunction(torch.autograd.Function):
             db = fused_beta_sigmoid_bwd(beta_raw, db, scale=2.0 if ctx.allow_neg_eigval else 1.0)
 
         return (dq.to(q), dk.to(k), dv.to(v), dg.to(g_input), db.to(beta_raw), dA, dbias, None, dh0,
-                None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+                None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
 
 
 @dispatch('kda')
-@torch.compiler.disable
 def chunk_kda(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -349,6 +352,8 @@ def chunk_kda(
             cu_seqlens=cu_seqlens
         )
     """
+    use_tilelang_helpers = kwargs.pop("_tilelang_helpers", False)
+
     if 'transpose_state_layout' in kwargs:
         if state_v_first:
             raise ValueError("Cannot pass both `state_v_first` and the deprecated `transpose_state_layout`.")
@@ -437,4 +442,5 @@ def chunk_kda(
         disable_recompute,
         return_intermediate_states,
         cp_context,
+        use_tilelang_helpers,
     )

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -456,6 +456,7 @@ def chunk_kda_bwd(
     dt_bias: torch.Tensor | None = None,
     disable_recompute: bool = False,
     cp_context: FLACPContext | None = None,
+    use_tilelang_helpers: bool = False,
     **kwargs,
 ):
     H, HV = q.shape[2], v.shape[2]
@@ -506,9 +507,20 @@ def chunk_kda_bwd(
             # Only the first sequence's state is non-zero as it's the only one that could be cross-rank.
             initial_state = expand_h0(initial_state, context=cp_context)
 
+    bwd_dav = chunk_kda_bwd_dAv
+    bwd_dqkg = chunk_kda_bwd_wy_dqkg_fused
+    bwd_intra = chunk_kda_bwd_intra
+    if use_tilelang_helpers:
+        from fla.ops.kda.backends.tilelang.chunk_bwd_dav import chunk_kda_bwd_dAv_tilelang
+        from fla.ops.kda.backends.tilelang.chunk_bwd_dqkg import chunk_kda_bwd_wy_dqkg_fused_tilelang
+        from fla.ops.kda.backends.tilelang.chunk_bwd_intra import chunk_kda_bwd_intra_tilelang
+        bwd_dav = chunk_kda_bwd_dAv_tilelang
+        bwd_dqkg = chunk_kda_bwd_wy_dqkg_fused_tilelang
+        bwd_intra = chunk_kda_bwd_intra_tilelang
+
     # dAqk = do @ v.T
     # dv = A @ do
-    dAqk, dv = chunk_kda_bwd_dAv(
+    dAqk, dv = bwd_dav(
         q=q,
         k=k,
         v=v_new,
@@ -555,7 +567,7 @@ def chunk_kda_bwd(
         state_v_first=state_v_first,
     )
 
-    dq, dk, dv, db, dg, dAkk = chunk_kda_bwd_wy_dqkg_fused(
+    dq, dk, dv, db, dg, dAkk = bwd_dqkg(
         q=q,
         k=k,
         v=v,
@@ -574,7 +586,7 @@ def chunk_kda_bwd(
         state_v_first=state_v_first,
     )
 
-    dq, dk, db, dg = chunk_kda_bwd_intra(
+    dq, dk, db, dg = bwd_intra(
         q=q,
         k=k,
         g=g,

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -39,6 +39,7 @@ def chunk_kda_fwd(
     disable_recompute: bool = False,
     return_intermediate_states: bool = False,
     cp_context: FLACPContext | None = None,
+    use_tilelang_helpers: bool = False,
 ):
     # Apply gate activation
     g_org = None
@@ -63,8 +64,13 @@ def chunk_kda_fwd(
             chunk_indices=chunk_indices
         )
 
+    fwd_intra = chunk_kda_fwd_intra
+    if use_tilelang_helpers:
+        from fla.ops.kda.backends.tilelang.chunk_fwd_intra import chunk_kda_fwd_intra_tilelang
+        fwd_intra = chunk_kda_fwd_intra_tilelang
+
     # qg = None if disable_recompute is False
-    w, u, qg, kg, Aqk, Akk = chunk_kda_fwd_intra(
+    w, u, qg, kg, Aqk, Akk = fwd_intra(
         q=q,
         k=k,
         v=v,

--- a/tests/ops/test_backends.py
+++ b/tests/ops/test_backends.py
@@ -120,6 +120,228 @@ def test_tilelang_backend_unavailable_without_tilelang(monkeypatch, backend_modu
     assert _backend_cls(backend_module).is_available() is False
 
 
+def _kda_tilelang_verifier_args(
+    H=2,
+    HV=4,
+    K=64,
+    V=64,
+    dtype=torch.bfloat16,
+    chunk_size=64,
+    state_v_first=False,
+    requires_grad=False,
+    g_dtype=torch.float32,
+    beta_dtype=torch.float32,
+    g_is_cuda=True,
+    beta_is_cuda=True,
+    g_contiguous=True,
+    beta_contiguous=True,
+):
+    B, T = 1, 64
+    q = SimpleNamespace(shape=(B, T, H, K), dtype=dtype, is_cuda=True, requires_grad=requires_grad)
+    k = SimpleNamespace(shape=q.shape, dtype=dtype, is_cuda=True, requires_grad=requires_grad)
+    v = SimpleNamespace(shape=(B, T, HV, V), dtype=dtype, is_cuda=True, requires_grad=requires_grad)
+    state_shape = (V, K) if state_v_first else (K, V)
+    h = SimpleNamespace(shape=(B, T // chunk_size, HV, *state_shape), dtype=dtype, is_cuda=True, requires_grad=requires_grad)
+    g = SimpleNamespace(
+        shape=(B, T, HV, K),
+        dtype=g_dtype,
+        is_cuda=g_is_cuda,
+        requires_grad=requires_grad,
+        is_contiguous=lambda: g_contiguous,
+    )
+    beta = SimpleNamespace(
+        shape=(B, T, HV),
+        dtype=beta_dtype,
+        is_cuda=beta_is_cuda,
+        requires_grad=requires_grad,
+        is_contiguous=lambda: beta_contiguous,
+    )
+    return dict(
+        q=q,
+        k=k,
+        v=v,
+        v_new=v,
+        g=g,
+        beta=beta,
+        A=SimpleNamespace(shape=(B, T, HV, chunk_size), dtype=dtype, is_cuda=True, requires_grad=requires_grad),
+        h=h,
+        do=v,
+        dh=h,
+        dv=v,
+        chunk_size=chunk_size,
+        state_v_first=state_v_first,
+    )
+
+
+def _kda_tilelang_public_verifier_args(
+    H=2,
+    HV=4,
+    K=128,
+    V=128,
+    dtype=torch.bfloat16,
+    chunk_size=32,
+    q_contiguous=True,
+    h0_contiguous=True,
+):
+    B, T = 1, 64
+    q = SimpleNamespace(shape=(B, T, H, K), dtype=dtype, is_cuda=True, is_contiguous=lambda: q_contiguous)
+    k = SimpleNamespace(shape=q.shape, dtype=dtype, is_cuda=True, is_contiguous=lambda: True)
+    v = SimpleNamespace(shape=(B, T, HV, V), dtype=dtype, is_cuda=True, is_contiguous=lambda: True)
+    g = SimpleNamespace(shape=(B, T, HV, K), dtype=torch.float32, is_cuda=True, is_contiguous=lambda: True)
+    beta = SimpleNamespace(shape=(B, T, HV), dtype=dtype, is_cuda=True, is_contiguous=lambda: True)
+    h0 = SimpleNamespace(shape=(B, HV, K, V), dtype=torch.float32, is_cuda=True, is_contiguous=lambda: h0_contiguous)
+    return dict(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=h0,
+        output_final_state=True,
+        chunk_size=chunk_size,
+    )
+
+
+@pytest.mark.parametrize(
+    ("H", "HV"),
+    [
+        pytest.param(4, 4, id="mha"),
+        pytest.param(2, 4, id="gva"),
+    ],
+)
+def test_kda_tilelang_backend_public_chunk_kda_verifier_accepts_measured_bucket(H, HV):
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_verifier(
+        **_kda_tilelang_public_verifier_args(H=H, HV=HV)
+    )
+
+    assert accepted is True
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    ("overrides", "kwargs", "expected_reason"),
+    [
+        pytest.param({"dtype": torch.float16}, {}, "requires q dtype torch.bfloat16", id="dtype"),
+        pytest.param({"K": 64, "V": 64}, {}, "K=V=128", id="dimension"),
+        pytest.param({"H": 2, "HV": 3}, {}, "divisible by H=2", id="non-divisible-gva"),
+        pytest.param({"chunk_size": 64}, {}, "supports chunk_size=32", id="chunk-size"),
+        pytest.param({"q_contiguous": False}, {}, "requires q to be contiguous", id="q-layout"),
+        pytest.param({"h0_contiguous": False}, {}, "requires initial_state to be contiguous", id="state-layout"),
+        pytest.param({}, {"safe_gate": True}, "safe_gate=False only", id="safe-gate"),
+        pytest.param({}, {"state_v_first": True}, "state_v_first=False only", id="state-v-first"),
+        pytest.param({}, {"cu_seqlens": SimpleNamespace(is_cuda=True)}, "dense fixed-length", id="varlen"),
+    ],
+)
+def test_kda_tilelang_backend_public_chunk_kda_verifier_rejects_unmeasured_cases(overrides, kwargs, expected_reason):
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_verifier(
+        **_kda_tilelang_public_verifier_args(**overrides),
+        **kwargs,
+    )
+
+    assert accepted is False
+    assert expected_reason in reason
+
+
+def test_kda_tilelang_backend_verifier_accepts_gva():
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(
+        **_kda_tilelang_verifier_args(H=2, HV=4)
+    )
+
+    assert accepted is True
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    ("K", "V", "state_v_first"),
+    [
+        pytest.param(128, 128, False, id="d128-state-k-first"),
+        pytest.param(128, 128, True, id="d128-state-v-first"),
+    ],
+)
+def test_kda_tilelang_backend_verifier_accepts_d128_state_layouts(K, V, state_v_first):
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(
+        **_kda_tilelang_verifier_args(K=K, V=V, state_v_first=state_v_first)
+    )
+
+    assert accepted is True
+    assert reason is None
+
+
+def test_kda_tilelang_backend_verifier_rejects_reordered_state_tiles():
+    args = _kda_tilelang_verifier_args()
+    state_shape = args["h"].shape
+    reordered = SimpleNamespace(
+        shape=(state_shape[2], state_shape[0], state_shape[1], *state_shape[3:]),
+        dtype=args["h"].dtype,
+        is_cuda=True,
+        requires_grad=False,
+    )
+    args["h"] = reordered
+    args["dh"] = reordered
+
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(**args)
+
+    assert accepted is False
+    assert "requires h/dh shape" in reason
+
+
+def test_kda_tilelang_backend_verifier_rejects_non_divisible_gva():
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(
+        **_kda_tilelang_verifier_args(H=2, HV=3)
+    )
+
+    assert accepted is False
+    assert "HV % H must be 0 for GVA" in reason
+
+
+def test_kda_tilelang_backend_verifier_rejects_untiled_dimension():
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(
+        **_kda_tilelang_verifier_args(K=60)
+    )
+
+    assert accepted is False
+    assert "to be divisible by its BK tile" in reason
+
+
+def test_kda_tilelang_backend_verifier_rejects_varlen():
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(
+        **_kda_tilelang_verifier_args(),
+        cu_seqlens=SimpleNamespace(is_cuda=True),
+    )
+
+    assert accepted is False
+    assert "dense fixed-length sequences only" in reason
+
+
+def test_kda_tilelang_backend_verifier_rejects_autograd_inputs():
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(
+        **_kda_tilelang_verifier_args(requires_grad=True)
+    )
+
+    assert accepted is False
+    assert "manual fused-backward calls" in reason
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_reason"),
+    [
+        pytest.param({"g_is_cuda": False}, "requires CUDA tensors", id="g-cpu"),
+        pytest.param({"beta_is_cuda": False}, "requires CUDA tensors", id="beta-cpu"),
+        pytest.param({"g_dtype": torch.float16}, "requires g dtype torch.float32", id="g-dtype"),
+        pytest.param({"beta_dtype": torch.int32}, "beta dtype torch.int32", id="beta-dtype"),
+        pytest.param({"g_contiguous": False}, "requires g to be contiguous", id="g-layout"),
+        pytest.param({"beta_contiguous": False}, "requires beta to be contiguous", id="beta-layout"),
+    ],
+)
+def test_kda_tilelang_backend_verifier_rejects_g_beta_unsupported_cases(overrides, expected_reason):
+    accepted, reason = kda_tilelang_backend.KDATileLangBackend().chunk_kda_bwd_wy_dqkg_fused_verifier(
+        **_kda_tilelang_verifier_args(**overrides)
+    )
+
+    assert accepted is False
+    assert expected_reason in reason
+
+
 def test_rwkv6_tilelang_backend_requires_opt_in(monkeypatch):
     monkeypatch.delenv("FLA_TILELANG", raising=False)
     assert rwkv6_tilelang_backend.RWKV6TileLangBackend.is_enabled() is False

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -12,6 +12,8 @@ import torch
 import torch.nn.functional as F
 
 from fla.ops.kda import chunk_kda, fused_recurrent_kda
+from fla.ops.kda.backends.tilelang import KDATileLangBackend
+from fla.ops.kda.chunk_bwd import chunk_kda_bwd_wy_dqkg_fused
 from fla.ops.kda.fused_recurrent import fused_recurrent_kda_fwd
 from fla.ops.kda.gate import fused_kda_gate, naive_kda_gate, naive_kda_lowerbound_gate
 from fla.ops.kda.naive import naive_chunk_kda, naive_recurrent_kda
@@ -1181,6 +1183,547 @@ def test_chunk_return_intermediate_states(dtype):
         assert h_varlen.shape[0] == 1, f"Varlen h batch dim should be 1, got: {h_varlen.shape[0]}"
         assert h_varlen.shape[2:] == (H, D, D), f"Varlen h dims mismatch: {h_varlen.shape[2:]}"
         assert h_varlen.dtype == dtype, f"Varlen h dtype should be {dtype}, got: {h_varlen.dtype}"
+
+
+_SKIP_TILELANG_KDA = pytest.mark.skipif(
+    not (IS_NVIDIA and KDATileLangBackend.is_available()),
+    reason="KDA TileLang backend requires NVIDIA GPU, TileLang, and a usable nvcc",
+)
+
+
+@_SKIP_TILELANG_KDA
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        pytest.param("gk-cpu", "requires gk to be a CUDA tensor", id="gk-cpu"),
+        pytest.param("gk-dtype", "requires gk dtype torch.float32", id="gk-dtype"),
+        pytest.param("q-layout", "requires q to be contiguous", id="q-layout"),
+        pytest.param("chunk-size", "supports chunk_size 32 or 64", id="chunk-size"),
+        pytest.param("k-size", "supports K=64 or 128", id="k-size"),
+        pytest.param("safe-gate", "safe_gate=False only", id="safe-gate"),
+        pytest.param("disable-recompute", "disable_recompute=False only", id="disable-recompute"),
+        pytest.param("non-divisible-gva", "requires HV=3 to be divisible by H=2", id="non-divisible-gva"),
+    ],
+)
+def test_tilelang_kda_fwd_intra_direct_wrapper_rejects_unsupported(case, expected_reason):
+    from fla.ops.kda.backends.tilelang.chunk_fwd_intra import chunk_kda_fwd_intra_tilelang
+
+    B, T, H, HV, D, BT = 1, 64, 2, 4, 64, 64
+    dtype = torch.bfloat16
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = torch.randn_like(q)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    gk = torch.cumsum(-torch.rand(B, T, HV, D, dtype=torch.float32, device=device) * 0.02, dim=1)
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device)
+    call_chunk_size = BT
+    safe_gate = False
+    disable_recompute = False
+
+    if case == "gk-cpu":
+        gk = gk.cpu()
+    elif case == "gk-dtype":
+        gk = gk.to(torch.float16)
+    elif case == "q-layout":
+        q = torch.empty(B, T, H, D * 2, dtype=dtype, device=device)[..., ::2]
+    elif case == "chunk-size":
+        call_chunk_size = 16
+    elif case == "k-size":
+        D = 96
+        q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+        k = torch.randn_like(q)
+        v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+        gk = torch.cumsum(-torch.rand(B, T, HV, D, dtype=torch.float32, device=device) * 0.02, dim=1)
+    elif case == "safe-gate":
+        safe_gate = True
+    elif case == "disable-recompute":
+        disable_recompute = True
+    elif case == "non-divisible-gva":
+        HV = 3
+        v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+        gk = torch.cumsum(-torch.rand(B, T, HV, D, dtype=torch.float32, device=device) * 0.02, dim=1)
+        beta = torch.rand(B, T, HV, dtype=dtype, device=device)
+
+    with pytest.raises(ValueError, match=expected_reason):
+        chunk_kda_fwd_intra_tilelang(
+            q=q,
+            k=k,
+            v=v,
+            gk=gk,
+            beta=beta,
+            scale=D ** -0.5,
+            chunk_size=call_chunk_size,
+            safe_gate=safe_gate,
+            disable_recompute=disable_recompute,
+        )
+
+
+@_SKIP_TILELANG_KDA
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        pytest.param("A-missing", "requires A", id="A-missing"),
+        pytest.param("do-cpu", "requires do to be a CUDA tensor", id="do-cpu"),
+        pytest.param("A-dtype", "requires A dtype torch.float32", id="A-dtype"),
+        pytest.param("do-layout", "requires do to be contiguous", id="do-layout"),
+        pytest.param("chunk-size", "supports chunk_size 32 or 64", id="chunk-size"),
+        pytest.param("A-shape", "requires A shape", id="A-shape"),
+        pytest.param("non-divisible-gva", "requires HV=3 to be divisible by H=2", id="non-divisible-gva"),
+    ],
+)
+def test_tilelang_kda_bwd_dav_direct_wrapper_rejects_unsupported(case, expected_reason):
+    from fla.ops.kda.backends.tilelang.chunk_bwd_dav import chunk_kda_bwd_dAv_tilelang
+
+    B, T, H, HV, D, BT = 1, 64, 2, 4, 64, 64
+    dtype = torch.bfloat16
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = torch.randn_like(q)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    do = torch.randn_like(v)
+    A = torch.randn(B, T, HV, BT, dtype=dtype, device=device) * 0.01
+    call_chunk_size = BT
+
+    if case == "A-missing":
+        A = None
+    elif case == "do-cpu":
+        do = do.cpu()
+    elif case == "A-dtype":
+        A = A.float()
+    elif case == "do-layout":
+        do = torch.empty(B, T, HV, D * 2, dtype=dtype, device=device)[..., ::2]
+    elif case == "chunk-size":
+        call_chunk_size = 16
+    elif case == "A-shape":
+        A = A[..., :32].contiguous()
+    elif case == "non-divisible-gva":
+        HV = 3
+        v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+        do = torch.randn_like(v)
+        A = torch.randn(B, T, HV, BT, dtype=dtype, device=device) * 0.01
+
+    with pytest.raises(ValueError, match=expected_reason):
+        chunk_kda_bwd_dAv_tilelang(
+            q=q,
+            k=k,
+            v=v,
+            do=do,
+            A=A,
+            scale=D ** -0.5,
+            chunk_size=call_chunk_size,
+        )
+
+
+@_SKIP_TILELANG_KDA
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        pytest.param("g-cpu", "requires g to be a CUDA tensor", id="g-cpu"),
+        pytest.param("beta-cpu", "requires beta to be a CUDA tensor", id="beta-cpu"),
+        pytest.param("g-dtype", "requires g dtype torch.float32", id="g-dtype"),
+        pytest.param("beta-dtype", "does not support beta dtype torch.int32", id="beta-dtype"),
+        pytest.param("g-layout", "requires g to be contiguous", id="g-layout"),
+        pytest.param("beta-layout", "requires beta to be contiguous", id="beta-layout"),
+        pytest.param("chunk-size", "supports chunk_size 32 or 64", id="chunk-size"),
+        pytest.param("A-shape", "requires A shape", id="A-shape"),
+        pytest.param("g-shape", "requires g shape", id="g-shape"),
+    ],
+)
+def test_tilelang_kda_bwd_wy_dqkg_direct_wrapper_rejects_unsupported(case, expected_reason):
+    from fla.ops.kda.backends.tilelang.chunk_bwd_dqkg import chunk_kda_bwd_wy_dqkg_fused_tilelang
+
+    B, T, H, HV, D, BT = 1, 64, 2, 4, 64, 64
+    dtype = torch.bfloat16
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    v_new = torch.randn_like(v)
+    g = -torch.rand(B, T, HV, D, dtype=torch.float32, device=device)
+    beta = torch.rand(B, T, HV, dtype=torch.float32, device=device)
+    A = torch.randn(B, T, HV, BT, dtype=dtype, device=device) * 0.01
+    h = torch.randn(B, 1, HV, D, D, dtype=dtype, device=device)
+    do = torch.randn_like(v)
+    dh = torch.randn_like(h)
+    dv = torch.randn_like(v)
+    call_chunk_size = BT
+
+    if case == "g-cpu":
+        g = g.cpu()
+    elif case == "beta-cpu":
+        beta = beta.cpu()
+    elif case == "g-dtype":
+        g = g.to(torch.float16)
+    elif case == "beta-dtype":
+        beta = torch.ones(B, T, HV, dtype=torch.int32, device=device)
+    elif case == "g-layout":
+        g = torch.empty(B, T, HV, D * 2, dtype=torch.float32, device=device)[..., ::2]
+    elif case == "beta-layout":
+        beta = torch.empty(B, T, HV * 2, dtype=torch.float32, device=device)[..., ::2]
+    elif case == "chunk-size":
+        call_chunk_size = 16
+    elif case == "A-shape":
+        A = A[..., :32].contiguous()
+    elif case == "g-shape":
+        g = g[:, :, :H].contiguous()
+
+    with pytest.raises(ValueError, match=expected_reason):
+        chunk_kda_bwd_wy_dqkg_fused_tilelang(
+            q=q,
+            k=k,
+            v=v,
+            v_new=v_new,
+            g=g,
+            beta=beta,
+            A=A,
+            h=h,
+            do=do,
+            dh=dh,
+            dv=dv,
+            scale=D ** -0.5,
+            chunk_size=call_chunk_size,
+        )
+
+
+@_SKIP_TILELANG_KDA
+@pytest.mark.parametrize(
+    ("H", "HV", "chunk_size", "D", "dtype"),
+    [
+        pytest.param(4, 4, 64, 64, torch.bfloat16, id="mha-BT64-D64-bf16"),
+        pytest.param(2, 4, 64, 64, torch.bfloat16, id="gva-BT64-D64-bf16"),
+        pytest.param(4, 4, 32, 128, torch.bfloat16, id="mha-BT32-D128-bf16"),
+        pytest.param(2, 4, 32, 128, torch.bfloat16, id="gva-BT32-D128-bf16"),
+    ],
+)
+def test_tilelang_kda_bwd_wy_dqkg_supported_dense_matrix_routing(monkeypatch, H, HV, chunk_size, D, dtype):
+    torch.manual_seed(42)
+
+    from fla.ops.backends import BackendRegistry
+
+    BackendRegistry.ensure_initialized('kda')
+    backend = BackendRegistry._registries['kda']._backends.get('tilelang')
+    assert backend is not None, 'TileLang KDA backend is not registered'
+
+    B, T, BT = 1, 64, chunk_size
+    q = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    k = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    v = torch.randn(B, T, HV, D, dtype=dtype, device=device)
+    v_new = torch.randn_like(v)
+    g = -torch.rand(B, T, HV, D, dtype=torch.float32, device=device)
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device)
+    A = torch.randn(B, T, HV, BT, dtype=dtype, device=device) * 0.01
+    h = torch.randn(B, T // BT, HV, D, D, dtype=dtype, device=device)
+    do = torch.randn_like(v)
+    dh = torch.randn_like(h)
+    dv = torch.randn_like(v)
+
+    def run_with_tilelang(enabled: bool):
+        monkeypatch.setenv("FLA_TILELANG", "1" if enabled else "0")
+        return chunk_kda_bwd_wy_dqkg_fused(
+            q=q,
+            k=k,
+            v=v,
+            v_new=v_new,
+            g=g,
+            beta=beta,
+            A=A,
+            h=h,
+            do=do,
+            dh=dh,
+            dv=dv,
+            scale=D ** -0.5,
+            chunk_size=BT,
+        )
+
+    ref = run_with_tilelang(False)
+
+    calls = []
+    original = backend.chunk_kda_bwd_wy_dqkg_fused
+
+    def spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_wy_dqkg_fused')
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(backend, 'chunk_kda_bwd_wy_dqkg_fused', spy)
+    tri = run_with_tilelang(True)
+
+    assert calls == ['chunk_kda_bwd_wy_dqkg_fused']
+    for name, ref_t, tri_t, rtol in zip(
+        ("dq", "dk", "dv", "db", "dg", "dA"),
+        ref,
+        tri,
+        (0.008, 0.008, 0.008, 0.02, 0.02, 0.02),
+    ):
+        assert_close(name, ref_t, tri_t, rtol)
+
+
+@_SKIP_TILELANG_KDA
+def test_tilelang_kda_bwd_wy_dqkg_state_v_first_routing(monkeypatch):
+    torch.manual_seed(42)
+
+    from fla.ops.backends import BackendRegistry
+
+    BackendRegistry.ensure_initialized('kda')
+    backend = BackendRegistry._registries['kda']._backends.get('tilelang')
+    assert backend is not None, 'TileLang KDA backend is not registered'
+
+    B, T, H, HV, K, V, BT = 1, 64, 2, 4, 128, 128, 64
+    dtype = torch.bfloat16
+    q = torch.randn(B, T, H, K, dtype=dtype, device=device)
+    k = torch.randn(B, T, H, K, dtype=dtype, device=device)
+    v = torch.randn(B, T, HV, V, dtype=dtype, device=device)
+    v_new = torch.randn_like(v)
+    g = -torch.rand(B, T, HV, K, dtype=torch.float32, device=device)
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device)
+    A = torch.randn(B, T, HV, BT, dtype=dtype, device=device) * 0.01
+    h = torch.randn(B, 1, HV, V, K, dtype=dtype, device=device)
+    do = torch.randn_like(v)
+    dh = torch.randn_like(h)
+    dv = torch.randn_like(v)
+
+    def run_with_tilelang(enabled: bool):
+        monkeypatch.setenv("FLA_TILELANG", "1" if enabled else "0")
+        return chunk_kda_bwd_wy_dqkg_fused(
+            q=q,
+            k=k,
+            v=v,
+            v_new=v_new,
+            g=g,
+            beta=beta,
+            A=A,
+            h=h,
+            do=do,
+            dh=dh,
+            dv=dv,
+            scale=K ** -0.5,
+            state_v_first=True,
+            chunk_size=BT,
+        )
+
+    ref = run_with_tilelang(False)
+
+    calls = []
+    original = backend.chunk_kda_bwd_wy_dqkg_fused
+
+    def spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_wy_dqkg_fused')
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(backend, 'chunk_kda_bwd_wy_dqkg_fused', spy)
+    tri = run_with_tilelang(True)
+
+    assert calls == ['chunk_kda_bwd_wy_dqkg_fused']
+    for name, ref_t, tri_t, rtol in zip(
+        ("dq", "dk", "dv", "db", "dg", "dA"),
+        ref,
+        tri,
+        (0.008, 0.008, 0.008, 0.02, 0.02, 0.02),
+    ):
+        assert_close(name, ref_t, tri_t, rtol)
+
+
+@_SKIP_TILELANG_KDA
+@pytest.mark.parametrize(
+    ("H", "HV"),
+    [
+        pytest.param(4, 4, id="mha"),
+        pytest.param(2, 4, id="gva"),
+    ],
+)
+def test_tilelang_kda_public_autograd_routes_dense_bf16(monkeypatch, H, HV):
+    torch.manual_seed(42)
+
+    from fla.ops.backends import BackendRegistry
+    from fla.ops.kda.backends.tilelang import chunk_bwd_dav as tilelang_dav
+    from fla.ops.kda.backends.tilelang import chunk_bwd_dqkg as tilelang_dqkg
+    from fla.ops.kda.backends.tilelang import chunk_bwd_intra as tilelang_intra
+    from fla.ops.kda.backends.tilelang import chunk_fwd_intra as tilelang_fwd
+
+    BackendRegistry.ensure_initialized('kda')
+    backend = BackendRegistry._registries['kda']._backends.get('tilelang')
+    assert backend is not None, 'TileLang KDA backend is not registered'
+
+    B, T, D, BT = 1, 64, 128, 32
+    dtype = torch.bfloat16
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, T, HV, D, dtype=torch.float32, device=device))
+    beta = torch.randn(B, T, HV, dtype=dtype, device=device).sigmoid()
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device) * 0.01
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    def run_with_tilelang(enabled: bool):
+        monkeypatch.setenv("FLA_TILELANG", "1" if enabled else "0")
+        q_i, k_i, v_i, g_i, beta_i, h0_i = (
+            x.detach().clone().requires_grad_(True) for x in (q, k, v, g, beta, h0)
+        )
+        o, ht = chunk_kda(
+            q=F.normalize(q_i, p=2, dim=-1),
+            k=F.normalize(k_i, p=2, dim=-1),
+            v=v_i,
+            g=g_i,
+            beta=beta_i,
+            scale=D ** -0.5,
+            initial_state=h0_i,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=False,
+            state_v_first=False,
+            chunk_size=BT,
+        )
+        ((o * do).sum() + (ht * dht).sum()).backward()
+        return o, ht, (q_i.grad, k_i.grad, v_i.grad, g_i.grad, beta_i.grad, h0_i.grad)
+
+    ref = run_with_tilelang(False)
+
+    calls = []
+    original_public = backend.chunk_kda
+    original_fwd = tilelang_fwd.chunk_kda_fwd_intra_tilelang
+    original_dav = tilelang_dav.chunk_kda_bwd_dAv_tilelang
+    original_dqkg = tilelang_dqkg.chunk_kda_bwd_wy_dqkg_fused_tilelang
+    original_intra = tilelang_intra.chunk_kda_bwd_intra_tilelang
+
+    def public_spy(*args, **kwargs):
+        calls.append('chunk_kda')
+        return original_public(*args, **kwargs)
+
+    def fwd_spy(*args, **kwargs):
+        calls.append('chunk_kda_fwd_intra')
+        return original_fwd(*args, **kwargs)
+
+    def dav_spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_dAv')
+        return original_dav(*args, **kwargs)
+
+    def dqkg_spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_wy_dqkg_fused')
+        return original_dqkg(*args, **kwargs)
+
+    def intra_spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_intra')
+        return original_intra(*args, **kwargs)
+
+    monkeypatch.setattr(backend, 'chunk_kda', public_spy)
+    monkeypatch.setattr(tilelang_fwd, 'chunk_kda_fwd_intra_tilelang', fwd_spy)
+    monkeypatch.setattr(tilelang_dav, 'chunk_kda_bwd_dAv_tilelang', dav_spy)
+    monkeypatch.setattr(tilelang_dqkg, 'chunk_kda_bwd_wy_dqkg_fused_tilelang', dqkg_spy)
+    monkeypatch.setattr(tilelang_intra, 'chunk_kda_bwd_intra_tilelang', intra_spy)
+    tri = run_with_tilelang(True)
+
+    assert calls == [
+        'chunk_kda',
+        'chunk_kda_fwd_intra',
+        'chunk_kda_bwd_dAv',
+        'chunk_kda_bwd_wy_dqkg_fused',
+        'chunk_kda_bwd_intra',
+    ]
+    for name, ref_t, tri_t, rtol in zip(
+        ("o", "ht", "dq", "dk", "dv", "dg", "db", "dh0"),
+        (ref[0], ref[1], *ref[2]),
+        (tri[0], tri[1], *tri[2]),
+        (0.005, 0.005, 0.008, 0.008, 0.008, 0.02, 0.02, 0.008),
+    ):
+        assert_close(name, ref_t, tri_t, rtol)
+
+
+@_SKIP_TILELANG_KDA
+@pytest.mark.parametrize(
+    ("H", "HV", "state_v_first"),
+    [
+        pytest.param(2, 2, False, id="mha"),
+        pytest.param(2, 4, False, id="gva"),
+        pytest.param(2, 4, True, id="gva-state-v-first"),
+    ],
+)
+def test_tilelang_kda_full_backward_falls_back_for_autograd(monkeypatch, H, HV, state_v_first):
+    torch.manual_seed(42)
+
+    from fla.ops.backends import BackendRegistry
+    from fla.ops.kda.backends.tilelang import chunk_bwd_dav as tilelang_dav
+    from fla.ops.kda.backends.tilelang import chunk_bwd_dqkg as tilelang_dqkg
+    from fla.ops.kda.backends.tilelang import chunk_bwd_intra as tilelang_intra
+    from fla.ops.kda.backends.tilelang import chunk_fwd_intra as tilelang_fwd
+
+    BackendRegistry.ensure_initialized('kda')
+    backend = BackendRegistry._registries['kda']._backends.get('tilelang')
+    assert backend is not None, 'TileLang KDA backend is not registered'
+
+    B, T, D, BT = 1, 64, 64, 64
+    dtype = torch.bfloat16
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, HV, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, T, HV, D, dtype=torch.float32, device=device))
+    beta = torch.randn(B, T, HV, dtype=dtype, device=device).sigmoid()
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32, device=device)
+    if state_v_first:
+        h0 = h0.transpose(-1, -2).contiguous()
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    def run_with_tilelang(enabled: bool):
+        monkeypatch.setenv("FLA_TILELANG", "1" if enabled else "0")
+        q_i, k_i, v_i, g_i, beta_i, h0_i = (
+            x.detach().clone().requires_grad_(True) for x in (q, k, v, g, beta, h0)
+        )
+        o, ht = chunk_kda(
+            q=F.normalize(q_i, p=2, dim=-1),
+            k=F.normalize(k_i, p=2, dim=-1),
+            v=v_i,
+            g=g_i,
+            beta=beta_i,
+            scale=D ** -0.5,
+            initial_state=h0_i,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=False,
+            state_v_first=state_v_first,
+            chunk_size=BT,
+        )
+        ((o * do).sum() + (ht * dht).sum()).backward()
+        return o, ht, (q_i.grad, k_i.grad, v_i.grad, g_i.grad, beta_i.grad, h0_i.grad)
+
+    ref = run_with_tilelang(False)
+
+    calls = []
+    original_public = backend.chunk_kda
+    original_fwd = tilelang_fwd.chunk_kda_fwd_intra_tilelang
+    original_dav = tilelang_dav.chunk_kda_bwd_dAv_tilelang
+    original_wy = tilelang_dqkg.chunk_kda_bwd_wy_dqkg_fused_tilelang
+    original_intra = tilelang_intra.chunk_kda_bwd_intra_tilelang
+
+    def public_spy(*args, **kwargs):
+        calls.append('chunk_kda')
+        return original_public(*args, **kwargs)
+
+    def fwd_spy(*args, **kwargs):
+        calls.append('chunk_kda_fwd_intra')
+        return original_fwd(*args, **kwargs)
+
+    def dav_spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_dAv')
+        return original_dav(*args, **kwargs)
+
+    def wy_spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_wy_dqkg_fused')
+        return original_wy(*args, **kwargs)
+
+    def intra_spy(*args, **kwargs):
+        calls.append('chunk_kda_bwd_intra')
+        return original_intra(*args, **kwargs)
+
+    monkeypatch.setattr(backend, 'chunk_kda', public_spy)
+    monkeypatch.setattr(tilelang_fwd, 'chunk_kda_fwd_intra_tilelang', fwd_spy)
+    monkeypatch.setattr(tilelang_dav, 'chunk_kda_bwd_dAv_tilelang', dav_spy)
+    monkeypatch.setattr(tilelang_dqkg, 'chunk_kda_bwd_wy_dqkg_fused_tilelang', wy_spy)
+    monkeypatch.setattr(tilelang_intra, 'chunk_kda_bwd_intra_tilelang', intra_spy)
+    tri = run_with_tilelang(True)
+
+    assert calls == []
+    for name, ref_t, tri_t, rtol in zip(
+        ("o", "ht", "dq", "dk", "dv", "dg", "db", "dh0"),
+        (ref[0], ref[1], *ref[2]),
+        (tri[0], tri[1], *tri[2]),
+        (0.001, 0.001, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03),
+    ):
+        assert_close(name, ref_t, tri_t, rtol)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Accelerates public `chunk_kda` autograd training with four TileLang kernels covering intra forward, `dAv`, fused `dq/kg`, and intra backward. The route supports both MHA and divisible GVA value heads and preserves the existing Triton implementation for calls outside the promoted bucket.

The helper kernels were validated across a broader dense matrix (`fp16`/`bf16`/`fp32`, `K` 64/128, chunk sizes 32/64, MHA/GVA). Public automatic dispatch starts with the workload that also demonstrated a repeatable end-to-end gain: dense BF16, `K=V=128`, `chunk_size=32`. This is a performance gate, not a public API restriction; existing KDA modes continue to work through the unchanged Triton path.

Blast radius is limited to KDA TileLang internals, the public KDA autograd routing flag, and KDA/backend tests. There are no API or default-argument changes.

## Test plan

GPU environment: `b200-1111`, NVIDIA B200, PyTorch `2.11.0a0+eb65b36914.nv26.02`, CUDA toolkit `13.1`, Triton `3.6.0`, TileLang `0.1.13`, `IS_NVIDIA_SM100=True`.

- Dependent test discovery:
  - `python scripts/find_dependent_tests.py fla/ops/kda/backends/tilelang fla/ops/kda/chunk.py fla/ops/kda/chunk_fwd.py fla/ops/kda/chunk_bwd.py tests/ops/test_kda.py tests/ops/test_backends.py`
- B200 public-route parity and fallback probe:
  - `CUDA_VISIBLE_DEVICES=4 CUDA_HOME=/usr/local/cuda-13.1 CUDA_PATH=/usr/local/cuda-13.1 python /tmp/fla_validate_kda_tilelang_public.py`
  - Confirmed the public route and all four helpers for MHA (`H=HV=4`) and divisible GVA (`H=2, HV=4`).
  - Compared `o`, `ht`, `dq`, `dk`, `dv`, `dg`, `db`, and `dh0` against `FLA_TILELANG=0`.
  - Calls outside the promoted public bucket matched Triton and recorded no TileLang helper launch before fallback.
- B200 pytest gates:
  - `python -m pytest -q tests/ops/test_backends.py tests/ops/test_kda.py::test_tilelang_kda_public_autograd_routes_dense_bf16` -> `41 passed`
  - `python -m pytest -q tests/ops/test_kda.py -k tilelang_kda` -> `34 passed`
- Pre-commit:
  - `pre-commit run --files fla/ops/kda/backends/tilelang/__init__.py fla/ops/kda/backends/tilelang/chunk_bwd_dqkg.py fla/ops/kda/backends/tilelang/chunk_bwd_dav.py fla/ops/kda/backends/tilelang/chunk_bwd_intra.py fla/ops/kda/backends/tilelang/chunk_fwd_intra.py fla/ops/kda/chunk.py fla/ops/kda/chunk_bwd.py fla/ops/kda/chunk_fwd.py tests/ops/test_backends.py tests/ops/test_kda.py`

## Benchmark / NCU (kernel changes only)

All numbers are same-machine B200 medians with BF16, `B=1`, `K=V=128`, `chunk_size=32`, and identical inputs for Triton and TileLang.

### Four accelerated stages (`T=1024`)

| Heads | Stage | Triton | TileLang | Speedup |
| --- | --- | ---: | ---: | ---: |
| MHA (`H=HV=4`) | intra forward | 0.2350 ms | 0.2087 ms | 1.126x |
| MHA (`H=HV=4`) | `dAv` | 0.0803 ms | 0.0521 ms | 1.541x |
| MHA (`H=HV=4`) | fused `dq/kg` | 0.1187 ms | 0.0877 ms | 1.353x |
| MHA (`H=HV=4`) | intra backward | 0.1218 ms | 0.0825 ms | 1.476x |
| **MHA total** | **four stages** | **0.5557 ms** | **0.4309 ms** | **1.290x** |
| GVA (`H=2, HV=4`) | intra forward | 0.2274 ms | 0.2037 ms | 1.116x |
| GVA (`H=2, HV=4`) | `dAv` | 0.0804 ms | 0.0527 ms | 1.526x |
| GVA (`H=2, HV=4`) | fused `dq/kg` | 0.1182 ms | 0.0867 ms | 1.363x |
| GVA (`H=2, HV=4`) | intra backward | 0.1220 ms | 0.0811 ms | 1.504x |
| **GVA total** | **four stages** | **0.5480 ms** | **0.4242 ms** | **1.292x** |

### Repeated public forward + backward (`T=1024`)

| Run | Heads | Triton | TileLang | Speedup |
| --- | --- | ---: | ---: | ---: |
| 1 | MHA | 1.6386 ms | 1.5195 ms | 1.078x |
| 1 | GVA | 1.6734 ms | 1.5241 ms | 1.098x |
| 2 | MHA | 1.6405 ms | 1.4933 ms | 1.099x |
| 2 | GVA | 1.6770 ms | 1.5288 ms | 1.097x |

A fresh closeout run on GPU 4 at `T=512` also measured 1.049x for MHA and 1.060x for GVA over 20 timed iterations after warmup.

NCU was not rerun for the PR closeout; the evidence above combines per-stage latency with repeated route-confirmed public forward+backward latency.

## Breaking changes

None. Calls outside the promoted TileLang performance bucket continue to use the existing Triton path.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).