### PR TITLE
[Fix] Validate rotary dimensions and offset caches

### DIFF
--- a/fla/layers/yoco.py
+++ b/fla/layers/yoco.py
@@ -179,7 +179,7 @@ class YOCOGatedRetention(nn.Module):
 
             if attention_mask is not None and seqlen_offset > 0:
                 seqlen_offset = prepare_lens_from_mask(attention_mask) - q_len
-                max_seqlen = q.shape[1] + seqlen_offset.max().item()
+                max_seqlen = attention_mask.shape[-1]
 
         if self.max_position_embeddings is not None:
             max_seqlen = max(max_seqlen, self.max_position_embeddings)
@@ -296,7 +296,7 @@ class YOCOSharedKVBuilder(nn.Module):
         if attention_mask is not None and (past_key_values is None or use_cache):
             # Left-padded prefills should use the same effective RoPE positions as the unpadded sequence.
             seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-            max_seqlen = k.shape[1] + seqlen_offset.max().item()
+            max_seqlen = attention_mask.shape[-1]
 
         if self.max_position_embeddings is not None:
             max_seqlen = max(max_seqlen, self.max_position_embeddings)
@@ -392,7 +392,7 @@ class YOCOCrossAttention(nn.Module):
 
         if attention_mask is not None:
             seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-            max_seqlen = max(max_seqlen, q.shape[1] + max(seqlen_offset))
+            max_seqlen = max(max_seqlen, attention_mask.shape[-1])
         if self.max_position_embeddings is not None:
             max_seqlen = max(max_seqlen, self.max_position_embeddings)
 

--- a/fla/layers/yoco.py
+++ b/fla/layers/yoco.py
@@ -74,7 +74,12 @@ class YOCORotaryEmbedding(RotaryEmbedding):
         cu_seqlens: torch.Tensor | None = None,
         max_seqlen: int | None = None,
     ) -> torch.Tensor:
-        self._update_cos_sin_cache_for_seqlen_offset(states, seqlen_offset, cu_seqlens, max_seqlen)
+        if max_seqlen is not None:
+            self._update_cos_sin_cache(max_seqlen, device=states.device, dtype=states.dtype)
+        elif isinstance(seqlen_offset, int):
+            self._update_cos_sin_cache(states.shape[1] + seqlen_offset, device=states.device, dtype=states.dtype)
+        else:
+            assert self._cos_cached is not None, "Tensor offsets require an initialized cache; pass max_seqlen on the first call"
         return rotary_embedding(
             states,
             self._cos_cached,

--- a/fla/layers/yoco.py
+++ b/fla/layers/yoco.py
@@ -74,10 +74,7 @@ class YOCORotaryEmbedding(RotaryEmbedding):
         cu_seqlens: torch.Tensor | None = None,
         max_seqlen: int | None = None,
     ) -> torch.Tensor:
-        if max_seqlen is not None:
-            self._update_cos_sin_cache(max_seqlen, device=states.device, dtype=states.dtype)
-        elif isinstance(seqlen_offset, int):
-            self._update_cos_sin_cache(states.shape[1] + seqlen_offset, device=states.device, dtype=states.dtype)
+        self._update_cos_sin_cache_for_seqlen_offset(states, seqlen_offset, cu_seqlens, max_seqlen)
         return rotary_embedding(
             states,
             self._cos_cached,

--- a/fla/modules/backends/triton_ascend/rotary.py
+++ b/fla/modules/backends/triton_ascend/rotary.py
@@ -156,6 +156,10 @@ def rotary_embedding_fwdbwd_npu(
     if isinstance(seqlen_offsets, torch.Tensor):
         assert seqlen_offsets.shape == (N,)
         assert seqlen_offsets.dtype in [torch.int32, torch.int64]
+        sequence_lengths = T if not is_varlen else cu_seqlens[1:] - cu_seqlens[:-1]
+        required_seqlen = (sequence_lengths + seqlen_offsets).max().item()
+        if required_seqlen > TR:
+            raise ValueError(f"Rotary cache is too short, required {required_seqlen} positions but got {TR}")
     else:
         assert seqlen_offsets + T <= TR
 

--- a/fla/modules/backends/triton_ascend/rotary.py
+++ b/fla/modules/backends/triton_ascend/rotary.py
@@ -145,8 +145,7 @@ def rotary_embedding_fwdbwd_npu(
     R2 = R * 2
 
     assert D <= 256, "Only support D <= 256"
-    if R2 > D:
-        raise ValueError(f"Rotary dimension must not exceed head dimension, got rotary_dim={R2} and head_dim={D}")
+    assert R2 <= D, f"Rotary dimension must not exceed head dimension, got rotary_dim={R2} and head_dim={D}"
     if not is_varlen:
         assert TR >= T, f"TR must be >= T, got {TR} and {T}"
 
@@ -157,9 +156,10 @@ def rotary_embedding_fwdbwd_npu(
         assert seqlen_offsets.shape == (N,)
         assert seqlen_offsets.dtype in [torch.int32, torch.int64]
         sequence_lengths = T if not is_varlen else cu_seqlens[1:] - cu_seqlens[:-1]
-        required_seqlen = (sequence_lengths + seqlen_offsets).max().item()
-        if required_seqlen > TR:
-            raise ValueError(f"Rotary cache is too short, required {required_seqlen} positions but got {TR}")
+        torch._assert_async(
+            torch.all(sequence_lengths + seqlen_offsets <= TR),
+            f"Rotary cache is too short for tensor offsets, got {TR} positions",
+        )
     else:
         assert seqlen_offsets + T <= TR
 

--- a/fla/modules/backends/triton_ascend/rotary.py
+++ b/fla/modules/backends/triton_ascend/rotary.py
@@ -145,7 +145,10 @@ def rotary_embedding_fwdbwd_npu(
     R2 = R * 2
 
     assert D <= 256, "Only support D <= 256"
-    assert TR >= T, f"TR must be >= T, got {TR} and {T}"
+    if R2 > D:
+        raise ValueError(f"Rotary dimension must not exceed head dimension, got rotary_dim={R2} and head_dim={D}")
+    if not is_varlen:
+        assert TR >= T, f"TR must be >= T, got {TR} and {T}"
 
     assert cos.dtype == sin.dtype, f"cos and sin must have the same dtype, got {cos.dtype} and {sin.dtype}"
     assert x.dtype == cos.dtype, f"Input and cos/sin must have the same dtype, got {x.dtype} and {cos.dtype}"

--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -180,6 +180,10 @@ def rotary_embedding_fwdbwd(
     if isinstance(seqlen_offsets, torch.Tensor):
         assert seqlen_offsets.shape == (N,)
         assert seqlen_offsets.dtype in [torch.int32, torch.int64]
+        sequence_lengths = T if not is_varlen else cu_seqlens[1:] - cu_seqlens[:-1]
+        required_seqlen = (sequence_lengths + seqlen_offsets).max().item()
+        if required_seqlen > TR:
+            raise ValueError(f"Rotary cache is too short, required {required_seqlen} positions but got {TR}")
     else:
         assert seqlen_offsets + T <= TR
 

--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -169,8 +169,7 @@ def rotary_embedding_fwdbwd(
     R2 = R * 2
 
     assert D <= 256, "Only support D <= 256"
-    if R2 > D:
-        raise ValueError(f"Rotary dimension must not exceed head dimension, got rotary_dim={R2} and head_dim={D}")
+    assert R2 <= D, f"Rotary dimension must not exceed head dimension, got rotary_dim={R2} and head_dim={D}"
     if not is_varlen:
         assert TR >= T, f"TR must be >= T, got {TR} and {T}"
 
@@ -181,9 +180,10 @@ def rotary_embedding_fwdbwd(
         assert seqlen_offsets.shape == (N,)
         assert seqlen_offsets.dtype in [torch.int32, torch.int64]
         sequence_lengths = T if not is_varlen else cu_seqlens[1:] - cu_seqlens[:-1]
-        required_seqlen = (sequence_lengths + seqlen_offsets).max().item()
-        if required_seqlen > TR:
-            raise ValueError(f"Rotary cache is too short, required {required_seqlen} positions but got {TR}")
+        torch._assert_async(
+            torch.all(sequence_lengths + seqlen_offsets <= TR),
+            f"Rotary cache is too short for tensor offsets, got {TR} positions",
+        )
     else:
         assert seqlen_offsets + T <= TR
 
@@ -366,8 +366,7 @@ class RotaryEmbedding(nn.Module):
         """
         super().__init__()
 
-        if dim % 2 != 0:
-            raise ValueError(f"Rotary dimension must be even, got {dim}")
+        assert dim % 2 == 0, f"Rotary dimension must be even, got {dim}"
 
         self.dim = dim
         self.base = float(base)
@@ -463,25 +462,6 @@ class RotaryEmbedding(nn.Module):
                 self._cos_k_cached = (torch.cos(freqs) / scale).to(dtype)
                 self._sin_k_cached = (torch.sin(freqs) / scale).to(dtype)
 
-    def _update_cos_sin_cache_for_seqlen_offset(
-        self,
-        x: torch.Tensor,
-        seqlen_offset: int | torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
-        max_seqlen: int | None,
-    ) -> None:
-        if max_seqlen is not None:
-            required_seqlen = max_seqlen
-        elif isinstance(seqlen_offset, int):
-            required_seqlen = x.shape[1] + seqlen_offset
-        else:
-            if cu_seqlens is None:
-                required_seqlen = max(x.shape[1], x.shape[1] + seqlen_offset.max().item())
-            else:
-                sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-                required_seqlen = (sequence_lengths + seqlen_offset).max().item()
-        self._update_cos_sin_cache(max(int(required_seqlen), 0), device=x.device, dtype=x.dtype)
-
     def forward(
         self,
         q: torch.Tensor,
@@ -500,10 +480,15 @@ class RotaryEmbedding(nn.Module):
             Most commonly used in inference when we have KV cache.
         cu_seqlens: [N + 1] or None
         max_seqlen:
-            Optional cache length. When omitted, it is inferred from seqlen_offset;
-            passing it explicitly avoids a device-to-host sync for tensor offsets.
+            Cache length used to initialize the rotary tables. Tensor offsets require this on the first call so cache sizing does not
+            synchronize the device.
         """
-        self._update_cos_sin_cache_for_seqlen_offset(q, seqlen_offset, cu_seqlens, max_seqlen)
+        if max_seqlen is not None:
+            self._update_cos_sin_cache(max_seqlen, device=q.device, dtype=q.dtype)
+        elif isinstance(seqlen_offset, int):
+            self._update_cos_sin_cache(q.shape[1] + seqlen_offset, device=q.device, dtype=q.dtype)
+        else:
+            assert self._cos_cached is not None, "Tensor offsets require an initialized cache; pass max_seqlen on the first call"
         if self.scale is None:
             q = rotary_embedding(
                 q,

--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -169,7 +169,10 @@ def rotary_embedding_fwdbwd(
     R2 = R * 2
 
     assert D <= 256, "Only support D <= 256"
-    assert TR >= T, f"TR must be >= T, got {TR} and {T}"
+    if R2 > D:
+        raise ValueError(f"Rotary dimension must not exceed head dimension, got rotary_dim={R2} and head_dim={D}")
+    if not is_varlen:
+        assert TR >= T, f"TR must be >= T, got {TR} and {T}"
 
     assert cos.dtype == sin.dtype, f"cos and sin must have the same dtype, got {cos.dtype} and {sin.dtype}"
     assert x.dtype == cos.dtype, f"Input and cos/sin must have the same dtype, got {x.dtype} and {cos.dtype}"
@@ -359,6 +362,9 @@ class RotaryEmbedding(nn.Module):
         """
         super().__init__()
 
+        if dim % 2 != 0:
+            raise ValueError(f"Rotary dimension must be even, got {dim}")
+
         self.dim = dim
         self.base = float(base)
         self.scale_base = scale_base
@@ -453,6 +459,25 @@ class RotaryEmbedding(nn.Module):
                 self._cos_k_cached = (torch.cos(freqs) / scale).to(dtype)
                 self._sin_k_cached = (torch.sin(freqs) / scale).to(dtype)
 
+    def _update_cos_sin_cache_for_seqlen_offset(
+        self,
+        x: torch.Tensor,
+        seqlen_offset: int | torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        max_seqlen: int | None,
+    ) -> None:
+        if max_seqlen is not None:
+            required_seqlen = max_seqlen
+        elif isinstance(seqlen_offset, int):
+            required_seqlen = x.shape[1] + seqlen_offset
+        else:
+            if cu_seqlens is None:
+                required_seqlen = max(x.shape[1], x.shape[1] + seqlen_offset.max().item())
+            else:
+                sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                required_seqlen = (sequence_lengths + seqlen_offset).max().item()
+        self._update_cos_sin_cache(max(int(required_seqlen), 0), device=x.device, dtype=x.dtype)
+
     def forward(
         self,
         q: torch.Tensor,
@@ -470,12 +495,11 @@ class RotaryEmbedding(nn.Module):
             Each sequence in x is shifted by this amount.
             Most commonly used in inference when we have KV cache.
         cu_seqlens: [N + 1] or None
-        max_seqlen: int
+        max_seqlen:
+            Optional cache length. When omitted, it is inferred from seqlen_offset;
+            passing it explicitly avoids a device-to-host sync for tensor offsets.
         """
-        if max_seqlen is not None:
-            self._update_cos_sin_cache(max_seqlen, device=q.device, dtype=q.dtype)
-        elif isinstance(seqlen_offset, int):
-            self._update_cos_sin_cache(q.shape[1] + seqlen_offset, device=q.device, dtype=q.dtype)
+        self._update_cos_sin_cache_for_seqlen_offset(q, seqlen_offset, cu_seqlens, max_seqlen)
         if self.scale is None:
             q = rotary_embedding(
                 q,

--- a/tests/modules/test_rotary.py
+++ b/tests/modules/test_rotary.py
@@ -5,6 +5,8 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
+from itertools import product
+
 import pytest
 import torch
 
@@ -39,19 +41,42 @@ def test_rotary(B: int, T: int, H: int, G: int, D: int, dtype: torch.dtype):
     assert_close("dk", ref_dk, tri_dk, ratio=1e-5)
 
 
-@pytest.mark.parametrize("B", [2])
-@pytest.mark.parametrize("T", [2048, 4096])
-@pytest.mark.parametrize("H", [4])
-@pytest.mark.parametrize("G", [1, 4])
-@pytest.mark.parametrize("D", [128, 256])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_rotary_with_offsets(B: int, T: int, H: int, G: int, D: int, dtype: torch.dtype):
+@pytest.mark.parametrize(
+    ("B", "T", "H", "G", "D", "dtype", "max_seqlen_delta"),
+    [
+        (*case, 0)
+        for case in product([2], [2048, 4096], [4], [1, 4], [128, 256], [torch.float32, torch.bfloat16])
+    ] + [
+        (2, 8, 1, 1, 8, torch.float32, -1),
+        (2, 8, 1, 1, 8, torch.float32, None),
+    ],
+)
+def test_rotary_with_offsets(
+    B: int,
+    T: int,
+    H: int,
+    G: int,
+    D: int,
+    dtype: torch.dtype,
+    max_seqlen_delta: int | None,
+):
     torch.manual_seed(42)
-    q = torch.randn(B, T, H, D).to(device).to(dtype=dtype).requires_grad_()
-    k = torch.randn(B, T, H//G, D).to(device).to(dtype=dtype).requires_grad_()
-    seqlen_offset = torch.randint(0, T//2, (B,)).to(device)
-    max_seqlen = T + seqlen_offset.max().item()
-    rotary = RotaryEmbedding(D).to(device)
+    test_device = "cpu" if max_seqlen_delta != 0 else device
+    q = torch.randn(B, T, H, D).to(test_device).to(dtype=dtype).requires_grad_()
+    k = torch.randn(B, T, H//G, D).to(test_device).to(dtype=dtype).requires_grad_()
+    seqlen_offset = torch.randint(0, T//2, (B,)).to(test_device)
+    rotary = RotaryEmbedding(D).to(test_device)
+
+    if max_seqlen_delta is None:
+        with pytest.raises(AssertionError, match="Tensor offsets require an initialized cache"):
+            rotary(q, k, seqlen_offset=seqlen_offset)
+        return
+
+    max_seqlen = T + seqlen_offset.max().item() + max_seqlen_delta
+    if max_seqlen_delta < 0:
+        with pytest.raises(RuntimeError, match="Rotary cache is too short"):
+            rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen)
+        return
 
     tri_q, tri_k = rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen)
     tri_dq = torch.autograd.grad(tri_q.sum(), q, retain_graph=True)[0]
@@ -155,19 +180,34 @@ def test_rotary_left_padding(B: int, T: int, H: int, D: int, dtype: torch.dtype)
         assert_close(f" k[{i}]", ref_k, tri_k[i:i+1, pad:], ratio=1e-5)
 
 
-@pytest.mark.parametrize("B", [2])
-@pytest.mark.parametrize("T", [256, 2048])
-@pytest.mark.parametrize("H", [4])
-@pytest.mark.parametrize("D", [128, 256])
-@pytest.mark.parametrize("rotary_dim", [64])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "rotary_dim", "dtype"),
+    [
+        (B, T, H, D, 64, dtype)
+        for B, T, H, D, dtype in product([2], [256, 2048], [4], [128, 256], [torch.float32, torch.float16])
+    ] + [
+        (2, 8, 1, 128, 63, torch.float32),
+        (2, 8, 1, 32, 64, torch.float32),
+    ],
+)
 def test_rotary_partial(B: int, T: int, H: int, D: int, rotary_dim: int, dtype: torch.dtype):
     # Partial rotary (rotary_dim < head_dim): only [:rotary_dim] is rotated and the
     # non-rotated tail [rotary_dim:] is carried over from the input. Previously untested.
+    if rotary_dim % 2:
+        with pytest.raises(AssertionError, match="Rotary dimension must be even"):
+            RotaryEmbedding(rotary_dim)
+        return
+
     torch.manual_seed(42)
-    q = torch.randn(B, T, H, D).to(device).to(dtype=dtype)
-    k = torch.randn(B, T, H, D).to(device).to(dtype=dtype)
-    rotary = RotaryEmbedding(rotary_dim).to(device)
+    test_device = "cpu" if rotary_dim > D else device
+    q = torch.randn(B, T, H, D).to(test_device).to(dtype=dtype)
+    k = torch.randn(B, T, H, D).to(test_device).to(dtype=dtype)
+    rotary = RotaryEmbedding(rotary_dim).to(test_device)
+
+    if rotary_dim > D:
+        with pytest.raises(AssertionError, match="Rotary dimension must not exceed head dimension"):
+            rotary(q, k)
+        return
 
     tri_q, tri_k = rotary(q, k)
 


### PR DESCRIPTION
## Summary

`RotaryEmbedding(dim)` previously accepted odd rotary dimensions even though its frequency table contains `ceil(dim / 2)` pairs. For `dim=33`, the kernels receive `R=17` and interpret the rotary width as `R2=34`, which reaches beyond a 33-dimensional head. This change rejects odd rotary dimensions at module construction and rejects low-level calls whose rotary width exceeds the head dimension. Valid even partial RoPE on odd head dimensions remains supported.

Tensor-valued `seqlen_offset` now uses the existing `max_seqlen` argument to initialize the rotary cache without deriving a Python scalar from a device tensor. Callers must provide `max_seqlen` on the first tensor-offset call, while later calls may reuse the initialized cache. Dense and packed cache bounds are validated with `torch._assert_async`, preserving the undersized-cache rejection without a device-to-host synchronization in forward or backward. The default Triton and Triton Ascend validation paths remain identical.

## Test plan

- Unit tests added/modified: extended the existing matrices in `tests/modules/test_rotary.py` with odd rotary dimension, rotary dimension greater than head dimension, undersized tensor-offset cache, and uninitialized tensor-offset cache cases.
- `python -m pytest -q tests/modules/test_rotary.py` — 62 passed on an NVIDIA RTX A1000 Laptop GPU.
- `tests/models/test_modeling_yoco.py::test_modeling[L4-B2-T32-H4-D32-attngated_retention-use_l2warpFalse-bsNone-torch.bfloat16]` — passed.
- `tests/layers/test_attn_varlen_pack_layout.py::test_layer_prefers_explicit_cu_seqlens_over_attention_mask[yoco-gated-retention]` — passed.
- A `torch.cuda.set_sync_debug_mode("error")` probe completed tensor-offset forward and backward without detecting a host synchronization.
- `pre-commit run --files fla/modules/rotary.py fla/modules/backends/triton_ascend/rotary.py fla/layers/yoco.py tests/modules/test_rotary.py` — passed.
- The mirrored Ascend validation was linted but not runtime-tested because no Ascend device was available.

## Benchmark / NCU (kernel changes only)

N/A. This PR does not modify a kernel body or launch configuration. The tensor-offset host path was verified with synchronization debug mode instead.

## Breaking changes

No valid-input behavior changes. Invalid odd rotary dimensions and rotary widths greater than the head dimension now raise `AssertionError`. A fresh module receiving tensor offsets must be given `max_seqlen` so its cache can be initialized without synchronizing the device.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
