### PR TITLE
[Fix] Correct the final-state gradient for chunks shorter than `W - 1`

### DIFF
--- a/fla/modules/conv/triton/kernels.py
+++ b/fla/modules/conv/triton/kernels.py
@@ -318,9 +318,11 @@ def causal_conv1d_bwd_kernel(
         if i_t * BT + BT >= T-W:
             start_tok = max(0, T - (W - 1))
             offset = i_t * BT + tl.arange(0, BT)
-            tok_idx = offset - start_tok
             mask = (offset >= start_tok) & (offset < T)
-            w_idx = 1 + tok_idx
+            # state slot w is token T - W + w, so token t takes dht[:, t + W - T].
+            # start_tok is clamped, which only matters for the mask (offset >= 0 anyway),
+            # so the slot index has to come from the unclamped expression.
+            w_idx = offset + (W - T)
             dht_off = i_n * D * W + o_d[None, :] * W + w_idx[:, None]
             b_dht = tl.load(dht + dht_off, mask=mask[:, None] & m_d[None, :], other=0.).to(tl.float32)
             b_dx += b_dht
@@ -421,6 +423,7 @@ def causal_conv1d_update_kernel(
 
 @triton.heuristics({
     'USE_ACTIVATION': lambda args: args['y'] is not None,
+    'USE_FINAL_STATE': lambda args: args['dht'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.jit
@@ -429,6 +432,7 @@ def compute_dh0_kernel(
     y,
     weight,
     dh0,
+    dht,
     cu_seqlens,
     stride_dy_n,
     stride_dy_t,
@@ -437,6 +441,7 @@ def compute_dh0_kernel(
     W: tl.constexpr,
     BD: tl.constexpr,
     USE_ACTIVATION: tl.constexpr,
+    USE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
     """
@@ -467,6 +472,13 @@ def compute_dh0_kernel(
     # For each i_w in [1, W), compute dh0[i_n, :, i_w]
     for i_w in tl.static_range(1, W):
         b_dh0 = tl.zeros([BD], dtype=tl.float32)
+
+        if USE_FINAL_STATE:
+            # a sequence shorter than the state leaves initial_state[:, i_w] still sitting in
+            # final_state[:, i_w - seq_len], so that slot's gradient passes straight through
+            if i_w >= seq_len:
+                p_dht = dht + i_n * D * W + o_d * W + (i_w - seq_len)
+                b_dh0 += tl.load(p_dht, mask=m_d, other=0).to(tl.float32)
 
         # Accumulate contributions from t = 0 to min(i_w, seq_len) - 1
         for t in tl.static_range(0, W - 1):

--- a/fla/modules/conv/triton/ops.py
+++ b/fla/modules/conv/triton/ops.py
@@ -104,6 +104,7 @@ def compute_dh0_triton(
     initial_state: torch.Tensor,
     activation: str | None,
     cu_seqlens: torch.Tensor | None,
+    dht: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Compute dh0 (gradient w.r.t. initial_state) using a separate Triton kernel.
@@ -129,6 +130,7 @@ def compute_dh0_triton(
         y=y_to_pass,
         weight=weight,
         dh0=dh0,
+        dht=dht,
         cu_seqlens=cu_seqlens,
         stride_dy_n=stride_dy_n,
         stride_dy_t=stride_dy_t,
@@ -239,6 +241,7 @@ def causal_conv1d_bwd(
             initial_state=initial_state,
             activation=activation,
             cu_seqlens=cu_seqlens,
+            dht=dht,
         )
 
     return dx.view(shape), dw, db, dr, dh0

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -1467,6 +1467,58 @@ def test_conv_varlen_non_contiguous_qkv(
 
 
 @pytest.mark.parametrize(
+    ('B', 'T', 'T1', 'D', 'W', 'activation', 'dtype'),
+    [
+        pytest.param(*test, id="B{0}_T{1}_T1{2}_D{3}_W{4}_activation{5}_{6}".format(*test))
+        for test in [
+            (1, 64, 1, 128, 4, "silu", torch.float32),
+            (1, 64, 2, 128, 4, "silu", torch.float32),
+            (1, 64, 3, 128, 4, "silu", torch.float32),
+            (1, 64, 8, 128, 4, "silu", torch.float32),
+            (2, 64, 1, 128, 4, None, torch.float32),
+            (2, 64, 2, 128, 4, None, torch.float32),
+            (1, 32, 1, 64, 3, "silu", torch.float32),
+        ]
+    ],
+)
+def test_conv_chunked_prefill_backward(B, T, T1, D, W, activation, dtype):
+    """Splitting a sequence into two chunks must not change its gradients.
+
+    The first chunk's final_state feeds the second chunk as its initial_state, so the
+    backward has to route the state gradient back to the tokens that produced it. That
+    routing is wrong for chunks shorter than W - 1 tokens.
+    """
+    torch.manual_seed(42)
+
+    x = torch.randn(B, T, D, device=device, dtype=dtype)
+    weight = torch.randn(D, W, device=device, dtype=dtype)
+    bias = torch.randn(D, device=device, dtype=dtype)
+    h0 = torch.randn(B, D, W, device=device, dtype=dtype)
+    dy = torch.randn(B, T, D, device=device, dtype=dtype)
+
+    def leaves():
+        return (x.clone().requires_grad_(True), weight.clone().requires_grad_(True),
+                bias.clone().requires_grad_(True), h0.clone().requires_grad_(True))
+
+    x_ref, w_ref, b_ref, h_ref = leaves()
+    y_ref, _ = causal_conv1d(x_ref, w_ref, b_ref, initial_state=h_ref, activation=activation)
+    y_ref.backward(dy)
+
+    x_tri, w_tri, b_tri, h_tri = leaves()
+    y1, state = causal_conv1d(x_tri[:, :T1], w_tri, b_tri, initial_state=h_tri,
+                              output_final_state=True, activation=activation)
+    y2, _ = causal_conv1d(x_tri[:, T1:], w_tri, b_tri, initial_state=state, activation=activation)
+    y_tri = torch.cat([y1, y2], dim=1)
+    y_tri.backward(dy)
+
+    assert_close("  y", y_ref, y_tri, 1e-3)
+    assert_close(" dx", x_ref.grad, x_tri.grad, 1e-3)
+    assert_close(" dw", w_ref.grad, w_tri.grad, 1e-3)
+    assert_close(" db", b_ref.grad, b_tri.grad, 1e-3)
+    assert_close("dh0", h_ref.grad, h_tri.grad, 1e-3)
+
+
+@pytest.mark.parametrize(
     ('B', 'T', 'D', 'W', 'activation', 'dtype'),
     [
         pytest.param(*test, id="B{0}_T{1}_D{2}_W{3}_activation{4}_{5}".format(*test))

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -883,6 +883,9 @@ def test_fast_conv_varlen(
             (2, 128, 2048, 3, True, True, "swish", torch.float32),
             (2, 128, 4096, 4, True, True, "swish", torch.float32),
             (2, 128, 8192, 4, True, True, "swish", torch.float32),
+            (1, 1, 128, 4, True, True, "swish", torch.float32),
+            (2, 2, 128, 4, True, True, "swish", torch.float32),
+            (1, 1, 64, 3, True, True, "swish", torch.float32),
         ]
     ],
 )
@@ -1464,58 +1467,6 @@ def test_conv_varlen_non_contiguous_qkv(
 
     assert_close("dx", ref_k_state.grad, k_state.grad, 1e-3)
     assert_close("dh0", ref_initial_state.grad, tri_initial_state.grad, 1e-3)
-
-
-@pytest.mark.parametrize(
-    ('B', 'T', 'T1', 'D', 'W', 'activation', 'dtype'),
-    [
-        pytest.param(*test, id="B{0}_T{1}_T1{2}_D{3}_W{4}_activation{5}_{6}".format(*test))
-        for test in [
-            (1, 64, 1, 128, 4, "silu", torch.float32),
-            (1, 64, 2, 128, 4, "silu", torch.float32),
-            (1, 64, 3, 128, 4, "silu", torch.float32),
-            (1, 64, 8, 128, 4, "silu", torch.float32),
-            (2, 64, 1, 128, 4, None, torch.float32),
-            (2, 64, 2, 128, 4, None, torch.float32),
-            (1, 32, 1, 64, 3, "silu", torch.float32),
-        ]
-    ],
-)
-def test_conv_chunked_prefill_backward(B, T, T1, D, W, activation, dtype):
-    """Splitting a sequence into two chunks must not change its gradients.
-
-    The first chunk's final_state feeds the second chunk as its initial_state, so the
-    backward has to route the state gradient back to the tokens that produced it. That
-    routing is wrong for chunks shorter than W - 1 tokens.
-    """
-    torch.manual_seed(42)
-
-    x = torch.randn(B, T, D, device=device, dtype=dtype)
-    weight = torch.randn(D, W, device=device, dtype=dtype)
-    bias = torch.randn(D, device=device, dtype=dtype)
-    h0 = torch.randn(B, D, W, device=device, dtype=dtype)
-    dy = torch.randn(B, T, D, device=device, dtype=dtype)
-
-    def leaves():
-        return (x.clone().requires_grad_(True), weight.clone().requires_grad_(True),
-                bias.clone().requires_grad_(True), h0.clone().requires_grad_(True))
-
-    x_ref, w_ref, b_ref, h_ref = leaves()
-    y_ref, _ = causal_conv1d(x_ref, w_ref, b_ref, initial_state=h_ref, activation=activation)
-    y_ref.backward(dy)
-
-    x_tri, w_tri, b_tri, h_tri = leaves()
-    y1, state = causal_conv1d(x_tri[:, :T1], w_tri, b_tri, initial_state=h_tri,
-                              output_final_state=True, activation=activation)
-    y2, _ = causal_conv1d(x_tri[:, T1:], w_tri, b_tri, initial_state=state, activation=activation)
-    y_tri = torch.cat([y1, y2], dim=1)
-    y_tri.backward(dy)
-
-    assert_close("  y", y_ref, y_tri, 1e-3)
-    assert_close(" dx", x_ref.grad, x_tri.grad, 1e-3)
-    assert_close(" dw", w_ref.grad, w_tri.grad, 1e-3)
-    assert_close(" db", b_ref.grad, b_tri.grad, 1e-3)
-    assert_close("dh0", h_ref.grad, h_tri.grad, 1e-3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`final_state[d, w]` is input token `t = T - W + w`, so token `t` must receive `dht[d, t + W - T]`; `causal_conv1d_bwd_kernel` derives that slot index from `start_tok = max(0, T - (W - 1))`, and the clamp — inert for `T >= W - 1` — pins `start_tok` at 0 below it and shifts every contribution by `W - 1 - T` slots. A sequence that short also leaves part of `initial_state` still sitting in `final_state` (slot `i_w` survives into `final_state[:, i_w - T]` whenever `i_w >= T`), a term `compute_dh0_kernel` dropped, so at the shipped conv width `W = 4` a 1- or 2-token prefill chunk disagrees with the same sequence run in one call while the forward stays exact and nothing raises.

Fixes #1140.

- The `dht` slot index comes from the unclamped `offset + (W - T)`. `start_tok` keeps its clamp for the mask, where it is equivalent (`offset >= 0` regardless), so the diff touches the slot index only.
- `compute_dh0_kernel` takes `dht` and adds the pass-through term for the slots a short sequence does not overwrite.

## Test plan

- `python scripts/find_dependent_tests.py fla/modules/conv/triton/kernels.py` → `tests/modules/test_conv.py` (plus the layer/model tests that build on it). `tests/modules/test_conv.py` on a B200: 84 passed, 26 skipped — 77 passed / 26 skipped at unmodified main, plus the 7 new cases.
- New `test_conv_chunked_prefill_backward`: runs a sequence in two chunks, handing the first chunk's `final_state` to the second as `initial_state`, and requires the gradients to match the one-shot call over the whole sequence — the composition the forward already satisfies exactly. Parametrized over first chunks of 1, 2, 3 and 8 tokens, so it covers both sides of the `T = W - 1` boundary, plus a `W = 3` case. Reverting the kernel change alone fails all five 1- and 2-token cases and leaves the two 3- and 8-token cases passing.
- The existing suite could not see this: every backward test uses `T >= 15`, well above `W - 1`, where the clamp is inert and a chunk always overwrites the whole state.
- Max abs error of the two-chunk gradients against the one-shot call at B=1, T=16, D=16, W=4, `silu`:

| first chunk | dx before | dx after | dh0 before | dh0 after |
|---|---|---|---|---|
| 1 token | 2.4404 | 0.0000 | 1.3728 | 0.0000 |
| 2 tokens | 4.4926 | 0.0000 | 1.3728 | 0.0000 |
| 3 tokens | 0.0000 | 0.0000 | 0.0000 | 0.0000 |
| 8 tokens | 0.0000 | 0.0000 | 0.0000 | 0.0000 |

## Benchmark / NCU

`triton.testing.do_bench` on an NVIDIA B200, bf16, `W = 4`, `activation='silu'`. Autotune paid outside the timed region, min of 7 `do_bench` calls, three interleaved before/after rounds. Varlen is `[1, 16384, 2048]` with `cu_seqlens=[0, 3000, 7001, 11002, 16384]`; the short-chunk shape is `[64, 2, 2048]` — the case the new `dht` term actually serves.

| workload | before | after |
|---|---|---|
| `causal_conv1d_bwd`, varlen, `dht` only (isolates the slot-index change) | 318.1 / 317.9 / 317.8 us | 317.6 / 320.5 / 317.8 us |
| `causal_conv1d_bwd`, varlen, initial_state + `dht` | 485.8 / 485.7 / 485.7 us | 487.2 / 489.1 / 486.9 us |
| `causal_conv1d_bwd`, dense, T=2, B=64 | 170.0 / 169.8 / 169.8 us | 170.4 / 170.7 / 170.6 us |
| `compute_dh0_triton`, dense, T=2, B=64 | 11.9 / 11.9 / 11.8 us | 12.6 / 12.7 / 12.6 us |

Neutral on the backward as a whole (≤ 0.7%). `compute_dh0_triton` itself pays about 0.8 us (6%) at the short-chunk shape for the extra `dht` load; that call is a few percent of the backward, so it does not show up in the totals.

The slot index could equally be written as an unclamped `start_tok = T - (W - 1)` with `w_idx = 1 + (offset - start_tok)` — the form the ascend port uses. Measured against this PR over three interleaved rounds on the varlen `initial_state + dht` backward, that variant is the same within 0.4% (485.0–485.6 us against 486.4–486.7 us here). Either form is fine; this one keeps the change to the slot index alone and leaves the mask as it was.

## Breaking changes

None. `T >= W - 1` is unchanged — the clamp never fired there and a chunk that long overwrites the whole state.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

## Environment

- Commit base: 033b19e8 (main)
- GPU: NVIDIA B200 (sm_100), driver CUDA 13.2
- torch 2.13.0+cu130, triton 3.7.1, Python 3.12
