### PR TITLE
[Fix] Handle a partial last chunk in log-linear attention

### DIFF
--- a/fla/ops/log_linear_attn/chunk.py
+++ b/fla/ops/log_linear_attn/chunk.py
@@ -168,7 +168,7 @@ def chunkwise_fwd_kernel(
     NT = tl.cdiv(T, BT)
     output_offset = -1 * (offset % BT)
     for i_t in range(NT):
-        b_h_ptrs = level_scales + ((bos + i_t * BT + i_idx) * H + i_h) * L + b_llut
+        b_h_ptrs = level_scales + ((bos + tl.minimum(i_t * BT + i_idx, T - 1)) * H + i_h) * L + b_llut
         b_h = tl.load(b_h_ptrs, mask=i_idx >= j_idx)
 
         o_t = (i_t * BT).to(tl.int64) + o_i
@@ -857,7 +857,9 @@ def chunkwise_bwd_kernel_dkg(
     b_dg -= tl.sum(b_k * b_dk, axis=1)
     b_dg_last += tl.sum(b_dk * b_k)
 
-    b_dg = tl.where(o_i < BT - 1, b_dg, b_dg + b_dg_last)
+    # deposit the chunk-scalar gradient on the last LIVE row, the one `last_idx` selected the
+    # gate from; on a partial last chunk row BT - 1 is dead and the masked store drops it
+    b_dg = tl.where(o_t < last_idx, b_dg, b_dg + b_dg_last)
 
     tl.store(p_dg, b_dg, mask=m_t)
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_tk)
@@ -986,7 +988,7 @@ def chunkwise_bwd_kernel_diag(
     i_idx = o_i[:, None]  # BT x 1
     j_idx = o_i[None, :]  # 1 x BT
 
-    b_h_ptrs = l + ((bos + i_t * BT + i_idx) * H + i_h) * L + b_llut
+    b_h_ptrs = l + ((bos + tl.minimum(i_t * BT + i_idx, T - 1)) * H + i_h) * L + b_llut
     b_h = tl.load(b_h_ptrs, mask=i_idx >= j_idx)
 
     p_g = g + bos * H + i_h + o_t * H

--- a/tests/ops/test_log_linear_attn.py
+++ b/tests/ops/test_log_linear_attn.py
@@ -10,8 +10,10 @@ import os
 import numpy as np
 import pytest
 import torch
+import triton
 
 from fla.ops.log_linear_attn import chunk_log_linear_attn
+from fla.ops.log_linear_attn.chunk import chunkwise_bwd_kernel_dkg
 from fla.ops.log_linear_attn.naive import naive_log_linear_attn
 from fla.utils import assert_close, device, device_platform
 
@@ -153,3 +155,101 @@ def test_chunk_varlen(
     ref = torch.cat(o, dim=1)
 
     assert_close("o", ref, out, 0.004)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "dtype"),
+    [
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
+        for test in [
+            (1, 70, 4, 64, torch.float32),
+            (1, 200, 4, 64, torch.float32),
+            (2, 320, 4, 64, torch.float32),  # divisible by the chunk size: control
+        ]
+    ],
+)
+@pytest.mark.skipif(device_platform == "intel", reason="Intel Triton Failure")
+def test_chunk_partial_last_chunk(
+    B: int,
+    T: int,
+    H: int,
+    D: int,
+    dtype: torch.dtype,
+):
+    """The rows of a last chunk shorter than the chunk size must not read `level_scales`.
+
+    `level_scales` is a view into a longer buffer whose tail is NaN, so any read past its end
+    lands on a NaN and shows up in the gradients.
+    """
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    L = int(np.ceil(np.log2(T))) + 1
+    x = torch.randn(B, T, H, D, dtype=dtype, device=device)
+    dt = torch.nn.functional.softplus(
+        torch.randn(B, T, H, dtype=torch.float32, device=device) - 4,
+    )
+    a = -torch.exp(torch.rand(H, dtype=torch.float32, device=device))
+    q = torch.randn(B, T, 1, D, dtype=dtype, device=device)
+    k = torch.randn(B, T, 1, D, dtype=dtype, device=device)
+    v = (x * dt.unsqueeze(-1)).to(dtype=dtype)
+    g = a * dt
+    do = torch.randn_like(v)
+
+    # level_scales sits at the front of a buffer whose tail holds NaN
+    numel = B * T * H * L
+    buffer = torch.full((numel + 64 * H * L,), float("nan"), dtype=dtype, device=device)
+    level_scales = buffer[:numel].view(B, T, H, L)
+    level_scales.copy_(torch.randn(B, T, H, L, dtype=dtype, device=device))
+
+    q, k, v, g, level_scales = map(lambda x: x.requires_grad_(), (q, k, v, g, level_scales))
+
+    out, _ = chunk_log_linear_attn(q, k, v, g, level_scales)
+    (out * do).sum().backward()
+
+    assert torch.isfinite(out).all(), "forward output is not finite"
+    for name, tensor in zip(
+        ("dq", "dk", "dv", "dg", "dl"), (q, k, v, g, level_scales),
+    ):
+        assert torch.isfinite(tensor.grad).all(), (
+            f"{name} is not finite: {(~torch.isfinite(tensor.grad)).sum().item()} of "
+            f"{tensor.grad.numel()} elements read past the end of level_scales"
+        )
+
+
+@pytest.mark.parametrize(
+    ("T", "H", "D"),
+    [
+        pytest.param(*test, id="T{}-H{}-D{}".format(*test))
+        for test in [(70, 4, 64), (200, 4, 64), (128, 4, 64)]
+    ],
+)
+@pytest.mark.skipif(device_platform == "intel", reason="Intel Triton Failure")
+def test_chunkwise_bwd_dkg_last_chunk_fold(T: int, H: int, D: int):
+    """The chunk-scalar gate gradient must land on the chunk's last LIVE row.
+
+    Driven directly because the wrapper hands the kernel a zero `dg_last` for the only chunk
+    that can be partial, which hides the misplaced deposit.  `dh` is zeroed so the fold is the
+    kernel's only contribution to `dg`.
+    """
+    torch.manual_seed(42)
+    B, BT = 1, 64
+    NT = triton.cdiv(T, BT)
+
+    g = torch.randn(B, T, H, dtype=torch.float32, device=device) * 0.1
+    dg = torch.zeros(B, T, H, dtype=torch.float32, device=device)
+    dg_last = torch.zeros(B, NT, H, dtype=torch.float32, device=device)
+    dg_last[:, NT - 1, :] = 1.0
+    dh = torch.zeros(B, NT, H, D, D, dtype=torch.float32, device=device)
+    k = torch.zeros(B, T, 1, D, dtype=torch.float32, device=device)
+    v = torch.zeros(B, T, H, D, dtype=torch.float32, device=device)
+    dk = torch.zeros(B, T, H, D, dtype=torch.float32, device=device)
+
+    chunkwise_bwd_kernel_dkg[(NT, B * H)](
+        dh=dh, k=k, v=v, g=g, dg_last=dg_last, dk=dk, dg=dg, cu_seqlens=None,
+        T=T, H=H, K=D, V=D, L=int(np.ceil(np.log2(T))) + 1, BT=BT, NT=NT,
+    )
+
+    ref = torch.zeros_like(dg)
+    ref[:, T - 1] = dg_last[:, NT - 1] * torch.exp(g[:, T - 1])
+    assert_close("dg", ref, dg, 0.002)


### PR DESCRIPTION
## Summary

`chunk_log_linear_attn` fixes the chunk size at `BT = 64`, so any sequence length that is not a multiple of 64 ends in a chunk whose trailing rows are dead. Three statements do not account for them.

Fixes #1142.

- `chunkwise_fwd_kernel` (`chunk.py:171`) and `chunkwise_bwd_kernel_diag` (`chunk.py:989`) gather `level_scales` by the raw row index under the causal predicate alone, so the dead rows read past the end of the tensor. Both now clamp the row with `tl.minimum(i_t * BT + i_idx, T - 1)`. Clamping rather than masking is deliberate: the loaded values for dead rows are already discarded — `b_s` and `b_a` are zero there — so the only thing that has to change is the address, and adding a predicate to the load costs ~1.5–2% on the forward (numbers below) while the clamp is free.
- `chunkwise_bwd_kernel_dkg` (`chunk.py:860`) reads the gate at the chunk's last *live* token (`last_idx = min((i_t + 1) * BT, T) - 1`) but folds the chunk-scalar gate gradient in at chunk-relative row `BT - 1`, which the masked store then discards on a partial chunk. The deposit row now follows `last_idx`. For a full chunk `o_t < last_idx` is exactly the old `o_i < BT - 1`, so aligned shapes are unchanged.

The `dkg` site looks latent today rather than live: `chunkwise_bwd_kernel_dhg` writes `dg_last[i_t]` under `if i_t & (1 << ell)`, and for the last chunk of a sequence that add always lands on the first iteration of its descending loop, where the accumulator is still zero — so the wrapper hands this kernel a zero `dg_last` for precisely the chunk that can be partial. I have fixed it anyway because the kernel contradicts itself and the correction is one token; happy to split it out if you would rather keep this PR to the memory-safety half.

## Test plan

- `python scripts/find_dependent_tests.py fla/ops/log_linear_attn/chunk.py` → `tests/ops/test_log_linear_attn.py`. On a B200: **7 passed** at unmodified main, **13 passed** on this branch (7 + 6 new). No pre-existing failures.
- New `test_chunk_partial_last_chunk[T70, T200, T320]`: `level_scales` is a view into a longer buffer whose tail is NaN, so any read past its end shows up in the gradients. At unmodified main `T=70` returns 384 non-finite `dk`, 1536 non-finite `dv` and 24 non-finite `dg` entries; `T=320` (a multiple of 64) is the control and is clean on both arms.
- New `test_chunkwise_bwd_dkg_last_chunk_fold[T70, T200, T128]`: drives `chunkwise_bwd_kernel_dkg` with the wrapper's own argument layout and a non-zero `dg_last`, with `dh` zeroed so the fold is the kernel's only contribution to `dg`. Unfixed, no row receives the term at all on a partial chunk (expected `+1.0410` at `dg[69]`, got `0`); `T=128` is the full-chunk control and passes on both arms. It is driven directly because the wrapper cannot currently produce a non-zero `dg_last` there, as noted above.
- Revert-checks against the committed fix, tests kept: reverting the whole kernel file fails 4 of the 6 new cases (both controls still pass); reverting only the two clamps fails exactly the two `partial_last_chunk` cases; reverting only the `dkg` line fails exactly the two `last_chunk_fold` cases.
- `compute-sanitizer --tool memcheck` with `PYTORCH_NO_CUDA_MEMORY_CACHING=1`, `B=1, T=70, H=4, D=64` forward+backward: at main, 16 invalid 4-byte reads at `chunk.py:172` past `level_scales`' 8,960-byte allocation and then `unspecified launch failure`; with only the forward clamped, the same 16 reads reappear in `chunkwise_bwd_kernel_diag`; with both, **0 errors** and the run completes.
- The shipped suite could not see any of this: `test_chunk` / `test_chunk_bwd` use `T` ∈ {512, 1024, 2048}, all multiples of 64, and `test_chunk_varlen` — whose `cu_seqlens` do produce partial chunks — is forward-only and does not check for reads past the tensor.

## Benchmark / NCU

`triton.testing.do_bench` on an NVIDIA B200, fp32, three interleaved before/after rounds (spread within a round shown as min–max):

| B, T, H, D | before fwd | after fwd | before fwd+bwd | after fwd+bwd |
|---|---|---|---|---|
| 2, 4096, 8, 64 (aligned) | 28.01–28.05 ms | 27.75–27.86 ms | 84.68–84.72 ms | 84.47–84.71 ms |
| 1, 8192, 8, 128 (aligned) | 175.4–176.8 ms | 176.2–179.1 ms | 646.2–647.4 ms | 648.9–649.0 ms |
| 2, 4000, 8, 64 (partial last chunk) | 27.68–27.76 ms | 27.07–27.14 ms | 82.76–82.95 ms | 82.97–83.04 ms |

Neutral. For the record, the first formulation of the same fix masked the gather instead of clamping the row (`mask=(i_idx >= j_idx) & m_t[:, None], other=0.0`) and cost 28.45–28.48 ms on the aligned 4096 forward and 28.31–28.32 ms on the partial 4000 forward — +1.5% and +2.0%, reproducible across all three rounds. That variant was discarded for this one.

## Breaking changes

None. Aligned shapes compile to the same addressing and the same deposit row.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

## Environment

- Commit base: 033b19e8 (main)
- GPU: NVIDIA B200 (sm_100), driver CUDA 13.2
- torch 2.13.0+cu130, triton 3.7.1, Python 3.12
