### PR TITLE
[Perf] Optimize Ascend KDA wy backward with 1D core-grid and T-contiguous loads

### DIFF
--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+from triton.runtime import driver
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp2
@@ -25,8 +26,8 @@ from fla.utils.ascend_ub_manager import (
 _DAV_NUM_WARPS = 2
 _DAV_MEM_MULT = 8.0
 _DAV_SAFETY_MARGIN = 0.75
-_FALLBACK_TILE = 8
-_MAX_TILE = 64
+_DAV_FALLBACK_TILE = 8
+_DAV_MAX_TILE = 64
 
 
 def _get_dAv_bv(BT: int, V: int) -> int:
@@ -34,9 +35,9 @@ def _get_dAv_bv(BT: int, V: int) -> int:
         BT, V, _DAV_MEM_MULT,
         tiling_row=False,
         safety_margin=_DAV_SAFETY_MARGIN,
-        fallback=_FALLBACK_TILE,
+        fallback=_DAV_FALLBACK_TILE,
         min_block=8,
-        max_block=min(_MAX_TILE, triton.next_power_of_2(V)),
+        max_block=min(_DAV_MAX_TILE, triton.next_power_of_2(V)),
     )
 
 
@@ -54,8 +55,6 @@ def _launch_dAv_2d_kernel(kernel, *, nt: int, bh_total: int, kernel_kwargs: dict
 
 @triton.jit(do_not_specialize=['T'])
 def chunk_kda_bwd_kernel_dAv_npu(
-    q,
-    k,
     v,
     A,
     do,
@@ -65,9 +64,7 @@ def chunk_kda_bwd_kernel_dAv_npu(
     chunk_indices,
     scale,
     T,
-    H: tl.constexpr,
     HV: tl.constexpr,
-    K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
     BV: tl.constexpr,
@@ -127,7 +124,7 @@ def chunk_kda_bwd_dAv_npu(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    B, T, H, K, HV, V = *k.shape, do.shape[2], do.shape[-1]
+    B, T, HV, V = k.shape[0], k.shape[1], do.shape[2], do.shape[-1]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -142,8 +139,6 @@ def chunk_kda_bwd_dAv_npu(
         nt=NT,
         bh_total=B * HV,
         kernel_kwargs=dict(
-            q=q,
-            k=k,
             v=v,
             A=A,
             do=do,
@@ -153,9 +148,7 @@ def chunk_kda_bwd_dAv_npu(
             chunk_indices=chunk_indices,
             scale=scale,
             T=T,
-            H=H,
             HV=HV,
-            K=K,
             V=V,
             BT=BT,
             BV=BV,
@@ -168,7 +161,6 @@ def chunk_kda_bwd_dAv_npu(
 
 
 _BC = 16
-_NUM_WARPS = 2
 _BWD_MEM_MULT = 10.0
 _SAFETY_MARGIN = 0.80
 _FALLBACK_TILE = 16
@@ -201,43 +193,52 @@ def _get_bv(V: int) -> int:
     )
 
 
-def _launch_2d_kernel(kernel, *, nt: int, bh_total: int, kernel_kwargs: dict, num_warps: int = _NUM_WARPS) -> None:
-    max_nt = max_grid_axis_chunks(nt, bh_total, max_grid=ASCEND_MAX_GRID_DIM)
-    for nt_off in range(0, nt, max_nt):
-        nt_len = min(max_nt, nt - nt_off)
-        kernel_kwargs['NT_OFFSET'] = nt_off
-        max_bh = max_grid_axis_chunks(bh_total, nt_len, max_grid=ASCEND_MAX_GRID_DIM)
-        for bh_off in range(0, bh_total, max_bh):
-            bh_len = min(max_bh, bh_total - bh_off)
-            kernel_kwargs['BH_OFFSET'] = bh_off
-            kernel[(nt_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+def _t_contig_arg(x: torch.Tensor, head_dim: int) -> tuple[torch.Tensor, bool]:
+    """Transpose [B, T, H*, ...] → [B, H*, T, ...] so T-loads are stride-1."""
+    if head_dim == 1:
+        return x, False
+    return x.transpose(1, 2).contiguous(), True
 
 
-def _launch_3d_kernel(
+def get_npu_properties():
+    device = torch.npu.current_device()
+    return driver.active.utils.get_device_properties(device)
+
+
+def _launch_wy_dA_finalize(
     kernel,
     *,
-    nk: int,
     nt: int,
     bh_total: int,
+    T: int,
+    BT: int,
+    is_varlen: bool,
+    num_core: int,
     kernel_kwargs: dict,
-    num_warps: int = _NUM_WARPS,
 ) -> None:
-    max_nk = max_grid_axis_chunks(nk, nt * bh_total, max_grid=ASCEND_MAX_GRID_DIM)
-    for nk_off in range(0, nk, max_nk):
-        nk_len = min(max_nk, nk - nk_off)
-        kernel_kwargs['K_OFFSET'] = nk_off
-        max_nt = max_grid_axis_chunks(nt, nk_len * bh_total, max_grid=ASCEND_MAX_GRID_DIM)
-        for nt_off in range(0, nt, max_nt):
-            nt_len = min(max_nt, nt - nt_off)
-            kernel_kwargs['NT_OFFSET'] = nt_off
-            max_bh = max_grid_axis_chunks(bh_total, nk_len * nt_len, max_grid=ASCEND_MAX_GRID_DIM)
-            for bh_off in range(0, bh_total, max_bh):
-                bh_len = min(max_bh, bh_total - bh_off)
-                kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(nk_len, nt_len, bh_len)](num_warps=num_warps, **kernel_kwargs)
+    """Host-split aligned bulk vs tail so TAIL_MODE is constexpr per launch."""
+    kwargs = dict(kernel_kwargs)
+    kwargs['num_core'] = num_core
+    if is_varlen:
+        kwargs['TAIL_MODE'] = 1
+        kwargs['NT_OFFSET'] = 0
+        kwargs['task_num'] = nt * bh_total
+        kernel[(num_core,)](**kwargs)
+        return
+    n_bulk = nt if T % BT == 0 else max(nt - 1, 0)
+    if n_bulk > 0:
+        kwargs['TAIL_MODE'] = 0
+        kwargs['NT_OFFSET'] = 0
+        kwargs['task_num'] = n_bulk * bh_total
+        kernel[(num_core,)](**kwargs)
+    if T % BT != 0 and nt > 0:
+        kwargs['TAIL_MODE'] = 1
+        kwargs['NT_OFFSET'] = n_bulk
+        kwargs['task_num'] = bh_total
+        kernel[(num_core,)](**kwargs)
 
 
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=['T', 'task_num', 'num_core', 'BH'])
 def chunk_kda_bwd_kernel_wy_v_part_npu(
     v,
     beta,
@@ -249,80 +250,86 @@ def chunk_kda_bwd_kernel_wy_v_part_npu(
     cu_seqlens,
     chunk_indices,
     T,
+    BH,
+    task_num,
+    num_core,
     HV: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
-    BC: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
+    G_T_CONTIG: tl.constexpr,
 ):
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
+    core_id = tl.program_id(0)
+    T_seq = T
 
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-    else:
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t = task_id // BH
+        i_bh = task_id % BH
+        i_b, i_hv = i_bh // HV, i_bh % HV
 
-    v += (bos * HV + i_hv) * V
-    beta += bos * HV + i_hv
-    A += (bos * HV + i_hv) * BT
-    dv += (bos * HV + i_hv) * V
-    dv2 += (bos * HV + i_hv) * V
-    dA_acc += (bos * HV + i_hv) * BT
-    db_acc += bos * HV + i_hv
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T = (eos - bos).to(tl.int32)
+        else:
+            bos, eos = tl.cast(i_b, tl.int64) * T, tl.cast(i_b, tl.int64) * T + T
 
-    n_sub = BT // BC
+        if G_T_CONTIG:
+            if IS_VARLEN:
+                v_ptr = v + tl.cast(i_hv, tl.int64) * T_seq * V + bos * V
+                dv_ptr = dv + tl.cast(i_hv, tl.int64) * T_seq * V + bos * V
+                A_ptr = A + tl.cast(i_hv, tl.int64) * T_seq * BT + bos * BT
+                beta_ptr = beta + tl.cast(i_hv, tl.int64) * T_seq + bos
+            else:
+                hv_off = tl.cast(i_b, tl.int64) * HV + i_hv
+                v_ptr = v + hv_off * T_seq * V
+                dv_ptr = dv + hv_off * T_seq * V
+                A_ptr = A + hv_off * T_seq * BT
+                beta_ptr = beta + hv_off * T_seq
+            v_stride_t = V
+            a_stride_t = BT
+            beta_stride = 1
+        else:
+            v_ptr = v + (bos * HV + i_hv) * V
+            dv_ptr = dv + (bos * HV + i_hv) * V
+            A_ptr = A + (bos * HV + i_hv) * BT
+            beta_ptr = beta + bos * HV + i_hv
+            v_stride_t = HV * V
+            a_stride_t = HV * BT
+            beta_stride = HV
 
-    for s_r in range(n_sub):
-        i_tc_r = i_t * BT + s_r * BC
+        dv2_ptr = dv2 + (bos * HV + i_hv) * V
+        dA_ptr = dA_acc + (bos * HV + i_hv) * BT
+        db_ptr = db_acc + bos * HV + i_hv
 
-        p_beta_r = tl.make_block_ptr(beta, (T,), (HV,), (i_tc_r,), (BC,), (0,))
-        b_beta_r = tl.load(p_beta_r, boundary_check=(0,))
+        p_A = tl.make_block_ptr(A_ptr, (BT, T), (1, a_stride_t), (0, i_t * BT), (BT, BT), (0, 1))
+        p_beta = tl.make_block_ptr(beta_ptr, (T,), (beta_stride,), (i_t * BT,), (BT,), (0,))
+        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_beta = tl.load(p_beta, boundary_check=(0,))
 
-        b_db_r = tl.zeros([BC], dtype=tl.float32)
-
-        for s_c in range(n_sub):
-            i_tc_c = i_t * BT + s_c * BC
-            b_dA_rc = tl.zeros([BC, BC], dtype=tl.float32)
-            for i_v in range(tl.cdiv(V, BV)):
-                p_dv_r = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_tc_r, i_v * BV), (BC, BV), (1, 0))
-                p_v_c = tl.make_block_ptr(v, (T, V), (HV * V, 1), (i_tc_c, i_v * BV), (BC, BV), (1, 0))
-                b_dv_r = tl.load(p_dv_r, boundary_check=(0, 1))
-                b_v_c = tl.load(p_v_c, boundary_check=(0, 1))
-                b_dA_rc += tl.dot(b_dv_r, tl.trans(b_v_c), allow_tf32=False)
-
-            p_dA = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_tc_r, s_c * BC), (BC, BC), (1, 0))
-            tl.store(p_dA, b_dA_rc.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-
+        b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+        b_db = tl.zeros([BT], dtype=tl.float32)
         for i_v in range(tl.cdiv(V, BV)):
-            b_dvb_r = tl.zeros([BC, BV], dtype=tl.float32)
-            for s_a in range(n_sub):
-                i_tc_a = i_t * BT + s_a * BC
-                p_A_ra = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (s_r * BC, i_tc_a), (BC, BC), (0, 1))
-                p_dv_a = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_tc_a, i_v * BV), (BC, BV), (1, 0))
-                b_A_ra = tl.load(p_A_ra, boundary_check=(0, 1))
-                b_dv_a = tl.load(p_dv_a, boundary_check=(0, 1))
-                b_dvb_r += tl.dot(b_A_ra, b_dv_a, allow_tf32=False)
+            p_dv = tl.make_block_ptr(dv_ptr, (T, V), (v_stride_t, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_v = tl.make_block_ptr(v_ptr, (T, V), (v_stride_t, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+            b_v = tl.load(p_v, boundary_check=(0, 1))
+            b_dA += tl.dot(b_dv, tl.trans(b_v), allow_tf32=False)
+            # Ascend tl.dot clobbers lhs; copy A before every V-slab use.
+            b_A_c = b_A + 0.0
+            b_dvb = tl.dot(b_A_c, b_dv, allow_tf32=False)
+            b_db += tl.sum(b_dvb * b_v, 1)
+            p_dv2 = tl.make_block_ptr(dv2_ptr, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            tl.store(p_dv2, (b_dvb * b_beta[:, None]).to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
 
-            p_v_r = tl.make_block_ptr(v, (T, V), (HV * V, 1), (i_tc_r, i_v * BV), (BC, BV), (1, 0))
-            b_v_r = tl.load(p_v_r, boundary_check=(0, 1))
-            b_db_r += tl.sum(b_dvb_r * b_v_r, 1)
-
-            b_dv2_r = b_dvb_r * b_beta_r[:, None]
-            p_dv2 = tl.make_block_ptr(dv2, (T, V), (HV * V, 1), (i_tc_r, i_v * BV), (BC, BV), (1, 0))
-            tl.store(p_dv2, b_dv2_r.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
-
-        p_db = tl.make_block_ptr(db_acc, (T,), (HV,), (i_tc_r,), (BC,), (0,))
-        tl.store(p_db, b_db_r.to(p_db.dtype.element_ty), boundary_check=(0,))
+        p_dA = tl.make_block_ptr(dA_ptr, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        p_db = tl.make_block_ptr(db_ptr, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
 
 
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=['T', 'task_num', 'num_core', 'BH'])
 def chunk_kda_bwd_kernel_wy_k_part_npu(
     q,
     k,
@@ -339,6 +346,9 @@ def chunk_kda_bwd_kernel_wy_k_part_npu(
     chunk_offsets,
     scale,
     T,
+    BH,
+    task_num,
+    num_core,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
@@ -350,132 +360,121 @@ def chunk_kda_bwd_kernel_wy_k_part_npu(
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     K_OFFSET: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
 ):
-    i_k = tl.program_id(0) + K_OFFSET
-    i_t = tl.program_id(1) + NT_OFFSET
-    i_bh = tl.program_id(2) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
-    i_h = i_hv // (HV // H)
+    i_k = K_OFFSET
+    core_id = tl.program_id(0)
 
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-        i_tg = tl.load(chunk_offsets + i_n).to(tl.int64) + i_t.to(tl.int64)
-    else:
-        i_tg = (i_b * tl.cdiv(T, BT) + i_t).to(tl.int64)
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t = task_id // BH
+        i_bh = task_id % BH
+        i_b, i_hv = i_bh // HV, i_bh % HV
+        i_h = i_hv // (HV // H)
 
-    q += (bos * H + i_h) * K
-    k += (bos * H + i_h) * K
-    v_new += (bos * HV + i_hv) * V
-    g += (bos * HV + i_hv) * K
-    h += (i_tg * HV + i_hv) * K * V
-    do += (bos * HV + i_hv) * V
-    dh += (i_tg * HV + i_hv) * K * V
-    dq += (bos * HV + i_hv) * K
-    dk += (bos * HV + i_hv) * K
-    dg += (bos * HV + i_hv) * K
-
-    o_k = i_k * BK + tl.arange(0, BK)
-    m_k = o_k < K
-
-    p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * HV * K + o_k
-    b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
-
-    o_i = tl.arange(0, BC)
-    n_sub = BT // BC
-    b_dgk = tl.zeros([BK], dtype=tl.float32)
-
-    for i_v in range(tl.cdiv(V, BV)):
-        if STATE_V_FIRST:
-            p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T = (eos - bos).to(tl.int32)
+            i_tg = tl.load(chunk_offsets + i_n).to(tl.int64) + i_t.to(tl.int64)
         else:
-            p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-        b_dh = tl.load(p_dh, boundary_check=(0, 1))
-        b_dgk += tl.sum(b_h * b_dh, axis=0)
+            i_tg = (i_b * tl.cdiv(T, BT) + i_t).to(tl.int64)
+            bos, eos = tl.cast(i_b, tl.int64) * T, tl.cast(i_b, tl.int64) * T + T
 
-    b_dgk *= exp2(b_gn)
+        q_ptr = q + (bos * H + i_h) * K
+        k_ptr = k + (bos * H + i_h) * K
+        v_new_ptr = v_new + (bos * HV + i_hv) * V
+        g_ptr = g + (bos * HV + i_hv) * K
+        h_ptr = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        do_ptr = do + (bos * HV + i_hv) * V
+        dh_ptr = dh + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        dq_ptr = dq + (bos * HV + i_hv) * K
+        dk_ptr = dk + (bos * HV + i_hv) * K
+        dg_ptr = dg + (bos * HV + i_hv) * K
 
-    b_kdk_sum = tl.zeros([BK], dtype=tl.float32)
-    for s in range(n_sub):
-        i_tc_s = i_t * BT + s * BC
-        m_s = (i_tc_s + o_i) < T
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
 
-        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        p_gn = g_ptr + (min(T, i_t * BT + BT) - 1).to(tl.int64) * HV * K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
 
-        b_dk = tl.zeros([BC, BK], dtype=tl.float32)
-        for i_v in range(tl.cdiv(V, BV)):
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (HV * V, 1), (i_tc_s, i_v * BV), (BC, BV), (1, 0))
-            if STATE_V_FIRST:
-                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-            else:
-                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
-            b_dh = tl.load(p_dh, boundary_check=(0, 1))
-            b_dk += tl.dot(b_v_new, b_dh.to(b_v_new.dtype), allow_tf32=False)
-
-        b_dk = b_dk * tl.where(m_s[:, None], exp2(b_gn[None, :] - b_g), 0)
-        b_kdk_sum += tl.sum(b_k * b_dk, axis=0)
-
-    b_dgk_total = b_dgk + b_kdk_sum
-
-    for s in range(n_sub):
-        i_tc_s = i_t * BT + s * BC
-        m_s = (i_tc_s + o_i) < T
-        m_last_s = (i_tc_s + o_i) == min(T, i_t * BT + BT) - 1
-
-        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-
-        b_dq = tl.zeros([BC, BK], dtype=tl.float32)
-        b_dk = tl.zeros([BC, BK], dtype=tl.float32)
+        o_i = tl.arange(0, BC)
+        n_sub = BT // BC
+        b_dgk = tl.zeros([BK], dtype=tl.float32)
 
         for i_v in range(tl.cdiv(V, BV)):
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (HV * V, 1), (i_tc_s, i_v * BV), (BC, BV), (1, 0))
-            p_do = tl.make_block_ptr(do, (T, V), (HV * V, 1), (i_tc_s, i_v * BV), (BC, BV), (1, 0))
             if STATE_V_FIRST:
-                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
-                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_h = tl.make_block_ptr(h_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_dh = tl.make_block_ptr(dh_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
             else:
-                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
-            b_do = tl.load(p_do, boundary_check=(0, 1))
+                p_h = tl.make_block_ptr(h_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                p_dh = tl.make_block_ptr(dh_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
             b_h = tl.load(p_h, boundary_check=(0, 1))
             b_dh = tl.load(p_dh, boundary_check=(0, 1))
+            b_dgk += tl.sum(b_h * b_dh, axis=0)
 
-            b_dq += tl.dot(b_do, b_h.to(b_do.dtype), allow_tf32=False)
-            b_dk += tl.dot(b_v_new, b_dh.to(b_v_new.dtype), allow_tf32=False)
+        b_dgk *= exp2(b_gn)
 
-        b_gk_exp = exp2(b_g)
-        b_dq = b_dq * b_gk_exp * scale
-        b_dk = b_dk * tl.where(m_s[:, None], exp2(b_gn[None, :] - b_g), 0)
+        b_kdk_sum = tl.zeros([BK], dtype=tl.float32)
+        for s in range(n_sub):
+            i_tc_s = i_t * BT + s * BC
+            m_s = (i_tc_s + o_i) < T
 
-        p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_kdk = b_k * b_dk
-        b_dg = b_q * b_dq - b_kdk + m_last_s[:, None] * b_dgk_total
+            p_k = tl.make_block_ptr(k_ptr, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            p_g = tl.make_block_ptr(g_ptr, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
 
-        p_dq = tl.make_block_ptr(dq, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
-        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+            b_dk = tl.zeros([BC, BK], dtype=tl.float32)
+            for i_v in range(tl.cdiv(V, BV)):
+                p_v_new = tl.make_block_ptr(v_new_ptr, (T, V), (HV * V, 1), (i_tc_s, i_v * BV), (BC, BV), (1, 0))
+                if STATE_V_FIRST:
+                    p_dh = tl.make_block_ptr(dh_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                else:
+                    p_dh = tl.make_block_ptr(dh_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
+                b_dh = tl.load(p_dh, boundary_check=(0, 1))
+                b_dk += tl.dot(b_v_new, b_dh.to(b_v_new.dtype), allow_tf32=False)
+
+            b_dk = b_dk * tl.where(m_s[:, None], exp2(b_gn[None, :] - b_g), 0)
+            b_kdk_sum += tl.sum(b_k * b_dk, axis=0)
+            p_dk = tl.make_block_ptr(dk_ptr, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+
+        b_dgk_total = b_dgk + b_kdk_sum
+
+        for s in range(n_sub):
+            i_tc_s = i_t * BT + s * BC
+            m_last_s = (i_tc_s + o_i) == min(T, i_t * BT + BT) - 1
+
+            p_k = tl.make_block_ptr(k_ptr, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            p_g = tl.make_block_ptr(g_ptr, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            p_q = tl.make_block_ptr(q_ptr, (T, K), (H * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            p_dk = tl.make_block_ptr(dk_ptr, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_dk = tl.load(p_dk, boundary_check=(0, 1)).to(tl.float32)
+
+            b_dq = tl.zeros([BC, BK], dtype=tl.float32)
+            for i_v in range(tl.cdiv(V, BV)):
+                p_do = tl.make_block_ptr(do_ptr, (T, V), (HV * V, 1), (i_tc_s, i_v * BV), (BC, BV), (1, 0))
+                if STATE_V_FIRST:
+                    p_h = tl.make_block_ptr(h_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                else:
+                    p_h = tl.make_block_ptr(h_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                b_do = tl.load(p_do, boundary_check=(0, 1))
+                b_h = tl.load(p_h, boundary_check=(0, 1))
+                b_dq += tl.dot(b_do, b_h.to(b_do.dtype), allow_tf32=False)
+
+            b_dq = b_dq * exp2(b_g) * scale
+            b_dg = b_q * b_dq - b_k * b_dk + m_last_s[:, None] * b_dgk_total
+
+            p_dq = tl.make_block_ptr(dq_ptr, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            p_dg = tl.make_block_ptr(dg_ptr, (T, K), (HV * K, 1), (i_tc_s, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=['T', 'task_num', 'num_core', 'BH'])
 def chunk_kda_bwd_kernel_wy_dw_part_npu(
     k,
     g,
@@ -483,7 +482,6 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
     A,
     h,
     dv,
-    dw,
     dA_acc,
     db_acc,
     dg,
@@ -492,259 +490,227 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
     chunk_indices,
     chunk_offsets,
     T,
+    BH,
+    task_num,
+    num_core,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
-    BC: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    K_T_CONTIG: tl.constexpr,
+    G_T_CONTIG: tl.constexpr,
     K_OFFSET: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
 ):
-    i_k = tl.program_id(0) + K_OFFSET
-    i_t = tl.program_id(1) + NT_OFFSET
-    i_bh = tl.program_id(2) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
-    i_h = i_hv // (HV // H)
+    i_k = K_OFFSET
+    core_id = tl.program_id(0)
+    T_seq = T
 
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-        i_tg = tl.load(chunk_offsets + i_n).to(tl.int64) + i_t.to(tl.int64)
-    else:
-        i_tg = (i_b * tl.cdiv(T, BT) + i_t).to(tl.int64)
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t = task_id // BH
+        i_bh = task_id % BH
+        i_b, i_hv = i_bh // HV, i_bh % HV
+        i_h = i_hv // (HV // H)
 
-    k += (bos * H + i_h) * K
-    g += (bos * HV + i_hv) * K
-    beta += bos * HV + i_hv
-    A += (bos * HV + i_hv) * BT
-    h += (i_tg * HV + i_hv).to(tl.int64) * K * V
-    dv += (bos * HV + i_hv) * V
-    dw += (bos * HV + i_hv) * K
-    dA_acc += (bos * HV + i_hv) * BT
-    db_acc += bos * HV + i_hv
-    dg += (bos * HV + i_hv) * K
-    dk += (bos * HV + i_hv) * K
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T = (eos - bos).to(tl.int32)
+            i_tg = tl.load(chunk_offsets + i_n).to(tl.int64) + i_t.to(tl.int64)
+        else:
+            i_tg = (i_b * tl.cdiv(T, BT) + i_t).to(tl.int64)
+            bos, eos = tl.cast(i_b, tl.int64) * T, tl.cast(i_b, tl.int64) * T + T
 
-    n_sub = BT // BC
-
-    # Precompute dw[s] = -dv[s] @ h once per sub-block.
-    for s in range(n_sub):
-        i_tc = i_t * BT + s * BC
-        b_dw = tl.zeros([BC, BK], dtype=tl.float32)
-        for i_v in range(tl.cdiv(V, BV)):
-            p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_tc, i_v * BV), (BC, BV), (1, 0))
-            if STATE_V_FIRST:
-                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+        if K_T_CONTIG:
+            if IS_VARLEN:
+                k_ptr = k + tl.cast(i_h, tl.int64) * T_seq * K + bos * K
             else:
-                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                k_ptr = k + (tl.cast(i_b, tl.int64) * H + i_h) * T_seq * K
+            k_stride_t = K
+        else:
+            k_ptr = k + (bos * H + i_h) * K
+            k_stride_t = H * K
+
+        if G_T_CONTIG:
+            if IS_VARLEN:
+                g_ptr = g + tl.cast(i_hv, tl.int64) * T_seq * K + bos * K
+                beta_ptr = beta + tl.cast(i_hv, tl.int64) * T_seq + bos
+                A_ptr = A + tl.cast(i_hv, tl.int64) * T_seq * BT + bos * BT
+                dv_ptr = dv + tl.cast(i_hv, tl.int64) * T_seq * V + bos * V
+            else:
+                hv_off = tl.cast(i_b, tl.int64) * HV + i_hv
+                g_ptr = g + hv_off * T_seq * K
+                beta_ptr = beta + hv_off * T_seq
+                A_ptr = A + hv_off * T_seq * BT
+                dv_ptr = dv + hv_off * T_seq * V
+            g_stride_t = K
+            a_stride_t = BT
+            dv_stride_t = V
+            beta_stride = 1
+        else:
+            g_ptr = g + (bos * HV + i_hv) * K
+            beta_ptr = beta + bos * HV + i_hv
+            A_ptr = A + (bos * HV + i_hv) * BT
+            dv_ptr = dv + (bos * HV + i_hv) * V
+            g_stride_t = HV * K
+            a_stride_t = HV * BT
+            dv_stride_t = HV * V
+            beta_stride = HV
+
+        h_ptr = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        dA_ptr = dA_acc + (bos * HV + i_hv) * BT
+        db_ptr = db_acc + bos * HV + i_hv
+        dg_ptr = dg + (bos * HV + i_hv) * K
+        dk_ptr = dk + (bos * HV + i_hv) * K
+
+        b_dw = tl.zeros([BT, BK], dtype=tl.float32)
+        for i_v in range(tl.cdiv(V, BV)):
+            p_dv = tl.make_block_ptr(dv_ptr, (T, V), (dv_stride_t, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            if STATE_V_FIRST:
+                p_h = tl.make_block_ptr(h_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            else:
+                p_h = tl.make_block_ptr(h_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
             b_dv = tl.load(p_dv, boundary_check=(0, 1))
             b_h = tl.load(p_h, boundary_check=(0, 1))
-            b_dw += tl.dot(b_dv.to(b_h.dtype), b_h.to(b_h.dtype), allow_tf32=False)
-        p_dw = tl.make_block_ptr(dw, (T, K), (HV * K, 1), (i_tc, i_k * BK), (BC, BK), (1, 0))
-        tl.store(p_dw, (-b_dw).to(p_dw.dtype.element_ty), boundary_check=(0, 1))
+            b_dw += tl.dot(b_dv, b_h.to(b_dv.dtype), allow_tf32=False)
 
-    for s_r in range(n_sub):
-        i_tc_r = i_t * BT + s_r * BC
-
-        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
-        p_beta_r = tl.make_block_ptr(beta, (T,), (HV,), (i_tc_r,), (BC,), (0,))
-        p_dw_r = tl.make_block_ptr(dw, (T, K), (HV * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
+        p_k = tl.make_block_ptr(k_ptr, (T, K), (k_stride_t, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_g = tl.make_block_ptr(g_ptr, (T, K), (g_stride_t, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_beta = tl.make_block_ptr(beta_ptr, (T,), (beta_stride,), (i_t * BT,), (BT,), (0,))
+        p_A = tl.make_block_ptr(A_ptr, (BT, T), (1, a_stride_t), (0, i_t * BT), (BT, BT), (0, 1))
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
-        b_beta_r = tl.load(p_beta_r, boundary_check=(0,))
-        b_dw_r = tl.load(p_dw_r, boundary_check=(0, 1))
+        b_beta = tl.load(p_beta, boundary_check=(0,))
+        b_A = tl.load(p_A, boundary_check=(0, 1))
         b_gk_exp = exp2(b_g)
         b_kg = b_k * b_gk_exp
-        b_gb = b_gk_exp * b_beta_r[:, None]
+        b_gb = b_gk_exp * b_beta[:, None]
+        # Match CUDA: downcast dw/kg to A.dtype before dA / dkgb GEMMs.
+        b_dw = -b_dw.to(b_A.dtype)
+        b_kg_a = b_kg.to(b_A.dtype)
+        b_dkgb = tl.dot(b_A, b_dw, allow_tf32=False)
 
-        b_dkgb_r = tl.zeros([BC, BK], dtype=tl.float32)
-        b_dw_r_p = b_dw_r + 0.0
-        for s_c in range(n_sub):
-            i_tc_c = i_t * BT + s_c * BC
-            p_dw_c = tl.make_block_ptr(dw, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
-            b_dw_c = tl.load(p_dw_c, boundary_check=(0, 1))
+        p_dA_acc = tl.make_block_ptr(dA_ptr, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        b_dA = tl.load(p_dA_acc, boundary_check=(0, 1)).to(tl.float32)
+        b_dw_c = b_dw + 0.0
+        b_dA += tl.dot(b_dw_c, tl.trans(b_kg_a), allow_tf32=False)
+        tl.store(p_dA_acc, b_dA.to(p_dA_acc.dtype.element_ty), boundary_check=(0, 1))
 
-            p_A_rc = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (s_r * BC, i_tc_c), (BC, BC), (0, 1))
-            b_A_rc = tl.load(p_A_rc, boundary_check=(0, 1))
-            b_dkgb_r += tl.dot(b_A_rc.to(tl.float32), b_dw_c.to(tl.float32), allow_tf32=False)
+        p_db_acc = tl.make_block_ptr(db_ptr, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        b_db = tl.load(p_db_acc, boundary_check=(0,)).to(tl.float32)
+        b_db += tl.sum(b_dkgb * b_kg, 1)
+        tl.store(p_db_acc, b_db.to(p_db_acc.dtype.element_ty), boundary_check=(0,))
 
-            p_k_c = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
-            p_g_c = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
-            b_kg_c = tl.load(p_k_c, boundary_check=(0, 1)) * exp2(
-                tl.load(p_g_c, boundary_check=(0, 1)).to(tl.float32),
-            )
-
-            p_dA_acc = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_tc_r, s_c * BC), (BC, BC), (1, 0))
-            b_dA_rc = tl.load(p_dA_acc, boundary_check=(0, 1)).to(tl.float32)
-            b_dw_r_c = b_dw_r_p + 0.0
-            b_dA_rc += tl.dot(b_dw_r_c.to(tl.float32), tl.trans(b_kg_c.to(tl.float32)), allow_tf32=False)
-            tl.store(p_dA_acc, b_dA_rc.to(p_dA_acc.dtype.element_ty), boundary_check=(0, 1))
-
-        p_db_acc = tl.make_block_ptr(db_acc, (T,), (HV,), (i_tc_r,), (BC,), (0,))
-        b_db_r = tl.load(p_db_acc, boundary_check=(0,)).to(tl.float32)
-        b_db_r += tl.sum(b_dkgb_r * b_kg, 1)
-        tl.store(p_db_acc, b_db_r.to(p_db_acc.dtype.element_ty), boundary_check=(0,))
-
-        p_dk = tl.make_block_ptr(dk, (T, K), (HV * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk_ptr, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_dk = tl.load(p_dk, boundary_check=(0, 1)).to(tl.float32)
-        b_dk = b_dk + b_dkgb_r * b_gb
+        b_dk = b_dk + b_dkgb * b_gb
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_dg = tl.make_block_ptr(dg, (T, K), (HV * K, 1), (i_tc_r, i_k * BK), (BC, BK), (1, 0))
+        p_dg = tl.make_block_ptr(dg_ptr, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_dg = tl.load(p_dg, boundary_check=(0, 1)).to(tl.float32)
-        b_dg = b_dg + b_kg * b_dkgb_r * b_beta_r[:, None]
+        b_dg = b_dg + b_kg * b_dkgb * b_beta[:, None]
         tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.jit(do_not_specialize=['T'])
-def chunk_kda_bwd_kernel_wy_dA_mask_npu(
-    beta,
-    dA_acc,
-    cu_seqlens,
-    chunk_indices,
-    T,
-    HV: tl.constexpr,
-    BT: tl.constexpr,
-    BC: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
-):
-    """In-place: dA_acc = mask * dA_acc * beta[None, :]."""
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
-
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-    else:
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
-
-    beta += bos * HV + i_hv
-    dA_acc += (bos * HV + i_hv) * BT
-
-    o_i = tl.arange(0, BC)
-    n_sub = BT // BC
-
-    for s_a in range(n_sub):
-        i_tc_a = i_t * BT + s_a * BC
-        m_a = (i_tc_a + o_i) < T
-        o_t_a = i_tc_a + o_i
-        for s_b in range(n_sub):
-            i_tc_b = i_t * BT + s_b * BC
-            m_b = (i_tc_b + o_i) < T
-            o_t_b = i_tc_b + o_i
-            p_dA = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_tc_a, s_b * BC), (BC, BC), (1, 0))
-            p_beta_b = tl.make_block_ptr(beta, (T,), (HV,), (i_tc_b,), (BC,), (0,))
-            b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
-            b_beta_b = tl.load(p_beta_b, boundary_check=(0,))
-            m_A = (o_t_a[:, None] > o_t_b[None, :]) & (m_a[:, None] & m_b[None, :])
-            b_M = tl.where(m_A, b_dA * b_beta_b[None, :], 0)
-            tl.store(p_dA, b_M.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
-
-
-@triton.jit(do_not_specialize=['T'])
-def chunk_kda_bwd_kernel_wy_dA_mid_npu(
-    A,
-    dA_acc,
-    dA_mid,
-    cu_seqlens,
-    chunk_indices,
-    T,
-    HV: tl.constexpr,
-    BT: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
-):
-    """dA_mid = dA_acc @ A after mask*beta has been applied to dA_acc."""
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
-
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-    else:
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
-
-    A += (bos * HV + i_hv) * BT
-    dA_acc += (bos * HV + i_hv) * BT
-    dA_mid += (bos * HV + i_hv) * BT
-
-    p_A = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_dA = tl.make_block_ptr(dA_acc, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    p_out = tl.make_block_ptr(dA_mid, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_dA = tl.load(p_dA, boundary_check=(0, 1)).to(tl.float32)
-    b_out = tl.dot(b_dA.to(b_A.dtype), b_A, allow_tf32=False)
-    tl.store(p_out, b_out.to(p_out.dtype.element_ty), boundary_check=(0, 1))
-
-
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=['T', 'task_num', 'num_core', 'BH', 'NT_OFFSET'])
 def chunk_kda_bwd_kernel_wy_dA_finalize_npu(
     A,
-    dA_mid,
+    beta,
+    dA_acc,
     db_acc,
     dA,
     db,
     cu_seqlens,
     chunk_indices,
     T,
+    BH,
+    task_num,
+    num_core,
+    NT_OFFSET,
     HV: tl.constexpr,
     BT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
+    G_T_CONTIG: tl.constexpr,
+    TAIL_MODE: tl.constexpr,
 ):
-    """dA = mask(-A @ dA_mid); copy db_acc into db."""
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_hv = i_bh // HV, i_bh % HV
+    """dA = mask(-A @ ((mask * dA_acc * beta) @ A)); copy db_acc into db.
 
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-    else:
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+    Fuses the old mask kernel into mid+finalize so dA_acc stays in UB.
+    TAIL_MODE 0 = aligned bulk (no boundary_check). TAIL_MODE 1 = tail/varlen.
+    First tl.dot clobbers masked dA (dead). Second uses b_A as lhs (dead after store).
+    """
+    core_id = tl.program_id(0)
+    T_seq = T
 
-    A += (bos * HV + i_hv) * BT
-    dA_mid += (bos * HV + i_hv) * BT
-    db_acc += bos * HV + i_hv
-    dA += (bos * HV + i_hv) * BT
-    db += bos * HV + i_hv
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t = NT_OFFSET + task_id // BH
+        i_bh = task_id % BH
+        i_b, i_hv = i_bh // HV, i_bh % HV
 
-    p_A = tl.make_block_ptr(A, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
-    p_T = tl.make_block_ptr(dA_mid, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T = (eos - bos).to(tl.int32)
+        else:
+            bos, eos = tl.cast(i_b, tl.int64) * T, tl.cast(i_b, tl.int64) * T + T
 
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_T = tl.load(p_T, boundary_check=(0, 1)).to(tl.float32)
-    b_dA = tl.dot(b_A, b_T.to(b_A.dtype), allow_tf32=False)
+        if G_T_CONTIG:
+            if IS_VARLEN:
+                A_ptr = A + tl.cast(i_hv, tl.int64) * T_seq * BT + bos * BT
+                beta_ptr = beta + tl.cast(i_hv, tl.int64) * T_seq + bos
+            else:
+                hv_off = tl.cast(i_b, tl.int64) * HV + i_hv
+                A_ptr = A + hv_off * T_seq * BT
+                beta_ptr = beta + hv_off * T_seq
+            a_stride_t = BT
+            beta_stride = 1
+        else:
+            A_ptr = A + (bos * HV + i_hv) * BT
+            beta_ptr = beta + bos * HV + i_hv
+            a_stride_t = HV * BT
+            beta_stride = HV
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
-    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t[None, :])
-    b_dA = tl.where(m_A, -b_dA, 0)
+        dA_acc_ptr = dA_acc + (bos * HV + i_hv) * BT
+        db_acc_ptr = db_acc + bos * HV + i_hv
+        dA_ptr = dA + (bos * HV + i_hv) * BT
+        db_ptr = db + bos * HV + i_hv
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+        p_A = tl.make_block_ptr(A_ptr, (BT, T), (1, a_stride_t), (0, i_t * BT), (BT, BT), (0, 1))
+        p_dA_acc = tl.make_block_ptr(dA_acc_ptr, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        p_dA = tl.make_block_ptr(dA_ptr, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        p_beta = tl.make_block_ptr(beta_ptr, (T,), (beta_stride,), (i_t * BT,), (BT,), (0,))
+        p_db_acc = tl.make_block_ptr(db_acc_ptr, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+        p_db = tl.make_block_ptr(db_ptr, (T,), (HV,), (i_t * BT,), (BT,), (0,))
 
-    p_db_acc = tl.make_block_ptr(db_acc, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-    tl.store(p_db, tl.load(p_db_acc, boundary_check=(0,)).to(p_db.dtype.element_ty), boundary_check=(0,))
+        o_t = i_t * BT + tl.arange(0, BT)
+        if TAIL_MODE == 0:
+            b_A = tl.load(p_A)
+            b_dA = tl.load(p_dA_acc).to(tl.float32)
+            b_beta = tl.load(p_beta)
+            m_A = o_t[:, None] > o_t[None, :]
+        else:
+            b_A = tl.load(p_A, boundary_check=(0, 1))
+            b_dA = tl.load(p_dA_acc, boundary_check=(0, 1)).to(tl.float32)
+            b_beta = tl.load(p_beta, boundary_check=(0,))
+            m_t = o_t < T
+            m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t[None, :])
+
+        b_dA = tl.where(m_A, b_dA * b_beta[None, :], 0)
+        # mid: (mask * dA_acc * beta) @ A. lhs clobbers b_dA; A is rhs then lhs.
+        b_mid = tl.dot(b_dA.to(b_A.dtype), b_A, allow_tf32=False)
+        b_fin = tl.dot(b_A, b_mid.to(b_A.dtype), allow_tf32=False)
+        b_fin = tl.where(m_A, -b_fin, 0)
+
+        if TAIL_MODE == 0:
+            tl.store(p_dA, b_fin.to(p_dA.dtype.element_ty))
+            tl.store(p_db, tl.load(p_db_acc).to(p_db.dtype.element_ty))
+        else:
+            tl.store(p_dA, b_fin.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_db, tl.load(p_db_acc, boundary_check=(0,)).to(p_db.dtype.element_ty), boundary_check=(0,))
 
 
 @input_guard
@@ -783,7 +749,6 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
     dA = torch.empty_like(A, dtype=torch.float)
     dA_acc = torch.zeros(B, T, HV, BT, dtype=torch.float, device=A.device)
     db_acc = torch.zeros(B, T, HV, dtype=torch.float, device=beta.device)
-    dw = g.new_empty(B, T, HV, K)
 
     BK = _get_bk(K)
     BV = _get_bv(V)
@@ -791,130 +756,129 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
     is_varlen = cu_seqlens is not None
     chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT) if is_varlen else g.new_zeros(1, dtype=torch.int64)
 
-    common_launch = dict(
+    v_arg, g_t_contig = _t_contig_arg(v, HV)
+    beta_arg = _t_contig_arg(beta, HV)[0]
+    A_arg = _t_contig_arg(A, HV)[0]
+    dv_arg = _t_contig_arg(dv, HV)[0]
+
+    bh_total = B * HV
+    num_core = get_npu_properties()['num_vectorcore']
+    task_num = NT * bh_total
+    chunk_kda_bwd_kernel_wy_v_part_npu[(num_core,)](
+        v=v_arg,
+        beta=beta_arg,
+        A=A_arg,
+        dv=dv_arg,
+        dv2=dv2,
+        dA_acc=dA_acc,
+        db_acc=db_acc,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         T=T,
+        BH=bh_total,
+        task_num=task_num,
+        num_core=num_core,
         HV=HV,
+        V=V,
         BT=BT,
+        BV=BV,
         IS_VARLEN=is_varlen,
-        NT_OFFSET=0,
-        BH_OFFSET=0,
-    )
-    common = dict(BC=_BC, **common_launch)
-    h_launch = dict(chunk_offsets=chunk_offsets, **common)
-
-    _launch_2d_kernel(
-        chunk_kda_bwd_kernel_wy_v_part_npu,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs=dict(
-            v=v,
-            beta=beta,
-            A=A,
-            dv=dv,
-            dv2=dv2,
-            dA_acc=dA_acc,
-            db_acc=db_acc,
-            V=V,
-            BV=BV,
-            **common,
-        ),
+        G_T_CONTIG=g_t_contig,
     )
 
-    _launch_3d_kernel(
-        chunk_kda_bwd_kernel_wy_k_part_npu,
-        nk=NK,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs=dict(
-            q=q,
-            k=k,
-            v_new=v_new,
-            g=g,
-            h=h,
-            do=do,
-            dh=dh,
-            dq=dq,
-            dk=dk,
-            dg=dg,
-            scale=scale,
-            H=H,
-            K=K,
-            V=V,
-            BK=BK,
-            BV=BV,
-            STATE_V_FIRST=state_v_first,
-            K_OFFSET=0,
-            **h_launch,
-        ),
-    )
-
-    dw_kwargs = dict(
+    k_part_kwargs = dict(
+        q=q,
         k=k,
+        v_new=v_new,
         g=g,
-        beta=beta,
-        A=A,
         h=h,
-        dv=dv,
-        dw=dw,
+        do=do,
+        dh=dh,
+        dq=dq,
+        dk=dk,
+        dg=dg,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+        scale=scale,
+        T=T,
+        BH=bh_total,
+        task_num=task_num,
+        num_core=num_core,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        BC=32 if BT >= 32 else _BC,
+        BK=BK,
+        BV=BV,
+        STATE_V_FIRST=state_v_first,
+        IS_VARLEN=is_varlen,
+    )
+    for k_off in range(NK):
+        k_part_kwargs['K_OFFSET'] = k_off
+        chunk_kda_bwd_kernel_wy_k_part_npu[(num_core,)](**k_part_kwargs)
+
+    k_arg, k_t_contig = _t_contig_arg(k, H)
+    g_arg, g_t_contig = _t_contig_arg(g, HV)
+    dw_kwargs = dict(
+        k=k_arg,
+        g=g_arg,
+        beta=beta_arg,
+        A=A_arg,
+        h=h,
+        dv=dv_arg,
         dA_acc=dA_acc,
         db_acc=db_acc,
         dg=dg,
         dk=dk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        BH=bh_total,
+        task_num=task_num,
+        num_core=num_core,
         H=H,
+        HV=HV,
         K=K,
         V=V,
+        BT=BT,
         BK=BK,
         BV=BV,
         STATE_V_FIRST=state_v_first,
-        **h_launch,
+        IS_VARLEN=is_varlen,
+        K_T_CONTIG=k_t_contig,
+        G_T_CONTIG=g_t_contig,
     )
     for k_off in range(NK):
         dw_kwargs['K_OFFSET'] = k_off
-        _launch_3d_kernel(
-            chunk_kda_bwd_kernel_wy_dw_part_npu,
-            nk=1,
-            nt=NT,
-            bh_total=B * HV,
-            kernel_kwargs=dw_kwargs,
-        )
+        chunk_kda_bwd_kernel_wy_dw_part_npu[(num_core,)](**dw_kwargs)
 
-    _launch_2d_kernel(
-        chunk_kda_bwd_kernel_wy_dA_mask_npu,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs=dict(
-            beta=beta,
-            dA_acc=dA_acc,
-            BC=_BC,
-            **common_launch,
-        ),
-    )
-
-    _launch_2d_kernel(
-        chunk_kda_bwd_kernel_wy_dA_mid_npu,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs=dict(
-            A=A,
-            dA_acc=dA_acc,
-            dA_mid=dA_acc,  # in-place alias; avoids a [B,T,HV,BT] fp32 workspace
-            **common_launch,
-        ),
-    )
-
-    _launch_2d_kernel(
+    _launch_wy_dA_finalize(
         chunk_kda_bwd_kernel_wy_dA_finalize_npu,
         nt=NT,
-        bh_total=B * HV,
+        bh_total=bh_total,
+        T=T,
+        BT=BT,
+        is_varlen=is_varlen,
+        num_core=num_core,
         kernel_kwargs=dict(
-            A=A,
-            dA_mid=dA_acc,  # in-place alias; avoids a [B,T,HV,BT] fp32 workspace
+            A=A_arg,
+            beta=beta_arg,
+            dA_acc=dA_acc,
             db_acc=db_acc,
             dA=dA,
             db=db,
-            **common_launch,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            BH=bh_total,
+            HV=HV,
+            BT=BT,
+            IS_VARLEN=is_varlen,
+            G_T_CONTIG=g_t_contig,
         ),
     )
 

--- a/fla/ops/utils/backends/triton_ascend/cumsum.py
+++ b/fla/ops/utils/backends/triton_ascend/cumsum.py
@@ -212,10 +212,10 @@ def chunk_local_cumsum_scalar_kernel_npu(
     p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
     p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
     b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
-    b_o = tl.cumsum(b_s, axis=0)
     if REVERSE:
-        b_z = tl.sum(b_s, axis=0)
-        b_o = -b_o + b_z[None] + b_s
+        b_o = tl.cumsum(b_s, axis=0, reverse=True)
+    else:
+        b_o = tl.cumsum(b_s, axis=0)
     if HAS_SCALE:
         b_o *= scale
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
@@ -301,10 +301,11 @@ def chunk_global_cumsum_scalar_kernel_npu(
         p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
         p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
         b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
-        b_o = tl.cumsum(b_s, axis=0)
-        b_ss = tl.sum(b_s, 0)
         if REVERSE:
-            b_o = -b_o + b_ss + b_s
+            b_o = tl.cumsum(b_s, axis=0, reverse=True)
+        else:
+            b_o = tl.cumsum(b_s, axis=0)
+        b_ss = tl.sum(b_s, 0)
         b_o += b_z
         if i_c >= 0:
             b_z += b_ss


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->
Follow-up to https://github.com/fla-org/flash-linear-attention/pull/1148 on the triton-ascend port. The original identity used by the NPU scalar core:
reverse_cumsum[i] = sum(x) - forward_cumsum[i] + x[i]
In float32, 32 * 1e8 + 32 will completely erase the trailing 1s, resulting in all‑1 suffix values. This causes mismatches for 31/32 elements with a maximum absolute error of 31.0.
The implementation has been modified in fla/ops/utils/backends/triton_ascend/cumsum.py to match that of the GPU / vector core: scanning from the tail.

Optimize the Ascend NPU KDA wy fused backward (`chunk_kda_bwd_wy_dqkg_fused_npu`) to cut host launch overhead, T-strided DMA, and extra HBM round-trips.
Scheduling
- Replace 2D/3D grids plus `ASCEND_MAX_GRID_DIM` host chunking with a 1D Vector core-grid: `grid=(num_vectorcore,)` and `for task_id in tl.range(core_id, task_num, num_core)`.
- Decode `task_id → (i_t, i_bh)` inside the kernel; rebind local pointers each iteration (`k_ptr = k + …`) instead of `ptr +=`.
- Host-loop `K_OFFSET` as constexpr (`NK` launches) so K-tile is compile-time.
Memory layout
- Host-transpose `[B, T, H*, …] → [B, H*, T, …]` when `H*/HV > 1` so T-loads are stride-1 (`G_T_CONTIG` / `K_T_CONTIG`).
- Keep `T_seq` before varlen overwrites `T`; use int64 for `bos`/`i_tg` pointer math.
Kernel changes
- `wy_v_part`: drop BC×BC nested tiling; full `BT×BV` GEMMs. Copy `A` before each V-slab (`b_A + 0.0`) because Ascend `tl.dot` clobbers lhs.
- `wy_k_part`: 1D task loop; store `dk` then compute `dq`/`dg`; `BC=32` when `BT >= 32`.
- `wy_dw_part`: keep `dw` in UB (drop `[B,T,HV,K]` workspace); full `BT` tiles; copy `b_dw` before the second GEMM.
- `wy_dA`: fuse mask + mid + finalize so `dA_acc` stays in UB. Host-split aligned bulk vs tail (`TAIL_MODE` constexpr: 0 = `block_ptr` only, 1 = masked tail/varlen) so unused DMA paths DCE.
- `dAv`: drop unused `q`/`k`/`H`/`K` kernel args.

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->
hardware: Atlas 800T A3(X86)
FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules tests/ops/utils tests/ops/test_gdn_kernels.py tests/ops/test_gdn.py tests/ops/test_kda.py tests/ops/test_attnres.py tests/ops/test_solve_tril.py
<img width="1295" height="372" alt="image" src="https://github.com/user-attachments/assets/f48d7202-0d56-4665-8009-58a973ff6684" />


## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
<img width="1262" height="685" alt="image" src="https://github.com/user-attachments/assets/5541262f-4afd-415f-a0dc-8ee9c8c130a4" />


## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->
None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
