### PR TITLE
[Docs] Tighten contributor docs and make the PR checklist N/A-aware

### DIFF
--- a/.agents/skills/fla-mr-readiness/SKILL.md
+++ b/.agents/skills/fla-mr-readiness/SKILL.md
@@ -42,7 +42,7 @@ well-scoped, well-tested, and well-documented.
      workloads if applicable, and a summary of any NCU profiling you did.
 
 6. **Write PR summary**
-   - Use the structure below.
+   - Use the CI-enforced structure below. The source of truth is `.github/pull_request_template.md`; the `check-pr-title` workflow rejects bodies that drop the checklist, so never trim it to save space.
 
 7. **Code style review**
    - Follow `CONTRIBUTING.md` for Python style, docstrings, comments, and commit prefixes.
@@ -54,7 +54,9 @@ well-scoped, well-tested, and well-documented.
    - Keep NVIDIA-only profiling commands in performance docs or scripts, not in
      generic correctness tests.
 
-## Suggested PR body structure
+## PR body structure
+
+Follow `.github/pull_request_template.md` exactly, checklist included:
 
 ```markdown
 ## Summary
@@ -65,16 +67,35 @@ One-paragraph description of what changed and why.
 - Dependent tests run: `<list>`
 - Varlen / CP / model tests: `<yes/no + details>`
 
-## Benchmark / NCU
+## Benchmark / NCU (kernel changes only)
 - Hardware: `<e.g., H100>`
 - Workload: `<batch, seq_len, dtype>`
 - Before: `<throughput or latency>`
 - After: `<throughput or latency>`
 - Conclusion: `<improvement / neutral / trade-off>`
+  (state "neutral" when the change is not performance-related)
 
 ## Breaking changes
 - None / list any API or behavior changes.
+
+## Checklist
+
+- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
+- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
+- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
+- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
+- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
+
+### If you ticked the "minor" box above
+
+<justification — required when the "minor" box is ticked; otherwise delete this section>
 ```
+
+What `check-pr-title` (`.github/workflows/check-pr-title.yml`) enforces:
+
+- The first four checklist boxes must always be ticked; each item carries its own N/A reading, so a tick means "considered — done or not applicable" (e.g. benchmark numbers on a docs-only PR).
+- The "minor" box is the inverse: leave it unticked for normal PRs. Tick it only when the PR genuinely is a typo/formatting/style-only tweak — then a justification of at least a sentence (≥ 20 non-whitespace characters, HTML comments stripped) under `### If you ticked` is required.
+- Editing the body re-triggers the check. To edit a PR title/body on this repo, use the REST API, not `gh pr edit` (see AGENTS.md "Opening PRs").
 
 ## Important reminders
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,13 +20,13 @@
 
 - [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
 - [ ] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
-- [ ] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
-- [ ] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable.
-- [ ] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable).
+- [ ] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
+- [ ] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
+- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
 
-### If you cannot tick the "not minor" box above
+### If you ticked the "minor" box above
 
 Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
-If you believe yours is an exception, justify here why it is worth a maintainer's review time — PRs without a justification may be closed without review:
+Justify here why yours is worth a maintainer's review time — minor PRs without a justification may be closed without review:
 
 <!-- justification, or delete this section if not applicable -->

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -45,10 +45,10 @@ jobs:
           require_checked "Dependent tests pass" "dependent tests"
           require_checked "Kernel changes include" "benchmark numbers (kernel changes)"
 
-          if ! grep -qiE "^[[:space:]]*- \[x\][[:space:]].*This is not a minor/cosmetic-only PR" <<<"$PR_BODY"; then
-            just=$(sed -n '/### If you cannot tick/,$p' <<<"$PR_BODY" | sed 's/<!--[^>]*-->//g' | tail -n +2 | tr -d '[:space:]')
+          if grep -qiE "^[[:space:]]*- \[x\][[:space:]].*This PR is minor/cosmetic-only" <<<"$PR_BODY"; then
+            just=$(sed -n '/### If you ticked/,$p' <<<"$PR_BODY" | sed 's/<!--[^>]*-->//g' | tail -n +2 | tr -d '[:space:]')
             if [ ${#just} -lt 20 ]; then
-              fail "Minor PR without justification: tick the 'not minor' box, or use the justification section to explain why this minor change is worth a maintainer's review time."
+              fail "You ticked the 'minor/cosmetic-only' box: add a justification under the '### If you ticked' heading explaining why this minor change is worth a maintainer's review time, or untick the box if the PR is not minor."
             fi
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,14 +126,16 @@ fla/
 │       └── README.md            # (optional) Mathematical derivations
 ├── models/          # Full language model definitions (config + modeling)
 ├── modules/         # Utility modules (norms, feature maps, rotary, etc.)
-└── utils.py         # Global utilities and decorators
+└── utils/           # Global utilities and decorators
 
 tests/
-├── conftest.py      # Pytest config with NaN memory poisoning
-├── ops/             # Operator tests
-├── layers/          # Layer tests
-├── models/          # Model tests
-└── modules/         # Module tests
+├── context_parallel/   # Context-parallel tests
+├── layers/             # Layer tests
+├── models/             # Model tests
+├── modules/            # Module tests
+├── ops/                # Operator tests
+├── utils/              # Tests for fla.utils
+└── conftest.py         # Pytest config with NaN memory poisoning
 ```
 
 ## Code Style
@@ -163,11 +165,15 @@ Key rules:
 - **Import sorting**: `isort`-compatible via Ruff (`fla` as first-party)
 - **Type hints**: Use modern syntax (`X | None` instead of `Optional[X]`, `list[str]` instead of `List[str]`)
 - Use `TYPE_CHECKING` for imports only needed at type-check time
-- **Multi-line calls**: don't wrap a call that fits within the line limit. When a call does overflow, use a hanging indent with **one keyword argument per line**, not several per line.
+- **Line width**: use the full 127 characters before reaching for a line break — a statement that fits on one line stays on one line.
+- **Calls**: prefer keyword arguments over positional ones. A call that fits within the limit stays on one line; a call that overflows breaks with a hanging indent, **one keyword argument per line** — never several.
+- **Parameter order**: keep related parameters adjacent, and pass keyword arguments at call sites in the same order they appear in the signature.
 
 ### Docstrings and Comments
 
 Comments and docstrings are hints for other readers, not a chain of thought. Give the reader what the code cannot say for itself, in as few words as possible — correct, simple, and with no narration of your reasoning.
+
+Write docstrings at a high level: say what the function or test does and the contract it guarantees, and let the code speak for its own mechanics. A docstring that only restates the body is better left unwritten.
 
 Use a two-line hanging format for `Args:` / `Returns:` entries: a `name (type, Optional):` header line, then the description and `Default:` on the next indented line(s).
 
@@ -234,7 +240,7 @@ Don't hard-wrap prose at an arbitrary short column — this covers Markdown file
   `int32` overflow behavior.
 - Gate autotune configs with `autotune_cache_kwargs` for cache support.
 - Kernel naming: `<op>_fwd_kernel_<suffix>` / `<op>_bwd_kernel_<suffix>`.
-- When renaming a symbol or adding/moving a parameter, sweep **every** site in one pass: the tensor, its `b_*` value, the `p_*` block pointer, comments, and — across the forward/backward kernels, host wrappers, and autograd `Function` — every signature, launch, return tuple, and `save_for_backward`/`saved_tensors` list. Keyword-argument order at each call site must match the parameter order in the signature.
+- When renaming a symbol or adding/moving a parameter, sweep **every** site in one pass: the tensor, its `b_*` value, the `p_*` block pointer, comments, and — across the forward/backward kernels, host wrappers, and autograd `Function` — every signature, launch, return tuple, and `save_for_backward`/`saved_tensors` list.
 
 ### PyTorch Operators
 
@@ -295,7 +301,7 @@ from fla.utils import assert_close, device, device_platform
 @pytest.mark.parametrize(
     ('B', 'T', 'H', 'D', 'dtype'),
     [
-        pytest.param(*test, id="B{}-T{}-H{}-D{}".format(*test))
+        pytest.param(*test, id="B{}-T{}-H{}-D{}-{}".format(*test))
         for test in [
             (1, 63, 1, 64, torch.float16),
             (2, 1000, 4, 128, torch.float16),
@@ -330,7 +336,6 @@ Key guidelines:
 
 - **Always use `torch.manual_seed(42)`** for reproducibility.
 - **Use `assert_close`** from `fla.utils` for numerical comparison with relative tolerance.
-- **Test both forward and backward** passes by computing gradients.
 - **Use `device` from `fla.utils`** for device-agnostic tests.
 - **Parametrize** with diverse shapes including non-power-of-2 sequence lengths (e.g., 63, 100, 2000).
 - **Skip unsupported platforms** with `@pytest.mark.skipif(device_platform == 'intel', ...)` when needed.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 * [Evaluation](#evaluation)
 * [Benchmarks](#benchmarks)
 * [Citation](#citation)
-* [Star History](#star-history)
 * [Acknowledgements](#acknowledgements)
 
 ## News
@@ -47,12 +46,12 @@
 - [2025-10] 🌘 Add Kimi Delta Attention (KDA) implementation to `fla` ([paper](https://arxiv.org/abs/2510.26692)).
 - [2025-09] 🌲 Add DeltaFormer implementation to `fla` ([paper](https://arxiv.org/abs/2505.19488v1)).
 - [2025-09] 🐻 Thrilled to announce that [GDN](fla/ops/gated_delta_rule) has been integrated into Qwen3-Next. Check out their [blog post](https://qwen.ai/blog?id=4074cca80393150c248e508aa62983f9cb7d27cd&from=research.latest-advancements-list) for more info!
-- [2025-08] 🌲 Add Log-Linear Attention implementation to `fla` ([paper](https://arxiv.org/abs/2506.04761)).
-- [2025-08] 🎓 Add MoM implementation to `fla` ([paper](https://arxiv.org/abs/2502.13685)).
 
 <details>
 <summary>Older news</summary>
 
+- [2025-08] 🌲 Add Log-Linear Attention implementation to `fla` ([paper](https://arxiv.org/abs/2506.04761)).
+- [2025-08] 🎓 Add MoM implementation to `fla` ([paper](https://arxiv.org/abs/2502.13685)).
 - [2025-07] 🐳 Add MLA implementation to `fla` ([paper](https://arxiv.org/abs/2405.04434)).
 - [2025-07] 🛣️ Add PaTH Attention implementation to `fla` ([paper](https://arxiv.org/abs/2505.16381)).
 - [2025-06] 🎉 Add MesaNet implementation to `fla` ([paper](https://arxiv.org/abs/2506.05233)).
@@ -80,44 +79,44 @@
 
 ## Models
 
-| Year  |        Model         | Paper                                                                                                                                         |                                                                                                        |
-| :---: | :------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------- |
-| 2022  |         ABC          | [ABC: Attention with Bounded-memory Control](https://arxiv.org/abs/2110.02488)                                                                | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/abc.py)                  |
-| 2023  |        RetNet        | [Retentive network: a successor to transformer for large language models](https://arxiv.org/abs/2307.08621)                                   | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/multiscale_retention.py) |
-| 2023  |         HGRN         | [Hierarchically Gated Recurrent Neural Network for Sequence Modeling](https://openreview.net/forum?id=P1TCHxJwLB)                             | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/hgrn.py)                 |
-| 2024  |         GLA          | [Gated Linear Attention Transformers with Hardware-Efficient Training](https://arxiv.org/abs/2312.06635)                                      | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/gla.py)                  |
-| 2024  |        Based         | [Simple linear attention language models balance the recall-throughput tradeoff](https://arxiv.org/abs/2402.18668)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/based.py)                |
-| 2024  |       Rebased        | [Linear Transformers with Learnable Kernel Functions are Better In-Context Models](https://arxiv.org/abs/2402.10644)                          | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/rebased.py)              |
-| 2024  |       DeltaNet       | [Parallelizing Linear Transformers with Delta Rule over Sequence Length](https://arxiv.org/abs/2406.06484)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/delta_net.py)            |
-| 2024  |        HGRN2         | [HGRN2: Gated Linear RNNs with State Expansion](https://arxiv.org/abs/2404.07904)                                                             | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/hgrn2.py)                |
-| 2024  |        RWKV6         | [Eagle and Finch: RWKV with Matrix-Valued States and Dynamic Recurrence](https://arxiv.org/abs/2404.05892)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/rwkv6.py)                |
-| 2024  |       LightNet       | [You Only Scan Once: Efficient Multi-dimension Sequential Modeling with LightNet](https://arxiv.org/abs/2405.21022)                           | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/lightnet.py)             |
-| 2024  |         YOCO         | [You Only Cache Once: Decoder-Decoder Architectures for Language Models](https://arxiv.org/abs/2405.05254)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/yoco)                    |
-| 2024  |        Mamba2        | [Transformers are SSMs: Generalized Models and Efficient Algorithms Through Structured State Space Duality](https://arxiv.org/abs/2405.21060) | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/mamba2)                  |
-| 2024  |         GSA          | [Gated Slot Attention for Efficient Linear-Time Sequence Modeling](https://arxiv.org/abs/2409.07146)                                          | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/models/gsa)                     |
-| 2024  |         MLA          | [DeepSeek-V2: A Strong, Economical, and Efficient Mixture-of-Experts Language Model](https://arxiv.org/abs/2405.04434)                        | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/mla.py)                  |
-| 2025  |        Samba         | [Samba: Simple Hybrid State Space Models for Efficient Unlimited Context Language Modeling](https://arxiv.org/abs/2406.07522)                 | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/samba)                   |
-| 2025  |    Gated DeltaNet    | [Gated Delta Networks: Improving Mamba2 with Delta Rule](https://arxiv.org/abs/2412.06464)                                                    | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/gated_delta_rule)           |
-| 2025  |        RWKV7         | [RWKV-7 "Goose" with Expressive Dynamic State Evolution](https://arxiv.org/abs/2503.14456)                                                    | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/rwkv7)                      |
-| 2025  |         NSA          | [Native Sparse Attention: Hardware-Aligned and Natively Trainable Sparse Attention](https://arxiv.org/abs/2502.11089)                         | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/nsa)                        |
-| 2025  |         FoX          | [Forgetting Transformer: Softmax Attention with a Forget Gate](https://arxiv.org/abs/2503.02130)                                              | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/forgetting_attn)            |
-| 2025  |     DeltaProduct     | [DeltaProduct: Improving State-Tracking in Linear RNNs via Householder Products](https://arxiv.org/abs/2502.10297)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/gated_deltaproduct.py)   |
-| 2025  |     Rodimus&ast;     | [Rodimus*: Breaking the Accuracy-Efficiency Trade-Off with Efficient Attentions](https://arxiv.org/abs/2410.06577)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/rodimus.py)              |
-| 2025  |       MesaNet        | [MesaNet: Sequence Modeling by Locally Optimal Test-Time Training](https://arxiv.org/abs/2506.05233)                                          | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/mesa_net.py)             |
-| 2025  |        Comba         | [Comba: Improving Bilinear RNNs with Closed-loop Control](https://arxiv.org/abs/2506.02475)                                                   | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/comba.py)                |
-| 2025  |         PaTH         | [PaTH Attention: Position Encoding via Accumulating Householder Transformations](https://arxiv.org/abs/2505.16381)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/path_attn.py)            |
-| 2025  |         MoM          | [MoM: Linear Sequence Modeling with Mixture-of-Memories](https://arxiv.org/abs/2502.13685)                                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/mom.py)                  |
-| 2025  | Log-Linear Attention | [Log-Linear Attention](https://arxiv.org/abs/2506.04761)                                                                                      | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/log_linear_attn)            |
-| 2025  |     DeltaFormer      | [Understanding Transformer from the Perspective of Associative Memory](https://arxiv.org/abs/2505.19488v1)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/deltaformer.py)          |
-| 2025  |         KDA          | [Kimi Linear: An Expressive, Efficient Attention Architecture](https://arxiv.org/abs/2510.26692)                                              | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/kda)                        |
-| 2025  |         MoBA         | [MoBA: Mixture of Block Attention for Long-Context LLMs](https://arxiv.org/abs/2502.13189)                                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/moba.py)                 |
-| 2026  |        Mamba3        | [Mamba-3: Improved Sequence Modeling using State Space Principles](https://arxiv.org/abs/2603.15569)                                          | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/mamba3)                  |
-| 2026  |        Raven         | [Raven: High-Recall Sequence Modeling with Sparse Memory Routing](https://github.com/goombalab/raven/blob/main/raven.pdf)                     | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/models/raven)                   |
-| 2026  |   Gated DeltaNet 2   | [Gated DeltaNet-2: Decoupling Erase and Write in Linear Attention](https://arxiv.org/abs/2605.22791)                                          | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/gdn2)                       |
-| 2026  |         Wall         | [Wall Attention: Length Generalization With Diagonal Gates](https://blog.tilderesearch.com/blog/wall-attn)                                    | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/wall_attn)                  |
-| 2026  |       Parallax       | [Parallax: Parameterized Local Linear Attention for Language Modeling](https://arxiv.org/abs/2605.29157)                                      | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/parallax)                   |
-| 2026  | Preconditioned Gated DeltaNet | [Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences](https://arxiv.org/abs/2604.21100)                | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/precond_gated_delta_rule)   |
-| 2026  | Preconditioned KDA   | [Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences](https://arxiv.org/abs/2604.21100)                         | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/precond_kda)                |
+| Year  |             Model             | Paper                                                                                                                                         |                                                                                                        |
+| :---: | :---------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------- |
+| 2022  |              ABC              | [ABC: Attention with Bounded-memory Control](https://arxiv.org/abs/2110.02488)                                                                | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/abc.py)                  |
+| 2023  |            RetNet             | [Retentive network: a successor to transformer for large language models](https://arxiv.org/abs/2307.08621)                                   | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/multiscale_retention.py) |
+| 2023  |             HGRN              | [Hierarchically Gated Recurrent Neural Network for Sequence Modeling](https://openreview.net/forum?id=P1TCHxJwLB)                             | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/hgrn.py)                 |
+| 2024  |              GLA              | [Gated Linear Attention Transformers with Hardware-Efficient Training](https://arxiv.org/abs/2312.06635)                                      | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/gla.py)                  |
+| 2024  |             Based             | [Simple linear attention language models balance the recall-throughput tradeoff](https://arxiv.org/abs/2402.18668)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/based.py)                |
+| 2024  |            Rebased            | [Linear Transformers with Learnable Kernel Functions are Better In-Context Models](https://arxiv.org/abs/2402.10644)                          | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/rebased.py)              |
+| 2024  |           DeltaNet            | [Parallelizing Linear Transformers with Delta Rule over Sequence Length](https://arxiv.org/abs/2406.06484)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/delta_net.py)            |
+| 2024  |             HGRN2             | [HGRN2: Gated Linear RNNs with State Expansion](https://arxiv.org/abs/2404.07904)                                                             | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/hgrn2.py)                |
+| 2024  |             RWKV6             | [Eagle and Finch: RWKV with Matrix-Valued States and Dynamic Recurrence](https://arxiv.org/abs/2404.05892)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/rwkv6.py)                |
+| 2024  |           LightNet            | [You Only Scan Once: Efficient Multi-dimension Sequential Modeling with LightNet](https://arxiv.org/abs/2405.21022)                           | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/lightnet.py)             |
+| 2024  |             YOCO              | [You Only Cache Once: Decoder-Decoder Architectures for Language Models](https://arxiv.org/abs/2405.05254)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/yoco)                    |
+| 2024  |            Mamba2             | [Transformers are SSMs: Generalized Models and Efficient Algorithms Through Structured State Space Duality](https://arxiv.org/abs/2405.21060) | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/mamba2)                  |
+| 2024  |              GSA              | [Gated Slot Attention for Efficient Linear-Time Sequence Modeling](https://arxiv.org/abs/2409.07146)                                          | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/models/gsa)                     |
+| 2024  |              MLA              | [DeepSeek-V2: A Strong, Economical, and Efficient Mixture-of-Experts Language Model](https://arxiv.org/abs/2405.04434)                        | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/mla.py)                  |
+| 2025  |             Samba             | [Samba: Simple Hybrid State Space Models for Efficient Unlimited Context Language Modeling](https://arxiv.org/abs/2406.07522)                 | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/samba)                   |
+| 2025  |        Gated DeltaNet         | [Gated Delta Networks: Improving Mamba2 with Delta Rule](https://arxiv.org/abs/2412.06464)                                                    | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/gated_delta_rule)           |
+| 2025  |             RWKV7             | [RWKV-7 "Goose" with Expressive Dynamic State Evolution](https://arxiv.org/abs/2503.14456)                                                    | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/rwkv7)                      |
+| 2025  |              NSA              | [Native Sparse Attention: Hardware-Aligned and Natively Trainable Sparse Attention](https://arxiv.org/abs/2502.11089)                         | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/nsa)                        |
+| 2025  |              FoX              | [Forgetting Transformer: Softmax Attention with a Forget Gate](https://arxiv.org/abs/2503.02130)                                              | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/forgetting_attn)            |
+| 2025  |         DeltaProduct          | [DeltaProduct: Improving State-Tracking in Linear RNNs via Householder Products](https://arxiv.org/abs/2502.10297)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/gated_deltaproduct.py)   |
+| 2025  |         Rodimus&ast;          | [Rodimus*: Breaking the Accuracy-Efficiency Trade-Off with Efficient Attentions](https://arxiv.org/abs/2410.06577)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/rodimus.py)              |
+| 2025  |            MesaNet            | [MesaNet: Sequence Modeling by Locally Optimal Test-Time Training](https://arxiv.org/abs/2506.05233)                                          | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/mesa_net.py)             |
+| 2025  |             Comba             | [Comba: Improving Bilinear RNNs with Closed-loop Control](https://arxiv.org/abs/2506.02475)                                                   | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/comba.py)                |
+| 2025  |             PaTH              | [PaTH Attention: Position Encoding via Accumulating Householder Transformations](https://arxiv.org/abs/2505.16381)                            | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/path_attn.py)            |
+| 2025  |              MoM              | [MoM: Linear Sequence Modeling with Mixture-of-Memories](https://arxiv.org/abs/2502.13685)                                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/mom.py)                  |
+| 2025  |     Log-Linear Attention      | [Log-Linear Attention](https://arxiv.org/abs/2506.04761)                                                                                      | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/log_linear_attn)            |
+| 2025  |          DeltaFormer          | [Understanding Transformer from the Perspective of Associative Memory](https://arxiv.org/abs/2505.19488v1)                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/deltaformer.py)          |
+| 2025  |              KDA              | [Kimi Linear: An Expressive, Efficient Attention Architecture](https://arxiv.org/abs/2510.26692)                                              | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/kda)                        |
+| 2025  |             MoBA              | [MoBA: Mixture of Block Attention for Long-Context LLMs](https://arxiv.org/abs/2502.13189)                                                    | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/layers/moba.py)                 |
+| 2026  |            Mamba3             | [Mamba-3: Improved Sequence Modeling using State Space Principles](https://arxiv.org/abs/2603.15569)                                          | [code](https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/mamba3)                  |
+| 2026  |             Raven             | [Raven: High-Recall Sequence Modeling with Sparse Memory Routing](https://github.com/goombalab/raven/blob/main/raven.pdf)                     | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/models/raven)                   |
+| 2026  |       Gated DeltaNet 2        | [Gated DeltaNet-2: Decoupling Erase and Write in Linear Attention](https://arxiv.org/abs/2605.22791)                                          | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/gdn2)                       |
+| 2026  |             Wall              | [Wall Attention: Length Generalization With Diagonal Gates](https://blog.tilderesearch.com/blog/wall-attn)                                    | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/wall_attn)                  |
+| 2026  |           Parallax            | [Parallax: Parameterized Local Linear Attention for Language Modeling](https://arxiv.org/abs/2605.29157)                                      | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/parallax)                   |
+| 2026  | Preconditioned Gated DeltaNet | [Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences](https://arxiv.org/abs/2604.21100)                         | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/precond_gated_delta_rule)   |
+| 2026  |      Preconditioned KDA       | [Preconditioned DeltaNet: Curvature-aware Sequence Modeling for Linear Recurrences](https://arxiv.org/abs/2604.21100)                         | [code](https://github.com/fla-org/flash-linear-attention/tree/main/fla/ops/precond_kda)                |
 
 ## Installation
 
@@ -259,14 +258,14 @@ We offer a collection of fused modules in `fla.modules` to facilitate faster tra
 * [`Linear KL Divergence`](fla/modules/fused_kl_div.py): fused linear layer and KL divergence loss in a similar vein as CE loss.
 
 > [!IMPORTANT]
-> You can control using `fuse_linear_cross_entropy` in the model configuration to enable/disable the fused linear cross entropy loss.
+> You can set `fuse_linear_cross_entropy` in the model configuration to enable or disable the fused linear cross entropy loss.
 >
 > This fused implementation is more memory-efficient but may reduce numerical precision. Due to this trade-off, it is disabled by default.
 > If you enable this feature and encounter training instability (e.g., loss divergence), we recommend disabling it to see if the issue is resolved.
 
 ### Generation
 
-Upon successfully pretraining a model, it becomes accessible for generating text using the 🤗 text generation APIs.
+After pretraining, the model can generate text with the 🤗 text generation APIs.
 In the following, we give a generation example:
 ```py
 >>> import fla
@@ -685,12 +684,6 @@ If you find this repository helpful, please cite our work:
   year      = {2024}
 }
 ```
-
-## Star History
-
-[![Stargazers repo roster for @fla-org/flash-linear-attention](https://bytecrank.com/nastyox/reporoster/php/stargazersSVG.php?user=fla-org&repo=flash-linear-attention)](https://github.com/fla-org/flash-linear-attention/stargazers)
-
-[![Star History Chart](https://api.star-history.com/svg?repos=fla-org/flash-linear-attention&type=Date)](https://star-history.com/#fla-org/flash-linear-attention&Date)
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary

Tightens the style guidance in `CONTRIBUTING.md`, applies the same standard to `README.md`, and rewrites the PR checklist with positive, N/A-aware items.

`CONTRIBUTING.md`:

- **New Formatting rules**, all stated so a first-time contributor can apply them without repo context:
  - **Line width** — fill lines up to the 127-character limit instead of breaking early.
  - **Calls** — prefer keyword arguments; keep the call on one line if it fits, otherwise break with one keyword per line.
  - **Parameter order** — keep related parameters adjacent, and pass call-site keywords in signature order.
- **Docstrings**: state at a high level what the code does; a docstring that only restates the code is better omitted.
- **Dedup**: the keyword-order rule was stated in both Formatting and Triton Kernels (kept in Formatting); the forward+backward test requirement was stated three times (kept in the Testing intro and the Review Checklist).
- **Factual fixes**: the project-structure tree (`fla/utils` is now a package; add `tests/context_parallel/` and `tests/utils/`), the Writing Tests example whose parametrize id dropped the `dtype` placeholder, and the self-referential Table of Contents entry.

`README.md`: two fluency fixes (the fused cross entropy note and the Generation intro). Verified every code link in the Models table resolves to an existing path — no dead links.

PR checklist (`.github/pull_request_template.md` + `check-pr-title.yml`):

- The tests/benchmark items now carry explicit N/A notes, so a tick reads as "considered — done or not applicable" instead of forcing a dishonest tick on docs-only PRs.
- The minor item is phrased positively ("This PR is minor/cosmetic-only"): tick it only when the PR is minor, in which case a justification under `### If you ticked` is required; normal PRs leave it unticked and are done. Bodies written against the old template still pass.
- `fla-mr-readiness` skill synced to both the template and the workflow — its previous body structure predated `check-pr-title`, so following it failed CI on first submit.

## Test plan

Docs and CI wording only, no code changes. Simulated the new `check-pr-title` logic locally against old-style bodies (ticked/unticked legacy box) and new-style bodies (minor ticked with/without justification, unticked) — behaves as intended in all five cases. Verified the touched rules do not contradict each other or the surrounding sections.

## Benchmark / NCU (kernel changes only)

Neutral — no kernel code changed.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
