### PR TITLE
[Perf] Optimize Ascend KDA intra backward with split kernels and 1D core-grid

### DIFF
--- a/fla/ops/kda/backends/triton_ascend/chunk_intra.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+from triton.runtime import driver
 
 from fla.ops.kda.backends.triton_ascend.wy_fast import recompute_w_u_fwd_kda_npu as _recompute_w_u_fwd_npu
 from fla.ops.kda.chunk_intra_token_parallel import chunk_kda_fwd_intra_token_parallel
@@ -162,13 +163,14 @@ def chunk_kda_fwd_kernel_diag_solve_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     i_ti = i_t * BT + i_i * BC
     if i_ti >= T:
         return
 
-    Akkd = Akkd + (bos * HV + i_hv) * BC
+    Akkd = Akkd + (bos * HV + i_hv).to(tl.int64) * BC
     o_i = tl.arange(0, BC)
     m_A = o_i[:, None] > o_i[None, :]
     m_I = o_i[:, None] == o_i[None, :]
@@ -177,7 +179,7 @@ def chunk_kda_fwd_kernel_diag_solve_npu(
     b_Akk = tl.load(p_Akk, boundary_check=(0, 1)).to(tl.float32)
     b_Ai = -tl.where(m_A, b_Akk, 0)
     for i in range(2, min(BC, T - i_ti)):
-        b_a = -tl.load(Akkd + (i_ti + i) * HV * BC + o_i)
+        b_a = -tl.load(Akkd + (i_ti + i).to(tl.int64) * HV * BC + o_i)
         b_a = tl.where(o_i < i, b_a, 0.)
         b_a += tl.sum(b_a[:, None] * b_Ai, 0)
         b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
@@ -219,7 +221,8 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     i_ti = i_t * BT + i_i * BC
     if i_ti >= T:
@@ -228,12 +231,12 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_npu(
     o_c = i_ti + tl.arange(0, BC)
     m_c = o_c < T
 
-    q = q + (bos * H + i_h) * K
-    k = k + (bos * H + i_h) * K
-    g = g + (bos * HV + i_hv) * K
-    beta = beta + bos * HV + i_hv
-    Aqk = Aqk + (bos * HV + i_hv) * BT
-    Akk = Akk + (bos * HV + i_hv) * BC
+    q = q + (bos * H + i_h).to(tl.int64) * K
+    k = k + (bos * H + i_h).to(tl.int64) * K
+    g = g + (bos * HV + i_hv).to(tl.int64) * K
+    beta = beta + (bos * HV + i_hv).to(tl.int64)
+    Aqk = Aqk + (bos * HV + i_hv).to(tl.int64) * BT
+    Akk = Akk + (bos * HV + i_hv).to(tl.int64) * BC
 
     p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
     p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
@@ -246,7 +249,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_npu(
     b_g = tl.load(p_g, boundary_check=(0, 1))
     b_beta = tl.load(p_beta, boundary_check=(0,))
 
-    p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + tl.arange(0, BK)
+    p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)).to(tl.int64) * HV * K + tl.arange(0, BK)
     b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
     b_gn = b_gn[None, :]
 
@@ -308,7 +311,8 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     if i_t * BT >= T:
         return
@@ -318,12 +322,12 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     i_tc2 = i_t * BT + 2 * BC
     i_tc3 = i_t * BT + 3 * BC
 
-    q += (bos * H + i_h) * K
-    k += (bos * H + i_h) * K
-    g += (bos * HV + i_hv) * K
-    Aqk += (bos * HV + i_hv) * BT
-    Akk += (bos * HV + i_hv) * BT
-    Akkd += (bos * HV + i_hv) * BC
+    q += (bos * H + i_h).to(tl.int64) * K
+    k += (bos * H + i_h).to(tl.int64) * K
+    g += (bos * HV + i_hv).to(tl.int64) * K
+    Aqk += (bos * HV + i_hv).to(tl.int64) * BT
+    Akk += (bos * HV + i_hv).to(tl.int64) * BT
+    Akkd += (bos * HV + i_hv).to(tl.int64) * BC
 
     o_i = tl.arange(0, BC)
     m_tc1 = (i_tc1 + o_i) < T
@@ -362,7 +366,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
         b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
         b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
-        b_gn1 = tl.load(g + i_tc1 * HV * K + o_k, mask=m_k & (i_tc1 < T), other=0).to(tl.float32)
+        b_gn1 = tl.load(g + i_tc1.to(tl.int64) * HV * K + o_k, mask=m_k & (i_tc1 < T), other=0).to(tl.float32)
         b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
         b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0))
         b_Aqk10 += tl.dot(b_q1 * b_gqn, b_kgt, allow_tf32=False)
@@ -375,7 +379,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
             b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
             b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
             b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
-            b_gn2 = tl.load(g + i_tc2 * HV * K + o_k, mask=m_k & (i_tc2 < T), other=0).to(tl.float32)
+            b_gn2 = tl.load(g + i_tc2.to(tl.int64) * HV * K + o_k, mask=m_k & (i_tc2 < T), other=0).to(tl.float32)
             b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
             b_qg2 = b_q2 * b_gqn2
             b_kg2 = b_k2 * b_gqn2
@@ -395,7 +399,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
                 b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
                 b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
                 b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
-                b_gn3 = tl.load(g + i_tc3 * HV * K + o_k, mask=m_k & (i_tc3 < T), other=0).to(tl.float32)
+                b_gn3 = tl.load(g + i_tc3.to(tl.int64) * HV * K + o_k, mask=m_k & (i_tc3 < T), other=0).to(tl.float32)
                 b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
                 b_qg3 = b_q3 * b_gqn3
                 b_kg3 = b_k3 * b_gqn3
@@ -416,7 +420,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
     tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-    p_b1 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,))
+    p_b1 = tl.make_block_ptr(beta + (bos * HV + i_hv).to(tl.int64), (T,), (HV,), (i_tc1,), (BC,), (0,))
     b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
     b_Akk10 = b_Akk10 * b_b1[:, None]
     if NC >= 3:
@@ -425,7 +429,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_b2 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,))
+        p_b2 = tl.make_block_ptr(beta + (bos * HV + i_hv).to(tl.int64), (T,), (HV,), (i_tc2,), (BC,), (0,))
         b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
         b_Akk20 = b_Akk20 * b_b2[:, None]
         b_Akk21 = b_Akk21 * b_b2[:, None]
@@ -437,7 +441,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_b3 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,))
+        p_b3 = tl.make_block_ptr(beta + (bos * HV + i_hv).to(tl.int64), (T,), (HV,), (i_tc3,), (BC,), (0,))
         b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
         b_Akk30 = b_Akk30 * b_b3[:, None]
         b_Akk31 = b_Akk31 * b_b3[:, None]
@@ -665,315 +669,413 @@ def chunk_kda_fwd_intra_npu(
     return w, u, qg, kg, Aqk, Akk
 
 
-_NUM_WARPS_BWD = 2
-# Vectorized diagonal path keeps BC×BK tiles live; keep BK small for Ascend UB.
-_BWD_INTRA_MEM_MULT = 18.0
-_FALLBACK_BK = 16
-_MAX_BK = 16
-# limit programs per launch to stay within Ascend AICore task time.
-_KDA_BWD_INTRA_LAUNCH_BLOCK_BUDGET = 4096
+# Split at debug_barrier: dq/db half has lower peak live set than dk/dg half.
+# BC=32 cuts NC 4→2 (chunk_size=64) so the future-subchunk loop in dkt_future
+# drops from 6 pair-blocks to 1; Cube tiles are 32×32 instead of 16×16.
+# SAFE_GATE diag keeps many concurrent BC×BK fp32 tiles live. mem_mult=9 lets
+# host pick BK=128 (NK 4→2 on D256) while dq_db (past+diag) still fits 192KB UB.
+# dk_dg has a smaller live set and can use BK=256 (NK=1). dkt_future compiles at
+# BK=256 but faults at runtime (UB address OOB), so it stays on BK=128.
+_BWD_INTRA_BC = 32
+_BWD_INTRA_DQ_MEM_MULT = 9.0
+_BWD_INTRA_DK_MEM_MULT = 4.5
+_MAX_BK_DQ = 128
+_MAX_BK_DK = 256
 
 
-def _get_bwd_intra_bk(K: int) -> int:
+def get_npu_properties():
+    device = torch.npu.current_device()
+    return driver.active.utils.get_device_properties(device)
+
+
+def _get_bwd_intra_bk(K: int, BC: int = _BWD_INTRA_BC, *, element_size: int = 2) -> int:
+    # fp32 I/O roughly doubles compile-time element-tile UB vs bf16 in dq_db SAFE_GATE.
+    max_bk = _MAX_BK_DQ if element_size <= 2 else min(_MAX_BK_DQ, 32)
     return compute_row_tile_block_size(
-        _BC,
+        BC,
         K,
-        _BWD_INTRA_MEM_MULT,
+        _BWD_INTRA_DQ_MEM_MULT,
         tiling_row=False,
         safety_margin=_SAFETY_MARGIN,
         fallback=_FALLBACK_BK,
         min_block=16,
-        max_block=min(_MAX_BK, triton.next_power_of_2(K)),
+        max_block=min(max_bk, triton.next_power_of_2(K)),
     )
 
 
-def _launch_bwd_intra_kernel(
-    kernel,
-    *,
-    nk_nc: int,
-    nt: int,
-    bh_total: int,
-    kernel_kwargs: dict,
-) -> None:
-    # limit programs per launch to stay within Ascend AICore task time.
-    budget = _KDA_BWD_INTRA_LAUNCH_BLOCK_BUDGET
-    chunk_indices = kernel_kwargs.get('chunk_indices')
-    cu_seqlens = kernel_kwargs.get('cu_seqlens')
-    nk_step = nk_nc if nk_nc * nt * bh_total <= budget else max(1, budget // max(nt * bh_total, 1))
-    for nknc_off in range(0, nk_nc, nk_step):
-        nknc_len = min(nk_step, nk_nc - nknc_off)
-        kernel_kwargs['NKNC_OFFSET'] = nknc_off
-        nt_budget = max(1, budget // max(nknc_len * bh_total, 1))
-        max_nt = min(
-            nt_budget,
-            max_grid_axis_chunks(nt, nknc_len * bh_total, max_grid=ASCEND_MAX_GRID_DIM),
-        )
-        for nt_off in range(0, nt, max_nt):
-            nt_len = min(max_nt, nt - nt_off)
-            if cu_seqlens is not None and chunk_indices is not None:
-                kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
-                kernel_kwargs['NT_OFFSET'] = 0
-            else:
-                kernel_kwargs['NT_OFFSET'] = nt_off
-            bh_budget = max(1, budget // max(nknc_len * nt_len, 1))
-            max_bh = min(
-                bh_budget,
-                max_grid_axis_chunks(bh_total, nknc_len * nt_len, max_grid=ASCEND_MAX_GRID_DIM),
-            )
-            for bh_off in range(0, bh_total, max_bh):
-                bh_len = min(max_bh, bh_total - bh_off)
-                kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(nknc_len, nt_len, bh_len)](num_warps=_NUM_WARPS_BWD, **kernel_kwargs)
+def _get_bwd_intra_bk_dk(K: int, BC: int = _BWD_INTRA_BC, *, element_size: int = 2) -> int:
+    """Wider K tile for dk_dg (no past-subchunk live set). dkt_future cannot use this."""
+    max_bk = _MAX_BK_DK if element_size <= 2 else min(_MAX_BK_DK, 32)
+    return compute_row_tile_block_size(
+        BC,
+        K,
+        _BWD_INTRA_DK_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_BK,
+        min_block=16,
+        max_block=min(max_bk, triton.next_power_of_2(K)),
+    )
 
 
-@triton.jit(do_not_specialize=['B', 'T', 'NKNC_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
-def chunk_kda_bwd_kernel_intra_npu(
-    q,
-    k,
-    g,
-    beta,
-    dAqk,
-    dAkk,
-    dq,
-    dq2,
-    dk,
-    dk2,
-    dg,
-    dg2,
-    db,
-    cu_seqlens,
-    chunk_indices,
-    B,
-    T,
-    H: tl.constexpr,
-    HV: tl.constexpr,
-    K: tl.constexpr,
-    BT: tl.constexpr,
-    BC: tl.constexpr,
-    BK: tl.constexpr,
-    NC: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-    SAFE_GATE: tl.constexpr,
-    NKNC_OFFSET,
-    NT_OFFSET,
-    BH_OFFSET,
+def _launch_bwd_intra_core_grid(kernel, *, task_num: int, kernel_kwargs: dict) -> None:
+    num_core = get_npu_properties()["num_aicore"]
+    kernel[(num_core,)](task_num=task_num, num_core=num_core, **kernel_kwargs)
+
+
+def _gk_npu_arg(g: torch.Tensor, HV: int) -> tuple[torch.Tensor, bool]:
+    """Transpose g to [B, HV, T, K] for stride-1 row loads along T."""
+    if HV == 1:
+        return g, False
+    return g.transpose(1, 2).contiguous(), True
+
+
+def _hv_t_npu_arg(x: torch.Tensor, HV: int) -> tuple[torch.Tensor, bool]:
+    """Transpose [B, T, HV] to [B, HV, T] for stride-1 loads along T."""
+    if HV == 1:
+        return x, False
+    return x.transpose(1, 2).contiguous(), True
+
+
+@triton.jit
+def _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN: tl.constexpr, BETA_T_CONTIG: tl.constexpr):
+    if BETA_T_CONTIG:
+        if IS_VARLEN:
+            return beta + (bos + i_hv.to(tl.int64) * T_seq)
+        return beta + (tl.cast(i_b, tl.int64) * HV + i_hv) * T_seq
+    return beta + (bos * HV + i_hv).to(tl.int64)
+
+
+@triton.jit
+def _bwd_intra_beta_row_stride(BETA_T_CONTIG: tl.constexpr, HV: tl.constexpr):
+    if BETA_T_CONTIG:
+        return 1
+    return HV
+
+
+@triton.jit
+def _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN: tl.constexpr, G_T_CONTIG: tl.constexpr):
+    if G_T_CONTIG:
+        if IS_VARLEN:
+            return g + (bos * K).to(tl.int64) + i_hv.to(tl.int64) * T_seq * K
+        return g + tl.cast(i_b, tl.int64) * HV * T_seq * K + i_hv.to(tl.int64) * T_seq * K
+    return g + (bos * HV + i_hv).to(tl.int64) * K
+
+
+@triton.jit
+def _bwd_intra_g_row_stride(G_T_CONTIG: tl.constexpr, HV: tl.constexpr, K: tl.constexpr):
+    if G_T_CONTIG:
+        return K
+    return HV * K
+
+
+@triton.jit
+def _bwd_intra_g_block_ptr(g_base, T, row, col, BC, BK, g_row_stride, K: tl.constexpr):
+    return tl.make_block_ptr(g_base, (T, K), (g_row_stride, 1), (row, col), (BC, BK), (1, 0))
+
+
+@triton.jit(do_not_specialize=['B', 'T', 'NT', 'BH_TOTAL', 'task_num', 'num_core'])
+def chunk_kda_bwd_kernel_intra_dq_db_npu(
+    q, k, g, beta, dAqk, dAkk, dq, dq2, dk2, dg2, db,
+    cu_seqlens, chunk_indices, B, T, NT, BH_TOTAL, task_num, num_core,
+    H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr, BT: tl.constexpr,
+    BC: tl.constexpr, BK: tl.constexpr, NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr, SAFE_GATE: tl.constexpr,
+    G_T_CONTIG: tl.constexpr, BETA_T_CONTIG: tl.constexpr,
 ):
-    i_kc = tl.program_id(0) + NKNC_OFFSET
-    i_t = tl.program_id(1) + NT_OFFSET
-    i_bh = tl.program_id(2) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
-    i_h = i_hv // (HV // H)
-    i_k, i_i = i_kc // NC, i_kc % NC
-
-    all = B * T
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-    else:
-        bos, eos = i_b * T, i_b * T + T
-    T = (eos - bos).to(tl.int32)
-
-    i_ti = i_t * BT + i_i * BC
-    if i_ti >= T:
-        return
-
-    o_k = i_k * BK + tl.arange(0, BK)
-    m_k = o_k < K
-
-    q += (bos * H + i_h) * K
-    k += (bos * H + i_h) * K
-    g += (bos * HV + i_hv) * K
-    beta += bos * HV + i_hv
-
-    dAqk += (bos * HV + i_hv) * BT
-    dAkk += (bos * HV + i_hv) * BT
-    dq += (bos * HV + i_hv) * K
-    dq2 += (bos * HV + i_hv) * K
-    dk += (bos * HV + i_hv) * K
-    dk2 += (bos * HV + i_hv) * K
-    dg += (bos * HV + i_hv) * K
-    dg2 += (bos * HV + i_hv) * K
-    db += (i_k * all + bos) * HV + i_hv
-
-    p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-
-    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
-    b_b = tl.load(p_b, boundary_check=(0,))
-
-    b_dq2 = tl.zeros([BC, BK], dtype=tl.float32)
-    b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
-    if i_i > 0:
-        p_gn = g + i_ti * HV * K + o_k
-        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
-        for i_j in range(0, i_i):
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
-            p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_gk = tl.load(p_gk, boundary_check=(0, 1))
-            b_kg = b_k * exp2(b_gn - b_gk)
-            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
-            b_dq2 += tl.dot(b_dAqk, b_kg, allow_tf32=False)
-            b_dk2 += tl.dot(b_dAkk, b_kg, allow_tf32=False)
-        b_gqn = exp2(b_g - b_gn)
-        b_dq2 *= b_gqn
-        b_dk2 *= b_gqn
-
+    core_id = tl.program_id(0)
+    g_row_stride = _bwd_intra_g_row_stride(G_T_CONTIG, HV, K)
+    beta_row_stride = _bwd_intra_beta_row_stride(BETA_T_CONTIG, HV)
     o_i = tl.arange(0, BC)
-    m_dA = (i_ti + o_i) < T
-    o_dA = (i_ti + o_i) * HV * BT + i_i * BC
-    p_kj = k + i_ti * H * K + o_k
-    p_gkj = g + i_ti * HV * K + o_k
-
-    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    b_q = tl.load(p_q, boundary_check=(0, 1))
-    b_k = tl.load(p_k, boundary_check=(0, 1))
-
-    if SAFE_GATE:
-        # Midpoint-offset vectorized path (bounded under lower_bound=-5).
-        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + o_k
-        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
-
-        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
-        b_dAqk_diag_qk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_qk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
-
-        m_i_diag_qk = (o_i[:, None] >= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
-        m_j_diag_qk = (i_ti + o_i[:, None]) < T
-
-        b_dAqk_diag_qk = tl.where(m_i_diag_qk, b_dAqk_diag_qk, 0.)
-        b_dAkk_diag_qk = tl.where(m_i_diag_qk, b_dAkk_diag_qk, 0.)
-        b_g_diag_qk = tl.where(m_j_diag_qk, b_g - b_gn, 0.)
-        exp_b_g_diag_qk = tl.where(m_j_diag_qk, exp2(b_g_diag_qk), 0.)
-        exp_neg_b_g_diag_qk = tl.where(m_j_diag_qk, exp2(-b_g_diag_qk), 0.)
-
-        b_k_exp_diag_qk = b_k * exp_neg_b_g_diag_qk
-        b_dq2 += tl.dot(b_dAqk_diag_qk, b_k_exp_diag_qk, allow_tf32=False) * exp_b_g_diag_qk
-        b_dk2 += tl.dot(b_dAkk_diag_qk, b_k_exp_diag_qk, allow_tf32=False) * exp_b_g_diag_qk
-    else:
-        # Pairwise scalar path required for unbounded non-safe gates (avoids Inf/NaN).
-        for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
-            b_dAqk = tl.load(dAqk + o_dA + j, mask=m_dA, other=0)
-            b_dAkk = tl.load(dAkk + o_dA + j, mask=m_dA, other=0)
-            b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
-            b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
-            m_i = o_i[:, None] >= j
-            b_gqk = exp2(b_g - b_gkj[None, :])
-            b_dq2 += tl.where(m_i, b_dAqk[:, None] * b_kj[None, :] * b_gqk, 0.)
-            b_dk2 += tl.where(m_i, b_dAkk[:, None] * b_kj[None, :] * b_gqk, 0.)
-
-            p_kj += H * K
-            p_gkj += HV * K
-
-    b_db = tl.sum(b_dk2 * b_k, 1)
-    b_dk2 *= b_b[:, None]
-
-    p_dq = tl.make_block_ptr(dq, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dq2 = tl.make_block_ptr(dq2, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_ti,), (BC,), (0,))
-
-    b_dg2 = b_q * b_dq2
-    b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
-    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
-
-    # synchronize before the second half of the kernel that reuses the same tiles.
-    tl.debug_barrier()
-    b_dkt = tl.zeros([BC, BK], dtype=tl.float32)
-
-    NC = min(NC, tl.cdiv(T - i_t * BT, BC))
-    if i_i < NC - 1:
-        p_gn = g + (min(i_ti + BC, T) - 1) * HV * K + o_k
-        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
-        for i_j in range(i_i + 1, NC):
-            p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_gk = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
-            p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT + i_j * BC,), (BC,), (0,))
-            p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV * BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
-            p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV * BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
+    # One (i_k, i_i) tile per task; NK*NC encoded in i_kc to keep parallel granularity.
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_bh = task_id % BH_TOTAL
+        rem = task_id // BH_TOTAL
+        i_t = rem % NT
+        i_kc = rem // NT
+        i_b, i_hv = i_bh // HV, i_bh % HV
+        i_h = i_hv // (HV // H)
+        i_k, i_i = i_kc // NC, i_kc % NC
+        T_seq = T
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        else:
+            bos = tl.cast(i_b, tl.int64) * T
+            eos = bos + T
+        T_cur = (eos - bos).to(tl.int32)
+        i_ti = i_t * BT + i_i * BC
+        if i_ti < T_cur:
+            all = tl.cast(B, tl.int64) * T
+            q_ptr = q + (bos * H + i_h).to(tl.int64) * K
+            k_ptr = k + (bos * H + i_h).to(tl.int64) * K
+            g_base = _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN, G_T_CONTIG)
+            beta_base = _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN, BETA_T_CONTIG)
+            dAqk_ptr = dAqk + (bos * HV + i_hv).to(tl.int64) * BT
+            dAkk_ptr = dAkk + (bos * HV + i_hv).to(tl.int64) * BT
+            dq_ptr = dq + (bos * HV + i_hv).to(tl.int64) * K
+            dq2_ptr = dq2 + (bos * HV + i_hv).to(tl.int64) * K
+            dk2_ptr = dk2 + (bos * HV + i_hv).to(tl.int64) * K
+            dg2_ptr = dg2 + (bos * HV + i_hv).to(tl.int64) * K
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            db_ptr = db + (i_k * all + bos).to(tl.int64) * HV + i_hv
+            p_g = _bwd_intra_g_block_ptr(g_base, T_cur, i_ti, i_k * BK, BC, BK, g_row_stride, K)
+            b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+            p_b = tl.make_block_ptr(beta_base, (T_cur,), (beta_row_stride,), (i_ti,), (BC,), (0,))
             b_b = tl.load(p_b, boundary_check=(0,))
+            b_dq2 = tl.zeros([BC, BK], dtype=tl.float32)
+            b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
+            if i_i > 0:
+                p_gn = g_base + i_ti.to(tl.int64) * g_row_stride + o_k
+                b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+                for i_j in range(0, i_i):
+                    p_k = tl.make_block_ptr(k_ptr, (T_cur, K), (H * K, 1),
+                                            (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+                    p_gk = _bwd_intra_g_block_ptr(g_base, T_cur, i_t * BT + i_j * BC,
+                                                  i_k * BK, BC, BK, g_row_stride, K)
+                    p_dAqk = tl.make_block_ptr(dAqk_ptr, (T_cur, BT), (HV * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+                    p_dAkk = tl.make_block_ptr(dAkk_ptr, (T_cur, BT), (HV * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    b_gk = tl.load(p_gk, boundary_check=(0, 1))
+                    b_kg = b_k * exp2(b_gn - b_gk.to(tl.float32))
+                    b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
+                    b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
+                    b_dq2 += tl.dot(b_dAqk.to(tl.float32), b_kg.to(tl.float32), allow_tf32=False)
+                    b_dk2 += tl.dot(b_dAkk.to(tl.float32), b_kg.to(tl.float32), allow_tf32=False)
+                b_gqn = exp2(b_g - b_gn)
+                b_dq2 *= b_gqn
+                b_dk2 *= b_gqn
+            m_dA = (i_ti + o_i) < T_cur
+            o_dA = (i_ti + o_i).to(tl.int64) * HV * BT + i_i * BC
+            p_kj = k_ptr + i_ti.to(tl.int64) * H * K + o_k
+            p_gkj = g_base + i_ti.to(tl.int64) * g_row_stride + o_k
+            p_k = tl.make_block_ptr(k_ptr, (T_cur, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            if SAFE_GATE:
+                p_gn = g_base + (i_ti + min(BC // 2, T_cur - i_ti - 1)).to(tl.int64) * g_row_stride + o_k
+                b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+                p_dAqk = tl.make_block_ptr(dAqk_ptr, (T_cur, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+                p_dAkk = tl.make_block_ptr(dAkk_ptr, (T_cur, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+                b_dAqk_diag = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
+                b_dAkk_diag = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+                m_i_diag = (o_i[:, None] >= o_i[None, :]) & (
+                    (i_ti + o_i[:, None]) < T_cur) & ((i_ti + o_i[None, :]) < T_cur)
+                m_j_diag = (i_ti + o_i[:, None]) < T_cur
+                b_dAqk_diag = tl.where(m_i_diag, b_dAqk_diag, 0.)
+                b_dAkk_diag = tl.where(m_i_diag, b_dAkk_diag, 0.)
+                b_g_diag = tl.where(m_j_diag, b_g - b_gn, 0.)
+                exp_b_g_diag = tl.where(m_j_diag, exp2(b_g_diag), 0.)
+                exp_neg_b_g_diag = tl.where(m_j_diag, exp2(-b_g_diag), 0.)
+                b_k_exp = b_k * exp_neg_b_g_diag
+                b_dq2 += tl.dot(b_dAqk_diag, b_k_exp, allow_tf32=False) * exp_b_g_diag
+                b_dk2 += tl.dot(b_dAkk_diag, b_k_exp, allow_tf32=False) * exp_b_g_diag
+            else:
+                for j in range(0, min(BC, T_cur - i_t * BT - i_i * BC)):
+                    b_dAqk = tl.load(dAqk_ptr + o_dA + j, mask=m_dA, other=0)
+                    b_dAkk = tl.load(dAkk_ptr + o_dA + j, mask=m_dA, other=0)
+                    b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
+                    b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+                    m_i = o_i[:, None] >= j
+                    b_gqk = exp2(b_g - b_gkj[None, :])
+                    b_dq2 += tl.where(m_i, b_dAqk[:, None] * b_kj[None, :] * b_gqk, 0.)
+                    b_dk2 += tl.where(m_i, b_dAkk[:, None] * b_kj[None, :] * b_gqk, 0.)
+                    p_kj += H * K
+                    p_gkj += g_row_stride
+            b_db = tl.sum(b_dk2 * b_k, 1)
+            b_dk2 *= b_b[:, None]
+            p_q = tl.make_block_ptr(q_ptr, (T_cur, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
             b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_kb = tl.load(p_k, boundary_check=(0, 1)) * b_b[:, None]
-            b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
-            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
-            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
+            p_dq = tl.make_block_ptr(dq_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_dq2 = tl.make_block_ptr(dq2_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_dk2 = tl.make_block_ptr(dk2_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_dg2 = tl.make_block_ptr(dg2_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_db = tl.make_block_ptr(db_ptr, (T_cur,), (HV,), (i_ti,), (BC,), (0,))
+            b_dg2 = b_q * b_dq2
+            b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
+            tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
 
-            o_j = i_t * BT + i_j * BC + o_i
-            m_j = o_j < T
-            b_gkn = exp2(b_gk - b_gn)
-            b_qg = b_q * tl.where(m_j[:, None], b_gkn, 0)
-            b_kbg = b_kb * tl.where(m_j[:, None], b_gkn, 0)
-            b_dkt += tl.dot(b_dAqk, b_qg, allow_tf32=False)
-            b_dkt += tl.dot(b_dAkk, b_kbg, allow_tf32=False)
-        b_dkt *= exp2(b_gn - b_g)
 
-    o_dA = i_ti * HV * BT + i_i * BC + o_i
-    p_qj = q + i_ti * H * K + o_k
-    p_kj = k + i_ti * H * K + o_k
-    p_gkj = g + i_ti * HV * K + o_k
-    p_bj = beta + i_ti * HV
+@triton.jit(do_not_specialize=['T', 'NT', 'BH_TOTAL', 'task_num', 'num_core'])
+def chunk_kda_bwd_kernel_intra_dkt_future_npu(
+    q, k, g, beta, dAqk, dAkk, dkt_part,
+    cu_seqlens, chunk_indices, T, NT, BH_TOTAL, task_num, num_core,
+    H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr, BT: tl.constexpr,
+    BC: tl.constexpr, BK: tl.constexpr, NC: tl.constexpr, NC_FUT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    G_T_CONTIG: tl.constexpr, BETA_T_CONTIG: tl.constexpr,
+):
+    core_id = tl.program_id(0)
+    g_row_stride = _bwd_intra_g_row_stride(G_T_CONTIG, HV, K)
+    beta_row_stride = _bwd_intra_beta_row_stride(BETA_T_CONTIG, HV)
+    o_i = tl.arange(0, BC)
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_bh = task_id % BH_TOTAL
+        rem = task_id // BH_TOTAL
+        i_t = rem % NT
+        i_kc = rem // NT
+        i_b, i_hv = i_bh // HV, i_bh % HV
+        i_h = i_hv // (HV // H)
+        i_k, i_i = i_kc // NC_FUT, i_kc % NC_FUT
+        T_seq = T
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        else:
+            bos = tl.cast(i_b, tl.int64) * T
+            eos = bos + T
+        T_cur = (eos - bos).to(tl.int32)
+        i_ti = i_t * BT + i_i * BC
+        if i_ti < T_cur:
+            q_ptr = q + (bos * H + i_h).to(tl.int64) * K
+            k_ptr = k + (bos * H + i_h).to(tl.int64) * K
+            g_base = _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN, G_T_CONTIG)
+            beta_base = _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN, BETA_T_CONTIG)
+            dAqk_ptr = dAqk + (bos * HV + i_hv).to(tl.int64) * BT
+            dAkk_ptr = dAkk + (bos * HV + i_hv).to(tl.int64) * BT
+            dkt_part_ptr = dkt_part + (bos * HV + i_hv).to(tl.int64) * K
+            nc_eff = min(NC, tl.cdiv(T_cur - i_t * BT, BC))
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            p_g = _bwd_intra_g_block_ptr(g_base, T_cur, i_ti, i_k * BK, BC, BK, g_row_stride, K)
+            b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+            b_dkt = tl.zeros([BC, BK], dtype=tl.float32)
+            if i_i < nc_eff - 1:
+                p_gn = g_base + (min(i_ti + BC, T_cur) - 1).to(tl.int64) * g_row_stride + o_k
+                b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+                for i_j in range(i_i + 1, nc_eff):
+                    p_q = tl.make_block_ptr(q_ptr, (T_cur, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+                    p_kj = tl.make_block_ptr(k_ptr, (T_cur, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+                    p_gk = _bwd_intra_g_block_ptr(g_base, T_cur, i_t * BT + i_j * BC, i_k * BK, BC, BK, g_row_stride, K)
+                    p_bj = tl.make_block_ptr(beta_base, (T_cur,), (beta_row_stride,), (i_t * BT + i_j * BC,), (BC,), (0,))
+                    p_dAqk = tl.make_block_ptr(dAqk_ptr, (T_cur, BT), (HV * BT, 1),
+                                               (i_t * BT + i_j * BC, i_i * BC), (BC, BC), (1, 0))
+                    p_dAkk = tl.make_block_ptr(dAkk_ptr, (T_cur, BT), (HV * BT, 1),
+                                               (i_t * BT + i_j * BC, i_i * BC), (BC, BC), (1, 0))
+                    b_bj = tl.load(p_bj, boundary_check=(0,))
+                    b_qj = tl.load(p_q, boundary_check=(0, 1))
+                    b_kj = tl.load(p_kj, boundary_check=(0, 1))
+                    b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+                    b_dAqk = tl.trans(tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32))
+                    b_dAkk = tl.trans(tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32))
+                    o_j = i_t * BT + i_j * BC + o_i
+                    m_j = o_j < T_cur
+                    b_gkn = exp2(b_gk - b_gn)
+                    b_qg = b_qj * tl.where(m_j[:, None], b_gkn, 0)
+                    b_kbg = b_kj * b_bj[:, None] * tl.where(m_j[:, None], b_gkn, 0)
+                    b_dkt += tl.dot(b_dAqk, b_qg.to(tl.float32), allow_tf32=False)
+                    b_dkt += tl.dot(b_dAkk, b_kbg.to(tl.float32), allow_tf32=False)
+                b_dkt *= exp2(b_gn - b_g)
+            p_dkt_part = tl.make_block_ptr(dkt_part_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_dkt_part, b_dkt.to(p_dkt_part.dtype.element_ty), boundary_check=(0, 1))
 
-    if SAFE_GATE:
-        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + o_k
-        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
-        p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
-        b_b = tl.load(p_b, boundary_check=(0,))
 
-        p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV * BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV * BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
-        b_dAqk_diag_kk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
-        b_dAkk_diag_kk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
-
-        m_i_diag_kk = (o_i[:, None] <= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
-        m_j_diag_kk = (i_ti + o_i[:, None]) < T
-
-        b_dAqk_diag_kk = tl.where(m_i_diag_kk, b_dAqk_diag_kk, 0.)
-        b_dAkk_diag_kk = tl.where(m_i_diag_kk, b_dAkk_diag_kk, 0.)
-        b_g_diag_kk = tl.where(m_j_diag_kk, b_g - b_gn, 0.)
-        exp_b_g_diag_kk = tl.where(m_j_diag_kk, exp2(b_g_diag_kk), 0.)
-        exp_neg_b_g_diag_kk = tl.where(m_j_diag_kk, exp2(-b_g_diag_kk), 0.)
-
-        b_q_exp = b_q * exp_b_g_diag_kk
-        b_kb_exp = b_k * b_b[:, None] * exp_b_g_diag_kk
-
-        b_dkt += tl.dot(b_dAqk_diag_kk, b_q_exp, allow_tf32=False) * exp_neg_b_g_diag_kk
-        b_dkt += tl.dot(b_dAkk_diag_kk, b_kb_exp, allow_tf32=False) * exp_neg_b_g_diag_kk
-    else:
-        for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
-            b_dAqk = tl.load(dAqk + o_dA + j * HV * BT)
-            b_dAkk = tl.load(dAkk + o_dA + j * HV * BT)
-            b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
-            b_kbj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32) * tl.load(p_bj)
-            b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
-            m_i = o_i[:, None] <= j
-            b_gkq = exp2(b_gkj[None, :] - b_g)
-            b_dkt += tl.where(m_i, b_dAqk[:, None] * b_qj[None, :] * b_gkq, 0.)
-            b_dkt += tl.where(m_i, b_dAkk[:, None] * b_kbj[None, :] * b_gkq, 0.)
-
-            p_qj += H * K
-            p_kj += H * K
-            p_gkj += HV * K
-            p_bj += HV
-
-    p_dk = tl.make_block_ptr(dk, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dk2 = tl.make_block_ptr(dk2, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg = tl.make_block_ptr(dg, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-    p_dg2 = tl.make_block_ptr(dg2, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
-
-    b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, boundary_check=(0, 1))
-    b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
-    b_dk2 += b_dkt
-
-    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+@triton.jit(do_not_specialize=['T', 'NT', 'BH_TOTAL', 'task_num', 'num_core'])
+def chunk_kda_bwd_kernel_intra_dk_dg_npu(
+    q, k, g, beta, dAqk, dAkk, dk, dk2, dg, dg2, dkt_part,
+    cu_seqlens, chunk_indices, T, NT, BH_TOTAL, task_num, num_core,
+    H: tl.constexpr, HV: tl.constexpr, K: tl.constexpr, BT: tl.constexpr,
+    BC: tl.constexpr, BK: tl.constexpr, NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr, SAFE_GATE: tl.constexpr,
+    G_T_CONTIG: tl.constexpr, BETA_T_CONTIG: tl.constexpr,
+):
+    core_id = tl.program_id(0)
+    g_row_stride = _bwd_intra_g_row_stride(G_T_CONTIG, HV, K)
+    beta_row_stride = _bwd_intra_beta_row_stride(BETA_T_CONTIG, HV)
+    o_i = tl.arange(0, BC)
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_bh = task_id % BH_TOTAL
+        rem = task_id // BH_TOTAL
+        i_t = rem % NT
+        i_kc = rem // NT
+        i_b, i_hv = i_bh // HV, i_bh % HV
+        i_h = i_hv // (HV // H)
+        i_k, i_i = i_kc // NC, i_kc % NC
+        T_seq = T
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        else:
+            bos = tl.cast(i_b, tl.int64) * T
+            eos = bos + T
+        T_cur = (eos - bos).to(tl.int32)
+        i_ti = i_t * BT + i_i * BC
+        if i_ti < T_cur:
+            q_ptr = q + (bos * H + i_h).to(tl.int64) * K
+            k_ptr = k + (bos * H + i_h).to(tl.int64) * K
+            g_base = _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN, G_T_CONTIG)
+            beta_base = _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN, BETA_T_CONTIG)
+            dAqk_ptr = dAqk + (bos * HV + i_hv).to(tl.int64) * BT
+            dAkk_ptr = dAkk + (bos * HV + i_hv).to(tl.int64) * BT
+            dk_ptr = dk + (bos * HV + i_hv).to(tl.int64) * K
+            dk2_ptr = dk2 + (bos * HV + i_hv).to(tl.int64) * K
+            dg_ptr = dg + (bos * HV + i_hv).to(tl.int64) * K
+            dg2_ptr = dg2 + (bos * HV + i_hv).to(tl.int64) * K
+            dkt_part_ptr = dkt_part + (bos * HV + i_hv).to(tl.int64) * K
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            p_g = _bwd_intra_g_block_ptr(g_base, T_cur, i_ti, i_k * BK, BC, BK, g_row_stride, K)
+            b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+            p_k = tl.make_block_ptr(k_ptr, (T_cur, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_b = tl.make_block_ptr(beta_base, (T_cur,), (beta_row_stride,), (i_ti,), (BC,), (0,))
+            b_b = tl.load(p_b, boundary_check=(0,))
+            p_dk2 = tl.make_block_ptr(dk2_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_dg2 = tl.make_block_ptr(dg2_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_dkt_part = tl.make_block_ptr(dkt_part_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            b_dk2 = tl.load(p_dk2, boundary_check=(0, 1)).to(tl.float32)
+            b_dg2 = tl.load(p_dg2, boundary_check=(0, 1)).to(tl.float32)
+            b_dkt = tl.load(p_dkt_part, boundary_check=(0, 1)).to(tl.float32)
+            o_dA = i_ti.to(tl.int64) * HV * BT + i_i * BC + o_i
+            p_qj = q_ptr + i_ti.to(tl.int64) * H * K + o_k
+            p_kj = k_ptr + i_ti.to(tl.int64) * H * K + o_k
+            p_gkj = g_base + i_ti.to(tl.int64) * g_row_stride + o_k
+            p_bj = beta_base + i_ti.to(tl.int64) * beta_row_stride
+            if SAFE_GATE:
+                p_gn = g_base + (i_ti + min(BC // 2, T_cur - i_ti - 1)).to(tl.int64) * g_row_stride + o_k
+                b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+                p_q = tl.make_block_ptr(q_ptr, (T_cur, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+                b_q = tl.load(p_q, boundary_check=(0, 1))
+                p_dAqk = tl.make_block_ptr(dAqk_ptr, (T_cur, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+                p_dAkk = tl.make_block_ptr(dAkk_ptr, (T_cur, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+                b_dAqk_diag = tl.trans(tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32))
+                b_dAkk_diag = tl.trans(tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32))
+                m_i_diag = (o_i[:, None] <= o_i[None, :]) & ((i_ti + o_i[:, None]) < T_cur) & ((i_ti + o_i[None, :]) < T_cur)
+                m_j_diag = (i_ti + o_i[:, None]) < T_cur
+                b_dAqk_diag = tl.where(m_i_diag, b_dAqk_diag, 0.)
+                b_dAkk_diag = tl.where(m_i_diag, b_dAkk_diag, 0.)
+                b_g_diag = tl.where(m_j_diag, b_g - b_gn, 0.)
+                exp_b_g_diag = tl.where(m_j_diag, exp2(b_g_diag), 0.)
+                exp_neg_b_g_diag = tl.where(m_j_diag, exp2(-b_g_diag), 0.)
+                b_q_exp = b_q * exp_b_g_diag
+                b_kb_exp = b_k * b_b[:, None] * exp_b_g_diag
+                b_dkt += tl.dot(b_dAqk_diag, b_q_exp, allow_tf32=False) * exp_neg_b_g_diag
+                b_dkt += tl.dot(b_dAkk_diag, b_kb_exp, allow_tf32=False) * exp_neg_b_g_diag
+            else:
+                for j in range(0, min(BC, T_cur - i_t * BT - i_i * BC)):
+                    b_dAqk = tl.load(dAqk_ptr + o_dA + j * HV * BT)
+                    b_dAkk = tl.load(dAkk_ptr + o_dA + j * HV * BT)
+                    b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
+                    b_kbj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32) * tl.load(p_bj)
+                    b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+                    m_i = o_i[:, None] <= j
+                    b_gkq = exp2(b_gkj[None, :] - b_g)
+                    b_dkt += tl.where(m_i, b_dAqk[:, None] * b_qj[None, :] * b_gkq, 0.)
+                    b_dkt += tl.where(m_i, b_dAkk[:, None] * b_kbj[None, :] * b_gkq, 0.)
+                    p_qj += H * K
+                    p_kj += H * K
+                    p_gkj += g_row_stride
+                    p_bj += beta_row_stride
+            p_dk = tl.make_block_ptr(dk_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            p_dg = tl.make_block_ptr(dg_ptr, (T_cur, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+            b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, boundary_check=(0, 1))
+            b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
+            b_dk2 += b_dkt
+            tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
 
 
 @input_guard
@@ -995,56 +1097,107 @@ def chunk_kda_bwd_intra_npu(
 ):
     B, T, H, K, HV = *k.shape, g.shape[2]
     BT = chunk_size
-    BC = min(_BC, BT)
-    BK = _get_bwd_intra_bk(K)
+    BC = min(_BWD_INTRA_BC, BT)
+    # dq_db writes past+diag into fp32 dk2/dg2; tile for fp32 I/O even if dq is bf16.
+    elem = max(dq.element_size(), 4)
+    BK = _get_bwd_intra_bk(K, BC, element_size=elem)
+    BK_dk = _get_bwd_intra_bk_dk(K, BC, element_size=elem)
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
     NK = triton.cdiv(K, BK)
+    NK_dk = triton.cdiv(K, BK_dk)
     is_varlen = cu_seqlens is not None
+    g_arg, g_t_contig = _gk_npu_arg(g, HV)
+    beta_arg, beta_t_contig = _hv_t_npu_arg(beta, HV)
 
     dq2 = torch.empty_like(dq)
-    dk2 = torch.empty_like(dk)
-    db2 = beta.new_empty(NK, *beta.shape, dtype=torch.float)
+    # Stream-ordered: dq_db writes past+diag here; dk_dg loads then stores in place.
+    # fp32 until the final store so dkt is fused without an intermediate bf16 round.
+    dk2 = torch.empty_like(dk, dtype=torch.float)
     dg2 = torch.empty_like(dg, dtype=torch.float)
+    # Last subchunk has no future blocks; keep zeros and skip those tasks.
+    dkt_part = torch.zeros_like(dk, dtype=torch.float)
+    db2 = beta.new_empty(NK, *beta.shape, dtype=torch.float)
 
-    _launch_bwd_intra_kernel(
-        chunk_kda_bwd_kernel_intra_npu,
-        nk_nc=NK * NC,
-        nt=NT,
-        bh_total=B * HV,
+    bh_total = B * HV
+    task_num = NK * NC * NT * bh_total
+    nc_fut = max(NC - 1, 1)
+    task_num_fut = NK * nc_fut * NT * bh_total
+    task_num_dk = NK_dk * NC * NT * bh_total
+    common_launch = dict(
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        NT=NT,
+        BH_TOTAL=bh_total,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+        BK=BK,
+        NC=NC,
+        IS_VARLEN=is_varlen,
+        G_T_CONTIG=g_t_contig,
+        BETA_T_CONTIG=beta_t_contig,
+    )
+
+    _launch_bwd_intra_core_grid(
+        chunk_kda_bwd_kernel_intra_dq_db_npu,
+        task_num=task_num,
         kernel_kwargs=dict(
             q=q,
             k=k,
-            g=g,
-            beta=beta,
+            g=g_arg,
+            beta=beta_arg,
             dAqk=dAqk,
             dAkk=dAkk,
             dq=dq,
             dq2=dq2,
+            dk2=dk2,
+            dg2=dg2,
+            db=db2,
+            B=B,
+            SAFE_GATE=safe_gate,
+            **common_launch,
+        ),
+    )
+    if NC > 1:
+        _launch_bwd_intra_core_grid(
+            chunk_kda_bwd_kernel_intra_dkt_future_npu,
+            task_num=task_num_fut,
+            kernel_kwargs=dict(
+                q=q,
+                k=k,
+                g=g_arg,
+                beta=beta_arg,
+                dAqk=dAqk,
+                dAkk=dAkk,
+                dkt_part=dkt_part,
+                NC_FUT=nc_fut,
+                **common_launch,
+            ),
+        )
+    _launch_bwd_intra_core_grid(
+        chunk_kda_bwd_kernel_intra_dk_dg_npu,
+        task_num=task_num_dk,
+        kernel_kwargs=dict(
+            q=q,
+            k=k,
+            g=g_arg,
+            beta=beta_arg,
+            dAqk=dAqk,
+            dAkk=dAkk,
             dk=dk,
             dk2=dk2,
             dg=dg,
             dg2=dg2,
-            db=db2,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            B=B,
-            T=T,
-            H=H,
-            HV=HV,
-            K=K,
-            BT=BT,
-            BC=BC,
-            BK=BK,
-            NC=NC,
-            IS_VARLEN=is_varlen,
+            dkt_part=dkt_part,
             SAFE_GATE=safe_gate,
-            NKNC_OFFSET=0,
-            NT_OFFSET=0,
-            BH_OFFSET=0,
+            **{**common_launch, 'BK': BK_dk},
         ),
     )
     dq = dq2


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->

Refactor KDA chunk intra backward on Ascend NPU: split the original monolithic chunk_kda_bwd_kernel_intra_npu into three independent kernels based on debug_barrier, and adopt a 1D AICore task loop to increase BC/BK, reduce Cube tile counts and host launch overhead.

Kernel Splitting (split by UB peak value with independent tiling for each)
• chunk_kda_bwd_kernel_intra_dq_db_npu: past + diag path, writes dq / db, and spills dk_part / dg_part to workspace
• chunk_kda_bwd_kernel_intra_dkt_future_npu: dkt for future subchunks; skip directly for the last chunk which has no future
• chunk_kda_bwd_kernel_intra_dk_dg_npu: diag path + accumulation of dk_part / dkt_part, outputs dk / dg

Scheduling
• Replace 3D grid plus sliced launch on host side with _KDA_BWD_INTRA_LAUNCH_BLOCK_BUDGET, using grid=(num_aicore,) + tl.range(core_id, task_num, num_core)
• Single launch covers all NK × NC × NT × B × HV tasks, remove the 4096‑block budget loop

Tiling (chunk_size=64, D=256, bf16)
• BC 16 → 32: NC 4 → 2; pair‑block of dkt_future drops from 6 to 1; Cube tile changes from 16×16 to 32×32
• dq_db: mem_mult=9, maximum BK=128 (NK 4 → 2)
• dk_dg: smaller live set, mem_mult=4.5, maximum BK=256 (NK=1)
• dkt_future keeps BK=128: BK=256 passes compilation but triggers UB address OOB at runtime
• fp32 I/O caps BK upper limit to 32 to prevent UB overflow on the SAFE_GATE diag path

Memory Layout
• Transpose g / beta to [B, HV, T, …] when HV > 1 for stride‑1 load along T
• Use int64 for pointers to avoid cu_seqlens overflow under varlen scenarios
• Rebind local pointers for each task (q_ptr = q + …) to circumvent incorrect compilation of ptr += in Ascend Triton

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->
hardware: Atlas 800T A3(X86)
FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules tests/ops/utils tests/ops/test_gdn_kernels.py tests/ops/test_gdn.py tests/ops/test_kda.py tests/ops/test_attnres.py tests/ops/test_solve_tril.py
<img width="1208" height="360" alt="c9c95b2c2a2f0a848de739c497608e99" src="https://github.com/user-attachments/assets/0c99a858-5a2b-4778-aa6a-8030830a8583" />


## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
<img width="1154" height="694" alt="image" src="https://github.com/user-attachments/assets/aae8b097-1f8a-4a32-a29d-d915f0b788cd" />


## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->
None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
