### PR TITLE
[GDN] Allow passing pre-computed chunk_indices to chunk_gated_delta_rule

### DIFF
--- a/fla/ops/gated_delta_rule/chunk.py
+++ b/fla/ops/gated_delta_rule/chunk.py
@@ -268,6 +268,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         state_v_first: bool = False,
         cu_seqlens: torch.LongTensor | None = None,
         cu_seqlens_cpu: torch.LongTensor | None = None,
+        chunk_indices: torch.LongTensor | None = None,
         use_qk_l2norm_in_kernel: bool = False,
         use_gate_in_kernel: bool = False,
         A_log: torch.Tensor | None = None,
@@ -286,8 +287,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         if use_beta_sigmoid_in_kernel:
             beta = fused_beta_sigmoid(beta_raw, scale=2.0 if allow_neg_eigval else 1.0)
 
-        chunk_indices = None
-        if cu_seqlens is not None:
+        if chunk_indices is None and cu_seqlens is not None:
             chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size, cu_seqlens_cpu=cu_seqlens_cpu)
         g, o, A, final_state, initial_state, g_input = chunk_gated_delta_rule_fwd(
             q=q,
@@ -387,7 +387,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             db = fused_beta_sigmoid_bwd(beta_raw, db, scale=2.0 if ctx.allow_neg_eigval else 1.0)
         return (
             dq.to(q), dk.to(k), dv.to(v), dg.to(g), db.to(beta_raw),
-            None, dh0, None, None, None, None, None, None, dA_log, ddt_bias,
+            None, dh0, None, None, None, None, None, None, None, dA_log, ddt_bias,
             None, None, None, None,
         )
 
@@ -409,6 +409,7 @@ def chunk_gated_delta_rule(
     state_v_first: bool = False,
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
     cp_context: FLACPContext | None = None,
     **kwargs,
 ):
@@ -463,6 +464,9 @@ def chunk_gated_delta_rule(
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
+        chunk_indices (Optional[torch.LongTensor]):
+            Pre-computed chunk indices for variable-length inputs.
+            If provided, they are used directly instead of being computed from `cu_seqlens`. Default: `None`.
         cp_context (Optional[FLACPContext]):
             Context parallel context for distributed training across multiple devices.
             When provided, `initial_state` and `output_final_state` are not supported,
@@ -576,6 +580,7 @@ def chunk_gated_delta_rule(
         state_v_first,
         cu_seqlens,
         cu_seqlens_cpu,
+        chunk_indices,
         use_qk_l2norm_in_kernel,
         use_gate_in_kernel,
         A_log,


### PR DESCRIPTION
## Summary

`chunk_gated_delta_rule` now accepts an optional `chunk_indices` argument, consistent with `causal_conv1d`. Callers that already know the chunk indices (e.g. a fixed `cu_seqlens` reused across layers) can compute them once and pass them in, instead of having every forward recompute them via `prepare_chunk_indices`. Pure API plumbing: all kernel-level functions on every backend (Triton, TileLang, triton-ascend) already accept `chunk_indices` and only compute it when not given. The FlashQLA whole-op backend receives it via `**kwargs` and ignores it — correct results, just no speedup on that path.

Closes #1127

## Test plan

- No new tests: opt-in pass-through only. The default path (`chunk_indices=None`) is unchanged and covered by the existing varlen tests in `tests/ops/test_gdn.py` (`test_chunk_varlen`, `test_chunk_varlen_prefill`).
- Verified locally: `ruff check` clean, import/signature smoke (arg lands at the expected position), forward arg count matches backward return count.
- Dependent tests (via `scripts/find_dependent_tests.py`): `test_gdn.py`, `test_gdn_kernels.py`, `test_delta_product.py`, `test_gdp.py`, GDN layer/model tests — covered by CI.

## Benchmark / NCU

N/A — no kernel change. The benefit is caller-side: skipping redundant `prepare_chunk_indices` calls (the issue reporter measured a 25% speedup in their project).

## Breaking changes

None. New optional keyword argument; default behavior unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
