### PR TITLE
[Ops] (utils): add the num_aicore option to the get_multiprocessor_count

### DIFF
--- a/fla/utils/_device.py
+++ b/fla/utils/_device.py
@@ -79,14 +79,15 @@ def check_pytorch_version(version_s: str = '2.4') -> bool:
 
 
 @cache
-def get_multiprocessor_count(tensor_idx: int = 0) -> int:
+def get_multiprocessor_count(tensor_idx: int = 0, *, use_aicore: bool = False) -> int:
     try:
         return triton.runtime.driver.active.utils.get_device_properties(tensor_idx)['multiprocessor_count']
     except Exception:
         # Maybe we use a NPU device.
         try:
             if triton.runtime.driver.active.get_current_target().backend == 'npu':
-                return triton.runtime.driver.active.utils.get_device_properties(tensor_idx)['num_vectorcore']
+                props = triton.runtime.driver.active.utils.get_device_properties(tensor_idx)
+                return props['num_aicore'] if use_aicore else props['num_vectorcore']
         except Exception:
             logger.debug('Failed to get NPU multiprocessor count, falling back to 1.', exc_info=True)
         return 1


### PR DESCRIPTION
## Summary

`fla.utils.get_multiprocessor_count` previously could only report the number of **Vector Cores** on Ascend NPU (`num_vectorcore`). However, some kernels require `num_aicore`.

This PR adds a keyword-only `use_aicore: bool = False` parameter to `get_multiprocessor_count` in `fla/utils/_device.py`:
- On NPU, `use_aicore=True` returns `num_aicore`; the default `use_aicore=False` keeps returning `num_vectorcore` (unchanged behavior for all existing call sites).
- On GPU, the parameter is naturally ignored (`multiprocessor_count` remains the only source).
- The `@cache` decorator keys on all arguments, so the two configurations cache independently.

This is backward compatible: no existing caller passes a second argument, and all current NPU call sites (rotary, layernorm, fused_norm_gate, causal_conv1d) will still use `num_vectorcore` correctly.

## Test plan

- No unit tests added: the change is a pure extension of the existing helper with a default that preserves current behavior.
- Grep-verified that no existing call site passes a second positional/keyword argument, so behavior is unchanged for all current callers.

## Benchmark / NCU

Neutral. The change is a host-side helper extension with no kernel or numerical impact; existing kernels launch with the exact same grid as before.

## Breaking changes

None. The function signature adds a keyword-only parameter with a default; all existing call sites behave identically. Downstream users who subclass or wrap this helper are unaffected unless they use positional-only introspection.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
