### PR TITLE
[Cleanup] Remove remaining `head_first` code paths

### DIFF
--- a/fla/ops/abc/chunk.py
+++ b/fla/ops/abc/chunk.py
@@ -1202,7 +1202,7 @@ def chunk_abc(
     s: torch.Tensor,
     initial_state: tuple[torch.Tensor] | None = None,
     output_final_state: bool = False,
-    head_first: bool = False,
+    **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""
     Args:
@@ -1218,9 +1218,6 @@ def chunk_abc(
             Initial states of shape `[B, H, K, M]` and `[B, H, M, V]`. Default: `None`.
         output_final_state (Optional[bool]):
             Whether to output the final state of shape `[B, H, K, M]` and `[B, H, M, V]`. Default: `False`.
-        head_first (Optional[bool]):
-            Whether the inputs are in the head-first format. Default: `False`.
-            This argument has been deprecated.
 
     Returns:
         o (torch.Tensor):
@@ -1228,9 +1225,11 @@ def chunk_abc(
         final_state (torch.Tensor):
             Final state of shape `[B, H, K, M]` and `[B, H, M, V]` if `output_final_state=True` else `None`.
     """
-    if not head_first:
-        q, k, v, s = map(lambda x: x.transpose(1, 2), (q, k, v, s))
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    q, k, v, s = map(lambda x: x.transpose(1, 2), (q, k, v, s))
     o, final_state = ChunkABCFunction.apply(q, k, v, s, initial_state, output_final_state)
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o.transpose(1, 2)
     return o, final_state

--- a/fla/ops/based/fused_chunk.py
+++ b/fla/ops/based/fused_chunk.py
@@ -380,16 +380,18 @@ def fused_chunk_based(
     v: torch.Tensor,
     scale: float | None = None,
     use_norm: bool = True,
-    head_first: bool = False,
+    **kwargs,
 ):
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     assert q.shape[-1] <= 16, 'only support feature dimension up to 16.'
     if scale is None:
         scale = q.shape[-1] ** -0.5
-    if not head_first:
-        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+    q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
     o, z = FusedChunkBasedFunction.apply(q, k, v, scale)
     if use_norm:
         o = o / (z[..., None] + 1e-6)
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o.transpose(1, 2)
     return o.to(q.dtype)

--- a/fla/ops/based/parallel.py
+++ b/fla/ops/based/parallel.py
@@ -423,16 +423,18 @@ def parallel_based(
     v: torch.Tensor,
     scale: float | None = None,
     use_norm: bool = True,
-    head_first: bool = False,
+    **kwargs,
 ):
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     assert q.shape[-1] <= 128, "only support feature dim up to 128"
     if scale is None:
         scale = q.shape[-1] ** -0.5
-    if not head_first:
-        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+    q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
     o, z = triton_parallel_based(q, k, v, scale)
     if use_norm:
         o = o / (z[..., None] + 1e-6)
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o.transpose(1, 2)
     return o.to(q.dtype)

--- a/fla/ops/rebased/parallel.py
+++ b/fla/ops/rebased/parallel.py
@@ -476,20 +476,22 @@ def parallel_rebased(
     use_scale: bool = True,
     use_normalize: bool = True,
     return_both: bool = False,
-    head_first: bool = False,
+    **kwargs,
 ):
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     assert q.shape[-1] <= 128, "only support feature dim up to 128"
     if use_scale:
         scale = q.shape[-1] ** -0.5
     else:
         scale = 1
-    if not head_first:
-        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+    q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
     o, z = ParallelBasedFunction.apply(q, k, v, scale)
     if return_both:
         return o, z
     if use_normalize:
         o = o / (z[..., None] + eps)
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o.transpose(1, 2)
     return o.to(q.dtype)

--- a/fla/ops/titans/naive.py
+++ b/fla/ops/titans/naive.py
@@ -318,18 +318,16 @@ def chunk_titans_linear_ref(
     chunk_size: int = 16,  # chunk size
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
-    head_first: bool = False,
     use_chunk: bool = True,
 ):
     assert q.dtype == k.dtype == v.dtype
     assert k.shape[-1] == v.shape[-1], "DK must equal to DV."
-    if not head_first:
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
-        eta = eta.transpose(1, 2)
-        alpha = alpha.transpose(1, 2)
-        theta = theta.transpose(1, 2)
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    eta = eta.transpose(1, 2)
+    alpha = alpha.transpose(1, 2)
+    theta = theta.transpose(1, 2)
     seq_len = q.shape[-2]
     pad_len = (chunk_size - (seq_len % chunk_size)) % chunk_size
     if pad_len > 0:
@@ -375,6 +373,5 @@ def chunk_titans_linear_ref(
             output_final_state,
         )
     o = o[:, :, :seq_len, :]
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o.transpose(1, 2)
     return o, final_state

--- a/fla/ops/ttt/naive.py
+++ b/fla/ops/ttt/naive.py
@@ -87,7 +87,6 @@ def chunk_ttt_linear_ref(
     initial_state: torch.Tensor = None,
     initial_state_bias: torch.Tensor = None,
     output_final_state: bool = False,
-    head_first: bool = False,
 ):
     assert q.dtype == k.dtype == v.dtype
     assert k.shape[-1] == v.shape[-1], "The key and value dimension must be the same."
@@ -95,11 +94,10 @@ def chunk_ttt_linear_ref(
         eta = torch.full_like(q[:, :, :, :1], eta)
     if scale is None:
         scale = k.shape[-1] ** -0.5
-    if not head_first:
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
-        eta = eta.transpose(1, 2)
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    eta = eta.transpose(1, 2)
     T = q.shape[-2]
     padded = (mini_batch_size - (T % mini_batch_size)) % mini_batch_size
     if padded > 0:
@@ -125,6 +123,5 @@ def chunk_ttt_linear_ref(
         output_final_state,
     )
     o = o[:, :, :T, :].contiguous()
-    if not head_first:
-        o = o.transpose(1, 2)
+    o = o.transpose(1, 2)
     return o, final_state, final_state_bias

--- a/fla/ops/utils/backends/triton_ascend/cumsum.py
+++ b/fla/ops/utils/backends/triton_ascend/cumsum.py
@@ -98,7 +98,6 @@ def _launch_local_cumsum_scalar(
     H,
     BT,
     NT,
-    head_first,
     reverse,
 ):
     bh_total = B * H
@@ -111,7 +110,6 @@ def _launch_local_cumsum_scalar(
         B=B,
         H=H,
         BT=BT,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
         num_warps=_NUM_WARPS,
     )
@@ -145,7 +143,6 @@ def _launch_local_cumsum_vector(
     BT,
     BS,
     NT,
-    head_first,
     reverse,
 ):
     bh_total = B * H
@@ -161,7 +158,6 @@ def _launch_local_cumsum_vector(
         S=S,
         BT=BT,
         BS=BS,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
         num_warps=_NUM_WARPS,
     )
@@ -199,7 +195,6 @@ def chunk_local_cumsum_scalar_kernel_npu(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
     NT_OFFSET: tl.constexpr,
     BH_OFFSET: tl.constexpr,
 ):
@@ -214,12 +209,8 @@ def chunk_local_cumsum_scalar_kernel_npu(
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    if HEAD_FIRST:
-        p_s = tl.make_block_ptr(s + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
-        p_o = tl.make_block_ptr(o + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
-    else:
-        p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
     b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
     b_o = tl.cumsum(b_s, axis=0)
     if REVERSE:
@@ -250,7 +241,6 @@ def chunk_local_cumsum_vector_kernel_npu(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
     NT_OFFSET: tl.constexpr,
     BH_OFFSET: tl.constexpr,
 ):
@@ -265,12 +255,8 @@ def chunk_local_cumsum_vector_kernel_npu(
     else:
         bos, eos = i_b * T, i_b * T + T
 
-    if HEAD_FIRST:
-        p_s = tl.make_block_ptr(s + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-        p_o = tl.make_block_ptr(o + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-    else:
-        p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-        p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+    p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+    p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
     b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
     if REVERSE:
         b_o = tl.cumsum(b_s, axis=0, reverse=True)
@@ -298,7 +284,6 @@ def chunk_global_cumsum_scalar_kernel_npu(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
     BH_OFFSET: tl.constexpr,
 ):
     i_nh = tl.program_id(0) + BH_OFFSET
@@ -313,12 +298,8 @@ def chunk_global_cumsum_scalar_kernel_npu(
     NT = tl.cdiv(T, BT)
     for i_c in range(NT):
         i_t = NT - 1 - i_c if REVERSE else i_c
-        if HEAD_FIRST:
-            p_s = tl.make_block_ptr(s + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
-            p_o = tl.make_block_ptr(o + bos*H + i_h*T, (T,), (1,), (i_t * BT,), (BT,), (0,))
-        else:
-            p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-            p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
         b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
         b_o = tl.cumsum(b_s, axis=0)
         b_ss = tl.sum(b_s, 0)
@@ -351,7 +332,6 @@ def chunk_global_cumsum_vector_kernel_npu(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
     BH_OFFSET: tl.constexpr,
 ):
     i_s, i_nh = tl.program_id(0), tl.program_id(1) + BH_OFFSET
@@ -366,12 +346,8 @@ def chunk_global_cumsum_vector_kernel_npu(
     NT = tl.cdiv(T, BT)
     for i_c in range(NT):
         i_t = NT - 1 - i_c if REVERSE else i_c
-        if HEAD_FIRST:
-            p_s = tl.make_block_ptr(s + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-            p_o = tl.make_block_ptr(o + (bos * H + i_h*T)*S, (T, S), (S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-        else:
-            p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
-            p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
+        p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
         b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
         if REVERSE:
             b_c = b_z[None, :] + tl.cumsum(b_s, axis=0, reverse=True)
@@ -389,14 +365,15 @@ def chunk_local_cumsum_scalar_npu(
     reverse: bool = False,
     scale: float = None,
     cu_seqlens: torch.Tensor | None = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T = g.shape
-    else:
-        B, T, H = g.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H = g.shape
     assert chunk_size == 2**(chunk_size.bit_length()-1), "chunk_size must be a power of 2"
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
@@ -414,7 +391,6 @@ def chunk_local_cumsum_scalar_npu(
         H=H,
         BT=BT,
         NT=NT,
-        head_first=head_first,
         reverse=reverse,
     )
     return g
@@ -426,14 +402,15 @@ def chunk_local_cumsum_vector_npu(
     reverse: bool = False,
     scale: float = None,
     cu_seqlens: torch.Tensor | None = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T, S = g.shape
-    else:
-        B, T, H, S = g.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H, S = g.shape
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -461,7 +438,6 @@ def chunk_local_cumsum_vector_npu(
         BT=BT,
         BS=BS,
         NT=NT,
-        head_first=head_first,
         reverse=reverse,
     )
     return g
@@ -473,13 +449,14 @@ def chunk_global_cumsum_scalar_npu(
     reverse: bool = False,
     cu_seqlens: torch.Tensor | None = None,
     scale: float = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T = s.shape
-    else:
-        B, T, H = s.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H = s.shape
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
 
     BT = _get_global_scalar_bt(T)
@@ -494,7 +471,6 @@ def chunk_global_cumsum_scalar_npu(
         B=B,
         H=H,
         BT=BT,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
         num_warps=_NUM_WARPS,
     )
@@ -510,13 +486,14 @@ def chunk_global_cumsum_vector_npu(
     reverse: bool = False,
     cu_seqlens: torch.Tensor | None = None,
     scale: float = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T, S = s.shape
-    else:
-        B, T, H, S = s.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H, S = s.shape
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
     BT, BS = _get_global_vector_tile_config(T, S)
     BS = compute_grid_limited_tile_size(
@@ -540,7 +517,6 @@ def chunk_global_cumsum_vector_npu(
         S=S,
         BT=BT,
         BS=BS,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
         num_warps=_NUM_WARPS,
     )
@@ -558,9 +534,13 @@ def chunk_global_cumsum_npu(
     reverse: bool = False,
     cu_seqlens: torch.Tensor | None = None,
     scale: float = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
+    **kwargs,
 ) -> torch.Tensor:
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     if cu_seqlens is not None:
         assert s.shape[0] == 1, "Only batch size 1 is supported when cu_seqlens are provided"
     if len(s.shape) == 3:
@@ -569,7 +549,6 @@ def chunk_global_cumsum_npu(
             reverse=reverse,
             cu_seqlens=cu_seqlens,
             scale=scale,
-            head_first=head_first,
             output_dtype=output_dtype,
         )
     if len(s.shape) == 4:
@@ -578,13 +557,11 @@ def chunk_global_cumsum_npu(
             reverse=reverse,
             cu_seqlens=cu_seqlens,
             scale=scale,
-            head_first=head_first,
             output_dtype=output_dtype,
         )
     raise ValueError(
         f"Unsupported input shape {s.shape}, "
-        f"which should be [B, T, H]/[B, T, H, D] if `head_first=False` "
-        f"or [B, H, T]/[B, H, T, D] otherwise",
+        f"which should be [B, T, H] or [B, T, H, D]",
     )
 
 
@@ -595,11 +572,14 @@ def chunk_local_cumsum_npu(
     reverse: bool = False,
     scale: float = None,
     cu_seqlens: torch.Tensor | None = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
     **kwargs,
 ) -> torch.Tensor:
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     if cu_seqlens is not None:
         assert g.shape[0] == 1, "Only batch size 1 is supported when cu_seqlens are provided"
     if len(g.shape) == 3:
@@ -609,7 +589,6 @@ def chunk_local_cumsum_npu(
             reverse=reverse,
             scale=scale,
             cu_seqlens=cu_seqlens,
-            head_first=head_first,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
         )
@@ -620,12 +599,10 @@ def chunk_local_cumsum_npu(
             reverse=reverse,
             scale=scale,
             cu_seqlens=cu_seqlens,
-            head_first=head_first,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
         )
     raise ValueError(
         f"Unsupported input shape {g.shape}, "
-        f"which should be (B, T, H, D) if `head_first=False` "
-        f"or (B, H, T, D) otherwise",
+        f"which should be (B, T, H) or (B, T, H, D)",
     )

--- a/fla/ops/utils/cumsum.py
+++ b/fla/ops/utils/cumsum.py
@@ -43,7 +43,6 @@ def chunk_local_cumsum_scalar_kernel(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
@@ -56,12 +55,8 @@ def chunk_local_cumsum_scalar_kernel(
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
-    if HEAD_FIRST:
-        p_s = s + bos*H + i_h*T + o_t
-        p_o = o + bos*H + i_h*T + o_t
-    else:
-        p_s = s + bos*H + i_h + o_t * H
-        p_o = o + bos*H + i_h + o_t * H
+    p_s = s + bos*H + i_h + o_t * H
+    p_o = o + bos*H + i_h + o_t * H
     # [BT]
     b_s = tl.load(p_s, mask=m_t, other=0.0).to(tl.float32)
     b_o = tl.cumsum(b_s, axis=0)
@@ -102,7 +97,6 @@ def chunk_local_cumsum_vector_kernel(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
 ):
     i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
@@ -116,12 +110,8 @@ def chunk_local_cumsum_vector_kernel(
     o_t = i_t * BT + tl.arange(0, BT)
     o_s = i_s * BS + tl.arange(0, BS)
     m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
-    if HEAD_FIRST:
-        p_s = s + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
-        p_o = o + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
-    else:
-        p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
-        p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+    p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+    p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
     # [BT, BS]
     b_s = tl.load(p_s, mask=m_s, other=0.0).to(tl.float32)
     if REVERSE:
@@ -160,7 +150,6 @@ def chunk_global_cumsum_scalar_kernel(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
 ):
     i_nh = tl.program_id(0).to(tl.int64)
     i_n, i_h = i_nh // H, i_nh % H
@@ -176,12 +165,8 @@ def chunk_global_cumsum_scalar_kernel(
         i_t = NT - 1 - i_c if REVERSE else i_c
         o_t = i_t * BT + tl.arange(0, BT)
         m_t = o_t < T
-        if HEAD_FIRST:
-            p_s = s + bos*H + i_h*T + o_t
-            p_o = o + bos*H + i_h*T + o_t
-        else:
-            p_s = s + bos*H + i_h + o_t * H
-            p_o = o + bos*H + i_h + o_t * H
+        p_s = s + bos*H + i_h + o_t * H
+        p_o = o + bos*H + i_h + o_t * H
         b_s = tl.load(p_s, mask=m_t, other=0.0).to(tl.float32)
         b_o = tl.cumsum(b_s, axis=0)
         b_ss = tl.sum(b_s, 0)
@@ -224,7 +209,6 @@ def chunk_global_cumsum_vector_kernel(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
 ):
     i_s, i_nh = tl.program_id(0), tl.program_id(1).to(tl.int64)
     i_n, i_h = i_nh // H, i_nh % H
@@ -241,12 +225,8 @@ def chunk_global_cumsum_vector_kernel(
         o_t = i_t * BT + tl.arange(0, BT)
         o_s = i_s * BS + tl.arange(0, BS)
         m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
-        if HEAD_FIRST:
-            p_s = s + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
-            p_o = o + (bos * H + i_h*T)*S + o_t[:, None] * S + o_s[None, :]
-        else:
-            p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
-            p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+        p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
+        p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H*S) + o_s[None, :]
         # [BT, BS]
         b_s = tl.load(p_s, mask=m_s, other=0.0).to(tl.float32)
         if REVERSE:
@@ -265,14 +245,15 @@ def chunk_local_cumsum_scalar(
     reverse: bool = False,
     scale: float = None,
     cu_seqlens: torch.Tensor | None = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T = g.shape
-    else:
-        B, T, H = g.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H = g.shape
     assert chunk_size == 2**(chunk_size.bit_length()-1), "chunk_size must be a power of 2"
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
@@ -290,7 +271,6 @@ def chunk_local_cumsum_scalar(
         B=B,
         H=H,
         BT=BT,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
     )
     return g
@@ -302,14 +282,15 @@ def chunk_local_cumsum_vector(
     reverse: bool = False,
     scale: float = None,
     cu_seqlens: torch.Tensor | None = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T, S = g.shape
-    else:
-        B, T, H, S = g.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H, S = g.shape
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -332,7 +313,6 @@ def chunk_local_cumsum_vector(
         H=H,
         S=S,
         BT=BT,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
     )
     return g
@@ -344,13 +324,14 @@ def chunk_global_cumsum_scalar(
     reverse: bool = False,
     cu_seqlens: torch.Tensor | None = None,
     scale: float = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T = s.shape
-    else:
-        B, T, H = s.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H = s.shape
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
 
     z = torch.empty_like(s, dtype=output_dtype or s.dtype)
@@ -363,7 +344,6 @@ def chunk_global_cumsum_scalar(
         T=T,
         B=B,
         H=H,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
     )
     return z
@@ -375,13 +355,14 @@ def chunk_global_cumsum_vector(
     reverse: bool = False,
     cu_seqlens: torch.Tensor | None = None,
     scale: float = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        B, H, T, S = s.shape
-    else:
-        B, T, H, S = s.shape
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    B, T, H, S = s.shape
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
     BS = min(32, triton.next_power_of_2(S))
 
@@ -397,7 +378,6 @@ def chunk_global_cumsum_vector(
         H=H,
         S=S,
         BS=BS,
-        HEAD_FIRST=head_first,
         REVERSE=reverse,
     )
     return z
@@ -410,9 +390,13 @@ def chunk_global_cumsum(
     reverse: bool = False,
     cu_seqlens: torch.Tensor | None = None,
     scale: float = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
+    **kwargs,
 ) -> torch.Tensor:
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     if cu_seqlens is not None:
         assert s.shape[0] == 1, "Only batch size 1 is supported when cu_seqlens are provided"
     if len(s.shape) == 3:
@@ -421,7 +405,6 @@ def chunk_global_cumsum(
             reverse=reverse,
             cu_seqlens=cu_seqlens,
             scale=scale,
-            head_first=head_first,
             output_dtype=output_dtype,
         )
     elif len(s.shape) == 4:
@@ -430,14 +413,12 @@ def chunk_global_cumsum(
             reverse=reverse,
             cu_seqlens=cu_seqlens,
             scale=scale,
-            head_first=head_first,
             output_dtype=output_dtype,
         )
     else:
         raise ValueError(
             f"Unsupported input shape {s.shape}, "
-            f"which should be [B, T, H]/[B, T, H, D] if `head_first=False` "
-            f"or [B, H, T]/[B, H, T, D] otherwise",
+            f"which should be [B, T, H] or [B, T, H, D]",
         )
 
 
@@ -449,11 +430,14 @@ def chunk_local_cumsum(
     reverse: bool = False,
     scale: float = None,
     cu_seqlens: torch.Tensor | None = None,
-    head_first: bool = False,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
     **kwargs,
 ) -> torch.Tensor:
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     if cu_seqlens is not None:
         assert g.shape[0] == 1, "Only batch size 1 is supported when cu_seqlens are provided"
     if len(g.shape) == 3:
@@ -463,7 +447,6 @@ def chunk_local_cumsum(
             reverse=reverse,
             scale=scale,
             cu_seqlens=cu_seqlens,
-            head_first=head_first,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
         )
@@ -474,13 +457,11 @@ def chunk_local_cumsum(
             reverse=reverse,
             scale=scale,
             cu_seqlens=cu_seqlens,
-            head_first=head_first,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
         )
     else:
         raise ValueError(
             f"Unsupported input shape {g.shape}, "
-            f"which should be (B, T, H, D) if `head_first=False` "
-            f"or (B, H, T, D) otherwise",
+            f"which should be (B, T, H) or (B, T, H, D)",
         )

--- a/fla/ops/utils/pooling.py
+++ b/fla/ops/utils/pooling.py
@@ -205,10 +205,12 @@ def mean_pooling(
     x: torch.Tensor,
     chunk_size: int,
     cu_seqlens: torch.LongTensor | None = None,
-    head_first: bool = False,
+    **kwargs,
 ) -> torch.Tensor:
-    if head_first:
-        x = x.transpose(1, 2)
+    if 'head_first' in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
     if cu_seqlens is not None:
         if x.shape[0] != 1:
             raise ValueError(
@@ -216,6 +218,4 @@ def mean_pooling(
                 f"Please flatten variable-length inputs before processing.",
             )
     o = MeanPoolingFunction.apply(x, chunk_size, cu_seqlens)
-    if head_first:
-        o = o.transpose(1, 2)
     return o


### PR DESCRIPTION
## Summary

Completes the `head_first` removal started in #853 by deleting the remaining head-major layout support, which that PR deliberately kept because it was still a functional format switch:

- `fla/ops/utils/cumsum.py` (Triton) and `fla/ops/utils/backends/triton_ascend/cumsum.py`: remove the `head_first` switch from the 6 host wrappers each, the `HEAD_FIRST` constexpr branches from the 4 kernels each, and the `head_first` plumbing in the Ascend launch helpers. The `head_first=False` addressing is kept unconditionally.
- `fla/ops/utils/pooling.py`: remove the `head_first` transpose shim from `mean_pooling`.
- `fla/ops/abc/chunk.py`, `fla/ops/based/{fused_chunk,parallel}.py`, `fla/ops/rebased/parallel.py`: remove the deprecated transpose shims; inputs are unconditionally treated as `[B, T, H, ...]`.
- `fla/ops/titans/naive.py`, `fla/ops/ttt/naive.py`: remove the parameter and shim from the reference implementations (no deprecation guard, per test-only status).

All public entry points above now accept `**kwargs` and raise `DeprecationWarning` when `head_first` is passed, matching the #853 convention. No in-tree caller (ops, layers, models, tests, benchmarks) passes `head_first`, by keyword or positionally.

Supersedes #1137: this removes the head-major cumsum paths instead of fixing their `cu_seqlens` addressing.

## Test plan

- `python scripts/find_dependent_tests.py` run over the 9 changed files; dependent tests (ops/layers/models/CP) are exercised by CI GPU runners — no GPU is available on the authoring machine.
- Local smoke (CPU): `python -m compileall` on all changed files, `ruff check` clean, `pre-commit run --files <changed files>` all pass, `import fla` plus imports of every touched entry point succeed, each new `DeprecationWarning` guard verified to raise on `head_first=True`, and the `titans`/`ttt` naive references run end-to-end on `[B, T, H, ...]` inputs.
- Repo-wide grep: remaining `head_first` hits are only the #853-style guards, the `RWKV7(Goose).md` doc, the `naive_deltaformer_attn_head_first` function name, and one comment in `tests/ops/test_simple_gla.py`.

## Benchmark / NCU (kernel changes only)

Neutral — dead code-path removal; the surviving kernels are the unchanged `head_first=False` branches.

## Breaking changes

- The `head_first` argument is removed from the entry points listed above. Callers passing it by keyword now get a `DeprecationWarning`; head-major inputs are no longer accepted anywhere. Migration: pass tensors in `[B, T, H, ...]` layout.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
