### PR TITLE
[Fix] Repeat Comba auxiliary keys for GVA

### DIFF
--- a/fla/layers/comba.py
+++ b/fla/layers/comba.py
@@ -275,7 +275,10 @@ class Comba(nn.Module):
         v = rearrange(v, '... (h d) -> ... h d', d=self.head_v_dim)
 
         if self.num_v_heads > self.num_heads:
-            q, k = map(lambda x: repeat(x, '... h d -> ... (h g) d', g=self.num_v_heads // self.num_heads), (q, k))
+            q, k, p = map(
+                lambda x: repeat(x, '... h d -> ... (h g) d', g=self.num_v_heads // self.num_heads),
+                (q, k, p),
+            )
 
         beta = self.b_proj(hidden_states).sigmoid()
         g = -self.A_log.float().exp() * F.softplus(self.a_proj(hidden_states).float() + self.dt_bias)


### PR DESCRIPTION
## Summary

Repeat Comba auxiliary keys alongside queries and keys when num_v_heads is greater than num_heads. Previously, p retained the original query/key head count after q and k were expanded, so chunk and fused recurrent kernels indexed p with the expanded head stride. This could read auxiliary keys from the wrong token or outside the tensor allocation.

The change only affects Comba GVA configurations where num_v_heads > num_heads. Configurations with equal query/key and value head counts are unchanged. There are no API or checkpoint compatibility changes.

## Test plan

- CI

## Benchmark / NCU (kernel changes only)

N/A; no kernel code changed.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.