### PR TITLE
[CP] use tf32x3 affine chain in kcp

### DIFF
--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -61,6 +61,7 @@ def pre_process_fwd_kernel_merged(
     USE_BG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     MULTI_SEQS: tl.constexpr,
+    AFFINE_CHAIN_PRECISION: tl.constexpr = "tf32",
 ):
     i_col, i_h = tl.program_id(0), tl.program_id(1)
     if MULTI_SEQS:
@@ -255,6 +256,7 @@ def pre_process_fwd_kernel_merged(
         # Initialize as identity matrix: M_0 = I
         b_m = tl.where(row[:, None] == col[None, :], 1.0, 0.0)
 
+        # option to improve the input_precision in dm propagation
         for i_t in range(NT):
             # Load k and w with full BK1 rows
             if USE_BG:
@@ -294,7 +296,7 @@ def pre_process_fwd_kernel_merged(
                 # GDN/KDA mode: M = (diag - k^T @ w) @ M
                 b_kw = tl.dot(tl.trans(b_k.to(b_w.dtype)), b_w)
                 b_m_i = b_diag - b_kw
-            b_m = tl.dot(b_m_i.to(tl.float32), b_m.to(tl.float32))
+            b_m = tl.dot(b_m_i.to(tl.float32), b_m.to(tl.float32), input_precision=AFFINE_CHAIN_PRECISION)
 
         # Store m result
         stride_hm_kv = K + V
@@ -335,6 +337,7 @@ def merge_fwd_bwd_kernel(
     NUM_SEQ_ENTRIES,         # num_split_seqs for intracard
     HAS_H0: tl.constexpr,                  # Heuristic: whether h0 is provided
     STATE_V_FIRST: tl.constexpr = False,  # When True, h0/h use [V, K] layout; ag_hm always [K, V+K]
+    AFFINE_CHAIN_PRECISION: tl.constexpr = "tf32",  # input_precision for M@h in the state update (h' = M @ h + he)
 ):
     """
     Unified merge kernel for both CP and Intra-card modes.
@@ -405,9 +408,9 @@ def merge_fwd_bwd_kernel(
             b_m = tl.load(p_m, boundary_check=(0, 1)).to(tl.float32)
             if STATE_V_FIRST:
                 # h_T' = h_T @ M^T + he^T
-                b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_m)) + tl.trans(b_he)
+                b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_m), input_precision=AFFINE_CHAIN_PRECISION) + tl.trans(b_he)
             else:
-                b_h = tl.dot(b_m.to(tl.float32), b_h.to(tl.float32)) + b_he.to(tl.float32)
+                b_h = tl.dot(b_m.to(tl.float32), b_h.to(tl.float32), input_precision=AFFINE_CHAIN_PRECISION) + b_he.to(tl.float32)
 
             # Store for non-first subseqs
             if idx < num_subseqs - 1:
@@ -445,9 +448,9 @@ def merge_fwd_bwd_kernel(
             p_ag_m = tl.make_block_ptr(ag_hm + cur_rank * stride + V, (K, K), (K + V, 1), (0, 0), (BK, BK), (1, 0))
             b_ag_m = tl.load(p_ag_m, boundary_check=(0, 1))
             if STATE_V_FIRST:
-                b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_ag_m).to(tl.float32)) + tl.trans(b_ag_h).to(tl.float32)
+                b_h = tl.dot(b_h.to(tl.float32), tl.trans(b_ag_m).to(tl.float32), input_precision=AFFINE_CHAIN_PRECISION) + tl.trans(b_ag_h).to(tl.float32)
             else:
-                b_h = tl.dot(b_ag_m.to(tl.float32), b_h.to(tl.float32)) + b_ag_h.to(tl.float32)
+                b_h = tl.dot(b_ag_m.to(tl.float32), b_h.to(tl.float32), input_precision=AFFINE_CHAIN_PRECISION) + b_ag_h.to(tl.float32)
         if STATE_V_FIRST:
             p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, 0), (BV, BK), (1, 0))
         else:
@@ -493,6 +496,7 @@ def pre_process_bwd_kernel_merged(
     USE_GK: tl.constexpr,
     USE_BG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    AFFINE_CHAIN_PRECISION: tl.constexpr = "tf32",
 ):
     """
     Merged backward kernel that computes both dh (K x V) and dm (K x K) in a single kernel.
@@ -723,7 +727,7 @@ def pre_process_bwd_kernel_merged(
                 # GDN/KDA mode: dM = (diag - w^T @ k) @ dM
                 b_m_i = b_diag - b_kw
             # Keep m chain in fp32 to avoid precision loss from repeated bf16 casting
-            b_m = tl.dot(b_m_i.to(tl.float32), b_m.to(tl.float32))
+            b_m = tl.dot(b_m_i.to(tl.float32), b_m.to(tl.float32), input_precision=AFFINE_CHAIN_PRECISION)
 
         # Store dm result
         p_m = tl.make_block_ptr(dhm + V, (K, K), (V + K, 1), (0, i_k_col * BLOCK_SIZE), (BK1, BLOCK_SIZE), (1, 0))
@@ -743,6 +747,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
     cu_seqlens: torch.LongTensor | None = None,
     initial_state: torch.Tensor | None = None,
     context: FLACPContext = None,
+    use_tf32x3_affine_chain: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if context is None or context.group is None:
         return initial_state
@@ -789,6 +794,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
             BK1=BK,
             BLOCK_SIZE=BLOCK_SIZE,
             MULTI_SEQS=False,
+            AFFINE_CHAIN_PRECISION="tf32x3" if use_tf32x3_affine_chain else "tf32",
         )
     ag_hm, _ = all_gather_into_tensor(hm, group=context.group)
     if not context.is_first_rank:
@@ -810,6 +816,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
             INTRACARD_MODE=False,
             NUM_SEQ_ENTRIES=0,
             STATE_V_FIRST=state_v_first,
+            AFFINE_CHAIN_PRECISION="tf32x3" if use_tf32x3_affine_chain else "tf32",
         )
     return initial_state
 
@@ -830,6 +837,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
     initial_state: torch.Tensor | None = None,
     context: FLACPContext | None = None,
     chunk_size: int = 64,
+    use_tf32x3_affine_chain: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if context is None or context.group is None:
         return dht, initial_state
@@ -876,6 +884,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
             BK1=BK,
             BLOCK_SIZE=BLOCK_SIZE,
             USE_BG=bg is not None,
+            AFFINE_CHAIN_PRECISION="tf32x3" if use_tf32x3_affine_chain else "tf32",
         )
 
     ag_dhm, _ = all_gather_into_tensor(dhm, group=context.group)
@@ -899,6 +908,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
             INTRACARD_MODE=False,
             NUM_SEQ_ENTRIES=0,
             STATE_V_FIRST=state_v_first,
+            AFFINE_CHAIN_PRECISION="tf32x3" if use_tf32x3_affine_chain else "tf32",
         )
 
     # initial_state is None in the CP mode

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -50,6 +50,7 @@ class ChunkKDAFunction(torch.autograd.Function):
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         cp_context: FLACPContext | None = None,
+        use_tf32x3_affine_chain_in_cp: bool = False,
     ):
         # Apply l2norm
         q_rstd, k_rstd = None, None
@@ -93,6 +94,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             return_intermediate_states=return_intermediate_states,
             cp_context=cp_context,
             state_v_first=state_v_first,
+            use_tf32x3_affine_chain_in_cp=use_tf32x3_affine_chain_in_cp,
         )
 
         if return_intermediate_states:
@@ -116,6 +118,7 @@ class ChunkKDAFunction(torch.autograd.Function):
         ctx.disable_recompute = disable_recompute
         ctx.cp_context = cp_context
         ctx.state_v_first = state_v_first
+        ctx.use_tf32x3_affine_chain_in_cp = use_tf32x3_affine_chain_in_cp
         return o.type_as(q), final_state
 
     @staticmethod
@@ -162,6 +165,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             kg=kg,
             v_new=v_new,
             h=h,
+            use_tf32x3_affine_chain_in_cp=ctx.use_tf32x3_affine_chain_in_cp,
         )
         if ctx.use_qk_l2norm_in_kernel:
             dq = l2norm_bwd(q, q_rstd, dq)
@@ -170,7 +174,7 @@ class ChunkKDAFunction(torch.autograd.Function):
             db = fused_beta_sigmoid_bwd(beta_raw, db, scale=2.0 if ctx.allow_neg_eigval else 1.0)
 
         return (dq.to(q), dk.to(k), dv.to(v), dg.to(g_input), db.to(beta_raw), dA, dbias, None, dh0,
-                None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+                None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
 
 
 @dispatch('kda')
@@ -196,6 +200,7 @@ def chunk_kda(
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     cp_context: FLACPContext = None,
+    use_tf32x3_affine_chain_in_cp: bool = False,
     **kwargs,
 ):
     r"""
@@ -275,6 +280,11 @@ def chunk_kda(
             Context parallel context for distributed training across multiple devices.
             When provided, ``initial_state`` and ``output_final_state`` are not supported,
             and ``cu_seqlens`` will be overridden by the context. Default: ``None``.
+        use_tf32x3_affine_chain_in_cp (bool):
+            Used only when ``cp_context`` is not ``None``.
+            If True, the h and grad_h propagation along subsequences and merging of transition matrix m along chunks 
+            in each subsequence is done in dot with input_precision ``tf32x3`` to improve precision, else ``tf32``.
+            Default: ``False``.
 
     Returns:
         - Normal mode (return_intermediate_states=False): A tuple (o, final_state)
@@ -437,4 +447,5 @@ def chunk_kda(
         disable_recompute,
         return_intermediate_states,
         cp_context,
+        use_tf32x3_affine_chain_in_cp,
     )

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -441,6 +441,7 @@ def chunk_kda_bwd(
     dt_bias: torch.Tensor | None = None,
     disable_recompute: bool = False,
     cp_context: FLACPContext | None = None,
+    use_tf32x3_affine_chain_in_cp: bool = False,
     **kwargs,
 ):
     H, HV = q.shape[2], v.shape[2]
@@ -522,6 +523,7 @@ def chunk_kda_bwd(
             context=cp_context,
             chunk_size=chunk_size,
             state_v_first=state_v_first,
+            use_tf32x3_affine_chain=use_tf32x3_affine_chain_in_cp,
         )
 
     dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -39,6 +39,7 @@ def chunk_kda_fwd(
     disable_recompute: bool = False,
     return_intermediate_states: bool = False,
     cp_context: FLACPContext | None = None,
+    use_tf32x3_affine_chain_in_cp: bool = False,
 ):
     # Apply gate activation
     g_org = None
@@ -89,6 +90,7 @@ def chunk_kda_fwd(
             context=cp_context,
             chunk_size=chunk_size,
             state_v_first=state_v_first,
+            use_tf32x3_affine_chain=use_tf32x3_affine_chain_in_cp,
         )
 
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(

--- a/tests/context_parallel/test_cp_kda.py
+++ b/tests/context_parallel/test_cp_kda.py
@@ -114,6 +114,7 @@ def run_cp_kda_test_worker(
     safe_gate: bool = False,
     lower_bound: float | None = None,
     state_v_first: bool = False,
+    use_tf32x3_affine_chain_in_cp: bool = False,
 ):
     """
     Worker function for CP KDA test.
@@ -341,6 +342,7 @@ def run_cp_kda_test_worker(
             A_log=A_log_global[:H].contiguous() if use_gate_in_kernel else None,
             dt_bias=dt_bias_global if use_gate_in_kernel else None,
             state_v_first=state_v_first,
+            use_tf32x3_affine_chain_in_cp=use_tf32x3_affine_chain_in_cp,
         )
 
         # CP Backward
@@ -422,6 +424,7 @@ def run_cp_test_with_spawn(
     safe_gate: bool = False,
     lower_bound: float | None = None,
     state_v_first: bool = False,
+    use_tf32x3_affine_chain_in_cp: bool = False,
 ):
     """
     Run CP test using torch.multiprocessing.spawn.
@@ -430,7 +433,7 @@ def run_cp_test_with_spawn(
     mp.start_processes(
         run_cp_kda_test_worker,
         args=(world_size, test_name, T, H, D, lengths, dtype, disable_recompute,
-              use_gate_in_kernel, safe_gate, lower_bound, state_v_first),
+              use_gate_in_kernel, safe_gate, lower_bound, state_v_first, use_tf32x3_affine_chain_in_cp),
         nprocs=world_size,
         join=True,
         start_method='spawn',
@@ -583,6 +586,59 @@ def test_cp4_state_v_first():
         lengths=[10240],
         dtype=torch.bfloat16,
         state_v_first=True,
+        **GATE_KWARGS,
+    )
+
+
+# ============================================================
+# tf32x3 Affine Chain Tests
+# ============================================================
+
+def test_cp2_sequence_cut_tf32x3():
+    """CP2: sequences cut across rank boundary, tf32x3 affine chain in CP."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_SequenceCut_TF32X3",
+        T=10240, H=12, D=128,
+        lengths=[3000, 4000, 3240],
+        dtype=torch.bfloat16,
+        use_tf32x3_affine_chain_in_cp=True,
+        **GATE_KWARGS,
+    )
+
+
+def test_cp4_single_sequence_tf32x3():
+    """CP4: single long sequence spanning all ranks, tf32x3 affine chain in CP."""
+    if torch.cuda.device_count() < 4:
+        pytest.skip("At least 4 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=4,
+        test_name="CP4_SingleSequence_TF32X3",
+        T=10240, H=12, D=128,
+        lengths=[10240],
+        dtype=torch.bfloat16,
+        use_tf32x3_affine_chain_in_cp=True,
+        **GATE_KWARGS,
+    )
+
+
+def test_cp2_state_v_first_tf32x3():
+    """CP2: state_v_first=True with sequence cut, tf32x3 affine chain in CP."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+
+    run_cp_test_with_spawn(
+        world_size=2,
+        test_name="CP2_TransposeState_TF32X3",
+        T=10240, H=12, D=128,
+        lengths=[3000, 4000, 3240],
+        dtype=torch.bfloat16,
+        state_v_first=True,
+        use_tf32x3_affine_chain_in_cp=True,
         **GATE_KWARGS,
     )
 


### PR DESCRIPTION
## Summary
<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->
Use tf32x3 in state update & affine transform matrix merging(pre_process_bwd_kernel_merged, pre_process_fwd_kernel_merged and merge_fwd_bwd_kernel) to avoid precision loss in long context.

KCP works like a 3-kernel prefix scan.
1. The first kernel that works as block-reduce is `pre_process_fwd_kernel_merged` and `pre_process_bwd_kernel_merged`, where the transformation done by a sub-sequence is summarized into affine parameters M & H by combining corresponding parameters in each chunk in the subsequence. The transition matrix M is combined by matmul Ms from all chunks. The matmul is `tl.dot(f32, f32, input_precision="tf32")` by default.
2. The second kernel that works as root-scan is `merge_fwd_bwd_kernel`, where the initial state is consecutively transformed by M & H of each sub-sequences. Here the transform is again done in `tl.dot(f32, f32, input_precision="tf32")`.
3. The third kernel that works as block-scan is the `chunk_gated_delta_rule_fwd_h` and `chunk_gated_delta_rule_bwd_dhu`. With the corrected initial states produced by the first 2 kernels, it works the same as cases where no CP is involved. In this kernel, however, the state propagation along chunks is done in high precision. It is not a standard affine transform (S* = MS+H), but a subtle formula instead. Matmul between Diag(gamma) and S is done in f32 fma on cuda cores, which has higher precision that TF32 matmuls on tensor cores.
<img width="750" height="63" alt="image" src="https://github.com/user-attachments/assets/fce568df-10bf-46c8-854d-e100b4820400" />

This introduces some numerical loss in KCP compared to KDA without CP, which accumulates as sequence length grows. We use tf32x3 emulation in the affine chain in the first 2 kernels to alleviate this numerical loss. Please refer to 

Ootomo, Hiroyuki, and Rio Yokota. “Recovering Single Precision Accuracy from Tensor Cores While Surpassing the FP32 Theoretical Peak Performance.” The International Journal of High Performance Computing Applications 36, no. 4 (2022): 475–91. https://doi.org/10.1177/10943420221090256.

for more details.

## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->

## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->

## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [ ] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [ ] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.

### If you ticked the "minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
Justify here why yours is worth a maintainer's review time — minor PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
