### PR TITLE
[Fix] Keep GDN eval gradients on chunk kernel

### DIFF
--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -233,8 +233,12 @@ class GatedDeltaNet(nn.Module):
             )
 
         batch_size, q_len, _ = hidden_states.shape
-        # change to inference mode.
-        mode = 'fused_recurrent' if (q_len <= 64 and not self.training) else self.mode
+        if torch.is_grad_enabled():
+            mode = 'chunk'
+        elif q_len <= 64 and not self.training:
+            mode = 'fused_recurrent'
+        else:
+            mode = self.mode
         if self.training:
             assert mode == 'chunk', "Only chunk mode is supported in training."
 

--- a/tests/layers/test_gated_deltanet.py
+++ b/tests/layers/test_gated_deltanet.py
@@ -14,6 +14,30 @@ from fla.layers.gated_deltanet import GatedDeltaNet
 from fla.utils import assert_close, device
 
 
+@pytest.mark.parametrize('mode', ['chunk', 'fused_recurrent'])
+def test_gated_deltanet_eval_with_grad_uses_chunk(mode: str):
+    torch.manual_seed(42)
+    layer = GatedDeltaNet(
+        hidden_size=512,
+        head_dim=64,
+        num_heads=6,
+        expand_v=2,
+        mode=mode,
+    ).to(device=device, dtype=torch.bfloat16).eval()
+    x = torch.randn(1, 32, 512, device=device, dtype=torch.bfloat16, requires_grad=True)
+
+    with mock.patch(
+        'fla.layers.gated_deltanet.fused_recurrent_gated_delta_rule',
+        side_effect=AssertionError("eval with autograd must not use the forward-only fused recurrent kernel"),
+    ) as fused_recurrent:
+        y = layer(x)[0]
+        y.sum().backward()
+
+    fused_recurrent.assert_not_called()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+
+
 @pytest.mark.parametrize(
     ('B', 'T', 'D', 'dtype'),
     [

--- a/tests/models/test_modeling_base.py
+++ b/tests/models/test_modeling_base.py
@@ -70,6 +70,7 @@ def run_test_model_forward_backward(
 # ===================================================================================
 # BASE TEST FOR GENERATION (K/V CACHE)
 # ===================================================================================
+@torch.no_grad()
 def run_test_generation(
     L: int,
     B: int,


### PR DESCRIPTION
## Summary

Make GatedDeltaNet dispatch to the backward-capable chunk kernel whenever autograd is enabled. This prevents short sequences in `.eval()` mode from selecting the forward-only fused recurrent kernel, including when the layer is explicitly configured with `mode="fused_recurrent"`.

Add a regression test covering short eval sequences with gradients for both configured modes. Also mark the shared generation test helper with `torch.no_grad()` so generation tests continue to exercise the intended inference dispatch without retaining autograd graphs.

The root cause was using the module's `training` flag as a proxy for whether backward could be requested, even though `.eval()` does not disable autograd.

## Test plan

- `pytest tests/layers/test_gated_deltanet.py -q` — 5 passed
- Dependent layer/model suite from `scripts/find_dependent_tests.py fla/layers/gated_deltanet.py` — 266 non-generation tests passed, 6 skipped
- `pytest tests/models/test_modeling_gated_deltanet.py tests/models/test_modeling_yoco.py -k generation -q` — 3 passed, 1 skipped
- `pre-commit run --files fla/layers/gated_deltanet.py tests/layers/test_gated_deltanet.py tests/models/test_modeling_base.py` — passed

## Benchmark / NCU (kernel changes only)

Not applicable; no kernel implementation or numerical behavior changed.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). No kernel changes are included in this PR.