### PR TITLE
[Perf] Optimize Ascend fused_attnres with N-tiling, fused bwd prep, and residual reuse

### DIFF
--- a/benchmarks/ops/run.py
+++ b/benchmarks/ops/run.py
@@ -28,11 +28,16 @@ Usage::
     # Forward only
     python -m benchmarks.ops.run --op chunk_gla --modes fwd
 
-    # Compare against main (auto git worktree, no stash needed)
+    # Compare against main (auto git worktree, no stash needed).
+    # HEAD and the baseline each run in an isolated subprocess so the parent
+    # never holds NPU/CUDA tensors across refs.
     python -m benchmarks.ops.run --op chunk_gla --base main
 
     # Compare against any branch/tag/commit
     python -m benchmarks.ops.run --op chunk_gla --base HEAD~3
+
+    # Current ref only (no baseline subprocess)
+    python -m benchmarks.ops.run --op chunk_gla --no-base
 
     # Save results to JSON
     python -m benchmarks.ops.run --op chunk_gla --json results.json
@@ -123,6 +128,9 @@ Benchmark methodology
    ``FLA_BENCH_WARMUP_MS`` / ``FLA_BENCH_REP_MS`` for noisier machines / CI).
 3. Input tensors (including gate transforms like logsigmoid) are prepared
    **before** timing — only the op call itself is measured.
+4. **Isolation**: HEAD and ``--base`` each run in a subprocess. The parent
+   never holds accelerator tensors, so a large HEAD shape cannot starve the
+   baseline process of HBM (and vice versa).
 """
 
 from __future__ import annotations
@@ -141,10 +149,10 @@ import tempfile
 
 import torch
 
-from fla.utils import device_name
-
 # Import registry — works both as a package (python -m benchmarks.ops.run)
 # and standalone (python /tmp/fla_bench_xxx/run.py) for cross-commit use.
+# ``device_name`` is imported inside ``benchmark_op`` so the parent compare
+# process never initializes the accelerator.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from registry import (  # noqa: E402
     SHAPE_CONFIGS,
@@ -159,7 +167,9 @@ logger = logging.getLogger(__name__)
 
 def _device_synchronize(device: str | None = None) -> None:
     """Synchronize the active accelerator before/after timed runs."""
-    dev = device or device_name
+    if device is None:
+        from fla.utils import device_name as device
+    dev = device
     dev_mod = getattr(torch, dev, None)
     if dev_mod is not None and hasattr(dev_mod, 'synchronize'):
         dev_mod.synchronize()
@@ -275,6 +285,8 @@ def benchmark_op(
     Returns a list of result dicts (one per shape x mode).
     """
     import triton
+
+    from fla.utils import device_name
 
     if modes is None:
         modes = ['fwd', 'fwdbwd']
@@ -548,6 +560,56 @@ def _find_project_root() -> str:
     return os.getcwd()
 
 
+_WORKER_ENV = 'FLA_BENCH_WORKER'
+
+
+def _isolated_bench_cmd(runner, op_names, shape_configs, modes, backend, out_json):
+    """Worker argv. ``--no-base`` plus ``FLA_BENCH_WORKER`` block nested compares."""
+    cmd = [sys.executable, runner, '--op', *op_names,
+           '--custom-shapes', json.dumps(shape_configs),
+           '--modes', *modes, '--json', out_json, '--no-base']
+    if backend is not None:
+        cmd += ['--backend', backend]
+    return cmd
+
+
+def _run_isolated_bench(cwd, cmd):
+    env = os.environ.copy()
+    env[_WORKER_ENV] = '1'
+    subprocess.run(cmd, cwd=cwd, env=env)
+
+
+def _read_bench_json(out_json):
+    if os.path.exists(out_json):
+        with open(out_json) as f:
+            data = json.load(f)
+        return data.get('results', []), data.get('machine_info')
+    return None, None
+
+
+def _bench_current(op_names, shape_configs, modes, backend=None):
+    """Run the current working tree in a subprocess, then exit to free HBM.
+
+    Returns (results_list, machine_info_dict) or (None, None) on failure.
+    """
+    project_root = _find_project_root()
+    tmpdir = tempfile.mkdtemp(prefix='fla_bench_HEAD_')
+    try:
+        print("\n  Benchmarking at HEAD (isolated subprocess)...")
+        runner = os.path.abspath(__file__)
+        out_json = os.path.join(tmpdir, 'results.json')
+        _run_isolated_bench(
+            project_root,
+            _isolated_bench_cmd(runner, op_names, shape_configs, modes, backend, out_json),
+        )
+        return _read_bench_json(out_json)
+    except Exception as e:
+        logger.warning(f"Failed to benchmark at HEAD: {e}")
+        return None, None
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def _bench_at_ref(ref, op_names, shape_configs, modes, backend=None):
     """Run benchmarks at a git ref using a temporary worktree.
 
@@ -579,18 +641,11 @@ def _bench_at_ref(ref, op_names, shape_configs, modes, backend=None):
 
         runner = os.path.join(runner_dir, 'run.py')
         out_json = os.path.join(tmpdir, 'results.json')
-        cmd = [sys.executable, runner, '--op', *op_names,
-               '--custom-shapes', json.dumps(shape_configs),
-               '--modes', *modes, '--json', out_json]
-        if backend is not None:
-            cmd += ['--backend', backend]
-        subprocess.run(cmd, cwd=worktree_dir)
-
-        if os.path.exists(out_json):
-            with open(out_json) as f:
-                data = json.load(f)
-            return data.get('results', []), data.get('machine_info')
-        return None, None
+        _run_isolated_bench(
+            worktree_dir,
+            _isolated_bench_cmd(runner, op_names, shape_configs, modes, backend, out_json),
+        )
+        return _read_bench_json(out_json)
     except Exception as e:
         logger.warning(f"Failed to benchmark at '{ref}': {e}")
         return None, None
@@ -637,7 +692,13 @@ def main():
     parser.add_argument(
         '--base', default=None,
         help='Git ref for the baseline (old) column, e.g. "main" or "HEAD~3". '
-             'Auto-detected as "main" when on a feature branch.',
+             'Auto-detected as "main" when on a feature branch. '
+             'HEAD and the baseline each run in an isolated subprocess.',
+    )
+    parser.add_argument(
+        '--no-base', action='store_true',
+        help='Skip baseline comparison. Nested worker processes pass this '
+             'so they never spawn another compare.',
     )
     parser.add_argument(
         '--list', action='store_true',
@@ -685,29 +746,42 @@ def main():
         op_names = list_ops() if args.op == ['all'] else args.op
     shape_configs = json.loads(args.custom_shapes) if args.custom_shapes else SHAPE_CONFIGS
 
-    machine_info = _get_machine_info()
-    print(_format_machine_line(machine_info))
+    is_worker = os.environ.get(_WORKER_ENV) == '1'
+    print(f"Git: {_get_git_label()}")
     print(f"Shapes: {len(shape_configs)} configs")
     print(f"Ops: {op_names}")
 
-    all_results = []
-    for op_name in op_names:
-        try:
-            all_results.extend(benchmark_op(op_name, shape_configs, modes=args.modes, backend=args.backend))
-        except Exception as e:
-            logger.error(f"Failed to benchmark {op_name}: {e}")
+    if is_worker:
+        machine_info = _get_machine_info()
+        print(_format_machine_line(machine_info))
+        all_results = []
+        for op_name in op_names:
+            try:
+                all_results.extend(
+                    benchmark_op(op_name, shape_configs, modes=args.modes, backend=args.backend),
+                )
+            except Exception as e:
+                logger.error(f"Failed to benchmark {op_name}: {e}")
+        baseline, baseline_info = None, None
+    else:
+        all_results, machine_info = _bench_current(
+            op_names, shape_configs, args.modes, backend=args.backend,
+        )
+        all_results = all_results or []
+        machine_info = machine_info or {'git_label': _get_git_label()}
 
-    # Determine baseline ref: explicit --base, or auto-detect main if on a feature branch.
-    git_label = machine_info.get('git_label', 'unknown')
-    current_branch = git_label.split('[')[0] if '[' in git_label else git_label
-    base_ref = args.base
-    if base_ref is None and current_branch not in ('main', 'master', 'unknown'):
-        base_ref = 'main'
+        git_label = machine_info.get('git_label', 'unknown')
+        current_branch = git_label.split('[')[0] if '[' in git_label else git_label
+        base_ref = None if args.no_base else args.base
+        if base_ref is None and not args.no_base and current_branch not in ('main', 'master', 'unknown'):
+            base_ref = 'main'
+        if base_ref == '':
+            base_ref = None
 
-    baseline, baseline_info = None, None
-    if base_ref:
-        baseline, baseline_info = _bench_at_ref(
-            base_ref, op_names, shape_configs, args.modes, backend=args.backend)
+        baseline, baseline_info = None, None
+        if base_ref:
+            baseline, baseline_info = _bench_at_ref(
+                base_ref, op_names, shape_configs, args.modes, backend=args.backend)
 
     # Sort by (mode, L, B, T, H, D, op) so the table groups by mode first
     # and (when present) by L so different residual-source counts cluster.
@@ -718,7 +792,10 @@ def main():
         r['B'], r['T'], r['H'], r['D'], r['op'],
     ))
 
-    print_results_table(all_results, machine_info, baseline=baseline, baseline_info=baseline_info)
+    # Workers print a per-ref table. The orchestrator prints the comparison
+    # (or nothing extra when --no-base, because the worker already printed).
+    if is_worker or baseline:
+        print_results_table(all_results, machine_info, baseline=baseline, baseline_info=baseline_info)
 
     if args.json_file:
         output = {'machine_info': machine_info, 'results': all_results}

--- a/benchmarks/ops/verify.py
+++ b/benchmarks/ops/verify.py
@@ -56,21 +56,16 @@ import os
 import subprocess
 import sys
 
-import torch
-
-from fla.utils import device_name
-
 # Import sibling modules. Works both as a package (python -m benchmarks.ops.verify)
 # and standalone, matching run.py's import strategy.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from registry import SHAPE_CONFIGS, get_op, list_ops  # noqa: E402
 from run import (  # noqa: E402
     _bench_at_ref,
+    _bench_current,
     _device_synchronize,
     _find_project_root,
     _format_machine_line,
-    _get_machine_info,
-    benchmark_op,
     print_results_table,
 )
 
@@ -121,8 +116,11 @@ def profile_op(op_name: str, modes: list[str]) -> None:
     """
     import importlib
 
+    import torch
     from registry import generate_inputs
     from torch.profiler import ProfilerActivity, profile
+
+    from fla.utils import device_name
 
     config = get_op(op_name)
     mod = importlib.import_module(config.import_path)
@@ -243,13 +241,15 @@ def main():
             return 1
         print("\n  GATE PASSED.")
 
-    # 2. Performance measurement (reuses run.py). Baseline compare via git worktree.
-    machine_info = _get_machine_info()
+    # 2. Performance measurement (reuses run.py). Each ref runs in a subprocess
+    # so the parent never holds NPU/CUDA tensors across HEAD vs --base.
+    results, machine_info = _bench_current([args.op], SHAPE_CONFIGS, args.modes)
+    results = results or []
+    machine_info = machine_info or {}
     print(f"\n  {_format_machine_line(machine_info)} | "
           f"Triton {machine_info.get('triton_version', 'N/A')} | "
           f"{machine_info.get('git_label', 'unknown')}")
 
-    results = benchmark_op(args.op, SHAPE_CONFIGS, modes=args.modes)
     baseline, baseline_info = (None, None)
     if args.base:
         baseline, baseline_info = _bench_at_ref(args.base, [args.op], SHAPE_CONFIGS, args.modes)

--- a/fla/ops/attnres/backends/triton_ascend/fused.py
+++ b/fla/ops/attnres/backends/triton_ascend/fused.py
@@ -9,14 +9,20 @@
 
 GPU passes a padded tuple of per-source pointers (``res[i]``). Triton-Ascend
 cannot bind tuple arguments, so sources are stacked in L-chunks as
-``[L_chunk, N, D]`` (capped at 512 MiB per chunk) instead of one ``[L, N, D]``
-buffer. Cross-chunk softmax stats are merged on the host; the weighted sum
-accumulates in a single fp32 ``o_mix`` buffer to match GPU register precision.
+``[L_chunk, N, D]`` (capped at 768 MiB per chunk). Cross-chunk softmax
+stats are merged on the host; the weighted sum accumulates in a single
+fp32 ``o_mix`` buffer to match GPU register precision.
+
+A 2D gather along L compiles to scalar, so ``fwd_p2`` / ``bwd_dv`` use 1D
+``[BD]`` tiles when ``BN==1``, and contiguous ``[BN, BD]`` tiles along N
+otherwise. ``BN>1`` is only launched when ``SINGLE_D`` (``BD >= D``); the
+host falls back to ``BN==1`` for the D-loop path. ``SINGLE_D`` keeps
+``q*w`` in UB; no-onorm ``SINGLE_D`` fuses ``bwd_prep`` (``FUSE_PREP``).
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 
 import torch
 import triton
@@ -32,9 +38,13 @@ from fla.utils.ascend_ub_manager import (
 
 _FWD_MEM_MULT = 3.0
 _BWD_DV_MEM_MULT = 6.0
+_FWD_BN_MEM_MULT = 3.0
+# bwd_dv holds more live tiles under Ascend multi-buffering than the host UB model.
+_BWD_BN_MEM_MULT = 8.0
 _SAFETY_MARGIN = 0.85
 _FALLBACK_BD = 256
-_MAX_L_CHUNK_BYTES = 512 << 20
+_MAX_BN = 8
+_MAX_L_CHUNK_BYTES = 768 << 20
 
 
 def _l_chunk_size(L: int, N: int, D: int, elem_size: int) -> int:
@@ -76,10 +86,6 @@ def _merge_online_softmax(
     return m_new, acc_new
 
 
-def _get_bl(L: int) -> int:
-    return min(8, max(1, triton.next_power_of_2(L)))
-
-
 def _get_bd(row_dim: int, col_dim: int, *, memory_multiplier: float) -> int:
     return compute_row_tile_block_size(
         row_dim,
@@ -90,13 +96,39 @@ def _get_bd(row_dim: int, col_dim: int, *, memory_multiplier: float) -> int:
         dtype_size=4,
         fallback=_FALLBACK_BD,
         min_block=64,
-        max_block=2048,
+        max_block=8192,
     )
 
 
 def _get_bl_bd(ll: int, D: int, *, mem_mult: float) -> tuple[int, int]:
-    bl = _get_bl(ll)
+    bl = min(8, max(1, triton.next_power_of_2(ll)))
     return bl, _get_bd(bl, D, memory_multiplier=mem_mult)
+
+
+def _get_bn(N: int, BD: int, *, mem_mult: float) -> int:
+    return compute_row_tile_block_size(
+        N,
+        BD,
+        memory_multiplier=mem_mult,
+        tiling_row=True,
+        safety_margin=_SAFETY_MARGIN,
+        dtype_size=4,
+        fallback=1,
+        min_block=1,
+        max_block=_MAX_BN,
+    )
+
+
+def _n_tile_bn(N: int, BD: int, D: int, *, mem_mult: float) -> int:
+    """N-tile only when D fits in one BD tile (``SINGLE_D``).
+
+    The ``BN>1 && BD < D`` D-loop is untested (A2 never reaches it; bwd
+    ``mem_mult=8`` keeps ``BN=1`` whenever ``BD < D``). ``BN==1`` already
+    covers that case.
+    """
+    if BD < D:
+        return 1
+    return _get_bn(N, BD, mem_mult=mem_mult)
 
 
 def _launch_n(
@@ -105,8 +137,10 @@ def _launch_n(
     /,
     **kwargs,
 ) -> None:
-    for n_off, n_len in iter_axis_launch_chunks(N, 1, max_grid=ASCEND_MAX_GRID_DIM):
-        kernel[(n_len,)](N_OFFSET=n_off, **kwargs)
+    bn = int(kwargs.get('BN', 1))
+    n_tiles = triton.cdiv(N, max(bn, 1))
+    for n_off, n_len in iter_axis_launch_chunks(n_tiles, 1, max_grid=ASCEND_MAX_GRID_DIM):
+        kernel[(n_len,)](N_OFFSET=n_off * bn, **kwargs)
 
 
 @triton.jit(do_not_specialize=['L', 'N', 'D', 'L_OFFSET'])
@@ -126,41 +160,77 @@ def attnres_fwd_p1_chunk_kernel(
     scale,
     BL: tl.constexpr,
     BD: tl.constexpr,
+    BN: tl.constexpr,
     L_OFFSET,
     N_OFFSET: tl.constexpr,
 ):
-    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
-    b_m = tl.full([], float('-inf'), dtype=tl.float32)
-    b_acc = tl.zeros([], dtype=tl.float32)
-    for i_l in range(tl.cdiv(L, BL)):
-        o_l = (i_l * BL + tl.arange(0, BL)).to(tl.int64)
-        m_l = o_l < L
-        b_v_sq = tl.zeros([BL], dtype=tl.float32)
-        b_v_qw = tl.zeros([BL], dtype=tl.float32)
-        for i_d in range(tl.cdiv(D, BD)):
-            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
-            m_d = o_d < D
-            b_qw = (
-                tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
-                * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
-            )
+    # BN==1: [BL, BD] along L. BN>1 implies SINGLE_D: [BN, BD] along N, q*w hoisted.
+    i_n0 = tl.program_id(0).to(tl.int64) * BN + N_OFFSET
+    if BN == 1:
+        i_n = i_n0
+        b_m = tl.full([], float('-inf'), dtype=tl.float32)
+        b_acc = tl.zeros([], dtype=tl.float32)
+        for i_l in range(tl.cdiv(L, BL)):
+            o_l = (i_l * BL + tl.arange(0, BL)).to(tl.int64)
+            m_l = o_l < L
+            b_v_sq = tl.zeros([BL], dtype=tl.float32)
+            b_v_qw = tl.zeros([BL], dtype=tl.float32)
+            for i_d in range(tl.cdiv(D, BD)):
+                o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+                m_d = o_d < D
+                b_qw = (
+                    tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+                    * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+                )
+                b_v = tl.load(
+                    res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
+                    mask=m_l[:, None] & m_d[None, :],
+                    other=0.0,
+                ).to(tl.float32)
+                b_v_sq += tl.sum(b_v * b_v, axis=1)
+                b_v_qw += tl.sum(b_v * b_qw[None, :], axis=1)
+            b_rstd = tl.rsqrt(b_v_sq / D + eps)
+            b_logit = b_v_qw * b_rstd
+            b_s = tl.where(m_l, b_logit * scale, float('-inf'))
+            b_m, b_mp = tl.maximum(b_m, tl.max(b_s, axis=0)), b_m
+            b_acc = b_acc * exp(b_mp - b_m) + tl.sum(exp(b_s - b_m), axis=0)
+            g_l = L_OFFSET + o_l
+            tl.store(rstd + g_l * N + i_n, b_rstd.to(rstd.dtype.element_ty), mask=m_l)
+            tl.store(logit + g_l * N + i_n, b_logit.to(logit.dtype.element_ty), mask=m_l)
+        tl.store(chunk_m + i_n, b_m)
+        tl.store(chunk_acc + i_n, b_acc)
+    else:
+        o_n = i_n0 + tl.arange(0, BN).to(tl.int64)
+        m_n = o_n < N
+        b_m = tl.full([BN], float('-inf'), dtype=tl.float32)
+        b_acc = tl.zeros([BN], dtype=tl.float32)
+        o_d = tl.arange(0, BD).to(tl.int64)
+        m_d = o_d < D
+        m_nd = m_n[:, None] & m_d[None, :]
+        b_qw = (
+            tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+            * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+        )
+        for i_l in range(L):
+            i_l64 = tl.cast(i_l, tl.int64)
+            g_l = L_OFFSET + i_l64
             b_v = tl.load(
-                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
-                mask=m_l[:, None] & m_d[None, :],
+                res + i_l64 * stride_ln + o_n[:, None] * D + o_d[None, :],
+                mask=m_nd,
                 other=0.0,
             ).to(tl.float32)
-            b_v_sq += tl.sum(b_v * b_v, axis=1)
-            b_v_qw += tl.sum(b_v * b_qw[None, :], axis=1)
-        b_rstd = tl.rsqrt(b_v_sq / D + eps)
-        b_logit = b_v_qw * b_rstd
-        b_s = tl.where(m_l, b_logit * scale, float('-inf'))
-        b_m, b_mp = tl.maximum(b_m, tl.max(b_s, axis=0)), b_m
-        b_acc = b_acc * exp(b_mp - b_m) + tl.sum(exp(b_s - b_m), axis=0)
-        g_l = L_OFFSET + o_l
-        tl.store(rstd + g_l * N + i_n, b_rstd.to(rstd.dtype.element_ty), mask=m_l)
-        tl.store(logit + g_l * N + i_n, b_logit.to(logit.dtype.element_ty), mask=m_l)
-    tl.store(chunk_m + i_n, b_m)
-    tl.store(chunk_acc + i_n, b_acc)
+            b_v_sq = tl.sum(tl.where(m_nd, b_v * b_v, 0.0), axis=1)
+            b_v_qw = tl.sum(tl.where(m_nd, b_v * b_qw[None, :], 0.0), axis=1)
+            b_rstd = tl.rsqrt(b_v_sq / D + eps)
+            b_logit = b_v_qw * b_rstd
+            b_s = tl.where(m_n, b_logit * scale, float('-inf'))
+            b_mp = b_m
+            b_m = tl.maximum(b_m, b_s)
+            b_acc = b_acc * exp(b_mp - b_m) + exp(b_s - b_m)
+            tl.store(rstd + g_l * N + o_n, b_rstd.to(rstd.dtype.element_ty), mask=m_n)
+            tl.store(logit + g_l * N + o_n, b_logit.to(logit.dtype.element_ty), mask=m_n)
+        tl.store(chunk_m + o_n, b_m, mask=m_n)
+        tl.store(chunk_acc + o_n, b_acc, mask=m_n)
 
 
 @triton.jit(do_not_specialize=['L', 'N', 'D', 'L_OFFSET'])
@@ -174,33 +244,64 @@ def attnres_fwd_p2_chunk_kernel(
     D,
     stride_ln,
     scale,
-    BL: tl.constexpr,
     BD: tl.constexpr,
+    BN: tl.constexpr,
     L_OFFSET,
     N_OFFSET: tl.constexpr,
-    ACCUM: tl.constexpr,
+    LOAD_OMIX: tl.constexpr,
 ):
-    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
-    b_lse = tl.load(lse + i_n).to(tl.float32)
-    for i_d in range(tl.cdiv(D, BD)):
-        o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
-        m_d = o_d < D
-        b_o = tl.zeros([BD], dtype=tl.float32)
-        for i_l in range(tl.cdiv(L, BL)):
-            o_l = (i_l * BL + tl.arange(0, BL)).to(tl.int64)
-            m_l = o_l < L
-            g_l = L_OFFSET + o_l
-            b_logit = tl.load(logit + g_l * N + i_n, mask=m_l, other=0.).to(tl.float32)
-            b_p = tl.where(m_l, exp(b_logit * scale - b_lse), 0.0)
-            b_v = tl.load(
-                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
-                mask=m_l[:, None] & m_d[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            b_o += tl.sum(b_p[:, None] * b_v, axis=0)
-        if ACCUM:
-            b_o += tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
-        tl.store(o_mix + i_n * D + o_d, b_o, mask=m_d)
+    # BN==1: 1D [BD]. BN>1: [BN, BD] along N. D-outer keeps b_o in UB; LOAD_OMIX=0 skips a zero load.
+    i_n0 = tl.program_id(0).to(tl.int64) * BN + N_OFFSET
+    if BN == 1:
+        i_n = i_n0
+        b_lse = tl.load(lse + i_n).to(tl.float32)
+        for i_d in range(tl.cdiv(D, BD)):
+            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+            m_d = o_d < D
+            if LOAD_OMIX:
+                b_o = tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            else:
+                b_o = tl.zeros([BD], dtype=tl.float32)
+            for i_l in range(L):
+                i_l64 = tl.cast(i_l, tl.int64)
+                g_l = L_OFFSET + i_l64
+                b_logit = tl.load(logit + g_l * N + i_n).to(tl.float32)
+                b_p = exp(b_logit * scale - b_lse)
+                b_v = tl.load(
+                    res + i_l64 * stride_ln + i_n * D + o_d,
+                    mask=m_d,
+                    other=0.0,
+                ).to(tl.float32)
+                b_o += b_p * b_v
+            tl.store(o_mix + i_n * D + o_d, b_o, mask=m_d)
+    else:
+        o_n = i_n0 + tl.arange(0, BN).to(tl.int64)
+        m_n = o_n < N
+        b_lse = tl.load(lse + o_n, mask=m_n, other=0.).to(tl.float32)
+        for i_d in range(tl.cdiv(D, BD)):
+            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+            m_d = o_d < D
+            m_nd = m_n[:, None] & m_d[None, :]
+            if LOAD_OMIX:
+                b_o = tl.load(
+                    o_mix + o_n[:, None] * D + o_d[None, :],
+                    mask=m_nd,
+                    other=0.,
+                ).to(tl.float32)
+            else:
+                b_o = tl.zeros([BN, BD], dtype=tl.float32)
+            for i_l in range(L):
+                i_l64 = tl.cast(i_l, tl.int64)
+                g_l = L_OFFSET + i_l64
+                b_logit = tl.load(logit + g_l * N + o_n, mask=m_n, other=0.).to(tl.float32)
+                b_p = exp(b_logit * scale - b_lse)
+                b_v = tl.load(
+                    res + i_l64 * stride_ln + o_n[:, None] * D + o_d[None, :],
+                    mask=m_nd,
+                    other=0.0,
+                ).to(tl.float32)
+                b_o += b_p[:, None] * b_v
+            tl.store(o_mix + o_n[:, None] * D + o_d[None, :], b_o, mask=m_nd)
 
 
 @triton.jit(do_not_specialize=['N', 'D'])
@@ -289,6 +390,7 @@ def attnres_bwd_dv_chunk_kernel(
     logit,
     lse,
     do_eff,
+    o_mix,
     dres,
     dqw,
     b_delta,
@@ -297,90 +399,174 @@ def attnres_bwd_dv_chunk_kernel(
     D,
     stride_ln,
     scale,
-    BL: tl.constexpr,
     BD: tl.constexpr,
+    BN: tl.constexpr,
+    SINGLE_D: tl.constexpr,
+    LOAD_DQW: tl.constexpr,
+    FUSE_PREP: tl.constexpr,
     L_OFFSET,
     N_OFFSET: tl.constexpr,
 ):
-    i_n = tl.program_id(0).to(tl.int64) + N_OFFSET
-    b_lse = tl.load(lse + i_n).to(tl.float32)
-    b_delta = tl.load(b_delta + i_n).to(tl.float32)
-    for i_l in range(tl.cdiv(L, BL)):
-        o_l = (i_l * BL + tl.arange(0, BL)).to(tl.int64)
-        m_l = o_l < L
-        g_l = L_OFFSET + o_l
-        b_rstd = tl.load(rstd + g_l * N + i_n, mask=m_l, other=0.).to(tl.float32)
-        b_logit = tl.load(logit + g_l * N + i_n, mask=m_l, other=0.).to(tl.float32)
-        b_p = tl.where(m_l, exp(b_logit * scale - b_lse), 0.0)
-        b_dp = tl.zeros([BL], dtype=tl.float32)
-        for i_d in range(tl.cdiv(D, BD)):
-            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+    # BN==1: 1D [BD]. BN>1 implies SINGLE_D: [BN, BD] along N. FUSE_PREP inlines delta from o_mix.
+    i_n0 = tl.program_id(0).to(tl.int64) * BN + N_OFFSET
+    if BN == 1:
+        i_n = i_n0
+        b_lse = tl.load(lse + i_n).to(tl.float32)
+        if SINGLE_D:
+            o_d = tl.arange(0, BD).to(tl.int64)
             m_d = o_d < D
-            b_do = tl.load(do_eff + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
-            b_v = tl.load(
-                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
-                mask=m_l[:, None] & m_d[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            b_dp += tl.sum(b_v * b_do[None, :], axis=1)
-        b_ds = b_p * (b_dp - b_delta) * scale
-        for i_d in range(tl.cdiv(D, BD)):
-            o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
-            m_d = o_d < D
-            m_v = m_l[:, None] & m_d[None, :]
             b_qw = (
                 tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
                 * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
             )
             b_do = tl.load(do_eff + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+            if FUSE_PREP:
+                b_dqw = tl.load(o_mix + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+                b_delta_n = tl.sum(tl.where(m_d, b_do * b_dqw, 0.0), axis=0)
+                if LOAD_DQW:
+                    b_dqw = tl.load(dqw + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+                else:
+                    b_dqw = b_dqw * 0.0
+            else:
+                b_delta_n = tl.load(b_delta + i_n).to(tl.float32)
+                if LOAD_DQW:
+                    b_dqw = tl.load(dqw + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+                else:
+                    b_dqw = tl.zeros([BD], dtype=tl.float32)
+            for i_l in range(L):
+                i_l64 = tl.cast(i_l, tl.int64)
+                g_l = L_OFFSET + i_l64
+                b_rstd = tl.load(rstd + g_l * N + i_n).to(tl.float32)
+                b_logit = tl.load(logit + g_l * N + i_n).to(tl.float32)
+                b_p = exp(b_logit * scale - b_lse)
+                b_v = tl.load(
+                    res + i_l64 * stride_ln + i_n * D + o_d,
+                    mask=m_d,
+                    other=0.0,
+                ).to(tl.float32)
+                b_dp = tl.sum(tl.where(m_d, b_v * b_do, 0.0), axis=0)
+                b_ds = b_p * (b_dp - b_delta_n) * scale
+                b_v = b_v * b_rstd
+                b_dqw += b_ds * b_v
+                b_v = b_v * (b_logit / D)
+                b_v = b_qw - b_v
+                b_v = (b_ds * b_rstd) * b_v
+                b_v = b_p * b_do + b_v
+                tl.store(
+                    dres + i_l64 * stride_ln + i_n * D + o_d,
+                    b_v.to(dres.dtype.element_ty),
+                    mask=m_d,
+                )
+            tl.store(dqw + i_n * D + o_d, b_dqw, mask=m_d)
+        else:
+            b_delta_n = tl.load(b_delta + i_n).to(tl.float32)
+            for i_l in range(L):
+                i_l64 = tl.cast(i_l, tl.int64)
+                g_l = L_OFFSET + i_l64
+                b_rstd = tl.load(rstd + g_l * N + i_n).to(tl.float32)
+                b_logit = tl.load(logit + g_l * N + i_n).to(tl.float32)
+                b_p = exp(b_logit * scale - b_lse)
+                b_dp = tl.zeros([], dtype=tl.float32)
+                for i_d in range(tl.cdiv(D, BD)):
+                    o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+                    m_d = o_d < D
+                    b_do = tl.load(do_eff + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+                    b_v = tl.load(
+                        res + i_l64 * stride_ln + i_n * D + o_d,
+                        mask=m_d,
+                        other=0.0,
+                    ).to(tl.float32)
+                    b_dp += tl.sum(tl.where(m_d, b_v * b_do, 0.0), axis=0)
+                b_ds = b_p * (b_dp - b_delta_n) * scale
+                for i_d in range(tl.cdiv(D, BD)):
+                    o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
+                    m_d = o_d < D
+                    b_qw = (
+                        tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+                        * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+                    )
+                    b_do = tl.load(do_eff + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+                    b_v = tl.load(
+                        res + i_l64 * stride_ln + i_n * D + o_d,
+                        mask=m_d,
+                        other=0.0,
+                    ).to(tl.float32)
+                    b_k = b_v * b_rstd
+                    b_dv = b_p * b_do + (b_ds * b_rstd) * (b_qw - b_k * (b_logit / D))
+                    tl.store(
+                        dres + i_l64 * stride_ln + i_n * D + o_d,
+                        b_dv.to(dres.dtype.element_ty),
+                        mask=m_d,
+                    )
+                    b_dqw = tl.load(dqw + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
+                    b_dqw += b_ds * b_k
+                    tl.store(dqw + i_n * D + o_d, b_dqw, mask=m_d)
+    else:
+        o_n = i_n0 + tl.arange(0, BN).to(tl.int64)
+        m_n = o_n < N
+        b_lse = tl.load(lse + o_n, mask=m_n, other=0.).to(tl.float32)
+        o_d = tl.arange(0, BD).to(tl.int64)
+        m_d = o_d < D
+        m_nd = m_n[:, None] & m_d[None, :]
+        b_qw = (
+            tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
+            * tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
+        )
+        b_do = tl.load(
+            do_eff + o_n[:, None] * D + o_d[None, :],
+            mask=m_nd,
+            other=0.,
+        ).to(tl.float32)
+        if FUSE_PREP:
+            b_dqw = tl.load(
+                o_mix + o_n[:, None] * D + o_d[None, :],
+                mask=m_nd,
+                other=0.,
+            ).to(tl.float32)
+            b_delta_n = tl.sum(tl.where(m_nd, b_do * b_dqw, 0.0), axis=1)
+            if LOAD_DQW:
+                b_dqw = tl.load(
+                    dqw + o_n[:, None] * D + o_d[None, :],
+                    mask=m_nd,
+                    other=0.,
+                ).to(tl.float32)
+            else:
+                b_dqw = b_dqw * 0.0
+        else:
+            b_delta_n = tl.load(b_delta + o_n, mask=m_n, other=0.).to(tl.float32)
+            if LOAD_DQW:
+                b_dqw = tl.load(
+                    dqw + o_n[:, None] * D + o_d[None, :],
+                    mask=m_nd,
+                    other=0.,
+                ).to(tl.float32)
+            else:
+                b_dqw = tl.zeros([BN, BD], dtype=tl.float32)
+        for i_l in range(L):
+            i_l64 = tl.cast(i_l, tl.int64)
+            g_l = L_OFFSET + i_l64
+            b_rstd = tl.load(rstd + g_l * N + o_n, mask=m_n, other=0.).to(tl.float32)
+            b_logit = tl.load(logit + g_l * N + o_n, mask=m_n, other=0.).to(tl.float32)
+            b_p = exp(b_logit * scale - b_lse)
             b_v = tl.load(
-                res + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
-                mask=m_v,
+                res + i_l64 * stride_ln + o_n[:, None] * D + o_d[None, :],
+                mask=m_nd,
                 other=0.0,
             ).to(tl.float32)
-            b_k = b_v * b_rstd[:, None]
-            b_dv = b_p[:, None] * b_do[None, :] + (b_ds * b_rstd)[:, None] * (
-                b_qw[None, :] - b_k * (b_logit / D)[:, None]
-            )
+            b_dp = tl.sum(tl.where(m_nd, b_v * b_do, 0.0), axis=1)
+            b_ds = b_p * (b_dp - b_delta_n) * scale
+            b_v = b_v * b_rstd[:, None]
+            b_dqw += b_ds[:, None] * b_v
+            b_v = b_v * (b_logit / D)[:, None]
+            b_v = b_qw[None, :] - b_v
+            b_v = (b_ds * b_rstd)[:, None] * b_v
+            b_v = b_p[:, None] * b_do + b_v
             tl.store(
-                dres + o_l[:, None] * stride_ln + i_n * D + o_d[None, :],
-                b_dv.to(dres.dtype.element_ty),
-                mask=m_v,
+                dres + i_l64 * stride_ln + o_n[:, None] * D + o_d[None, :],
+                b_v.to(dres.dtype.element_ty),
+                mask=m_nd,
             )
-            b_dqw = tl.load(dqw + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
-            b_dqw += tl.sum(b_ds[:, None] * b_k, axis=0)
-            tl.store(dqw + i_n * D + o_d, b_dqw, mask=m_d)
-
-
-@triton.jit(do_not_specialize=['N', 'D'])
-def attnres_bwd_kernel_dqdw_npu(
-    q,
-    w,
-    dqw,
-    dow_partial,
-    dq,
-    dw,
-    dow,
-    N,
-    D,
-    BD: tl.constexpr,
-    HAS_ONORM: tl.constexpr,
-):
-    i_d = tl.program_id(0)
-    o_d = (i_d * BD + tl.arange(0, BD)).to(tl.int64)
-    m_d = o_d < D
-    b_dqw = tl.zeros([BD], dtype=tl.float32)
-    b_dow = tl.zeros([BD], dtype=tl.float32)
-    for i_n in range(N):
-        b_dqw += tl.load(dqw + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
-        if HAS_ONORM:
-            b_dow += tl.load(dow_partial + i_n * D + o_d, mask=m_d, other=0.).to(tl.float32)
-    b_q = tl.load(q + o_d, mask=m_d, other=0.).to(tl.float32)
-    b_w = tl.load(w + o_d, mask=m_d, other=0.).to(tl.float32)
-    tl.store(dq + o_d, b_dqw * b_w, mask=m_d)
-    tl.store(dw + o_d, b_dqw * b_q, mask=m_d)
-    if HAS_ONORM:
-        tl.store(dow + o_d, b_dow, mask=m_d)
+        tl.store(dqw + o_n[:, None] * D + o_d[None, :], b_dqw, mask=m_nd)
 
 
 def _get_o_mix(
@@ -389,19 +575,18 @@ def _get_o_mix(
     lse: torch.Tensor,
     scale: float,
     device: torch.device,
-    o_pre: torch.Tensor | None = None,
-    o_mix: torch.Tensor | None = None,
+    chunks: Iterable[tuple[int, int, torch.Tensor, int, int, int]] | None = None,
 ) -> torch.Tensor:
-    if o_pre is not None:
-        return o_pre
-    if o_mix is None:
-        o_mix = torch.zeros(*sources[0].shape, device=device, dtype=torch.float32)
-    first = True
-    for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
-        bl, bd = _get_bl_bd(ll, D, mem_mult=_FWD_MEM_MULT)
+    o_mix = torch.zeros(*sources[0].shape, device=device, dtype=torch.float32)
+    load_omix = 0
+    stream = chunks if chunks is not None else _iter_l_chunks(sources)
+    for l0, ll, chunk, stride_ln, N, D in stream:
+        bd = _get_bd(1, D, memory_multiplier=_FWD_MEM_MULT)
+        bn = _get_bn(N, bd, mem_mult=_FWD_BN_MEM_MULT)
         _launch_n(
             attnres_fwd_p2_chunk_kernel,
             N,
+            BN=bn,
             res=chunk,
             logit=logit,
             lse=lse,
@@ -411,12 +596,11 @@ def _get_o_mix(
             D=D,
             stride_ln=stride_ln,
             scale=scale,
-            BL=bl,
             BD=bd,
             L_OFFSET=l0,
-            ACCUM=not first,
+            LOAD_OMIX=load_omix,
         )
-        first = False
+        load_omix = 1
         del chunk
     return o_mix
 
@@ -432,7 +616,11 @@ def _dres_chunk(
         if flat_dvs[l0] is None:
             flat_dvs[l0] = torch.empty_like(sources[l0])
         return flat_dvs[l0].unsqueeze(0)
-    return torch.empty_like(chunk)
+    # views into the stacked buffer; avoid a per-layer copy_
+    dres = torch.empty_like(chunk)
+    for i in range(ll):
+        flat_dvs[l0 + i] = dres[i]
+    return dres
 
 
 def fused_attnres_fwd_npu(
@@ -443,7 +631,7 @@ def fused_attnres_fwd_npu(
     eps: float,
     scale: float,
     checkpoint_level: int,
-) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     L, N, D = len(sources), *sources[0].shape
     dtype = sources[0].dtype
     save_opre = checkpoint_level == 0
@@ -456,13 +644,21 @@ def fused_attnres_fwd_npu(
 
     m = torch.full((N,), float('-inf'), device=sources[0].device, dtype=torch.float32)
     acc = torch.zeros(N, device=sources[0].device, dtype=torch.float32)
+    reuse_chunks = _l_chunk_size(L, N, D, sources[0].element_size()) >= L
+    held: list[tuple[int, int, torch.Tensor, int, int, int]] = []
     for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
         chunk_m = torch.empty(N, device=chunk.device, dtype=torch.float32)
         chunk_acc = torch.empty(N, device=chunk.device, dtype=torch.float32)
-        bl, bd = _get_bl_bd(ll, D, mem_mult=_FWD_MEM_MULT)
+        bd = _get_bd(1, D, memory_multiplier=_FWD_MEM_MULT)
+        bn = _n_tile_bn(N, bd, D, mem_mult=_FWD_BN_MEM_MULT)
+        if bn == 1:
+            bl, bd = _get_bl_bd(ll, D, mem_mult=_FWD_MEM_MULT)
+        else:
+            bl = 1
         _launch_n(
             attnres_fwd_p1_chunk_kernel,
             N,
+            BN=bn,
             q=q,
             res=chunk,
             w=w,
@@ -481,10 +677,16 @@ def fused_attnres_fwd_npu(
             L_OFFSET=l0,
         )
         m, acc = _merge_online_softmax(m, acc, chunk_m, chunk_acc)
-        del chunk, chunk_m, chunk_acc
-
+        del chunk_m, chunk_acc
+        if reuse_chunks:
+            held.append((l0, ll, chunk, stride_ln, N, D))
+        else:
+            del chunk
     lse.copy_(m + torch.log(acc))
-    o_mix = _get_o_mix(sources, logit, lse, scale, sources[0].device)
+    o_mix = _get_o_mix(
+        sources, logit, lse, scale, sources[0].device,
+        chunks=held if reuse_chunks else None,
+    )
 
     if save_opre:
         o_pre.copy_(o_mix.to(dtype))
@@ -504,7 +706,8 @@ def fused_attnres_fwd_npu(
             eps=eps,
             BD=_get_bd(1, D, memory_multiplier=2.0),
         )
-    return o, o_pre, rstd, logit, lse
+    stacked = held[0][2].detach() if held else None
+    return o, o_pre, rstd, logit, lse, stacked
 
 
 def fused_attnres_bwd_npu(
@@ -519,43 +722,63 @@ def fused_attnres_bwd_npu(
     lse: torch.Tensor,
     eps: float,
     scale: float,
-    checkpoint_level: int,
+    stacked: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, list[torch.Tensor]]:
-    del checkpoint_level
     has_onorm = ow is not None
     N, D = do.shape
     flat_dvs: list[torch.Tensor | None] = [None] * len(sources)
 
-    do_eff = torch.empty_like(do, dtype=torch.float32)
-    b_delta = torch.empty(N, device=do.device, dtype=torch.float32)
     dqw = torch.zeros_like(do, dtype=torch.float32)
     dq, dw = torch.empty_like(q), torch.empty_like(w)
     dow = torch.empty_like(ow) if has_onorm else None
-    dow_partial = torch.empty_like(do, dtype=torch.float32) if has_onorm else do_eff
+    dow_partial = torch.empty_like(do, dtype=torch.float32) if has_onorm else None
 
-    o_mix = _get_o_mix(sources, logit, lse, scale, do.device, o_pre=o_pre)
-    _launch_n(
-        attnres_bwd_prep_kernel,
-        N,
-        ow=ow if ow is not None else w,
-        o_mix=o_mix,
-        do=do,
-        do_eff=do_eff,
-        dow_partial=dow_partial,
-        b_delta=b_delta,
-        N=N,
-        D=D,
-        eps=eps,
-        BD=_get_bd(1, D, memory_multiplier=_BWD_DV_MEM_MULT),
-        HAS_ONORM=has_onorm,
+    if stacked is not None:
+        ll, N, D = stacked.shape
+        held = [(0, ll, stacked, N * D, N, D)]
+    else:
+        held = None
+    # ckpt=1: drop o_mix in fwd (same as CUDA) and recompute here.
+    o_mix = o_pre if o_pre is not None else _get_o_mix(
+        sources, logit, lse, scale, do.device, chunks=held,
     )
+    bd0 = _get_bd(1, D, memory_multiplier=_BWD_DV_MEM_MULT)
+    fuse_prep = (not has_onorm) and bd0 >= D
+    if fuse_prep:
+        do_eff = do
+        b_delta = lse
+    else:
+        do_eff = torch.empty_like(do, dtype=torch.float32)
+        b_delta = torch.empty(N, device=do.device, dtype=torch.float32)
+        if dow_partial is None:
+            dow_partial = do_eff
+        _launch_n(
+            attnres_bwd_prep_kernel,
+            N,
+            ow=ow if ow is not None else w,
+            o_mix=o_mix,
+            do=do,
+            do_eff=do_eff,
+            dow_partial=dow_partial,
+            b_delta=b_delta,
+            N=N,
+            D=D,
+            eps=eps,
+            BD=bd0,
+            HAS_ONORM=has_onorm,
+        )
 
-    for l0, ll, chunk, stride_ln, N, D in _iter_l_chunks(sources):
+    load_dqw = 0
+    stream = held if held is not None else _iter_l_chunks(sources)
+    for l0, ll, chunk, stride_ln, N, D in stream:
         dres = _dres_chunk(flat_dvs, sources, l0, ll, chunk)
-        bl, bd = _get_bl_bd(ll, D, mem_mult=_BWD_DV_MEM_MULT)
+        bd = _get_bd(1, D, memory_multiplier=_BWD_DV_MEM_MULT)
+        single_d = 1 if bd >= D else 0
+        bn = _n_tile_bn(N, bd, D, mem_mult=_BWD_BN_MEM_MULT)
         _launch_n(
             attnres_bwd_dv_chunk_kernel,
             N,
+            BN=bn,
             q=q,
             res=chunk,
             w=w,
@@ -563,6 +786,7 @@ def fused_attnres_bwd_npu(
             logit=logit,
             lse=lse,
             do_eff=do_eff,
+            o_mix=o_mix,
             dres=dres,
             dqw=dqw,
             b_delta=b_delta,
@@ -571,33 +795,20 @@ def fused_attnres_bwd_npu(
             D=D,
             stride_ln=stride_ln,
             scale=scale,
-            BL=bl,
             BD=bd,
+            SINGLE_D=single_d,
+            LOAD_DQW=load_dqw,
+            FUSE_PREP=1 if fuse_prep else 0,
             L_OFFSET=l0,
         )
-        if ll > 1:
-            for i in range(ll):
-                idx = l0 + i
-                if flat_dvs[idx] is None:
-                    flat_dvs[idx] = torch.empty_like(sources[idx])
-                flat_dvs[idx].copy_(dres[i])
-            del dres
+        load_dqw = 1
         del chunk
 
-    bd = _get_bd(1, D, memory_multiplier=2.0)
-    attnres_bwd_kernel_dqdw_npu[(triton.cdiv(D, bd),)](
-        q=q,
-        w=w,
-        dqw=dqw,
-        dow_partial=dow_partial,
-        dq=dq,
-        dw=dw,
-        dow=dow if dow is not None else dq,
-        N=N,
-        D=D,
-        BD=bd,
-        HAS_ONORM=has_onorm,
-    )
+    dqw_sum = dqw.sum(dim=0)
+    dq.copy_((dqw_sum * w.float()).to(dq.dtype))
+    dw.copy_((dqw_sum * q.float()).to(dw.dtype))
+    if has_onorm:
+        dow.copy_(dow_partial.sum(dim=0).to(dow.dtype))
     assert all(t is not None for t in flat_dvs)
     return dq, dw, dow, flat_dvs  # type: ignore[return-value]
 
@@ -618,14 +829,22 @@ class FusedAttnresNpuFunction(torch.autograd.Function):
         checkpoint_level: int,
         *residuals: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        o, o_pre, rstd, logit, lse = fused_attnres_fwd_npu(
+        o, o_pre, rstd, logit, lse, stacked = fused_attnres_fwd_npu(
             query, residuals, rms_weight, output_rms_weight,
             rms_eps, scale, checkpoint_level,
         )
-        ctx.save_for_backward(
-            query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse, *residuals,
-        )
-        ctx.eps, ctx.scale, ctx.checkpoint_level = rms_eps, scale, checkpoint_level
+        if stacked is None:
+            ctx.save_for_backward(
+                query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse, *residuals,
+            )
+            ctx.has_stack = False
+        else:
+            ctx.save_for_backward(
+                query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse, stacked, *residuals,
+            )
+            ctx.has_stack = True
+        ctx.eps = rms_eps
+        ctx.scale = scale
         p = (logit * scale - lse).exp() if return_weights else o.new_empty(0)
         ctx.mark_non_differentiable(p)
         return o, p
@@ -635,10 +854,16 @@ class FusedAttnresNpuFunction(torch.autograd.Function):
     @autocast_custom_bwd
     def backward(ctx, do: torch.Tensor, dp: torch.Tensor | None = None):
         del dp
-        query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse, *residuals = ctx.saved_tensors
+        saved = ctx.saved_tensors
+        query, rms_weight, output_rms_weight, o_pre, rstd, logit, lse = saved[:7]
+        if ctx.has_stack:
+            stacked, residuals = saved[7], saved[8:]
+        else:
+            stacked, residuals = None, saved[7:]
         dq, dw, dow, flat_dvs = fused_attnres_bwd_npu(
             do, query, residuals, rms_weight, output_rms_weight,
-            o_pre, rstd, logit, lse, ctx.eps, ctx.scale, ctx.checkpoint_level,
+            o_pre, rstd, logit, lse, ctx.eps, ctx.scale,
+            stacked=stacked,
         )
         return (dq, dw, dow, None, None, None, None, *flat_dvs)
 


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->
Optimize the Ascend NPU (`triton_ascend`) fused AttnRes kernels to vectorize along the contiguous N axis, cut host TensorMoves, and skip redundant restacks / prep launches. Public AttnRes API is unchanged; GPU path is untouched.
Tiling / vectorization
- Add `_get_bn` (`BN` up to 8). Grid is over N-tiles, not one program per token.
- `BN==1` keeps 1D `[BD]` tiles: a 2D gather along L compiles to scalar on Triton-Ascend. `BN>1` uses contiguous `[BN, BD]` tiles along N.
- `SINGLE_D` (`BD >= D`) hoists `q*w` out of the L loop and keeps tiles in UB.
- `fwd_p2` is D-outer so `b_o` stays in UB and `o_mix` is written once per D-tile. `LOAD_OMIX=0` skips the first-chunk zero load.
Host / launch savings
- When the stacked residual fits in the 768 MiB L-chunk, reuse it for `fwd_p2` and save it for bwd instead of restacking sources.
- `checkpoint_level=1` still keeps fp32 `o_mix` so bwd skips the p2 restack.
- `_dres_chunk` returns views into the stacked buffer instead of `copy_` out (avoids a handful of TensorMoves per chunk).
- Replace `attnres_bwd_kernel_dqdw_npu` with a host `dqw.sum(dim=0)`.
Backward fusion
- No-onorm + `SINGLE_D`: `FUSE_PREP` inlines `bwd_prep` (`delta` from `o_mix`) into `bwd_dv`. `LOAD_DQW=0` skips the first-chunk zero load of `dqw`.
Bench isolation
- `benchmarks/ops/run.py` / `verify.py`: HEAD and `--base` each run in an isolated subprocess so the parent never holds NPU/CUDA tensors across refs (avoids HBM starvation). Add `--no-base`; lazy-import `device_name`.

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->
hardware: Atlas 800T A3(X86)
FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules tests/ops/utils tests/ops/test_gdn_kernels.py tests/ops/test_gdn.py tests/ops/test_kda.py tests/ops/test_attnres.py tests/ops/test_solve_tril.py
<img width="1298" height="458" alt="image" src="https://github.com/user-attachments/assets/26659a5d-0c33-4a45-acaa-c003b6427efd" />

## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
<img width="1184" height="604" alt="image" src="https://github.com/user-attachments/assets/a241cd77-7849-4624-904b-09de3db6feaf" />

## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->
None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).

### If you cannot tick the "not minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
