### PR TITLE
[Fix] Pin NPU kernels for torch_npu=2.9.0.post6, triton-ascend=3.2.2 and cann=9.1.0

### DIFF
--- a/.github/workflows/ascend-a2-benchmark-ci.yml
+++ b/.github/workflows/ascend-a2-benchmark-ci.yml
@@ -1,6 +1,7 @@
 name: ascend-a2-benchmark-ci
 
-# Pinned stack: CANN 9.0.0 + pyproject [npu] extra (torch/torch_npu/torchvision/triton-ascend)
+# Pinned stack: CANN 9.1.0 image + pyproject [npu] extra
+# (torch 2.9.0 / torch_npu 2.9.0.post6 / torchvision 0.24.0 / triton-ascend 3.2.2)
 # Runs NPU performance benchmarks for triton-ascend backends and causal conv.
 
 on:
@@ -60,8 +61,8 @@ jobs:
             }
             core.setOutput('npu_related', related.length > 0 ? 'true' : 'false');
 
-  benchmark-a2-npu-pytorch-2-7:
-    name: Benchmark A2 NPU (PyTorch 2.7.1)
+  benchmark-a2-npu-pytorch-2-9:
+    name: Benchmark A2 NPU (PyTorch 2.9.0)
     needs: changes
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -81,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.11"
+          - "3.12"
         os:
           - "linux-aarch64-a2-4"
 
@@ -94,7 +95,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     container:
-      image: ascendai/cann:9.0.0-910b-ubuntu22.04-py3.11
+      image: ascendai/cann:9.1.0-910b-ubuntu22.04-py3.12
       options: >-
         --shm-size 16g
       env:

--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -1,6 +1,7 @@
 name: ascend-a2-ci
 
-# Pinned stack: CANN 9.0.0 + pyproject [npu] extra (torch/torch_npu/torchvision/triton-ascend)
+# Pinned stack: CANN 9.1.0 image + pyproject [npu] extra
+# (torch 2.9.0 / torch_npu 2.9.0.post6 / torchvision 0.24.0 / triton-ascend 3.2.2)
 
 on:
   workflow_dispatch:
@@ -58,8 +59,8 @@ jobs:
             }
             core.setOutput('npu_related', related.length > 0 ? 'true' : 'false');
 
-  test-a2-npu-pytorch-2-7:
-    name: Test A2 NPU (PyTorch 2.7.1)
+  test-a2-npu-pytorch-2-9:
+    name: Test A2 NPU (PyTorch 2.9.0)
     needs: changes
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -79,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.11"
+          - "3.12"
         os:
           - "linux-aarch64-a2-8"
 
@@ -92,7 +93,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     container:
-      image: ascendai/cann:9.0.0-910b-ubuntu22.04-py3.11
+      image: ascendai/cann:9.1.0-910b-ubuntu22.04-py3.12
       options: >-
         --shm-size 16g
       env:

--- a/.github/workflows/oj.yml
+++ b/.github/workflows/oj.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: linux-aarch64-a2-1
     timeout-minutes: 60
     container:
-      image: ascendai/cann:9.0.0-910b-ubuntu22.04-py3.11
+      image: ascendai/cann:9.1.0-910b-ubuntu22.04-py3.12
       options: >-
         --shm-size 16g
       env:
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,15 +57,15 @@ old "install fla, then `pip uninstall triton`, then install `triton-ascend`"
 dance is no longer needed.
 
 ```sh
-# 1. install CANN 9.0.0 + source set_env.sh
+# 1. install CANN 9.1.0 + source set_env.sh
 # 2. install torch / torch_npu / triton-ascend, then fla with the npu extra
-pip install torch==2.7.1 torch_npu==2.7.1 torchvision==0.22.1
-pip install triton-ascend==3.2.1 --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple
+pip install torch==2.9.0 torch_npu==2.9.0.post6 torchvision==0.24.0
+pip install triton-ascend==3.2.2 --extra-index-url=https://triton-ascend.osinfra.cn/pypi/simple
 pip install flash-linear-attention[npu]
 ```
 
-The `[npu]` extra pins `torch==2.7.1`, `torch_npu==2.7.1`, `torchvision==0.22.1`,
-and `triton-ascend==3.2.1` (CANN 9.0.0 stack tested in CI). Install
+The `[npu]` extra pins `torch==2.9.0`, `torch_npu==2.9.0.post6`, `torchvision==0.24.0`,
+and `triton-ascend==3.2.2` (CANN 9.1.0 stack tested on A2). Install
 `triton-ascend` with `--extra-index-url` as shown above.
 
 ## From source

--- a/fla/ops/common/fused_recurrent.py
+++ b/fla/ops/common/fused_recurrent.py
@@ -10,7 +10,7 @@ import triton
 import triton.language as tl
 
 from fla.ops.utils.op import exp
-from fla.utils import autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
+from fla.utils import ascend_compile_kwargs, autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
 
 @triton.heuristics({
@@ -506,6 +506,7 @@ def fused_recurrent_bwd(
         dgv = gv.new_empty(NK, *gv.shape, dtype=torch.float32)
 
     grid = (NV * NK * N * H,)
+    # disable auto-multi-buffer on the gate-gradient accumulate
     fused_recurrent_bwd_kernel[grid](
         q=q,
         k=k,
@@ -540,6 +541,7 @@ def fused_recurrent_bwd(
         USE_GV=gv is not None,
         REVERSE=reverse,
         STATE_V_FIRST=state_v_first,
+        **ascend_compile_kwargs(),
     )
     dq = dq.sum(0)
     dk = dk.sum(0)

--- a/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
@@ -16,7 +16,7 @@ import triton.runtime.driver as driver
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
-from fla.utils import input_guard
+from fla.utils import ascend_compile_kwargs, input_guard
 from fla.utils.ascend_ub_manager import (
     ASCEND_MAX_GRID_DIM,
     compute_row_tile_block_size,
@@ -117,7 +117,8 @@ def _launch_wy_kernel(kernel, *, NT: int, bh_total: int, kernel_kwargs: dict) ->
 
 def _launch_wy_core_grid(kernel, *, task_num: int, kernel_kwargs: dict) -> None:
     num_core = get_npu_properties()["num_aicore"]
-    kernel[(num_core,)](task_num=task_num, num_core=num_core, **kernel_kwargs)
+    # disable auto-multi-buffer on this core-grid launch
+    kernel[(num_core,)](task_num=task_num, num_core=num_core, **ascend_compile_kwargs(), **kernel_kwargs)
 
 
 @triton.heuristics({
@@ -672,29 +673,30 @@ def recompute_w_u_fwd_npu(
     if g is not None:
         g = g.transpose(1, 2).contiguous()
 
-    num_core = get_npu_properties()["num_aicore"]
-    task_num = NT * B * HV
-    recompute_w_u_fwd_kernel_npu[(num_core,)](
-        k=k,
-        v=v,
-        beta=beta,
-        w=w,
-        u=u,
-        A=A,
-        g=g,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-        T=T,
-        B=B,
-        task_num=task_num,
-        num_core=num_core,
-        H=H,
-        HV=HV,
-        K=K,
-        V=V,
-        BT=BT,
-        BK=BK,
-        BV=BV,
+    # disable auto-multi-buffer on this core-grid launch
+    _launch_wy_core_grid(
+        recompute_w_u_fwd_kernel_npu,
+        task_num=NT * B * HV,
+        kernel_kwargs=dict(
+            k=k,
+            v=v,
+            beta=beta,
+            w=w,
+            u=u,
+            A=A,
+            g=g,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            B=B,
+            H=H,
+            HV=HV,
+            K=K,
+            V=V,
+            BT=BT,
+            BK=BK,
+            BV=BV,
+        ),
     )
     return w, u
 

--- a/fla/ops/gla/backends/triton_ascend/chunk.py
+++ b/fla/ops/gla/backends/triton_ascend/chunk.py
@@ -15,7 +15,7 @@ import triton.language as tl
 
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
-from fla.utils import input_guard
+from fla.utils import ascend_compile_kwargs, input_guard
 from fla.utils.ascend_ub_manager import (
     compute_row_tile_block_size,
     get_npu_properties,
@@ -26,6 +26,9 @@ _BC = 16
 _SAFETY_MARGIN = 0.80
 _FALLBACK = 16
 _MAX_TILE = 64
+
+# disable auto-multi-buffer on inter and K>256 intra-A split/merge launches
+_GLA_COMPILE_KWARGS = ascend_compile_kwargs()
 
 
 def _get_bk(K: int) -> int:
@@ -311,6 +314,7 @@ def chunk_gla_fwd_intra_gk_npu(
             offset_keys=('NK_OFFSET', 'NTNC_OFFSET', 'BH_OFFSET'),
             quanta=(1, NC, 1),
             kernel_kwargs=split_base,
+            compile_kwargs=_GLA_COMPILE_KWARGS,
         )
         merge_base = dict(
             A=A_intra, A2=A, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices,
@@ -322,6 +326,7 @@ def chunk_gla_fwd_intra_gk_npu(
             (NT, NC, B * H),
             offset_keys=('NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'),
             kernel_kwargs=merge_base,
+            compile_kwargs=_GLA_COMPILE_KWARGS,
         )
     return A
 
@@ -961,5 +966,6 @@ def chunk_gla_bwd_dqkg_npu(
             H=H, K=K, V=V, BT=BT, BK=BK, BV=BV, STATE_V_FIRST=state_v_first,
             A_OFFSET=0, NT_OFFSET=0, BH_OFFSET=0,
         ),
+        compile_kwargs=_GLA_COMPILE_KWARGS,
     )
     return dq2, dk2, dg

--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -16,7 +16,7 @@ from triton.runtime import driver
 
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.op import exp2
-from fla.utils import input_guard
+from fla.utils import ascend_compile_kwargs, input_guard
 from fla.utils.ascend_ub_manager import (
     ASCEND_MAX_GRID_DIM,
     compute_row_tile_block_size,
@@ -764,6 +764,7 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
     bh_total = B * HV
     num_core = get_npu_properties()['num_vectorcore']
     task_num = NT * bh_total
+    # disable auto-multi-buffer on this V-slab launch
     chunk_kda_bwd_kernel_wy_v_part_npu[(num_core,)](
         v=v_arg,
         beta=beta_arg,
@@ -784,6 +785,7 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
         BV=BV,
         IS_VARLEN=is_varlen,
         G_T_CONTIG=g_t_contig,
+        **ascend_compile_kwargs(),
     )
 
     k_part_kwargs = dict(

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra.py
@@ -18,7 +18,7 @@ from fla.ops.kda.backends.triton_ascend.wy_fast import recompute_w_u_fwd_kda_npu
 from fla.ops.kda.chunk_intra_token_parallel import chunk_kda_fwd_intra_token_parallel
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.op import exp2
-from fla.utils import input_guard
+from fla.utils import ascend_compile_kwargs, input_guard
 from fla.utils.ascend_ub_manager import (
     ASCEND_MAX_GRID_DIM,
     compute_row_tile_block_size,
@@ -35,6 +35,10 @@ _FALLBACK_BK = 16
 _MAX_INTER_BK = 64
 # limit programs per launch to stay within Ascend AICore task time.
 _KDA_LAUNCH_BLOCK_BUDGET = 4096
+
+
+# disable auto-multi-buffer and AutoBlockify on the fused inter launch
+_INTER_COMPILE_KWARGS = ascend_compile_kwargs(blacklist_auto_blockify=True)
 
 
 def _get_sub_chunk_bk(K: int) -> int:
@@ -131,7 +135,11 @@ def _launch_inter_kernel(
         for bh_off in range(0, bh_total, max_bh):
             bh_len = min(max_bh, bh_total - bh_off)
             kernel_kwargs['BH_OFFSET'] = bh_off
-            kernel[(nt_len, bh_len)](num_warps=_NUM_WARPS_INTER, **kernel_kwargs)
+            kernel[(nt_len, bh_len)](
+                num_warps=_NUM_WARPS_INTER,
+                **kernel_kwargs,
+                **_INTER_COMPILE_KWARGS,
+            )
 
 
 @triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'])

--- a/fla/utils/__init__.py
+++ b/fla/utils/__init__.py
@@ -12,6 +12,7 @@ from ._compat import (  # noqa: F401
     TRITON_ABOVE_3_4_0,
     TRITON_ABOVE_3_5_1,
     TRITON_ABOVE_3_7_1,
+    ascend_compile_kwargs,
     autotune_cache_kwargs,
     find_spec_cached,
     has_usable_nvcc,

--- a/fla/utils/_compat.py
+++ b/fla/utils/_compat.py
@@ -11,6 +11,7 @@ import inspect
 import logging
 import os
 import shutil
+import sys
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -18,6 +19,7 @@ import triton
 from packaging import version as package_version
 
 from ._config import FLA_CACHE_RESULTS
+from ._device import IS_NPU
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,34 @@ TRITON_ABOVE_3_7_1 = package_version.parse(triton.__version__) >= package_versio
 
 SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters
 autotune_cache_kwargs = {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
+
+
+def ascend_compile_kwargs(*, blacklist_auto_blockify: bool = False) -> dict:
+    """Return NPU Triton launch kwargs that disable auto-multi-buffer.
+
+    Empty on non-NPU devices. When ``blacklist_auto_blockify`` is set, also
+    disable AutoBlockify if the installed compiler exposes that option.
+    """
+    if not IS_NPU:
+        return {}
+    kwargs = {'multibuffer': False}
+    if blacklist_auto_blockify:
+        try:
+            from triton.backends.ascend.compiler import NPUOptions
+        except ImportError:
+            return kwargs
+        if 'has_auto_blockify_blacklist_op' in getattr(NPUOptions, '__dataclass_fields__', {}):
+            kwargs['has_auto_blockify_blacklist_op'] = True
+    return kwargs
+
+
+# expose extra.cann as extra.ascend for torch_npu inductor
+try:
+    import triton.language as tl
+    if not hasattr(tl.extra, 'ascend') and hasattr(tl.extra, 'cann'):
+        tl.extra.ascend = sys.modules['triton.language.extra.ascend'] = tl.extra.cann
+except (ImportError, AttributeError):
+    logger.debug("could not alias triton.language.extra.cann as extra.ascend")
 
 
 @functools.cache

--- a/fla/utils/ascend_ub_manager.py
+++ b/fla/utils/ascend_ub_manager.py
@@ -592,6 +592,7 @@ def launch_grid_chunked(
     kernel_kwargs: dict,
     quanta: tuple[int, ...] | None = None,
     budget: int = ASCEND_LAUNCH_BLOCK_BUDGET,
+    compile_kwargs: dict | None = None,
 ) -> None:
     """Launch a triton kernel over `grid` in host-side chunks.
 
@@ -603,9 +604,11 @@ def launch_grid_chunked(
     blocks, for grids packing several logical indices into one axis
     (e.g. ``nt * nc``). Keeping the product within `budget`
     (<= `ASCEND_MAX_GRID_DIM`) also keeps every axis within the per-axis limit.
+    `compile_kwargs` is forwarded unchanged to each ``kernel[grid](...)`` launch.
     """
     dims = len(grid)
     quanta = quanta or (1,) * dims
+    extra = compile_kwargs or {}
     lens = [0] * dims
 
     def _recurse(ax: int, prod_so_far: int) -> None:
@@ -620,7 +623,7 @@ def launch_grid_chunked(
             lens[ax] = min(len_q * quantum, grid[ax] - offset)
             kernel_kwargs[offset_keys[ax]] = offset
             if ax == dims - 1:
-                kernel[tuple(lens)](**kernel_kwargs)
+                kernel[tuple(lens)](**kernel_kwargs, **extra)
             else:
                 _recurse(ax + 1, prod_so_far * len_q * quantum)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ cuda = ["torch>=2.7.0", "triton>=3.3"]
 # on stable, triton-rocm on nightly, etc.).
 rocm = ["torch>=2.7.0"]
 xpu  = ["torch>=2.7.0"]
-npu  = ["torch==2.7.1", "torch_npu==2.7.1.post4", "torchvision==0.22.1", "triton-ascend==3.2.1"]
+npu  = ["torch==2.9.0", "torch_npu==2.9.0.post6", "torchvision==0.24.0", "triton-ascend==3.2.2"]
 cpu  = ["torch>=2.7.0", "triton>=3.3"]
 tilelang = ["tilelang>=0.1.9"]
 conv1d = ["causal-conv1d>=1.4.0"]


### PR DESCRIPTION
## Summary

Companion-stack upgrade for Ascend A2: `torch 2.9.0` / `torch_npu 2.9.0.post6` / `triton-ascend 3.2.2` / `CANN 9.1.0`. The `3.2.2` compiler turns auto-multi-buffer (and AutoBlockify) on by default, and `torch_npu` inductor still imports `triton.language.extra.ascend`. Same FLA math then fails or hangs on a few NPU launches.

This PR does not change kernel formulas, precision, tiling, or GPU paths. It adds a small inductor import shim, pins compile flags on the isolated NPU launches, and updates the `[npu]` extra / INSTALL / A2 CI to the validated stack.

### 1. `extra.cann` import shim

`triton-ascend` installs language extensions at `triton.language.extra.cann`. Both `3.2.1` and `3.2.2` ship only `cann/` — there is no `extra.ascend` package.

**Code:** `fla/utils/_compat.py` aliases `tl.extra.cann` to `tl.extra.ascend` (and `sys.modules`) only when `ascend` is missing and `cann` exists. GPU Triton has no `cann`, so this is a no-op there.


### 2. Per-launch compile pins (`multibuffer` / AutoBlockify)

3.2.2 `NPUOptions` defaults `multibuffer=True` and `num_stages=2`, which compile as `--enable-auto-multi-buffer=True` and alias UB across `tl.range` tasks and slab loops. AutoBlockify (`TRITON_ALL_BLOCKS_PARALLEL`, default `"true"`) remaps multi-program grids. 3.2.1 JIT rejects unknown compile kwargs, so `has_auto_blockify_blacklist_op` is passed only when `NPUOptions` has the field.

Helper: `fla.utils.ascend_compile_kwargs` (empty on non-NPU). `launch_grid_chunked` forwards optional `compile_kwargs` to each host-chunked launch. Pins are per launch after A/B isolation — not a repo-wide default flip.

| Launch | Site | Pin | Why |
|---|---|---|---|
| GDN WY core-grid | `_launch_wy_core_grid` in `fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py` | `multibuffer=False` | Default ping-pong aliases UB across `tl.range` tasks and clobbers WY bwd `dk`/`db`. |
| KDA fused inter | `_launch_inter_kernel` via `_INTER_COMPILE_KWARGS` in `fla/ops/kda/backends/triton_ascend/chunk_intra.py` | `multibuffer=False` and AutoBlockify blacklist | Either new default alone livelocks the multi-program fused inter (AICore 100%, HBM ~0). |
| KDA WY v_part | `chunk_kda_bwd_kernel_wy_v_part_npu` in `fla/ops/kda/backends/triton_ascend/chunk_bwd.py` | `multibuffer=False` | Default multibuffer writes NaN into the V-slab `db`/`dA` accumulate. Other WY parts stay at 3.2.2 defaults. |
| GLA inter + K>256 intra-A split/merge | `_GLA_COMPILE_KWARGS` in `fla/ops/gla/backends/triton_ascend/chunk.py` | `multibuffer=False` | Inter V-slab `tl.sum`+`tl.dot` clobbers `dq`/`dk`; K>256 split/merge corrupts `o`. AutoBlockify was not isolated here. |
| `fused_recurrent` backward | `fused_recurrent_bwd` in `fla/ops/common/fused_recurrent.py` | `multibuffer=False` | Default multibuffer makes `dg`/`dgk` nondeterministic. Forward was stable and is unpinned. |

### 3. Declared NPU stack and CI

`pyproject.toml` `[npu]` extra, `INSTALL.md`, and A2 CI / benchmark / `oj.yml` pin `torch==2.9.0`, `torch_npu==2.9.0.post6`, `torchvision==0.24.0`, `triton-ascend==3.2.2`, CANN **9.1.0**. Official `ascendai/cann:9.1.0-910b-ubuntu22.04` images are **py3.12** only, so those jobs follow.

This PR only pins the launches we isolated so the new stack is usable. Follow-up work will keep FLA compatible with triton-ascend 3.2.2 and later companion stacks (newer CANN / torch_npu / compiler defaults): isolate any further AutoBlockify or auto-multi-buffer breakages per kernel, and drop a pin only when the compiler no longer needs it.

## Test plan

- ascend-a2-ci.yml
- ascend-a2-benchmark-ci.yml

## Benchmark / NCU

N/A. Compile-flag pins to restore 3.2.1-class correctness, not a throughput change. No tiling or algorithm rewrite.

## Breaking changes

- **`[npu]` extra versions.** Users installing `flash-linear-attention[npu]` move from torch 2.7.1 / torch_npu 2.7.1 / triton-ascend 3.2.1 / CANN 9.0.0 to the 2.9.0.post6 + 3.2.2 + CANN 9.1.0 stack. Plain `torch_npu==2.9.0` (no post) is not sufficient.
- **A2 CI image / Python.** A2 workflows now use `ascendai/cann:9.1.0-910b-ubuntu22.04-py3.12` (Python 3.12).
- No public operator API, checkpoint, or GPU-path change. NPU numerics are intended to match the previous stack within existing `assert_close` tolerances.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). (N/A — compile-flag correctness pins, performance-neutral by construction.)
