### PR TITLE
[Perf] Optimize NSA compression dKV query grouping

### DIFF
--- a/benchmarks/ops/registry.py
+++ b/benchmarks/ops/registry.py
@@ -559,6 +559,92 @@ register_op(OpConfig(
 # explicitly — the generic randn/randint input factory cannot produce a valid one.
 
 
+def _shape_nsa_gate(B, T, H, D, HQ=None, **kw):
+    if HQ is None:
+        raise ValueError("NSA gate shape requires HQ")
+    return (B, T, HQ)
+
+
+def _shape_nsa_compressed_k(B, T, H, D, block_size=64, **kw):
+    return (B, (T + block_size - 1) // block_size, H, D)
+
+
+def _shape_nsa_compressed_v(B, T, H, D, V=None, block_size=64, **kw):
+    if V is None:
+        raise ValueError("NSA value shape requires V")
+    return (B, (T + block_size - 1) // block_size, H, V)
+
+
+def _shape_nsa_v(B, T, H, D, V=None, **kw):
+    if V is None:
+        raise ValueError("NSA value shape requires V")
+    return (B, T, H, V)
+
+
+def _nsa_compression_post_init(inputs, B, T, H, D, block_size=64, **kw):
+    inputs['TK'] = T
+    inputs['block_size'] = block_size
+    inputs['scale'] = D**-0.5
+
+
+def _nsa_windowed_post_init(inputs, B, T, H, D, S=16, block_size=64, window_size=512, **kw):
+    inputs['block_counts'] = S
+    inputs['block_size'] = block_size
+    inputs['scale'] = D**-0.5
+    inputs['window_size'] = window_size
+
+
+_nsa_compression_bq_shapes = {
+    'B1_T8K_H4_HQ64_K32_V32': {
+        'B': 1, 'T': 8192, 'H': 4, 'HQ': 64, 'D': 32, 'V': 32, 'S': 16, 'block_size': 64,
+    },
+    'B1_T16K_H4_HQ64_K32_V32': {
+        'B': 1, 'T': 16384, 'H': 4, 'HQ': 64, 'D': 32, 'V': 32, 'S': 16, 'block_size': 64,
+    },
+    'B1_T32K_H4_HQ64_K32_V32': {
+        'B': 1, 'T': 32768, 'H': 4, 'HQ': 64, 'D': 32, 'V': 32, 'S': 16, 'block_size': 64,
+    },
+    'B1_T16K_H4_HQ64_K64_V128': {
+        'B': 1, 'T': 16384, 'H': 4, 'HQ': 64, 'D': 64, 'V': 128, 'S': 16, 'block_size': 64,
+    },
+}
+
+
+register_op(OpConfig(
+    name='parallel_nsa_compression',
+    import_path='fla.ops.nsa.compression',
+    inputs={
+        'q': TensorSpec(shape_q_hq),
+        'k': TensorSpec(_shape_nsa_compressed_k),
+        'v': TensorSpec(_shape_nsa_compressed_v),
+    },
+    post_init=_nsa_compression_post_init,
+    output_is_tuple=True,
+    default_shapes=_nsa_compression_bq_shapes,
+    category='nsa',
+    test_file='tests/ops/test_nsa.py',
+))
+
+register_op(OpConfig(
+    name='parallel_nsa_windowed',
+    import_path='fla.ops.nsa',
+    func_name='parallel_nsa',
+    inputs={
+        'q': TensorSpec(shape_q_hq),
+        'k': TensorSpec(shape_BTHD),
+        'v': TensorSpec(_shape_nsa_v),
+        'g_cmp': TensorSpec(_shape_nsa_gate, transform=sigmoid_transform),
+        'g_slc': TensorSpec(_shape_nsa_gate, transform=sigmoid_transform),
+        'g_swa': TensorSpec(_shape_nsa_gate, transform=sigmoid_transform),
+    },
+    post_init=_nsa_windowed_post_init,
+    output_is_tuple=False,
+    default_shapes=_nsa_compression_bq_shapes,
+    category='nsa',
+    test_file='tests/ops/test_nsa.py',
+))
+
+
 def _nsa_post_init(inputs, B, T, H, D, HQ=None, S=16, block_size=64, **kw):
     # build block_indices [B, T, H, S]: for each query t, pick S of the causal
     # blocks (block i is selectable iff i <= t // block_size), -1-padded when

--- a/fla/ops/nsa/compression.py
+++ b/fla/ops/nsa/compression.py
@@ -233,15 +233,43 @@ def parallel_nsa_compression_bwd_kernel_dq(
     tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_q)
 
 
+def _prune_compression_dkv_bq(configs, nargs, **kwargs):
+    args = {**(nargs or {}), **kwargs}
+    G = args.get('G', 1)
+    BS = args.get('BS', 0)
+    BK = args.get('BK', 0)
+    BV = args.get('BV', 0)
+    T_BUCKET = args.get('T_BUCKET', 0)
+    LAYOUT = args.get('LAYOUT', -1)
+    is_packed_heavy = LAYOUT == 1 and G == 32 and BK == 128 and BV == 64
+    return [
+        config
+        for config in configs
+        if config.kwargs['BQ'] == 1 or (
+            T_BUCKET > 0
+            and LAYOUT in (0, 1)
+            and BS in (32, 64)
+            and BK <= 128
+            and BV <= 128
+            and 2 * G <= 256
+            and config.num_stages == (2 if is_packed_heavy else 3)
+        )
+    ]
+
+
 @triton.heuristics({
     'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
 })
 @triton.autotune(
     configs=[
-        triton.Config({}, num_warps=num_warps)
+        triton.Config({'BQ': 1}, num_warps=num_warps)
         for num_warps in [1, 2, 4]
+    ] + [
+        triton.Config({'BQ': 2}, num_warps=4),
+        triton.Config({'BQ': 2}, num_warps=4, num_stages=2),
     ],
-    key=['BS', 'BK', 'BV'],
+    key=['BS', 'BK', 'BV', 'G', 'T_BUCKET', 'LAYOUT'],
+    prune_configs_by={'early_config_prune': _prune_compression_dkv_bq},
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T', 'TC'])
@@ -270,17 +298,23 @@ def parallel_nsa_compression_bwd_kernel_dkv(
     BS: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    T_BUCKET: tl.constexpr,
+    LAYOUT: tl.constexpr,
+    BQ: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_c, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
+    i_v, i_c, i_bh = (tl.program_id(0).to(tl.int64),
+                       tl.program_id(1).to(tl.int64),
+                       tl.program_id(2).to(tl.int64))
     i_b, i_h = i_bh // H, i_bh % H
 
-    all = B * TC.to(tl.int64)
+    T, TC = T.to(tl.int64), TC.to(tl.int64)
+    all = B * TC
 
     if IS_VARLEN:
-        i_n, i_c = tl.load(chunk_indices + i_c * 2).to(tl.int32), tl.load(chunk_indices + i_c * 2 + 1).to(tl.int64)
+        i_n, i_c = tl.load(chunk_indices + i_c * 2).to(tl.int64), tl.load(chunk_indices + i_c * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
+        T = eos - bos
         # the number of compression representations in total
         TC = tl.cdiv(T, BS)
         boc = tl.load(chunk_offsets + i_n).to(tl.int64)
@@ -305,32 +339,39 @@ def parallel_nsa_compression_bwd_kernel_dkv(
     b_v = tl.load(p_v, mask=m_v, other=0.0)
     b_dv = tl.zeros([BC, BV], dtype=tl.float32)
 
-    for i in range(i_c * BC * BS, T):
-        o_g = i_h * G + tl.arange(0, G)
-        p_q = q + (bos + i) * HQ*K + o_g[:, None] * K + o_d[None, :]
-        # [G, BK]
-        b_q = tl.load(p_q, mask=(o_g[:, None] < HQ) & (o_d[None, :] < K), other=0.0)
+    for i in range(i_c * BC * BS, T, BQ):
+        o_qg = tl.arange(0, BQ * G)
+        o_q = i + o_qg // G
+        o_g = i_h * G + o_qg % G
+        m_q = (o_q < T) & (o_g < HQ)
+        p_q = q + (bos + o_q[:, None]) * HQ*K + o_g[:, None] * K + o_d[None, :]
+        # [BQ*G, BK]
+        b_q = tl.load(p_q, mask=m_q[:, None] & (o_d[None, :] < K), other=0.0)
         b_q = (b_q * scale).to(b_q.dtype)
 
-        p_do = do + (bos + i) * HQ*V + o_g[:, None] * V + o_v[None, :]
-        p_lse = lse + (bos + i) * HQ + i_h * G + tl.arange(0, G)
-        p_delta = delta + (bos + i) * HQ + i_h * G + tl.arange(0, G)
-        # [G, BV]
-        b_do = tl.load(p_do, mask=(o_g[:, None] < HQ) & (o_v[None, :] < V), other=0.0)
-        # [G]
-        b_lse = tl.load(p_lse)
-        b_delta = tl.load(p_delta)
-        # [BC, G]
+        p_do = do + (bos + o_q[:, None]) * HQ*V + o_g[:, None] * V + o_v[None, :]
+        p_lse = lse + (bos + o_q) * HQ + o_g
+        p_delta = delta + (bos + o_q) * HQ + o_g
+        # [BQ*G, BV]
+        b_do = tl.load(p_do, mask=m_q[:, None] & (o_v[None, :] < V), other=0.0)
+        # [BQ*G]
+        b_lse = tl.load(p_lse, mask=m_q, other=0.0)
+        b_delta = tl.load(p_delta, mask=m_q, other=0.0)
+        # [BC, BQ*G]
         b_s = tl.dot(b_k, tl.trans(b_q))
         b_p = exp(b_s - b_lse[None, :])
-        b_p = tl.where((i >= max(0, (o_c + 1) * BS - 1))[:, None], b_p, 0)
-        # [BC, G] @ [G, BV] -> [BC, BV]
+        b_p = tl.where(
+            m_q[None, :] & (o_q[None, :] >= tl.maximum(0, (o_c + 1) * BS - 1)[:, None]),
+            b_p,
+            0,
+        )
+        # [BC, BQ*G] @ [BQ*G, BV] -> [BC, BV]
         b_dv += tl.dot(b_p.to(b_do.dtype), b_do)
-        # [BC, BV] @ [BV, G] -> [BC, G]
+        # [BC, BV] @ [BV, BQ*G] -> [BC, BQ*G]
         b_dp = tl.dot(b_v, tl.trans(b_do))
-        # [BC, G]
+        # [BC, BQ*G]
         b_ds = b_p * (b_dp - b_delta[None, :])
-        # [BC, G] @ [G, BK] -> [BC, BK]
+        # [BC, BQ*G] @ [BQ*G, BK] -> [BC, BK]
         b_dk += tl.dot(b_ds.to(b_q.dtype), b_q)
 
     tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
@@ -415,6 +456,8 @@ def parallel_nsa_compression_bwd(
     BK = max(triton.next_power_of_2(K), 16)
     BV = min(128, max(triton.next_power_of_2(v.shape[-1]), 16))
     NV = triton.cdiv(V, BV)
+    T_BUCKET = 0 if T < 8192 else 1 if T < 32768 else 2
+    LAYOUT = int(cu_seqlens is not None)
     if cu_seqlens is not None:
         chunk_offsets = prepare_chunk_offsets(cu_seqlens, BS)
         if chunk_indices is None:
@@ -483,6 +526,8 @@ def parallel_nsa_compression_bwd(
         BS=BS,
         BK=BK,
         BV=BV,
+        T_BUCKET=T_BUCKET,
+        LAYOUT=LAYOUT,
     )
     dk = dk.sum(0)
     return dq, dk, dv

--- a/fla/ops/nsa/compression.py
+++ b/fla/ops/nsa/compression.py
@@ -304,8 +304,8 @@ def parallel_nsa_compression_bwd_kernel_dkv(
     IS_VARLEN: tl.constexpr,
 ):
     i_v, i_c, i_bh = (tl.program_id(0).to(tl.int64),
-                       tl.program_id(1).to(tl.int64),
-                       tl.program_id(2).to(tl.int64))
+                      tl.program_id(1).to(tl.int64),
+                      tl.program_id(2).to(tl.int64))
     i_b, i_h = i_bh // H, i_bh % H
 
     T, TC = T.to(tl.int64), TC.to(tl.int64)

--- a/tests/ops/test_nsa.py
+++ b/tests/ops/test_nsa.py
@@ -949,7 +949,7 @@ def test_parallel_compressive_bq_fixture(
     block_size: int,
     dtype: torch.dtype,
 ):
-    torch.manual_seed(20260822)
+    torch.manual_seed(42)
     cu_seqlens = (
         torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
         if cu_seqlens is not None

--- a/tests/ops/test_nsa.py
+++ b/tests/ops/test_nsa.py
@@ -915,3 +915,91 @@ def test_parallel_varlen_decode(
         scale=scale, window_size=window_size, cu_seqlens=(cu_seqlens_q, cu_seqlens), )
 
     assert_close(' o', o_dec, o_dec_ref, 0.005)
+
+
+@pytest.mark.parametrize(
+    ('T', 'cu_seqlens', 'H', 'HQ', 'K', 'V', 'block_size', 'dtype'),
+    [
+        pytest.param(8192, None, 4, 64, 32, 32, 64, torch.bfloat16, id='dense-T8K-G16-K32-V32-bf16'),
+        pytest.param(16384, None, 4, 64, 32, 32, 64, torch.bfloat16, id='dense-T16K-G16-K32-V32-bf16'),
+        pytest.param(32768, None, 4, 64, 32, 32, 64, torch.bfloat16, id='dense-T32K-G16-K32-V32-bf16'),
+        pytest.param(16384, None, 4, 64, 64, 128, 64, torch.bfloat16, id='dense-T16K-G16-K64-V128-bf16'),
+        pytest.param(
+            16384,
+            [0, 4097, 9220, 16384],
+            1,
+            32,
+            128,
+            64,
+            64,
+            torch.bfloat16,
+            id='varlen-4097-5123-7164-G32-K128-V64-bf16',
+        ),
+        pytest.param(131, None, 4, 64, 32, 32, 64, torch.float16, id='tail-T131-G16-K32-V32-fp16'),
+        pytest.param(131, None, 4, 64, 32, 32, 64, torch.bfloat16, id='tail-T131-G16-K32-V32-bf16'),
+    ],
+)
+def test_parallel_compressive_bq_fixture(
+    T: int,
+    cu_seqlens,
+    H: int,
+    HQ: int,
+    K: int,
+    V: int,
+    block_size: int,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(20260822)
+    cu_seqlens = (
+        torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+        if cu_seqlens is not None
+        else None
+    )
+    TC = (
+        triton.cdiv(T, block_size)
+        if cu_seqlens is None
+        else int(prepare_chunk_offsets(cu_seqlens, block_size)[-1])
+    )
+    q = torch.randn((1, T, HQ, K), dtype=dtype, device=device).requires_grad_(True)
+    k = torch.randn((1, TC, H, K), dtype=dtype, device=device).requires_grad_(True)
+    v = torch.randn((1, TC, H, V), dtype=dtype, device=device).requires_grad_(True)
+    do = torch.randn((1, T, HQ, V), dtype=dtype, device=device)
+    scale = K**-0.5
+
+    def run(fn):
+        q.grad = k.grad = v.grad = None
+        o, lse = fn(
+            q=q,
+            k=k,
+            v=v,
+            TK=T,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        ) if fn is parallel_nsa_compression else fn(
+            q=q,
+            k_cmp=k,
+            v_cmp=v,
+            block_size=block_size,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+        o.backward(do)
+        return o.detach(), lse.detach(), q.grad.detach().clone(), k.grad.detach().clone(), v.grad.detach().clone()
+
+    tri = run(parallel_nsa_compression)
+    ref = run(naive_nsa_compression)
+    assert_close('  o', tri[0], ref[0], 0.005)
+    assert_close('lse', tri[1], torch.where(ref[1] == float('-inf'), 0, ref[1]), 0.005)
+    assert_close(' dq', tri[2], ref[2], 0.005)
+    assert_close(' dk', tri[3], ref[3], 0.005)
+    assert_close(' dv', tri[4], ref[4], 0.005)
+    for name, tensor in zip(('o', 'lse', 'dq', 'dk', 'dv'), tri):
+        assert torch.isfinite(tensor).all(), f'{name} contains non-finite values'
+
+    if T == 131:
+        repeat = run(parallel_nsa_compression)
+        for name, actual, expected in zip(('o', 'lse', 'dq', 'dk', 'dv'), repeat, tri):
+            assert torch.equal(actual, expected), f'{name} is not deterministic'
+        assert torch.count_nonzero(tri[3][:, -1]) == 0
+        assert torch.count_nonzero(tri[4][:, -1]) == 0


### PR DESCRIPTION
## Summary

Batch two adjacent query positions across each GQA group in the NSA compression dKV backward kernel so the four existing contractions use a wider MMA N dimension. Every original BQ=1 autotune configuration remains available as a fallback, while BQ=2 is enabled only for bounded long, supported dense or packed layouts.

The packed G32/K128/V64 bucket uses a four-warp, two-stage BQ=2 configuration; dense BQ=2 keeps the three-stage configuration. The change preserves FP32 accumulators, causal and packed-sequence masks, CTA/output ownership, int64 program-derived addressing, and the existing public API. It adds no workspace, atomics, or block pointers.

Tracked in [fork issue #26](https://github.com/heiheiha798/flash-linear-attention/issues/26). The original engineering record remains in [fork draft PR #29](https://github.com/heiheiha798/flash-linear-attention/pull/29).

## Test plan

The fork PR records the following completed validation on NVIDIA B300/SM103:

- Untouched gate, job 5592: full NSA operator and model suites passed with only the existing Hopper-only model skip.
- Frozen fixture gate, job 5594: 55 operator tests passed with no skips; fixture-only `BENCH_BASE` is `e3fbafa49c4c879fcba8013dfa955d5f21d07baf`.
- Candidate gate, job 5600: 55 operator tests passed with no skips; 5 model tests passed with the one unchanged Hopper-only skip; default-window `NativeSparseAttention` and two-layer NSA training oracles passed.
- Post-commit gate, job 5646: the same operator, model, and training gates passed, and repository-native `parallel_nsa_compression` forward and forward+backward verification passed all four frozen rows.
- Review-response packed integration, job 5659: the public explicit-cu unequal-packed `NativeSparseAttention` training path produced finite outputs and hidden/q/k/v/g/o projection gradients, and selected BQ=2 in all five candidate rounds.
- Submission preflight: `python scripts/find_dependent_tests.py benchmarks/ops/registry.py fla/ops/nsa/compression.py tests/ops/test_nsa.py` identified `tests/ops/test_nsa.py` and `tests/models/test_modeling_nsa.py`, both covered by the recorded gates above.
- Submission preflight: `pre-commit run --files benchmarks/ops/registry.py fla/ops/nsa/compression.py tests/ops/test_nsa.py`, `git diff --check`, and `python scripts/check_header.py --check` passed after applying the repository formatter.

## Benchmark / NCU (kernel changes only)

Measured on one NVIDIA B300 SM103 with identical inputs, isolated source roots and autotune caches, five alternating rounds, and at least 50 direct samples per row.

| Gate | Result |
| --- | ---: |
| dKV T16K/T32K geomean | 1.5107x |
| Direct compression forward+backward geomean | 1.4350x |
| Windowed full-path T16K/T32K geomean | 1.1623x |
| `NativeSparseAttention` layer forward+backward | 1.1552-1.1669x |
| Two-layer NSA training forward+backward | 1.1434-1.1437x |
| Unequal packed direct forward+backward | 1.1228x |
| Unequal packed dKV | 1.1378x |
| Unequal packed `NativeSparseAttention` forward | 1.0001x |
| Unequal packed `NativeSparseAttention` forward+backward | 1.1107x |
| Unequal packed `NativeSparseAttention` dKV | 1.5095x |
| Peak allocation | unchanged |

Job 5632 confirmed that the packed two-stage configuration is selected while dense buckets retain the three-stage configuration. Packed NCU reports show zero local-spilling requests, zero local L2 sectors, and no spill-attributed LDL/STL, with the dKV grid and global-store count unchanged.

Job 5659 used explicit cumulative lengths `[0, 4097, 9220, 16384]` with input/output shape `[1, 16384, 2048]`; five alternating rounds (`n=50` for forward and forward+backward) showed equal peak allocation. The raw evidence references are retained in the original fork draft PR.

This optimization was validated on B300/SM103. Unsupported, short, or autotune-losing buckets retain the original BQ=1 path.

## Breaking changes

None. The public API is unchanged, and the original BQ=1 configurations remain as fallbacks.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
