### PR TITLE
[Fix] Correct Ascend causal_conv1d short-chunk cache backward

### DIFF
--- a/fla/modules/backends/triton_ascend/__init__.py
+++ b/fla/modules/backends/triton_ascend/__init__.py
@@ -459,6 +459,7 @@ class TritonAscendBackend(BaseBackend):
         initial_state,
         activation,
         cu_seqlens,
+        dht=None,
     ):
         from fla.modules.backends.triton_ascend.causal_conv1d import compute_dh0_npu
         return compute_dh0_npu(
@@ -468,6 +469,7 @@ class TritonAscendBackend(BaseBackend):
             initial_state,
             activation,
             cu_seqlens,
+            dht,
         )
 
     def causal_conv1d_update_states(

--- a/fla/modules/backends/triton_ascend/causal_conv1d.py
+++ b/fla/modules/backends/triton_ascend/causal_conv1d.py
@@ -1248,7 +1248,9 @@ def _launch_bwd_dwdb_core(
     if BD is None:
         pow2_t = triton.next_power_of_2(T)
         floor_t = pow2_t if pow2_t == T else pow2_t // 2
-        BT = min(64, floor_t)
+        # BT=1 (T=1) miscompiles the initial_state dw contribution on Ascend
+        # (masked [1, BD] reduce / store); pad to at least 8 and mask o_t >= T.
+        BT = min(64, max(8, floor_t))
         BD = min(16, max(8, triton.next_power_of_2(D)))
     if cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT, cu_seqlens_cpu=cu_seqlens_cpu)
@@ -1305,6 +1307,7 @@ def _launch_bwd_dwdb_core(
 
 @triton.heuristics({
     'USE_ACTIVATION': lambda args: args['y'] is not None,
+    'USE_FINAL_STATE': lambda args: args['dht'] is not None,
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.jit
@@ -1313,6 +1316,7 @@ def compute_dh0_kernel(
     y,
     weight,
     dh0,
+    dht,
     cu_seqlens,
     stride_dy_n,
     stride_dy_t,
@@ -1325,6 +1329,7 @@ def compute_dh0_kernel(
     W: tl.constexpr,
     BD: tl.constexpr,
     USE_ACTIVATION: tl.constexpr,
+    USE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     CHUNK_OFFSET: tl.constexpr,
 ):
@@ -1344,6 +1349,13 @@ def compute_dh0_kernel(
 
     for i_w in tl.static_range(1, W):
         b_dh0 = tl.zeros([BD], dtype=tl.float32)
+
+        if USE_FINAL_STATE:
+            # a sequence shorter than the state leaves initial_state[:, i_w] still sitting in
+            # final_state[:, i_w - seq_len], so that slot's gradient passes straight through
+            if i_w >= seq_len:
+                p_dht = dht + i_n * D * W + o_d * W + (i_w - seq_len)
+                b_dh0 += tl.load(p_dht, mask=m_d, other=0).to(tl.float32)
 
         for t in tl.static_range(0, W - 1):
             if t < i_w:
@@ -2091,6 +2103,7 @@ def causal_conv1d_bwd_npu(
             initial_state=initial_state,
             activation=activation,
             cu_seqlens=cu_seqlens,
+            dht=dht,
         )
 
     return dx.view(shape), dw, db, dr, dh0
@@ -2103,6 +2116,7 @@ def compute_dh0_npu(
     initial_state: torch.Tensor,
     activation: str | None,
     cu_seqlens: torch.Tensor | None,
+    dht: torch.Tensor | None = None,
 ) -> torch.Tensor:
     D, W = weight.shape
     N = initial_state.shape[0]
@@ -2126,6 +2140,7 @@ def compute_dh0_npu(
         y=y if activation in ('swish', 'silu') else None,
         weight=weight,
         dh0=dh0,
+        dht=dht,
         cu_seqlens=cu_seqlens,
         stride_dy_n=stride_dy_n,
         stride_dy_t=stride_dy_t,


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->
Follow-up to #1141 on the triton-ascend port. Short sequences (`T < W - 1`) with `initial_state` and final-state grad failed `test_conv_cache_backward` on NPU (T=1 + swish).
- Pad the dw/db tile to `BT >= 8`. `T=1` used a degenerate `BT=1` tile; Ascend miscompiled the masked `[1, BD]` reduce, so the `initial_state` contribution to `dw` was dropped (last weight column matched, earlier columns were 0 / garbage).
- Thread `dht` through `compute_dh0_npu`. When `T < W - 1`, leftover cache slots still sit in `final_state`; that pass-through term was present on CUDA and missing on Ascend.

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->
FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules/test_conv.py
<img width="1379" height="456" alt="image" src="https://github.com/user-attachments/assets/f70d4236-6814-4cc2-b5f7-7dac31bffa79" />


## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
<img width="691" height="1038" alt="image" src="https://github.com/user-attachments/assets/cd3fa2ec-b1c0-4218-866f-29e091e33d11" />


## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->
None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
