### PR TITLE
[Fix] Repair LogLinearMamba2 Triton cached decoding

### DIFF
--- a/fla/layers/log_linear_mamba2.py
+++ b/fla/layers/log_linear_mamba2.py
@@ -150,6 +150,7 @@ def hmamba_split_conv1d_scan_combined(
     norm_before_gate: bool = True,
     conv1d_fn=None,
     conv_backend: str = "cuda",
+    attention_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Argument:
@@ -167,6 +168,7 @@ def hmamba_split_conv1d_scan_combined(
         outproj_bias: (out_dim,)
         headdim: if D is 1D, headdim must be passed in
         norm_before_gate: if True, we do RMSNorm(x) * F.silu(z). If False, we do RMSNorm(x * F.silu(z))
+        attention_mask: padding mask with shape (batch, seqlen)
     Return:
         out: (batch, seqlen, dim)
     """
@@ -219,17 +221,28 @@ def hmamba_split_conv1d_scan_combined(
     zxBCdtl_splits = [dim, dim + 2 * ngroups * dstate, nheads, nheads * dlambda]
     xBC_splits = [dim, ngroups * dstate, ngroups * dstate]
     z, xBC, dt, dl = torch.split(zxbcdtdl, zxBCdtl_splits, dim=-1)
+    xBC = apply_mask_to_padding_states(xBC, attention_mask)
     _conv_fn = conv1d_fn if conv1d_fn is not None else causal_conv1d_fn
-    _conv_out = _conv_fn(
-        rearrange(xBC, "b s d -> b d s"),
-        conv1d_weight,
-        bias=conv1d_bias,
-        activation=activation,
-        seq_idx=seq_idx,
-    )
     if conv_backend == 'triton':
-        _conv_out = _conv_out[0]
-    xBC = rearrange(_conv_out, "b d s -> b s d")
+        xBC, _ = _conv_fn(
+            x=xBC,
+            weight=conv1d_weight,
+            bias=conv1d_bias,
+            activation=activation,
+            seq_idx=seq_idx,
+        )
+    else:
+        xBC = rearrange(
+            _conv_fn(
+                x=rearrange(xBC, "b s d -> b d s"),
+                weight=conv1d_weight,
+                bias=conv1d_bias,
+                activation=activation,
+                seq_idx=seq_idx,
+            ),
+            "b d s -> b s d",
+        )
+    xBC = apply_mask_to_padding_states(xBC, attention_mask)
     x, B, C = torch.split(xBC, xBC_splits, dim=-1)
     x = rearrange(x, "b l (h p) -> b l h p", h=nheads, p=headdim)
     B = rearrange(B, "b l (g n) -> b l g n", g=ngroups, n=dstate)
@@ -486,13 +499,23 @@ class LogLinearMamba2(nn.Module):
 
             # 2. Convolution sequence transformation
             conv_state = last_state['conv_state']
-            xBC = self.causal_conv1d_update(
-                xBC,
-                conv_state,
-                rearrange(self.conv1d.weight, "d 1 w -> d w"),
-                self.conv1d.bias,
-                self.activation,
-            )
+            conv_weight = rearrange(self.conv1d.weight, "d 1 w -> d w")
+            if self.backend == 'triton':
+                xBC, conv_state = self.causal_conv1d_update(
+                    x=xBC,
+                    cache=conv_state,
+                    weight=conv_weight,
+                    bias=self.conv1d.bias,
+                    activation=self.activation,
+                )
+            else:
+                xBC = self.causal_conv1d_update(
+                    xBC,
+                    conv_state,
+                    conv_weight,
+                    self.conv1d.bias,
+                    self.activation,
+                )
 
             x, B, C = torch.split(
                 xBC,
@@ -542,6 +565,7 @@ class LogLinearMamba2(nn.Module):
                 C=C,
                 dl=dl_reshaped,
                 L=self.L,
+                chunk_size=self.chunk_size,
                 D=self._get_D(),
                 z=None,
                 dt_bias=self.dt_bias,
@@ -602,6 +626,7 @@ class LogLinearMamba2(nn.Module):
                     ngroups=self.n_groups,
                     norm_before_gate=self.norm_before_gate,
                     return_final_states=False,
+                    attention_mask=attention_mask,
                     **dt_limit_kwargs,
                 )
                 return out, None, None
@@ -629,16 +654,20 @@ class LogLinearMamba2(nn.Module):
                         (self.conv_kernel_size - xBC_t.shape[-1], 0),
                     )
 
-                _conv1d_output = self.causal_conv1d_fn(
-                    x=xBC.transpose(1, 2),
-                    weight=rearrange(self.conv1d.weight, "d 1 w -> d w"),
-                    bias=self.conv1d.bias,
-                    activation=self.activation,
-                )
                 if self.backend == 'cuda':
-                    xBC = _conv1d_output.transpose(1, 2)
+                    xBC = self.causal_conv1d_fn(
+                        x=masked_xBC.transpose(1, 2),
+                        weight=rearrange(self.conv1d.weight, "d 1 w -> d w"),
+                        bias=self.conv1d.bias,
+                        activation=self.activation,
+                    ).transpose(1, 2)
                 elif self.backend == 'triton':
-                    xBC = _conv1d_output[0].transpose(1, 2).contiguous()
+                    xBC, _ = self.causal_conv1d_fn(
+                        x=masked_xBC,
+                        weight=rearrange(self.conv1d.weight, "d 1 w -> d w"),
+                        bias=self.conv1d.bias,
+                        activation=self.activation,
+                    )
                 else:
                     raise ValueError(f"Unsupported backend: {self.backend}")
 

--- a/fla/layers/mamba2.py
+++ b/fla/layers/mamba2.py
@@ -421,7 +421,7 @@ class Mamba2(nn.Module):
                         raise ValueError(f"Unsupported backend: {self.backend}")
 
                 hidden_states_B_C = (hidden_states_B_C * attention_mask[:, :, None]).to(hidden_states_B_C.dtype) \
-                    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1 \
+                    if attention_mask is not None and attention_mask.shape == hidden_states_B_C.shape[:2] \
                     else hidden_states_B_C
                 hidden_states, B, C = torch.split(
                     hidden_states_B_C,
@@ -509,7 +509,7 @@ class Mamba2(nn.Module):
 
         if last_state is None:
             hidden_states_B_C = (hidden_states_B_C * attention_mask[:, :, None]).to(hidden_states_B_C.dtype) \
-                if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1 \
+                if attention_mask is not None and attention_mask.shape == hidden_states_B_C.shape[:2] \
                 else hidden_states_B_C
         hidden_states, B, C = torch.split(
             hidden_states_B_C,
@@ -684,7 +684,7 @@ class Mamba2(nn.Module):
             output, conv_state, ssm_state = self.cuda_kernels_forward(hidden_states, last_state, use_cache, attention_mask)
         else:
             dtype = hidden_states.dtype
-            if last_state is None and attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+            if last_state is None and attention_mask is not None and attention_mask.shape == hidden_states.shape[:2]:
                 hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
             output, conv_state, ssm_state = self.torch_forward(hidden_states, last_state, use_cache, attention_mask)
 

--- a/fla/layers/mamba2.py
+++ b/fla/layers/mamba2.py
@@ -43,7 +43,7 @@ def apply_mask_to_padding_states(hidden_states, attention_mask):
     """
     Tunes out the hidden states for padding tokens, see https://github.com/state-spaces/mamba/issues/66
     """
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if attention_mask is not None and attention_mask.shape == hidden_states.shape[:2]:
         dtype = hidden_states.dtype
         hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 

--- a/fla/ops/log_linear_attn/chunk.py
+++ b/fla/ops/log_linear_attn/chunk.py
@@ -38,7 +38,7 @@ BLOCK_K = 64
     key=["H", "K", "V"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=["T"])
+@triton.jit(do_not_specialize=["T", "output_T"])
 def chunkwise_fwd_kernel(
     q,
     k,
@@ -52,7 +52,10 @@ def chunkwise_fwd_kernel(
     offsets,
     new_offsets,
     cu_seqlens,
+    output_cu_seqlens,
+    stride_o_n,
     T,
+    output_T,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -165,6 +168,13 @@ def chunkwise_fwd_kernel(
             p_kv_11 = h0 + ((i_n * L_IN + 11) * H + i_h) * K * V + o_kk[:, None] * V + o_v[None, :]
             kv_11 = tl.load(p_kv_11, mask=m_kv, other=0.0)
 
+    if not USE_INITIAL_STATE:
+        output_T = T
+    elif IS_VARLEN:
+        output_bos = tl.load(output_cu_seqlens + i_n).to(tl.int64)
+        output_eos = tl.load(output_cu_seqlens + i_n + 1).to(tl.int64)
+        output_T = (output_eos - output_bos).to(tl.int32)
+
     NT = tl.cdiv(T, BT)
     output_offset = -1 * (offset % BT)
     for i_t in range(NT):
@@ -174,7 +184,7 @@ def chunkwise_fwd_kernel(
         o_t = (i_t * BT).to(tl.int64) + o_i
         o_to = o_t + output_offset
         m_t = o_t < T
-        m_to = (o_to >= 0) & (o_to < T)
+        m_to = (o_to >= 0) & (o_to < output_T)
         m_qk = m_t[:, None] & (o_kk[None, :] < K)
         m_kt = (o_kk[:, None] < K) & m_t[None, :]
         m_tv = m_t[:, None] & (o_v[None, :] < V)
@@ -183,7 +193,14 @@ def chunkwise_fwd_kernel(
         p_q = q + bos * K + o_t[:, None] * K + o_kk[None, :]
         p_k = k + bos * K + o_kk[:, None] + o_t[None, :] * K
         p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
-        p_o = o + ((bos * H + i_h) * (K // BK) + i_k) * V + o_to[:, None] * (H * (K // BK) * V) + o_v[None, :]
+        if USE_INITIAL_STATE:
+            if IS_VARLEN:
+                p_o = o + ((output_bos * H + i_h) * (K // BK) + i_k) * V
+            else:
+                p_o = o + i_n.to(tl.int64) * stride_o_n + (i_h * (K // BK) + i_k) * V
+        else:
+            p_o = o + ((bos * H + i_h) * (K // BK) + i_k) * V
+        p_o = p_o + o_to[:, None] * (H * (K // BK) * V) + o_v[None, :]
 
         b_g = tl.load(p_g, mask=m_t, other=0.0)
         b_q = tl.load(p_q, mask=m_qk, other=0.0)
@@ -414,7 +431,7 @@ def chunkwise_fwd_kernel(
 @triton.heuristics({
     "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
 })
-@triton.jit(do_not_specialize=["T"])
+@triton.jit(do_not_specialize=["T", "input_T"])
 def copy_input_kernel(
     q,
     k,
@@ -422,6 +439,7 @@ def copy_input_kernel(
     g,
     level_scales,
     cu_seqlens,
+    input_cu_seqlens,
     q_prev,
     k_prev,
     v_prev,
@@ -434,6 +452,7 @@ def copy_input_kernel(
     g_new,
     level_scales_new,
     T,
+    input_T,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -450,9 +469,16 @@ def copy_input_kernel(
             tl.load(cu_seqlens + i_n).to(tl.int64),
             tl.load(cu_seqlens + i_n + 1).to(tl.int64),
         )
+        input_bos, input_eos = (
+            tl.load(input_cu_seqlens + i_n).to(tl.int64),
+            tl.load(input_cu_seqlens + i_n + 1).to(tl.int64),
+        )
         T = (eos - bos).to(tl.int32)
+        input_T = (input_eos - input_bos).to(tl.int32)
     else:
-        bos, eos = (i_n * T).to(tl.int64), (i_n * T + T).to(tl.int64)
+        bos = i_n.to(tl.int64) * T
+        eos = bos + T
+        input_bos = i_n.to(tl.int64) * input_T
 
     offset = tl.load(offsets + i_n)
     input_offset = -1 * (offset % BT)
@@ -465,16 +491,16 @@ def copy_input_kernel(
     for i_t in range(NT):
         o_t = (i_t * BT + input_offset).to(tl.int64) + o_i
         o_tn = (i_t * BT).to(tl.int64) + o_i
-        m_t = (o_t >= 0) & (o_t < T)
+        m_t = (o_t >= 0) & (o_t < input_T)
         m_tn = o_tn < T
         m_tk = m_t[:, None] & (o_k[None, :] < K)
         m_tv = m_t[:, None] & (o_v[None, :] < V)
         m_tnk = m_tn[:, None] & (o_k[None, :] < K)
         m_tnv = m_tn[:, None] & (o_v[None, :] < V)
-        p_g = g + bos * H + i_h + o_t * H
-        p_q = q + bos * K + o_t[:, None] * K + o_k[None, :]
-        p_k = k + bos * K + o_t[:, None] * K + o_k[None, :]
-        p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        p_g = g + input_bos * H + i_h + o_t * H
+        p_q = q + input_bos * K + o_t[:, None] * K + o_k[None, :]
+        p_k = k + input_bos * K + o_t[:, None] * K + o_k[None, :]
+        p_v = v + (input_bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
         p_g_new = g_new + bos * H + i_h + o_tn * H
         p_q_new = q_new + bos * K + o_tn[:, None] * K + o_k[None, :]
         p_k_new = k_new + bos * K + o_tn[:, None] * K + o_k[None, :]
@@ -502,7 +528,7 @@ def copy_input_kernel(
         tl.store(p_v_new, b_v, mask=m_tnv)
 
         for i in range(L):
-            p_l = level_scales + (bos * H + i_h) * L + o_t[:, None] * (H * L) + i
+            p_l = level_scales + (input_bos * H + i_h) * L + o_t[:, None] * (H * L) + i
             p_l_new = level_scales_new + (bos * H + i_h) * L + o_tn[:, None] * (H * L) + i
             b_l = tl.load(p_l, mask=m_t[:, None], other=0.0)
             if i_t == 0:
@@ -1135,6 +1161,8 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
 
         h0 = initial_state.ht if initial_state is not None else None
         offsets = initial_state.offsets if initial_state is not None else None
+        original_cu_seqlens = cu_seqlens
+        original_T = T
 
         if cu_seqlens is None:
             NT = ceil_div(T + (torch.max(offsets) if offsets is not None else 0), BT)
@@ -1154,6 +1182,19 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
             MAX_LEVEL = ceil_log(NT, 2) - 1
             B = len(cu_seqlens) - 1
 
+        # Exact powers of two need one more level in the serialized state than in the current outputs.
+        if output_final_state:
+            if cu_seqlens is None:
+                max_sequence_length = T + (offsets.max().item() if offsets is not None else 0)
+            else:
+                sequence_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+                if offsets is not None:
+                    sequence_lengths = [length + offset for length, offset in zip(sequence_lengths, offsets.tolist())]
+                max_sequence_length = max(sequence_lengths)
+            completed_chunks = max_sequence_length // BT
+            if completed_chunks > 0:
+                MAX_LEVEL = max(MAX_LEVEL, math.floor(math.log2(completed_chunks)))
+
         if MAX_LEVEL > 10:
             raise ValueError("Sequence length must be less than 2**17")
 
@@ -1166,7 +1207,7 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
 
         if initial_state is not None:
             if cu_seqlens is not None:
-                cu_seqlens = cu_seqlens + F.pad(torch.cumsum(offsets % BT), (1, 0))
+                cu_seqlens = cu_seqlens + F.pad(torch.cumsum(offsets % BT, dim=0), (1, 0))
             else:
                 assert (offsets == offsets[0]).all()
                 T += offsets[0].item() % BT
@@ -1184,6 +1225,7 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
                 g=g,
                 level_scales=level_scales,
                 cu_seqlens=cu_seqlens,
+                input_cu_seqlens=original_cu_seqlens,
                 q_prev=initial_state.q_prev,
                 k_prev=initial_state.k_prev,
                 v_prev=initial_state.v_prev,
@@ -1196,6 +1238,7 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
                 level_scales_new=level_scales_new,
                 offsets=offsets,
                 T=T,
+                input_T=original_T,
                 H=H,
                 K=K,
                 V=V,
@@ -1216,6 +1259,8 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
         )
 
         new_offsets = torch.zeros((B,), dtype=torch.int32, device=v.device)
+        # Cache raw decay increments so a continued partial chunk is cumulatively summed exactly once.
+        g_for_state = g
         g = chunk_local_cumsum(g, chunk_size=BT, cu_seqlens=cu_seqlens)
 
         def grid(meta):
@@ -1239,7 +1284,10 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
             offsets=offsets,
             new_offsets=new_offsets,
             cu_seqlens=cu_seqlens,
+            output_cu_seqlens=original_cu_seqlens,
+            stride_o_n=o.stride(0),
             T=T,
+            output_T=original_T,
             H=H,
             K=K,
             V=V,
@@ -1265,7 +1313,7 @@ class ChunkLogLinearAttentionFunction(torch.autograd.Function):
                 q=q,
                 k=k,
                 v=v,
-                g=g,
+                g=g_for_state,
                 level_scales=level_scales,
                 cu_seqlens=cu_seqlens,
                 q_prev=q_prev,

--- a/tests/models/test_modeling_log_linear_mamba2.py
+++ b/tests/models/test_modeling_log_linear_mamba2.py
@@ -10,6 +10,7 @@ import os
 import pytest
 import torch
 
+import fla.layers.log_linear_mamba2 as log_linear_mamba2
 from fla.models import LogLinearMamba2Config, LogLinearMamba2ForCausalLM
 from fla.utils import device
 
@@ -77,3 +78,100 @@ def test_modeling(
     # Backward pass
     y.logits.sum().backward()
     print(f"Test test_modeling passed with H={H}, D={D}, backend={conv_backend}.")
+
+
+def test_fused_conv_padding_mask(monkeypatch):
+    batch_size, seq_len, num_heads, head_dim, state_size, num_levels = 1, 3, 1, 4, 2, 3
+    dim = num_heads * head_dim
+    conv_dim = dim + 2 * state_size
+    projected_size = 2 * dim + 2 * state_size + num_heads * (num_levels + 1)
+    observed = {}
+
+    def conv(*, x, **kwargs):
+        observed['conv_input'] = x
+        return x + 1, None
+
+    def scan(**kwargs):
+        observed['scan_input'] = kwargs['x']
+        return kwargs['x'], None
+
+    monkeypatch.setattr(log_linear_mamba2, 'hmamba_chunk_scan_combined', scan)
+    output = log_linear_mamba2.hmamba_split_conv1d_scan_combined(
+        zxbcdtdl=torch.ones(batch_size, seq_len, projected_size),
+        conv1d_weight=torch.ones(conv_dim, 4),
+        conv1d_bias=torch.ones(conv_dim),
+        dt_bias=torch.ones(num_heads),
+        A=-torch.ones(num_heads),
+        L=torch.ones(num_heads, num_levels),
+        D=torch.ones(num_heads),
+        chunk_size=64,
+        outproj_weight=torch.eye(dim),
+        headdim=head_dim,
+        conv1d_fn=conv,
+        conv_backend='triton',
+        attention_mask=torch.tensor([[0, 1, 1]]),
+    )
+
+    assert torch.count_nonzero(observed['conv_input'][:, 0]) == 0
+    assert torch.count_nonzero(observed['scan_input'][:, 0]) == 0
+    assert output.shape == (batch_size, seq_len, dim)
+
+
+def test_conv_backend_padding_and_cached_decode_parity(monkeypatch):
+    torch.manual_seed(42)
+    config = LogLinearMamba2Config(
+        num_hidden_layers=1,
+        hidden_size=32,
+        expand=2,
+        num_heads=1,
+        head_dim=64,
+        state_size=64,
+        use_bias=True,
+        vocab_size=128,
+    )
+
+    cuda_available = (
+        log_linear_mamba2.causal_conv1d_fn is not None and log_linear_mamba2.causal_conv1d_update is not None
+    )
+    backends = ['cuda', 'triton'] if cuda_available else ['triton']
+    models = []
+    for backend in backends:
+        monkeypatch.setenv('FLA_CONV_BACKEND', backend)
+        model = LogLinearMamba2ForCausalLM(config).to(device=device, dtype=torch.bfloat16).eval()
+        if models:
+            model.load_state_dict(models[0].state_dict())
+        models.append(model)
+    assert [model.backbone.layers[0].mixer.backend for model in models] == backends
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 74), device=device)
+    attention_mask = torch.ones_like(input_ids, dtype=torch.bool)
+    attention_mask[0, :2] = False
+    attention_mask[1, :1] = False
+    prefill_len = 70
+
+    def cached_logits(model):
+        output = model(
+            input_ids=input_ids[:, :prefill_len],
+            attention_mask=attention_mask[:, :prefill_len],
+            use_cache=True,
+        )
+        logits = [output.logits]
+        for index in range(prefill_len, input_ids.shape[1]):
+            output = model(
+                input_ids=input_ids[:, index:index + 1],
+                attention_mask=attention_mask[:, :index + 1],
+                past_key_values=output.past_key_values,
+                use_cache=True,
+            )
+            logits.append(output.logits)
+        return torch.cat(logits, dim=1)
+
+    with torch.no_grad():
+        full = [model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False).logits for model in models]
+        cached = [cached_logits(model) for model in models]
+
+    if cuda_available:
+        torch.testing.assert_close(full[0], full[1], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(cached[0], cached[1], rtol=2e-2, atol=2e-2)
+    for expected, actual in zip(full, cached):
+        torch.testing.assert_close(expected[attention_mask], actual[attention_mask], rtol=2e-2, atol=2e-2)

--- a/tests/ops/test_log_linear_attn.py
+++ b/tests/ops/test_log_linear_attn.py
@@ -60,7 +60,7 @@ def test_chunk(
 def test_chunk_initial_state(varlen: bool):
     torch.manual_seed(42)
     H, K, V, L = 1, 64, 32, 15
-    prefix_lengths = [70, 75, 128, 133] if varlen else [70, 70]
+    prefix_lengths = [64, 70, 75, 128] if varlen else [64, 64]
     sequences = [
         (
             torch.randn(1, length + 1, 1, K, dtype=torch.float32, device=device),

--- a/tests/ops/test_log_linear_attn.py
+++ b/tests/ops/test_log_linear_attn.py
@@ -55,6 +55,48 @@ def test_chunk(
     assert_close("o", ref, out, 0.004)
 
 
+@pytest.mark.parametrize("varlen", [False, True], ids=["dense", "varlen"])
+@pytest.mark.skipif(device_platform == "intel", reason="Intel Triton Failure")
+def test_chunk_initial_state(varlen: bool):
+    torch.manual_seed(42)
+    H, K, V, L = 1, 64, 32, 15
+    prefix_lengths = [70, 75, 128, 133] if varlen else [70, 70]
+    sequences = [
+        (
+            torch.randn(1, length + 1, 1, K, dtype=torch.float32, device=device),
+            torch.randn(1, length + 1, 1, K, dtype=torch.float32, device=device),
+            torch.randn(1, length + 1, H, V, dtype=torch.float32, device=device),
+            -torch.rand(1, length + 1, H, dtype=torch.float32, device=device),
+            torch.rand(1, length + 1, H, L, dtype=torch.float32, device=device),
+        )
+        for length in prefix_lengths
+    ]
+    cat_dim = 1 if varlen else 0
+    prefix = tuple(torch.cat([x[index][:, :length] for x, length in zip(sequences, prefix_lengths)], cat_dim)
+                   for index in range(len(sequences[0])))
+    new_tokens = tuple(torch.cat([x[index][:, length:] for x, length in zip(sequences, prefix_lengths)], cat_dim)
+                       for index in range(len(sequences[0])))
+    prefix_cu_seqlens = (
+        torch.tensor([0, *prefix_lengths], dtype=torch.long, device=device).cumsum(0) if varlen else None
+    )
+    decode_cu_seqlens = torch.arange(len(sequences) + 1, dtype=torch.long, device=device) if varlen else None
+
+    _, state = chunk_log_linear_attn(
+        *prefix,
+        output_final_state=True,
+        cu_seqlens=prefix_cu_seqlens,
+    )
+    suffix, _ = chunk_log_linear_attn(
+        *new_tokens,
+        initial_state=state,
+        cu_seqlens=decode_cu_seqlens,
+    )
+
+    expected = [chunk_log_linear_attn(*sequence)[0][:, -1:] for sequence in sequences]
+
+    assert_close("suffix", torch.cat(expected, dim=cat_dim), suffix, 0.004)
+
+
 @pytest.mark.parametrize(
     ("B", "T", "H", "D", "dtype"),
     [


### PR DESCRIPTION
## Summary

- align LogLinearMamba2's Triton convolution calls with FLA's `[B, T, D]`, keyword-argument, and `(output, cache)` protocols while preserving the CUDA causal-conv1d protocol
- mask the tensor that actually enters convolution and mask convolution output before the scan in both fused training and non-fused prefill, including single-item batches
- pass the missing scan `chunk_size` during decode
- preserve original input/output layout metadata while initial-state chunks are aligned, and serialize raw partial-chunk decay values plus every completed hierarchy level
- cover CUDA/Triton padding and cached-decode parity plus dense and heterogeneous-varlen initial-state behavior with focused tests

## Why

This PR fixes correctness failures on the same prefill-to-decode path, plus the equivalent padding gap in the fused training path.

### 1. LogLinearMamba2 used the causal-conv1d calling convention for FLA's Triton convolution

When `FLA_CONV_BACKEND=triton`, LogLinearMamba2 binds `self.causal_conv1d_fn` and `self.causal_conv1d_update` to FLA's helpers. Those helpers do not have the same contract as the external causal-conv1d package.

The old decode call was equivalent to:

```python
self.causal_conv1d_update(xBC, conv_state, weight, bias, activation)
```

FLA's update signature is:

```python
causal_conv1d_update(x, cache, residual=None, weight=None, bias=None, activation=None)
```

That produced the following binding:

| Caller value | FLA parameter | Result |
| --- | --- | --- |
| `xBC` | `x` | correct |
| `conv_state` | `cache` | correct |
| convolution `weight` | `residual` | the weight tensor is treated as a residual |
| convolution `bias` | `weight` | a 1D bias is used where a 2D convolution weight is expected |
| activation string | `bias` | a string is used as the bias |
| nothing | `activation` | activation is silently lost |

FLA update also returns `(output, updated_cache)`. The old caller assigned the complete tuple to `xBC` and then passed it to `torch.split`. Therefore Triton cached decoding could fail either inside convolution because of the shifted arguments or immediately afterward because `xBC` was a tuple.

Prefill had two additional contract violations:

- FLA convolution consumes `[batch, time, channels]`, while the old code transposed `xBC` to `[batch, channels, time]`, which is the layout required by the external CUDA extension.
- `masked_xBC` was used only to construct the cache; convolution still received the original `xBC`.

The padding detail matters at two separate boundaries. Masking hidden states before `in_proj` is insufficient when `in_proj` has a bias: a zero padding hidden state can project to a nonzero `xBC`. Masking only before convolution is also insufficient when convolution has a bias (enabled by default): zero convolution input can produce a nonzero `xBC` that is then split into `x`, `B`, and `C` and passed to the state-space scan. Therefore the correct invariant is:

```text
projected xBC -> padding mask -> convolution -> padding mask -> scan
```

The non-fused prefill path now follows that invariant with the tensor actually passed to convolution. The fused training helper receives `attention_mask` and applies the same pre/post-convolution masking, so training no longer has a separate padding behavior. The shared mask helper now applies whenever the mask shape exactly matches `[batch, time]`; this covers batch size 1 without accidentally applying an accumulated decode mask whose time dimension does not match a one-token input.

The backend contracts remain explicit rather than being normalized by positional shims: CUDA continues using `[B, D, T]` and its existing positional update protocol, while Triton receives `[B, T, D]`, uses keyword arguments, and has `(output, cache)` unpacked. The decode scan also receives the previously omitted `chunk_size`; this missing required argument became reachable once convolution stopped failing first.

### 2. Initial-state execution mixed compact/aligned layouts and serialized an incomplete recurrent state

After repairing the convolution call, the real CUDA/Triton prefill-to-decode test still showed previously computed logits changing after a decode step. The mutation came from the shared log-linear attention initial-state path, not from convolution.

The attention kernel uses chunks of `BT=64`. For a concrete example, after a 70-token prefix the cached offset has a six-token partial chunk (`70 % 64 == 6`). A one-token decode input is physically allocated as `[B, 1, ...]`, but the host temporarily prepends the six cached tokens and launches the kernel with a logical length of seven:

```text
compact input:       [new token]                    T_original = 1
aligned work buffer: [cached x 6][new token]        T_aligned  = 7
```

Previously that expanded length was also used as the physical batch stride and output bound:

- input copying used `i_n * 7` to locate batch `i_n` in the original `[B, 1, ...]` input, so batch 1 read beyond its real one-token row;
- output addressing used the expanded `bos` and allowed `o_to < 7`, even though the output allocation still contained only one row per batch;
- batch 0 could consequently write across batch 1's output and later allocations, while batch 1 could write past the end of the tensor. In the model test this corrupted logits that had already been appended to the cached output list, making backend parity dependent on allocation order.

Varlen decoding had the same logical/physical mismatch after `cu_seqlens` was expanded. It also called `torch.cumsum(offsets % BT)` without a `dim`, so that path raised before reaching the kernel.

The fix preserves both coordinate systems instead of trying to make one length describe two allocations:

- expanded `T` / `cu_seqlens` describe the temporary chunk-aligned computation;
- original input length / `cu_seqlens` locate the compact decode inputs;
- original output length / `cu_seqlens` and the real dense batch stride bound stores to the compact output;
- new dense pointer products use 64-bit batch indexing before applying strides.

For the example above, the aligned output coordinate of the new token is `o_t=6`, while `output_offset=-6`, so `o_to=0` and the kernel writes only `output[batch, 0]`. In varlen mode, original and aligned `cu_seqlens` are passed separately: the former addresses packed input/output tensors and the latter addresses the expanded work buffer.

Making the addresses safe exposed two state-serialization errors that backend parity alone could not distinguish:

- `g` enters this op as per-token decay increments and is transformed by `chunk_local_cumsum` for computation. The old final-state path copied that already-cumulative tensor into `g_prev`. On continuation, the cached partial chunk was prepended to the new input and passed through `chunk_local_cumsum` again. A one-element partial chunk happened to hide this, but a 70-token prefix cached six cumulative values and accumulated them twice. The fix retains the raw `g` tensor for `copy_last_chunk_kernel`; each invocation now performs the cumulative transform exactly once.
- the normal forward `MAX_LEVEL` is the highest hierarchy level needed to produce outputs in the current call. A final state can require one additional level when the number of completed 64-token chunks is an exact power of two. For example, a 128-token prefix merges two level-0 chunks into level 1, but the old `MAX_LEVEL=0` prevented level 1 from being stored. The host now computes the number of completed chunks and expands `MAX_LEVEL` only when `output_final_state=True`, so the complete hierarchy is serialized without changing the normal no-state kernel path.

The state fix was checked at prefixes `1, 63, 64, 65, 70, 71, 75, 127, 128, 133`; every one-token cached suffix exactly matched the corresponding one-shot full-forward output after the change. The model regression now performs a 70-token padded prefill followed by four decode steps.

The committed dense and packed-varlen cases also compare cached suffixes directly with one-shot full-forward suffixes, rather than merely comparing batched and singleton cached execution. The varlen case uses prefix lengths `[70, 75, 128, 133]`, whose chunk remainders are `[6, 11, 0, 5]`, to exercise different cumulative alignment shifts and the exact two-chunk hierarchy boundary in one test. It also uses `K=64, V=32` to cover unequal key/value dimensions without exceeding smaller GPUs' shared-memory limits.

These are boundary fixes, not fallback behavior: each convolution backend follows its native API, fused and non-fused padding share one invariant, compact and aligned allocations have explicit metadata, and the recurrent state preserves the raw/derived distinction and complete hierarchy needed by the next call.

## Test plan

Dependent tests were identified with:

```text
python scripts/find_dependent_tests.py fla/layers/mamba2.py
python scripts/find_dependent_tests.py fla/layers/log_linear_mamba2.py
python scripts/find_dependent_tests.py fla/ops/log_linear_attn/chunk.py
```

Passed on an NVIDIA RTX A1000 Laptop GPU with PyTorch 2.13.0+cu130, Triton 3.7.1, and a source-built causal-conv1d 1.6.2.post1:

```text
python -m pytest \
  tests/models/test_modeling_log_linear_mamba2.py::test_fused_conv_padding_mask \
  tests/models/test_modeling_log_linear_mamba2.py::test_conv_backend_padding_and_cached_decode_parity \
  tests/ops/test_log_linear_attn.py::test_chunk_initial_state -q
# 4 passed

uvx ruff check \
  fla/layers/mamba2.py \
  fla/layers/log_linear_mamba2.py \
  fla/ops/log_linear_attn/chunk.py \
  tests/models/test_modeling_log_linear_mamba2.py \
  tests/ops/test_log_linear_attn.py
# All checks passed
```

The backend test always exercises a 70-token Triton prefill followed by four cached decode steps with padding. When the optional causal-conv1d package is available it additionally instantiates a real CUDA-backend model and checks CUDA/Triton parity; when it is unavailable, it does not request CUDA and therefore cannot silently fall back to Triton or fail a false backend assertion. The Triton-only branch was also verified locally by forcing both imported causal-conv1d helpers to `None`.

A broader impacted run completed 21 selected tests successfully. Four existing large configurations exceeded this 4 GiB GPU: three require 115,200 bytes of Triton shared memory while the device limit is 101,376 bytes, and one naive reference attempts a 32 GiB CUDA allocation. None reached a correctness assertion.

## Benchmark / NCU (kernel changes only)

Same RTX A1000 Laptop GPU, BF16, H=1, D=64, `triton.testing.do_bench` median with 100 ms warmup and 500 ms measurement:

| Path without initial state | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Dense B=2, T=1024 | 0.838496 ms | 0.841728 ms | +0.39% |
| Varlen 2x1024 tokens | 1.046528 ms | 1.049088 ms | +0.24% |

Neutral. Post-fix cached decode latency after a 70-token prefix was 1.041488 ms for dense B=2, T=1 and 1.271808 ms for packed varlen 2x1. A before/after comparison for the affected path is not valid because the old dense path writes out of bounds and the old varlen path raises before launch.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
