### PR TITLE
[Fix] Correct the head-major addressing of the cumsum kernels under `cu_seqlens`

### DIFF
--- a/fla/ops/utils/cumsum.py
+++ b/fla/ops/utils/cumsum.py
@@ -50,15 +50,18 @@ def chunk_local_cumsum_scalar_kernel(
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        # heads of the packed sequence stride by the total length, not by the segment length
+        boh = i_h * T + bos
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
+        boh = bos * H + i_h * T
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     if HEAD_FIRST:
-        p_s = s + bos*H + i_h*T + o_t
-        p_o = o + bos*H + i_h*T + o_t
+        p_s = s + boh + o_t
+        p_o = o + boh + o_t
     else:
         p_s = s + bos*H + i_h + o_t * H
         p_o = o + bos*H + i_h + o_t * H
@@ -109,16 +112,19 @@ def chunk_local_cumsum_vector_kernel(
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        # heads of the packed sequence stride by the total length, not by the segment length
+        boh = i_h * T + bos
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
+        boh = bos * H + i_h * T
 
     o_t = i_t * BT + tl.arange(0, BT)
     o_s = i_s * BS + tl.arange(0, BS)
     m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
     if HEAD_FIRST:
-        p_s = s + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
-        p_o = o + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
+        p_s = s + boh*S + o_t[:, None] * S + o_s[None, :]
+        p_o = o + boh*S + o_t[:, None] * S + o_s[None, :]
     else:
         p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
         p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
@@ -166,8 +172,11 @@ def chunk_global_cumsum_scalar_kernel(
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        # heads of the packed sequence stride by the total length, not by the segment length
+        boh = i_h * T + bos
     else:
         bos, eos = i_n * T, i_n * T + T
+        boh = bos * H + i_h * T
     T = eos - bos
 
     b_z = tl.zeros([], dtype=tl.float32)
@@ -177,8 +186,8 @@ def chunk_global_cumsum_scalar_kernel(
         o_t = i_t * BT + tl.arange(0, BT)
         m_t = o_t < T
         if HEAD_FIRST:
-            p_s = s + bos*H + i_h*T + o_t
-            p_o = o + bos*H + i_h*T + o_t
+            p_s = s + boh + o_t
+            p_o = o + boh + o_t
         else:
             p_s = s + bos*H + i_h + o_t * H
             p_o = o + bos*H + i_h + o_t * H
@@ -230,8 +239,11 @@ def chunk_global_cumsum_vector_kernel(
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        # heads of the packed sequence stride by the total length, not by the segment length
+        boh = i_h * T + bos
     else:
         bos, eos = i_n * T, i_n * T + T
+        boh = bos * H + i_h * T
     T = eos - bos
 
     b_z = tl.zeros([BS], dtype=tl.float32)
@@ -242,8 +254,8 @@ def chunk_global_cumsum_vector_kernel(
         o_s = i_s * BS + tl.arange(0, BS)
         m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
         if HEAD_FIRST:
-            p_s = s + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
-            p_o = o + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
+            p_s = s + boh*S + o_t[:, None] * S + o_s[None, :]
+            p_o = o + boh*S + o_t[:, None] * S + o_s[None, :]
         else:
             p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
             p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]

--- a/tests/ops/utils/test_cumsum.py
+++ b/tests/ops/utils/test_cumsum.py
@@ -247,3 +247,44 @@ def test_local_cumsum_varlen(
     ], 1)
     tri = chunk_local_cumsum(s, chunk_size=C, cu_seqlens=cu_seqlens)
     assert_close('local_cumsum', ref, tri, 1e-3)
+
+
+@pytest.mark.parametrize(
+    ('H', 'C', 'D', 'cu_seqlens', 'dtype'),
+    [
+        pytest.param(*test, id="H{}-C{}-D{}-cu_seqlens{}-{}".format(*test))
+        for test in [
+            (1, 16, 60, [0, 100, 300], torch.float),
+            (2, 16, 60, [0, 100, 300], torch.float),
+            (3, 64, 100, [0, 256, 500, 1000], torch.float),
+            (4, 64, 256, [0, 15, 100, 300, 1200, 2000], torch.float),
+        ]
+    ],
+)
+@pytest.mark.skipif(
+    os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
+    reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set',
+)
+def test_cumsum_varlen_head_first(
+    H: int,
+    C: int,
+    D: int,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+):
+    # head-major input must give the same result as the default layout on its transpose
+    torch.manual_seed(42)
+    T = cu_seqlens[-1]
+    cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+    for shape in ((1, H, T), (1, H, T, D)):
+        s = torch.randn(*shape, dtype=dtype).to(device)
+        st = s.transpose(1, 2).contiguous()
+
+        ref = chunk_local_cumsum(st, chunk_size=C, cu_seqlens=cu_seqlens).transpose(1, 2)
+        tri = chunk_local_cumsum(s, chunk_size=C, cu_seqlens=cu_seqlens, head_first=True)
+        assert_close('local_cumsum', ref, tri, 1e-3)
+
+        ref = chunk_global_cumsum(st, cu_seqlens=cu_seqlens).transpose(1, 2)
+        tri = chunk_global_cumsum(s, cu_seqlens=cu_seqlens, head_first=True)
+        assert_close('global_cumsum', ref, tri, 1e-3)


### PR DESCRIPTION
## Summary

All four cumsum kernels build the head-major base as `(bos * H + i_h * T) * S`, which is `((i_b * H + i_h) * T) * S` and correct in the dense case but wrong in the packed one: `T` has just been rebound to the segment length, and `bos` is a token offset into a single packed sequence of `T_total` tokens, so head `i_h`'s copy of token `bos` sits at `(i_h * T_total + bos) * S`. `head_first` is public on `chunk_local_cumsum`, `chunk_global_cumsum` and their four scalar/vector entry points with nothing guarding it against `cu_seqlens`, so output is silently wrong for every head above 0 whenever there is more than one segment — unnoticed because no in-tree caller and no test passes `head_first=True`, and because the wrong expression coincides with the right one at `H = 1` and for a single whole-tensor segment.

Fixes #1136.

- Each kernel computes the head base `boh` in the branch that already knows which layout it is in: `i_h * T + bos` in the packed branch (before `T` is rebound to the segment length), `bos * H + i_h * T` in the dense branch. The `HEAD_FIRST` pointers use `boh`; the `head_first=False` pointers are untouched.

`head_first` has been removed from 24 other public ops in `fla/ops/**`, which would be the other way to close this — deleting the branch instead of repairing it. Happy to redo the PR that way if that is the direction you want; this version keeps the API working.

## Test plan

- `python scripts/find_dependent_tests.py fla/ops/utils/cumsum.py` → `tests/ops/utils/test_cumsum.py` plus 54 op/model/CP suites. `tests/ops/utils/test_cumsum.py` on a B200: 35 passed in 9 min 40 s (31 before this PR, 4 new). The 54 downstream suites all call cumsum with the default `head_first=False`, and that branch is byte-identical — the dense `head_first=True` path is unchanged too, so only the packed head-major branch behaves differently.
- New `test_cumsum_varlen_head_first`: for both ops and both the scalar and vector shapes, a head-major tensor through `head_first=True` must equal the default `head_first=False` path on its transpose. Parametrized over `H` in {1, 2, 3, 4} and packings with 2, 3 and 5 segments. Reverting the kernel changes alone makes 3 of the 4 cases fail — the `H = 1` case still passes, which is the point: that is where the wrong expression happens to coincide with the right one.
- The existing suite could not see this: `tests/ops/utils/test_cumsum.py` never passes `head_first=True`, so the whole branch was untested.
- Max abs error of `head_first=True` against the default path at `[1, H, 16, 8]`, `chunk_size=4`:

| op | H | cu_seqlens | before | after |
|---|---|---|---|---|
| local | 2 | [0, 5, 11, 16] | 3.6404 | 0.0000 |
| local | 3 | [0, 5, 11, 16] | 3.6404 | 0.0000 |
| global | 2 | [0, 4, 16] | 6.4411 | 0.0000 |
| global | 3 | [0, 5, 11, 16] | 3.9556 | 0.0000 |
| either | 1 | any | 0.0000 | 0.0000 |

## Benchmark / NCU

`triton.testing.do_bench` on an NVIDIA B200, fp32, `chunk_size=64`; dense `[4, 4096, 8, 128]`, varlen `[1, 16384, 8, 128]` with `cu_seqlens=[0, 3000, 7001, 11002, 16384]`. Autotune paid outside the timed region, min of 5 `do_bench` calls, two interleaved before/after rounds:

| workload | before | after |
|---|---|---|
| local, dense, head_first=0 | 26.8 / 26.8 us | 26.8 / 26.8 us |
| local, dense, head_first=1 | 26.6 / 26.7 us | 26.7 / 26.7 us |
| local, varlen, head_first=0 | 28.8 / 28.8 us | 28.8 / 28.8 us |
| local, varlen, head_first=1 | 28.7 / 28.7 us | 28.3 / 28.3 us |
| global, dense, head_first=0 | 77.8 / 77.8 us | 77.8 / 77.8 us |
| global, dense, head_first=1 | 74.8 / 74.8 us | 75.0 / 74.9 us |
| global, varlen, head_first=0 | 98.5 / 98.6 us | 98.6 / 98.6 us |
| global, varlen, head_first=1 | 96.0 / 96.0 us | 95.6 / 95.7 us |

Neutral everywhere (the two head-major varlen rows come out marginally faster, the rest are unchanged). The head base is one integer expression hoisted out of the pointer arithmetic; the `head_first=False` path drops it entirely.

## Breaking changes

None. `head_first=False` — every in-tree call — is untouched, and the dense `head_first=True` path is bit-identical.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

## Environment

- Commit base: 033b19e8 (main)
- GPU: NVIDIA B200 (sm_100), driver CUDA 13.2
- torch 2.13.0+cu130, triton 3.7.1, Python 3.12
