### PR TITLE
[Fix] Honor the real layouts of `y` and `dy` in `compute_dh0_kernel`

### DIFF
--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -432,6 +432,7 @@ def compute_dh0_kernel(
     cu_seqlens,
     stride_dy_n,
     stride_dy_t,
+    stride_dy_d,
     T,
     D: tl.constexpr,
     W: tl.constexpr,
@@ -474,15 +475,16 @@ def compute_dh0_kernel(
                 w_idx = i_w - 1 - t
 
                 # Load dy[t, :] relative to dy_base
-                p_dy = dy_base + t * stride_dy_t + o_d
+                p_dy = dy_base + t * stride_dy_t + o_d * stride_dy_d
                 m_t = (t < seq_len) & m_d
                 b_dy = tl.load(p_dy, mask=m_t, other=0).to(tl.float32)
 
                 if USE_ACTIVATION:
+                    # `y` is recomputed contiguous [*, T, D]; only `dy` may carry other strides
                     if IS_VARLEN:
-                        p_y = y + bos * stride_dy_t + t * stride_dy_t + o_d
+                        p_y = y + bos * D + t * D + o_d
                     else:
-                        p_y = y + tl.cast(i_n, tl.int64) * stride_dy_n + t * stride_dy_t + o_d
+                        p_y = y + tl.cast(i_n, tl.int64) * T * D + t * D + o_d
                     b_y = tl.load(p_y, mask=m_t, other=0).to(tl.float32)
                     b_ys = tl.sigmoid(b_y)
                     b_dy = b_dy * b_ys * (1 + b_y * (1 - b_ys))

--- a/fla/modules/conv/triton/ops.py
+++ b/fla/modules/conv/triton/ops.py
@@ -120,9 +120,8 @@ def compute_dh0_triton(
     grid = (triton.cdiv(D, BD) * N,)
 
     y_to_pass = y if activation in ('swish', 'silu') else None
-    # dy is [B, T, D], stride_n = T*D, stride_t = D
-    stride_dy_n = dy.stride(0)
-    stride_dy_t = dy.stride(1)
+    # dy is [B, T, D] but may be a strided view; `y` is always contiguous
+    stride_dy_n, stride_dy_t, stride_dy_d = dy.stride()
 
     compute_dh0_kernel[grid](
         dy=dy,
@@ -132,6 +131,7 @@ def compute_dh0_triton(
         cu_seqlens=cu_seqlens,
         stride_dy_n=stride_dy_n,
         stride_dy_t=stride_dy_t,
+        stride_dy_d=stride_dy_d,
         T=T,
         D=D,
         W=W,

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -1488,19 +1488,22 @@ def test_conv_non_contiguous_dy(B, T, D, W, activation, dtype):
 
     weight = torch.randn(D, W, device=device, dtype=dtype).requires_grad_(True)
     weight_ref = weight.detach().clone().requires_grad_(True)
+    h0 = torch.randn(B, D, W, device=device, dtype=dtype)
+    h0_ref = h0.clone().requires_grad_(True)
 
     # --- Reference: contiguous path ---
     x_ref = torch.randn(B, T, D, device=device, dtype=dtype, requires_grad=True)
-    y_ref, _ = causal_conv1d(x_ref, weight_ref, activation=activation)
+    y_ref, _ = causal_conv1d(x_ref, weight_ref, initial_state=h0_ref, activation=activation)
     dy = torch.randn_like(y_ref)
     y_ref.backward(dy)
 
     # --- Test: non-contiguous dy via cat/split pattern ---
     x_test = x_ref.detach().clone().requires_grad_(True)
     weight_test = weight.detach().clone().requires_grad_(True)
+    h0_test = h0.clone().requires_grad_(True)
 
     # Forward through conv
-    y_test, _ = causal_conv1d(x_test, weight_test, activation=activation)
+    y_test, _ = causal_conv1d(x_test, weight_test, initial_state=h0_test, activation=activation)
 
     # Simulate non-contiguous dy: cat into [B, T, 3D] then split back
     dummy = torch.zeros_like(dy)
@@ -1514,3 +1517,21 @@ def test_conv_non_contiguous_dy(B, T, D, W, activation, dtype):
 
     assert_close(" dx", x_ref.grad, x_test.grad, 1e-3)
     assert_close(" dw", weight_ref.grad, weight_test.grad, 1e-3)
+    assert_close("dh0", h0_ref.grad, h0_test.grad, 1e-3)
+
+    # a gradient autograd expanded, e.g. from `y.sum()`, has stride 0 in every dimension
+    x_sum = x_ref.detach().clone().requires_grad_(True)
+    weight_sum = weight.detach().clone().requires_grad_(True)
+    h0_sum = h0.clone().requires_grad_(True)
+    y_sum, _ = causal_conv1d(x_sum, weight_sum, initial_state=h0_sum, activation=activation)
+    y_sum.sum().backward()
+
+    x_ones = x_ref.detach().clone().requires_grad_(True)
+    weight_ones = weight.detach().clone().requires_grad_(True)
+    h0_ones = h0.clone().requires_grad_(True)
+    y_ones, _ = causal_conv1d(x_ones, weight_ones, initial_state=h0_ones, activation=activation)
+    y_ones.backward(torch.ones_like(y_ones))
+
+    assert_close(" dx", x_ones.grad, x_sum.grad, 1e-3)
+    assert_close(" dw", weight_ones.grad, weight_sum.grad, 1e-3)
+    assert_close("dh0", h0_ones.grad, h0_sum.grad, 1e-3)


### PR DESCRIPTION
## Summary

`compute_dh0_kernel` receives `stride_dy_n` and `stride_dy_t`, both read off `dy`, and uses them to address `y` — the recomputed pre-activation forward output, which `causal_conv1d_bwd` always allocates contiguous `[B, T, D]` — while addressing `dy`'s own last dimension with a hardcoded stride of 1. So `dh0` is silently wrong whenever `dy.stride(1) != D` (a gradient from a fused-QKV consumer) or `dy.stride(2) != 1` (anything autograd expanded, including plain `y.sum().backward()`), while `dx`, `dweight` and `dbias` stay correct because the main backward kernel already takes all three of `dy`'s strides. Both wrong addresses also leave the tensor they read: the `.sum()` case reads past a 4-byte allocation, and at a varlen training shape the `y` offset lands twice past the end of `y` and aborts the process.

Fixes #1138.

- Both `p_y` expressions use `y`'s own row pitch `D` instead of `dy`'s strides, matching every other `y` access in this file (`kernels.py:236`, `:258`, `:280`, `:295`). The varlen branch's `bos * stride_dy_t` becomes `bos * D` for the same reason.
- `compute_dh0_triton` passes `stride_dy_d` and the `dy` load uses it, as the main backward kernel does.

## Test plan

- `python scripts/find_dependent_tests.py fla/modules/conv/triton/kernels.py` → `tests/modules/test_conv.py` (plus the layer/model tests that build on it). `tests/modules/test_conv.py` on a B200: 77 passed, 26 skipped — the same counts as unmodified main.
- `test_conv_non_contiguous_dy` (added by #871) now also passes an `initial_state` and asserts `dh0`, and gains a `y.sum().backward()` case checked against `y.backward(torch.ones_like(y))`. That is exactly the gap: the test had the non-contiguous `dy` but no initial state, so `compute_dh0_triton` was never reached; `test_conv_non_contiguous_qkv` does assert `dh0`, but its `dy` is contiguous. Reverting the kernel change alone makes all four parametrizations fail — including the `activation=None` ones, which exercise only the `stride_dy_d` half.
- Max abs error against a torch autograd reference at B=2, T=8, D=16, W=4, `silu`, with an initial state (`dx`, `dweight` and `dbias` are 0.0000 in every row, before and after):

| `dy` | `dh0` before | `dh0` after |
|---|---|---|
| contiguous, stride (128, 16, 1) | 0.0000 | 0.0000 |
| row pitch `3*D`, stride (384, 48, 1) | 1.3937 | 0.0000 |
| expanded by `.sum()`, stride (0, 0, 0) | 6.7535 | 0.0000 |
| varlen `cu_seqlens=[0, 5, 11, 20]`, row pitch `3*D` | 1.7702 | 0.0000 |

- The reads are also out of bounds, not just mis-addressed. Under `compute-sanitizer --tool memcheck` with `PYTORCH_NO_CUDA_MEMORY_CACHING=1` the case above reports 122 invalid reads at `kernels.py:479` — the `.sum()` gradient's whole allocation is one 4-byte scalar — and zero with this PR. The `y` half scales with the shape: at `[1, 16384, 2048]` varlen with a `3*D`-pitched `dy`, `bos * stride_dy_t` is 67.6M elements into a 33.6M-element `y`, and `compute_dh0_triton` aborts with an illegal memory access on the first call (4 of 4 attempts on main, 0 of 3 with this PR).

## Benchmark / NCU

`triton.testing.do_bench` on an NVIDIA B200, bf16, `W = 4`, `activation='silu'` with an initial state; dense `[8, 2048, 2048]`, varlen `[1, 16384, 2048]` with `cu_seqlens=[0, 3000, 7001, 11002, 16384]`. Autotune paid outside the timed region, min of 5 `do_bench` calls, two interleaved before/after rounds (a third round is not reported: on main it died with the illegal memory access described above):

| workload | before | after |
|---|---|---|
| `compute_dh0_triton`, dense, contiguous dy | 8.6 / 8.6 us | 8.7 / 8.6 us |
| `compute_dh0_triton`, dense, dy pitch 3*D | 8.8 / 8.8 us | 8.7 / 8.6 us |
| `compute_dh0_triton`, varlen, contiguous dy | 9.5 / 9.5 us | 9.4 / 9.4 us |
| `compute_dh0_triton`, varlen, dy pitch 3*D | 9.4 / 9.4 us | 9.3 / 9.4 us |
| `causal_conv1d_bwd`, dense | 456.9 / 457.0 us | 457.5 / 457.2 us |
| `causal_conv1d_bwd`, varlen | 486.5 / 486.5 us | 487.1 / 486.4 us |

Neutral (within run-to-run spread). The change replaces one stride operand with another and adds one multiply on the `dy` column index; the kernel is a handful of `W-1` iterations over `BD = 32` lanes and is under 2% of the backward's time.

## Breaking changes

None. `dh0` becomes independent of `dy`'s layout; results for a contiguous `dy` are unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

## Environment

- Commit base: 033b19e8 (main)
- GPU: NVIDIA B200 (sm_100), driver CUDA 13.2
- torch 2.13.0+cu130, triton 3.7.1, Python 3.12
