### PR TITLE
[Fix] zero-initialize Aqk in chunk_gdn2_fwd_intra (#1158)

### DIFF
--- a/fla/ops/gdn2/chunk_intra.py
+++ b/fla/ops/gdn2/chunk_intra.py
@@ -712,7 +712,8 @@ def chunk_gdn2_fwd_intra(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    Aqk = torch.empty(B, T, H, BT, device=k.device, dtype=k.dtype)
+    # Aqk must be zero-initialized - kernel only writes lower triangular.
+    Aqk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
     # Akk must be zero-initialized - kernel only writes lower triangular.
     Akk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
     Akkd = torch.empty(B, T, H, BC, device=k.device, dtype=torch.float32)


### PR DESCRIPTION
# fix: zero-initialize Aqk in chunk_gdn2_fwd_intra (#1158)

Fixes #1158

## Summary

- `Aqk` in `chunk_gdn2_fwd_intra` is allocated with `torch.empty`, but the Triton kernel only writes the lower-triangular portion (`m_Aqk = o_i[:, None] >= o_i[None, :]`). The strict-upper triangle retains whatever the CUDA allocator left in that memory.
- The sibling `Akk` on the very next line already uses `torch.zeros` with the comment `# Akk must be zero-initialized - kernel only writes lower triangular.` `Aqk` simply missed the same treatment.
- Uninitialized `Aqk` values feed into `chunk_gla_fwd_o_gk` (via the `A=Aqk` argument), producing incorrect outputs with no diagnostic.

## Fix

```python
# before
Aqk = torch.empty(B, T, H, BT, device=k.device, dtype=k.dtype)

# after
Aqk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
```

## Testing

- CPU-only verification: after the fix, `Aqk` is guaranteed zero-initialized before the kernel writes the lower triangle; the strict-upper triangle is always 0 as expected.
- The sibling `Akk` allocation already follows this pattern and has been stable in production.

## Limitations

- Full integration test requires GPU + fla training pipeline (not available in current environment).
- Correctness is inferred from code analysis: the kernel's `m_Aqk` mask explicitly excludes the strict-upper triangle, matching the `Akk` pattern exactly.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] This is not a minor/cosmetic-only PR (typo, formatting, style-only tweaks).
- [x] Dependent tests pass locally or in CI; new behavior is covered by tests where applicable. (Not applicable — one-line allocation fix matching existing `Akk` pattern.)
- [x] Kernel changes include same-hardware before/after benchmark numbers (dense + varlen where applicable). (Not a kernel change.)