### PR TITLE
[Fix] Use native reverse scans in Ascend scalar cumsum

### DIFF
--- a/fla/ops/utils/backends/triton_ascend/cumsum.py
+++ b/fla/ops/utils/backends/triton_ascend/cumsum.py
@@ -212,10 +212,10 @@ def chunk_local_cumsum_scalar_kernel_npu(
     p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
     p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
     b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
-    b_o = tl.cumsum(b_s, axis=0)
     if REVERSE:
-        b_z = tl.sum(b_s, axis=0)
-        b_o = -b_o + b_z[None] + b_s
+        b_o = tl.cumsum(b_s, axis=0, reverse=True)
+    else:
+        b_o = tl.cumsum(b_s, axis=0)
     if HAS_SCALE:
         b_o *= scale
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
@@ -301,10 +301,11 @@ def chunk_global_cumsum_scalar_kernel_npu(
         p_s = tl.make_block_ptr(s + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
         p_o = tl.make_block_ptr(o + bos*H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
         b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
-        b_o = tl.cumsum(b_s, axis=0)
-        b_ss = tl.sum(b_s, 0)
         if REVERSE:
-            b_o = -b_o + b_ss + b_s
+            b_o = tl.cumsum(b_s, axis=0, reverse=True)
+        else:
+            b_o = tl.cumsum(b_s, axis=0)
+        b_ss = tl.sum(b_s, 0)
         b_o += b_z
         if i_c >= 0:
             b_z += b_ss


### PR DESCRIPTION
## Summary

#1095 replaced the total-minus-prefix reverse formula with native `tl.cumsum(reverse=True)` in the NVIDIA scalar cumsum kernels, but the two `triton_ascend` scalar copies kept the old formula, which loses small suffixes to fp32 cancellation. This is what currently turns main's A2 CI red on `tests/ops/utils/test_cumsum.py::test_scalar_reversed_cumsum_preserves_small_suffix`.

This PR mirrors #1095 in `chunk_local_cumsum_scalar_kernel_npu` and `chunk_global_cumsum_scalar_kernel_npu` (+7/−6, single file).

## Test plan

Dependent tests (`python scripts/find_dependent_tests.py fla/ops/utils/backends/triton_ascend/cumsum.py`) resolve to `tests/ops/utils/test_cumsum.py`, including the case currently failing on main A2.

No local NPU access, so I verified on the A2 runner through the repo's OJ mechanism (`tests/oj/` + `gh workflow run oj.yml`): the exact failing precision case, randomized reverse-cumsum parity against a flip-cumsum-flip reference (multi-chunk, scaled, ragged T), and a forward-path regression check all pass: https://github.com/fla-org/flash-linear-attention/actions/runs/32235140179 (scratch tests removed before opening).

## Benchmark / NCU (kernel changes only)

Neutral — numerics bugfix, no scheduling/tiling changes.

## Breaking changes

None. Forward path is bit-identical; the reverse path only fixes precision for ill-conditioned inputs.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). (N/A — numerics fix, performance-neutral by construction.)
