### PR TITLE
[Ops] Support native GVA in Comba chunk kernel

### DIFF
--- a/fla/layers/comba.py
+++ b/fla/layers/comba.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
-from einops import rearrange, repeat
+from einops import rearrange
 from torch.nn import functional as F
 
 from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
@@ -273,12 +273,6 @@ class Comba(nn.Module):
             q = q - self.D[None, None, :, None] * p
 
         v = rearrange(v, '... (h d) -> ... h d', d=self.head_v_dim)
-
-        if self.num_v_heads > self.num_heads:
-            q, k, p = map(
-                lambda x: repeat(x, '... h d -> ... (h g) d', g=self.num_v_heads // self.num_heads),
-                (q, k, p),
-            )
 
         beta = self.b_proj(hidden_states).sigmoid()
         g = -self.A_log.float().exp() * F.softplus(self.a_proj(hidden_states).float() + self.dt_bias)

--- a/fla/ops/comba/chunk.py
+++ b/fla/ops/comba/chunk.py
@@ -312,22 +312,23 @@ def chunk_comba(
         k (torch.Tensor):
             keys of shape `[B, T, H, K]`.
         v (torch.Tensor):
-            values of shape `[B, T, H, V]`.
+            values of shape `[B, T, HV, V]`.
+            GVA (Grouped Value Attention) is applied if `HV > H`, where `HV` must be divisible by `H`.
         p (torch.Tensor):
             auxiliary keys of shape `[B, T, H, K]`.
         g (torch.Tensor):
-            (forget) gating tensor (in log space!) of shape `[B, T, H]`.
+            (forget) gating tensor (in log space!) of shape `[B, T, HV]`.
         beta (torch.Tensor):
-            betas of shape `[B, T, H]`.
+            betas of shape `[B, T, HV]`.
         scale (Optional[int]):
             Scale factor for the RetNet attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
         initial_state (Optional[torch.Tensor]):
-            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            Initial state of shape `[N, HV, K, V]` for `N` input sequences.
             For equal-length input sequences, `N` equals the batch size `B`.
             Default: `None`.
         output_final_state (Optional[bool]):
-            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+            Whether to output the final state of shape `[N, HV, K, V]`. Default: `False`.
         use_qk_l2norm_in_kernel (bool):
             Whether to apply L2norm to the q/k tensor internally. Default: `False`.
         cu_seqlens (torch.LongTensor):
@@ -336,9 +337,9 @@ def chunk_comba(
 
     Returns:
         o (torch.Tensor):
-            Outputs of shape `[B, T, H, V]`.
+            Outputs of shape `[B, T, HV, V]`.
         final_state (torch.Tensor):
-            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+            Final state of shape `[N, HV, K, V]` if `output_final_state=True` else `None`.
 
     Examples::
         >>> import torch
@@ -373,6 +374,17 @@ def chunk_comba(
     """
     if p is None:
         p = k
+    if q.shape[2] != k.shape[2] or q.shape[2] != p.shape[2]:
+        raise ValueError(
+            f"q, k and p must have the same number of heads, "
+            f"but got q.shape[2]={q.shape[2]}, k.shape[2]={k.shape[2]} and p.shape[2]={p.shape[2]}"
+        )
+    H, HV = q.shape[2], v.shape[2]
+    if HV % H != 0:
+        raise ValueError(
+            f"For GVA, num_v_heads (HV={HV}) must be evenly divisible by "
+            f"num_heads (H={H}), but got HV % H = {HV % H}"
+        )
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(

--- a/fla/ops/comba/wy_fast.py
+++ b/fla/ops/comba/wy_fast.py
@@ -25,7 +25,7 @@ from fla.utils import autotune_cache_kwargs, check_shared_mem
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'BT', 'IS_VARLEN', 'USE_G'],
+    key=['H', 'HV', 'K', 'BT', 'IS_VARLEN', 'USE_G'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -40,6 +40,7 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     BK: tl.constexpr,
@@ -47,7 +48,7 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
     USE_G: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -57,23 +58,23 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
 
-    p_beta = beta + bos*H + i_h + o_t * H
+    p_beta = beta + bos*HV + i_h + o_t * HV
     b_beta = tl.load(p_beta, mask=m_t, other=0.0)
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = m_t[:, None] & (o_k[None, :] < K)
-        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
-        p_p = p + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k = k + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_p = p + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
         b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_p = tl.load(p_p, mask=m_k, other=0.0)
         b_pb = b_p * b_beta[:, None]
         b_A += tl.dot(b_pb.to(b_k.dtype), tl.trans(b_k))
 
     if USE_G:
-        p_g0 = g0 + bos*H + i_h + o_t * H
-        p_g = g + bos*H + i_h + o_t * H
+        p_g0 = g0 + bos*HV + i_h + o_t * HV
+        p_g = g + bos*HV + i_h + o_t * HV
         b_g0 = tl.load(p_g0, mask=m_t, other=0.0)
         b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_A = b_A * exp2(b_g0[:, None] - b_g[None, :])
@@ -81,7 +82,7 @@ def chunk_scaled_dot_comba_pkt_fwd_kernel(
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
     o_A = tl.arange(0, BT)
-    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (BT*H) + o_A[None, :]
+    p_A = A + (bos*HV + i_h) * BT + o_t[:, None] * (BT*HV) + o_A[None, :]
     tl.store(p_A, b_A.to(p_A.dtype.element_ty), mask=m_t[:, None] & (o_A[None, :] < BT))
 
 
@@ -105,12 +106,12 @@ def chunk_scaled_dot_comba_pkt_fwd(
         p (torch.Tensor):
             The auxiliary key tensor of shape `[B, T, H, K]`.
         beta (torch.Tensor):
-            The beta tensor of shape `[B, T, H]`.
+            The beta tensor of shape `[B, T, HV]`.
         g0 (torch.Tensor):
-            The cumulative sum minus the original one of the gate tensor of shape `[B, T, H]`.
+            The cumulative sum minus the original one of the gate tensor of shape `[B, T, HV]`.
             Default: None
         g (torch.Tensor):
-            The cumulative sum of the gate tensor of shape `[B, T, H]`.
+            The cumulative sum of the gate tensor of shape `[B, T, HV]`.
             Default: None
         cu_seqlens (torch.LongTensor):
             The cumulative sequence lengths of the input tensor.
@@ -121,15 +122,15 @@ def chunk_scaled_dot_comba_pkt_fwd(
             The dtype of the output tensor. Default: `torch.float32`
 
     Returns:
-        beta * K * K^T of shape `[B, T, H, BT]` where `BT` is the chunk size.
+        beta * K * K^T of shape `[B, T, HV, BT]` where `BT` is the chunk size.
     """
-    B, T, H, K = k.shape
+    B, T, H, K, HV = *k.shape, beta.shape[2]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
-    A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
-    chunk_scaled_dot_comba_pkt_fwd_kernel[(NT, B * H)](
+    A = torch.empty(B, T, HV, BT, device=k.device, dtype=output_dtype)
+    chunk_scaled_dot_comba_pkt_fwd_kernel[(NT, B * HV)](
         k=k,
         p=p,
         beta=beta,
@@ -140,6 +141,7 @@ def chunk_scaled_dot_comba_pkt_fwd(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         BT=BT,
     )
@@ -155,7 +157,7 @@ def chunk_scaled_dot_comba_pkt_fwd(
         for num_warps in [2, 4]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -179,6 +181,7 @@ def prepare_wy_repr_bwd_kernel(
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
@@ -187,7 +190,7 @@ def prepare_wy_repr_bwd_kernel(
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -199,10 +202,10 @@ def prepare_wy_repr_bwd_kernel(
     o_A = tl.arange(0, BT)
     m_t = o_t < T
     m_AT = (o_A[:, None] < BT) & m_t[None, :]
-    p_beta = beta + (bos*H + i_h) + o_t * H
-    p_g0 = g0 + (bos*H + i_h) + o_t * H
-    p_g = g + (bos*H + i_h) + o_t * H
-    p_A = A + (bos*H + i_h) * BT + o_A[:, None] + o_t[None, :] * (H*BT)
+    p_beta = beta + (bos*HV + i_h) + o_t * HV
+    p_g0 = g0 + (bos*HV + i_h) + o_t * HV
+    p_g = g + (bos*HV + i_h) + o_t * HV
+    p_A = A + (bos*HV + i_h) * BT + o_A[:, None] + o_t[None, :] * (HV*BT)
 
     b_A = tl.load(p_A, mask=m_AT, other=0.0)
     b_beta = tl.load(p_beta, mask=m_t, other=0.0)
@@ -217,9 +220,9 @@ def prepare_wy_repr_bwd_kernel(
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = m_t[:, None] & (o_k[None, :] < K)
-        p_p = p + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
-        p_dp = dp + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
-        p_dw = dw + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_p = p + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dp = dp + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dw = dw + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
         b_p = tl.load(p_p, mask=m_k, other=0.0)
         b_p_beta_g0 = (b_p * b_beta[:, None] * b_g0_exp[:, None]).to(b_p.dtype)
         b_dw = tl.load(p_dw, mask=m_k, other=0.0)
@@ -233,9 +236,9 @@ def prepare_wy_repr_bwd_kernel(
     for i_v in range(tl.cdiv(V, BV)):
         o_v = i_v * BV + tl.arange(0, BV)
         m_v = m_t[:, None] & (o_v[None, :] < V)
-        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
-        p_dv = dv + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
-        p_du = du + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v = v + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_dv = dv + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_du = du + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
         b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_v_beta = (b_v * b_beta[:, None]).to(b_v.dtype)
         b_du = tl.load(p_du, mask=m_v, other=0.0)
@@ -256,10 +259,10 @@ def prepare_wy_repr_bwd_kernel(
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = m_t[:, None] & (o_k[None, :] < K)
-        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
-        p_p = p + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
-        p_dk = dk + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
-        p_dp = dp + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k = k + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_p = p + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_dk = dk + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
+        p_dp = dp + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
         b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_p = tl.load(p_p, mask=m_k, other=0.0)
         b_dp = tl.load(p_dp, mask=m_k, other=0.0)
@@ -275,9 +278,9 @@ def prepare_wy_repr_bwd_kernel(
     b_dA_A = b_dA * b_A
     b_dg0 += tl.sum(b_dA_A, axis=1)
     b_dg = - tl.sum(b_dA_A, axis=0)
-    p_dg = dg + (bos*H + i_h) + o_t * H
-    p_dg0 = dg0 + (bos*H + i_h) + o_t * H
-    p_dbeta = dbeta + (bos*H + i_h) + o_t * H
+    p_dg = dg + (bos*HV + i_h) + o_t * HV
+    p_dg0 = dg0 + (bos*HV + i_h) + o_t * HV
+    p_dbeta = dbeta + (bos*HV + i_h) + o_t * HV
     tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), mask=m_t)
     tl.store(p_dg0, b_dg0.to(p_dg0.dtype.element_ty), mask=m_t)
     tl.store(p_dbeta, b_dbeta.to(p_dbeta.dtype.element_ty), mask=m_t)
@@ -292,7 +295,7 @@ def prepare_wy_repr_bwd_kernel(
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
+    key=['H', 'HV', 'K', 'V', 'BT', 'BK', 'BV', 'IS_VARLEN'],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=['T'])
@@ -308,6 +311,7 @@ def recompute_w_u_fwd_kernel(
     chunk_indices,
     T,
     H: tl.constexpr,
+    HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
@@ -316,7 +320,7 @@ def recompute_w_u_fwd_kernel(
     IS_VARLEN: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
-    i_b, i_h = i_bh // H, i_bh % H
+    i_b, i_h = i_bh // HV, i_bh % HV
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -327,9 +331,9 @@ def recompute_w_u_fwd_kernel(
     o_A = tl.arange(0, BT)
     m_t = o_t < T
     m_A = m_t[:, None] & (o_A[None, :] < BT)
-    p_beta = beta + bos*H + i_h + o_t * H
-    p_g = g + (bos*H + i_h) + o_t * H
-    p_A = A + (bos*H + i_h) * BT + o_t[:, None] * (H*BT) + o_A[None, :]
+    p_beta = beta + bos*HV + i_h + o_t * HV
+    p_g = g + (bos*HV + i_h) + o_t * HV
+    p_A = A + (bos*HV + i_h) * BT + o_t[:, None] * (HV*BT) + o_A[None, :]
     b_beta = tl.load(p_beta, mask=m_t, other=0.0)
     b_A = tl.load(p_A, mask=m_A, other=0.0)
     b_g = exp2(tl.load(p_g, mask=m_t, other=0.0))
@@ -337,8 +341,8 @@ def recompute_w_u_fwd_kernel(
     for i_v in range(tl.cdiv(V, BV)):
         o_v = i_v * BV + tl.arange(0, BV)
         m_v = m_t[:, None] & (o_v[None, :] < V)
-        p_v = v + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
-        p_u = u + (bos*H + i_h) * V + o_t[:, None] * (H*V) + o_v[None, :]
+        p_v = v + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
+        p_u = u + (bos*HV + i_h) * V + o_t[:, None] * (HV*V) + o_v[None, :]
         b_v = tl.load(p_v, mask=m_v, other=0.0)
         b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb, allow_tf32=False)
@@ -347,8 +351,8 @@ def recompute_w_u_fwd_kernel(
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = m_t[:, None] & (o_k[None, :] < K)
-        p_k = k + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
-        p_w = w + (bos*H + i_h) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_k = k + (bos*H + i_h // (HV // H)) * K + o_t[:, None] * (H*K) + o_k[None, :]
+        p_w = w + (bos*HV + i_h) * K + o_t[:, None] * (HV*K) + o_k[None, :]
         b_k = tl.load(p_k, mask=m_k, other=0.0)
         b_kb = (b_k * b_beta[:, None] * b_g[:, None]).to(b_k.dtype)
         b_w = tl.dot(b_A, b_kb)
@@ -364,7 +368,7 @@ def recompute_w_u_fwd(
     cu_seqlens: torch.LongTensor | None,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    B, T, H, K, V = *k.shape, v.shape[-1]
+    B, T, H, K, V, HV = *k.shape, v.shape[-1], v.shape[2]
     BT = A.shape[-1]
 
     if chunk_indices is None and cu_seqlens is not None:
@@ -374,8 +378,8 @@ def recompute_w_u_fwd(
     BV = 64
 
     u = torch.empty_like(v)
-    w = torch.empty_like(k)
-    recompute_w_u_fwd_kernel[(NT, B*H)](
+    w = k.new_empty(B, T, HV, K)
+    recompute_w_u_fwd_kernel[(NT, B*HV)](
         k=k,
         v=v,
         beta=beta,
@@ -387,6 +391,7 @@ def recompute_w_u_fwd(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         V=V,
         BT=BT,
@@ -409,7 +414,7 @@ def prepare_wy_repr_bwd(
     cu_seqlens: torch.LongTensor | None,
     chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    B, T, H, K, V = *k.shape, v.shape[-1]
+    B, T, H, K, V, HV = *k.shape, v.shape[-1], v.shape[2]
     BT = A.shape[-1]
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -418,13 +423,13 @@ def prepare_wy_repr_bwd(
     BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
     BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
 
-    dk = torch.empty_like(k)
+    dk = k.new_empty(B, T, HV, K)
     dv = torch.empty_like(v)
-    dp = torch.empty_like(p)
+    dp = p.new_empty(B, T, HV, K)
     dbeta = torch.empty_like(beta)
     dg0 = torch.empty_like(g0)
     dg = torch.empty_like(g)
-    prepare_wy_repr_bwd_kernel[(NT, B * H)](
+    prepare_wy_repr_bwd_kernel[(NT, B * HV)](
         k=k,
         v=v,
         p=p,
@@ -444,10 +449,14 @@ def prepare_wy_repr_bwd(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        HV=HV,
         K=K,
         V=V,
         BT=BT,
         BK=BK,
         BV=BV,
     )
+    if H != HV:
+        dk = dk.view(B, T, H, HV // H, K).sum(3)
+        dp = dp.view(B, T, H, HV // H, K).sum(3)
     return dk, dv, dp, dbeta, dg0, dg

--- a/tests/ops/test_comba.py
+++ b/tests/ops/test_comba.py
@@ -10,6 +10,7 @@ import os
 import pytest
 import torch
 import torch.nn.functional as F
+from einops import repeat
 
 from fla.ops.comba import chunk_comba, fused_recurrent_comba
 from fla.ops.comba.naive import naive_chunk_comba
@@ -58,18 +59,20 @@ def test_cumsum_local_scalar_fwd(
 
 
 @pytest.mark.parametrize(
-    ('B', 'T', 'H', 'D', 'scale', 'gate_logit_normalizer', 'dtype'),
+    ('B', 'T', 'H', 'HV', 'D', 'scale', 'gate_logit_normalizer', 'dtype'),
     [
-        pytest.param(*test, id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test))
+        pytest.param(*test, id="B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-{}".format(*test))
         for test in [
-            (1, 63, 1, 64, 1, 1, torch.float),
-            (2, 1024, 4, 60, 1, 1, torch.float),
-            (2, 1024, 8, 128, 1, 0.1, torch.float),
-            (2, 1024, 8, 128, 0.1, 1, torch.float),
-            (2, 1024, 8, 128, 1, 10, torch.float),
-            (4, 2048, 8, 64, 0.1, 1, torch.float),
-            (2, 1024, 8, 128, 1, 0.1, torch.float16),
-            (2, 1024, 8, 128, 1, 10, torch.float16),
+            (1, 63, 1, 1, 64, 1, 1, torch.float),
+            (2, 1024, 4, 4, 60, 1, 1, torch.float),
+            (2, 1024, 8, 8, 128, 1, 0.1, torch.float),
+            (2, 1024, 8, 8, 128, 0.1, 1, torch.float),
+            (2, 1024, 8, 8, 128, 1, 10, torch.float),
+            (4, 2048, 8, 8, 64, 0.1, 1, torch.float),
+            (2, 1024, 8, 8, 128, 1, 0.1, torch.float16),
+            (2, 1024, 8, 8, 128, 1, 10, torch.float16),
+            (2, 1024, 2, 8, 128, 1, 0.1, torch.float),
+            (2, 1024, 4, 8, 128, 1, 10, torch.float16),
         ]
     ],
 )
@@ -77,6 +80,7 @@ def test_fused_recurrent(
     B: int,
     T: int,
     H: int,
+    HV: int,
     D: int,
     scale: float,
     gate_logit_normalizer: float,
@@ -85,18 +89,18 @@ def test_fused_recurrent(
     torch.manual_seed(42)
     q = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
     k = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
-    v = torch.randn(B, T, H, D, dtype=dtype)
+    v = torch.randn(B, T, HV, D, dtype=dtype)
     p = F.normalize(torch.randn(B, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
-    beta = torch.rand(B, T, H, dtype=dtype).sigmoid()
-    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    beta = torch.rand(B, T, HV, dtype=dtype).sigmoid()
+    g = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32))
     g = g / gate_logit_normalizer
-    h0 = torch.randn(B, H, D, D, dtype=torch.float32)
+    h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     q, k, v, p, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, p, beta, g, h0))
     ref, ref_ht = naive_chunk_comba(
-        q=q.clone(),
-        k=k.clone(),
+        q=repeat(q.clone(), 'b t h d -> b t (h g) d', g=HV // H),
+        k=repeat(k.clone(), 'b t h d -> b t (h g) d', g=HV // H),
         v=v.clone(),
-        p=p.clone(),
+        p=repeat(p.clone(), 'b t h d -> b t (h g) d', g=HV // H),
         beta=beta.clone(),
         g=g.clone(),
         scale=scale,
@@ -119,21 +123,24 @@ def test_fused_recurrent(
 
 
 @pytest.mark.parametrize(
-    ('B', 'T', 'H', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),
+    ('B', 'T', 'H', 'HV', 'D', 'scale', 'gate_logit_normalizer', 'mask_p', 'use_qk_l2norm_in_kernel', 'dtype'),
     [
         pytest.param(
             *test,
-            id="B{}-T{}-H{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
+            id="B{}-T{}-H{}-HV{}-D{}-scale{}-gate_logit_normalizer{}-mask_p{}-use_qk_l2norm_in_kernel{}-{}".format(*test),
         )
         for test in [
-            (1, 63, 1, 64, 1, 1, 0, False, torch.float16),
-            (2, 1000, 3, 60, 1, 1, 0, False, torch.float16),
-            (2, 1024, 3, 64, 0.1, 1, 0.5, False, torch.float16),
-            (2, 1024, 4, 100, 1, 0.1, 0, False, torch.float16),
-            (2, 1024, 4, 128, 0.1, 1, 0, True, torch.float16),
-            (2, 1024, 4, 128, 0.1, 1, 0.5, False, torch.float16),
-            (2, 1024, 4, 128, 0.1, 10, 0, False, torch.float16),
-            (4, 2048, 8, 64, 0.1, 1, 0, True, torch.float16),
+            (1, 63, 1, 1, 64, 1, 1, 0, False, torch.float16),
+            (2, 1000, 3, 3, 60, 1, 1, 0, False, torch.float16),
+            (2, 1024, 3, 3, 64, 0.1, 1, 0.5, False, torch.float16),
+            (2, 1024, 4, 4, 100, 1, 0.1, 0, False, torch.float16),
+            (2, 1024, 4, 4, 128, 0.1, 1, 0, True, torch.float16),
+            (2, 1024, 4, 4, 128, 0.1, 1, 0.5, False, torch.float16),
+            (2, 1024, 4, 4, 128, 0.1, 10, 0, False, torch.float16),
+            (4, 2048, 8, 8, 64, 0.1, 1, 0, True, torch.float16),
+            (2, 1000, 2, 8, 64, 1, 1, 0, False, torch.float16),
+            (2, 1024, 2, 8, 128, 0.1, 1, 0.5, False, torch.float16),
+            (2, 1024, 4, 8, 128, 0.1, 1, 0, True, torch.float16),
         ]
     ],
 )
@@ -141,6 +148,7 @@ def test_chunk(
     B: int,
     T: int,
     H: int,
+    HV: int,
     D: int,
     scale: float,
     gate_logit_normalizer: float,
@@ -150,16 +158,18 @@ def test_chunk(
 ):
     if IS_INTEL_ALCHEMIST and D > 128:
         pytest.skip(reason='chunk_gated_delta_rule is not supported on alchemist for D>128')
+    assert HV % H == 0
+    G = HV // H
 
     q = torch.randn(B, T, H, D, dtype=dtype)
     k = torch.randn(B, T, H, D, dtype=dtype)
     p = torch.randn(B, T, H, D, dtype=dtype)
-    v = torch.randn(B, T, H, D, dtype=dtype)
-    beta = torch.rand(B, T, H, dtype=dtype).sigmoid()
-    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32))
+    v = torch.randn(B, T, HV, D, dtype=dtype)
+    beta = torch.rand(B, T, HV, dtype=dtype).sigmoid()
+    g = F.logsigmoid(torch.rand(B, T, HV, dtype=torch.float32))
     g = g / gate_logit_normalizer
     g = g * (torch.rand_like(g) > mask_p)
-    h0 = torch.zeros(B, H, D, D, dtype=torch.float32)
+    h0 = torch.zeros(B, HV, D, D, dtype=torch.float32)
     q, k, v, p, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, p, beta, g, h0))
 
     tri, tri_ht = chunk_comba(
@@ -181,9 +191,9 @@ def test_chunk(
     q.grad = k.grad = v.grad = p.grad = beta.grad = g.grad = h0.grad = None
 
     ref, ref_ht = naive_chunk_comba(
-        q=F.normalize(q.clone(), p=2, dim=-1),
-        k=F.normalize(k.clone(), p=2, dim=-1),
-        p=F.normalize(p.clone(), p=2, dim=-1),
+        q=F.normalize(repeat(q.clone(), 'b t h d -> b t (h g) d', g=G), p=2, dim=-1),
+        k=F.normalize(repeat(k.clone(), 'b t h d -> b t (h g) d', g=G), p=2, dim=-1),
+        p=F.normalize(repeat(p.clone(), 'b t h d -> b t (h g) d', g=G), p=2, dim=-1),
         v=v.clone(),
         g=g.clone(),
         beta=beta.clone(),
@@ -207,14 +217,15 @@ def test_chunk(
 
 
 @pytest.mark.parametrize(
-    ('H', 'D', 'mask_p', 'cu_seqlens', 'dtype'),
+    ('H', 'HV', 'D', 'mask_p', 'cu_seqlens', 'dtype'),
     [
-        pytest.param(*test, id="H{}-D{}-mask_p{}-cu_seqlens{}-{}".format(*test))
+        pytest.param(*test, id="H{}-HV{}-D{}-mask_p{}-cu_seqlens{}-{}".format(*test))
         for test in [
-            (4, 64, 0, [0, 15], torch.float16),
-            (4, 64, 0, [0, 256, 500, 1000], torch.float16),
-            (4, 64, 0.5, [0, 256, 500, 1000], torch.float16),
-            (4, 100, 0, [0, 15, 100, 300, 1200, 2000], torch.float16),
+            (4, 4, 64, 0, [0, 15], torch.float16),
+            (4, 4, 64, 0, [0, 256, 500, 1000], torch.float16),
+            (4, 4, 64, 0.5, [0, 256, 500, 1000], torch.float16),
+            (4, 4, 100, 0, [0, 15, 100, 300, 1200, 2000], torch.float16),
+            (2, 8, 64, 0, [0, 256, 500, 1000], torch.float16),
         ]
     ],
 )
@@ -224,6 +235,7 @@ def test_chunk(
 )
 def test_chunk_varlen(
     H: int,
+    HV: int,
     D: int,
     mask_p: float,
     cu_seqlens: list[int],
@@ -240,12 +252,12 @@ def test_chunk_varlen(
 
     q = torch.randn((1, T, H, D), dtype=dtype)
     k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
-    v = torch.randn((1, T, H, D), dtype=dtype)
+    v = torch.randn((1, T, HV, D), dtype=dtype)
     p = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32), p=2, dim=-1).to(dtype)
-    g = F.logsigmoid(torch.rand(1, T, H, dtype=dtype))
+    g = F.logsigmoid(torch.rand(1, T, HV, dtype=dtype))
     g = g * (torch.rand_like(g) > mask_p)
-    beta = torch.rand(1, T, H, dtype=dtype).sigmoid()
-    h0 = torch.randn((N, H, D, D), dtype=dtype)
+    beta = torch.rand(1, T, HV, dtype=dtype).sigmoid()
+    h0 = torch.randn((N, HV, D, D), dtype=dtype)
 
     q, k, v, p, beta, g, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, p, beta, g, h0))
     do = torch.randn_like(v)
@@ -270,10 +282,10 @@ def test_chunk_varlen(
     ref_ht = []
     for i in range(N):
         ref_i, ref_ht_i = naive_chunk_comba(
-            q=q[:, cu_seqlens[i]:cu_seqlens[i+1]],
-            k=k[:, cu_seqlens[i]:cu_seqlens[i+1]],
+            q=repeat(q[:, cu_seqlens[i]:cu_seqlens[i+1]], 'b t h d -> b t (h g) d', g=HV // H),
+            k=repeat(k[:, cu_seqlens[i]:cu_seqlens[i+1]], 'b t h d -> b t (h g) d', g=HV // H),
             v=v[:, cu_seqlens[i]:cu_seqlens[i+1]],
-            p=p[:, cu_seqlens[i]:cu_seqlens[i+1]],
+            p=repeat(p[:, cu_seqlens[i]:cu_seqlens[i+1]], 'b t h d -> b t (h g) d', g=HV // H),
             beta=beta[:, cu_seqlens[i]:cu_seqlens[i+1]],
             g=g[:, cu_seqlens[i]:cu_seqlens[i+1]],
             initial_state=h0[i],


### PR DESCRIPTION
## Summary

Add native GVA (`HV > H`) support to `chunk_comba`: value-side tensors (v, g, beta, states) keep `HV` heads while q/k/p keep `H` heads, with the head mapping and gradient reduction handled inside the Comba kernels — the same pattern as `gated_delta_rule`/`kda`. The `Comba` layer no longer repeats q/k/p when `num_v_heads > num_heads`, removing the workaround from #1169.

`H == HV` configurations are unaffected; there are no API or checkpoint changes.

## Test plan

- `tests/ops/test_comba.py` is parametrized with `HV` and gains GVA cases (including varlen and `use_qk_l2norm_in_kernel`), checked against the naive reference with q/k/p repeated, as in `tests/ops/test_gdn.py`.
- `pytest tests/ops/test_comba.py tests/models/test_modeling_comba.py tests/models/test_hybrid_attention.py tests/layers/test_attn_varlen_pack_layout.py tests/layers/test_layer_cache_layer_idx.py -q` — 288 passed, 4 skipped (NVIDIA GB200, torch 2.11).

## Benchmark / NCU (kernel changes only)

- Hardware: NVIDIA GB200 (CUDA 13.2, torch 2.11)
- Workload: `python -m benchmarks.ops.run --op chunk_comba --base main`, all registered shapes, fwd and fwd+bwd
- Before/after: 0.97x–1.00x across all shapes (e.g. fwd 1.576 → 1.575 ms on B1 T8192 H96 D128; fwd+bwd 8.878 → 8.877 ms on B8 T2048 H32 D256)
- Conclusion: neutral — feature addition; the `H == HV` path is index-identical to `main`.

## Breaking changes

- None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
