### PR TITLE
[Fix] Mask GDN gk/gv recurrent gate loads and key chunk autotuners on K/V

### DIFF
--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -30,7 +30,7 @@ BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST'],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST', 'K', 'V'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -173,7 +173,7 @@ def chunk_fwd_kernel_h(
         for num_warps in [1, 2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST'],
+    key=['BT', 'USE_G', 'USE_GK', 'USE_GV', 'STATE_V_FIRST', 'K', 'V'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/fla/ops/gated_delta_rule/fused_recurrent.py
+++ b/fla/ops/gated_delta_rule/fused_recurrent.py
@@ -138,14 +138,14 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
             b_h *= exp(b_g)
 
         if USE_GK:
-            b_gk = tl.load(p_gk).to(tl.float32)
+            b_gk = tl.load(p_gk, mask=mask_k, other=0).to(tl.float32)
             if STATE_V_FIRST:
                 b_h *= exp(b_gk[None, :])
             else:
                 b_h *= exp(b_gk[:, None])
 
         if USE_GV:
-            b_gv = tl.load(p_gv).to(tl.float32)
+            b_gv = tl.load(p_gv, mask=mask_v, other=0).to(tl.float32)
             if STATE_V_FIRST:
                 b_h *= exp(b_gv[:, None])
             else:

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_bwd.py
@@ -242,7 +242,7 @@ def chunk_dplr_bwd_o_kernel(
         for BK in BK_LIST
         for BV in BK_LIST
     ],
-    key=['BT'],
+    key=['BT', 'K', 'V'],
     **autotune_cache_kwargs,
 )
 @triton.jit

--- a/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
+++ b/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
@@ -28,7 +28,7 @@ BK_LIST = [32, 64, 128] if check_shared_mem() else [16, 32]
         for num_warps in NUM_WARPS_AUTOTUNE
         for num_stages in [2, 3, 4]
     ],
-    key=['BT'],
+    key=['BT', 'K', 'V'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -339,7 +339,7 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'HV', 'STATE_V_FIRST'],
+    key=['BT', 'HV', 'STATE_V_FIRST', 'K', 'V'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -127,7 +127,7 @@ def chunk_kda_bwd_kernel_dAv(
         if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
         if not (IS_NVIDIA_SM100 and BK == 32 and num_warps != 2)
     ],
-    key=['BT', 'HV', 'STATE_V_FIRST'],
+    key=['BT', 'HV', 'STATE_V_FIRST', 'K', 'V'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/fla/ops/precond_kda/chunk_bwd.py
+++ b/fla/ops/precond_kda/chunk_bwd.py
@@ -174,7 +174,7 @@ def chunk_precond_kda_bwd_dAv(
         for num_stages in [2, 3, 4]
         if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
     ],
-    key=['BT', 'TRANSPOSE_STATE'],
+    key=['BT', 'TRANSPOSE_STATE', 'K', 'V'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -104,6 +104,26 @@ def test_fused_recurrent(
     assert_close('o', ref, tri, 0.002)
     assert_close('ht', ref_ht, tri_ht, 0.002)
 
+    if D & (D - 1):
+        numel = B * T * HV * D
+        for name in ('gk', 'gv'):
+            storage = torch.full((numel + 64,), float("nan"), device=device)
+            gg = storage[:numel].view(B, T, HV, D)
+            gg.copy_(g.detach()[..., None].expand(B, T, HV, D))
+            tri2, tri2_ht = fused_recurrent_gated_delta_rule(
+                q=q.clone(),
+                k=k.clone(),
+                v=v.clone(),
+                beta=beta.clone(),
+                **{name: gg},
+                scale=scale,
+                initial_state=h0.clone(),
+                use_qk_l2norm_in_kernel=True,
+                output_final_state=True,
+            )
+            assert_close(name, ref, tri2, 0.002)
+            assert_close(f'{name}_ht', ref_ht, tri2_ht, 0.002)
+
 
 @pytest.mark.parametrize(
     ('B', 'T', 'H', 'HV', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),


### PR DESCRIPTION
## Summary

Two small fixes of the same classes as #1135 and #1120.

**1. Mask the `gk`/`gv` loads in `fused_recurrent_gated_delta_rule_fwd_kernel`.** Same shape as #1135 (KDA) and #1165 (GDN2): the gate vectors load over the full `BK`/`BV` tiles, and the padding lanes past a non-power-of-2 `K`/`V` read out of bounds while the sibling q/k/v loads are all masked. Reachable via the public op API `fused_recurrent_gated_delta_rule(gk=.../gv=...)` with a non-pow2 head dim; an OOB `NaN`/`Inf` lane propagates through `exp` into all outputs and the final state. The repo layers only pass scalar `g`, so this only affects direct op callers.

**2. Key the chunk autotuners on `K` and `V`.** Same shape as #1120: these kernels sweep `BK`/`BV` (and warps/stages) in their configs but don't have `K`/`V` in the autotune key, so a second geometry in the same process reuses the first geometry's winner. Adds `'K', 'V'` to the key of:

- `common/chunk_h.py` `chunk_fwd_kernel_h` / `chunk_bwd_kernel_dh` (shared by gla, gsa, simple_gla, rwkv6, mesa_net)
- `kda/chunk_bwd.py` `chunk_kda_bwd_kernel_wy_dqkg_fused` (the gdn2 twin is covered by #1120)
- `precond_kda/chunk_bwd.py` `chunk_precond_kda_bwd_kernel_wy_dqkg`
- `gla/chunk.py` `chunk_gla_fwd_kernel_o`
- `dplr/chunk_o_fwd.py` / `dplr/chunk_o_bwd.py` (rwkv7 chunk path)

## Test plan

- No new test: folded into the existing `test_fused_recurrent` in `tests/ops/test_gdn.py`. When `D` is not a power of two (already covered by the `D=60` row), it additionally runs `gk`/`gv` built as a NaN-poisoned tail view holding the scalar gate broadcast per channel, which must match the scalar-`g` reference exactly.
- Dependent tests for the touched kernels run in CI (`scripts/find_dependent_tests.py` selection).

## Benchmark / NCU (kernel changes only)

Neutral — the mask change is correctness-only, and the autotune-key change only partitions the config cache per geometry (it restores per-geometry tuning rather than changing any steady-state kernel).

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
