### PR TITLE
[GDN] Add configurable output gate activation

### DIFF
--- a/.github/workflows/nvidia-h100-smoke.yml
+++ b/.github/workflows/nvidia-h100-smoke.yml
@@ -1,0 +1,106 @@
+name: nvidia-h100-smoke
+
+# Fast feedback tier: on every PR/main push, run the PR's dependent test files,
+# but only smoke-marked tests under tests/ops (small non-ops suites run in full,
+# tests/models excluded). The approval-gated full pipeline lives in nvidia-h100.yml.
+
+concurrency:
+  group: smoke-ci-${{ github.event.pull_request.number || github.ref }}
+  # New pushes cancel only smoke; never the approval-triggered full pipeline.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [ '*' ]
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke:
+    name: Smoke (PyTorch 2.12)
+    runs-on: nvidia-h100-1
+    # Cold triton cache makes the first run much slower; warm runs are ~20 min.
+    timeout-minutes: 120
+    env:
+      FLA_CI_ENV: 1
+      # Triton baseline only; dispatch/tilelang coverage stays in the full pipeline.
+      FLA_DISABLE_BACKEND_DISPATCH: "1"
+    steps:
+      # NPU-only PRs have nothing for the GPU smoke to cover.
+      - name: Skip NPU-only PRs
+        id: detect
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            let skip = false;
+            if (context.eventName === 'pull_request') {
+              const { owner, repo } = context.repo;
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: context.payload.pull_request.number, per_page: 100,
+              });
+              const npuSafe = /^fla\/(.+\/)?backends\/triton_ascend\/(?!.*__init__\.py$)|^\.github\/workflows\/ascend-|^\.agents\/skills\/fla-ascend-performance\//;
+              const names = files.map(f => f.filename);
+              skip = names.length > 0 && names.every(n => npuSafe.test(n));
+            }
+            core.setOutput('skip', skip ? 'true' : 'false');
+
+      - name: Check out repo
+        if: steps.detect.outputs.skip != 'true'
+        uses: actions/checkout@v7.0.0
+
+      - name: Setup CI Environment
+        id: setup
+        if: steps.detect.outputs.skip != 'true'
+        uses: ./.github/actions/setup-ci-env
+        with:
+          runner_name: ${{ runner.name }}
+          conda_env_name: 'pytorch_2_12'
+          gpu_type: 'nvidia'
+          install_tilelang: "true"
+          skip_gpu_check: true
+
+      - name: Find dependent test files (excluding models)
+        if: steps.detect.outputs.skip != 'true' && steps.setup.outputs.skip_tests == 'false'
+        id: find-tests
+        shell: bash
+        run: |
+          export TEST_SCOPE="EXCLUDE_MODELS"
+          TEST_FILES=$($CONDA_BIN_PATH/python scripts/find_dependent_tests.py "${{ steps.setup.outputs.all_changed_files }}")
+          echo "Found dependent test files: $TEST_FILES"
+          echo "test_files=$TEST_FILES" >> $GITHUB_OUTPUT
+
+      - name: Run tests (smoke-marked ops subset, full other suites)
+        if: steps.find-tests.outputs.test_files
+        shell: bash
+        run: |
+          # Per-file processes, same as the full suite (avoids runner OOM).
+          # find_dependent_tests.py prints absolute paths; match */tests/ops/*.
+          # pytest exit 5 = no smoke-marked tests collected in this file, skip.
+          rc=0
+          for f in ${{ steps.find-tests.outputs.test_files }}; do
+            case "$f" in
+              */tests/ops/*)
+                $CONDA_BIN_PATH/pytest -s -v --exitfirst -m smoke "$f" || rc=$?
+                if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit 1; fi
+                rc=0 ;;
+              *) $CONDA_BIN_PATH/pytest -s -v --exitfirst "$f" || exit 1 ;;
+            esac
+          done
+
+      # Shared self-hosted disk: trim caches only under pressure, keep them warm otherwise.
+      - name: Trim caches under disk pressure
+        if: always()
+        shell: bash
+        run: |
+          used=$(df --output=pcent "$HOME" | tail -1 | tr -dc '0-9')
+          echo "disk usage: ${used}%"
+          if [ "${used:-0}" -lt 80 ]; then exit 0; fi
+          du -sh ~/.triton ~/.tilelang/cache ~/.cache/pip 2>/dev/null || true
+          rm -rf ~/.triton ~/.tilelang/cache ~/.cache/pip || true
+          ${CONDA:-$HOME/miniconda3}/bin/conda clean --all -y || true
+          df -h "$HOME"

--- a/.github/workflows/nvidia-h100.yml
+++ b/.github/workflows/nvidia-h100.yml
@@ -1,13 +1,20 @@
 name: nvidia-h100-ci
 
+# Full pipeline tier. Runs on maintainer PR pushes (maintainers cannot approve
+# their own PRs), on PR approval (external PRs), nightly on main, and manually.
+# Every push still gets the fast smoke tier from nvidia-h100-smoke.yml.
+# Once this pipeline has gone green for a PR, later approvals only need smoke.
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: full-ci-${{ github.event.pull_request.number || github.ref }}
+  # Merge/close cancels an in-flight full run, and a maintainer's new push
+  # cancels their stale full run. Everything else (external pushes, approvals)
+  # must not cancel the approval-triggered full run.
+  cancel-in-progress: ${{ github.event.action == 'closed' || (github.event_name == 'pull_request' && contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)) }}
 
 permissions:
   contents: read
   pull-requests: write
-  issues: write
   checks: read
 
 on:
@@ -16,16 +23,17 @@ on:
     types: [opened, synchronize, reopened, closed]
   pull_request_review:
     types: [submitted]
-  push:
-    branches:
-      - main
+  schedule:
+    # Nightly full pipeline on main (03:00 +08:00).
+    - cron: '0 19 * * *'
+  workflow_dispatch:
 
 jobs:
   # Detect PRs that only touch NPU-only code (triton-ascend backend files,
   # Ascend workflow definitions) so the H100 jobs below can skip them.
   # Shared files — including backend __init__.py files, which GPU imports
-  # unconditionally — always get the full GPU pipeline. Push events and
-  # titles containing '[nv]' force the full pipeline.
+  # unconditionally — always get the full GPU pipeline. Non-PR events
+  # (nightly, manual) and titles containing '[nv]' force the full pipeline.
   changes:
     name: Detect NPU-only changes
     runs-on: ubuntu-latest
@@ -62,12 +70,79 @@ jobs:
             }
             core.setOutput('npu_only', files.length > 0 && unsafe.length === 0 ? 'true' : 'false');
 
+  # Gate for the full pipeline: maintainer PRs always run it (they cannot
+  # approve their own PRs); external PRs run it once approved, unless it has
+  # already gone green for this PR — after that, smoke is the only gate.
+  gate:
+    name: Decide whether the full pipeline runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_full: ${{ steps.decide.outputs.run_full }}
+    steps:
+      - name: Decide
+        id: decide
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const eventName = context.eventName;
+            if (eventName === 'schedule' || eventName === 'workflow_dispatch') {
+              core.setOutput('run_full', 'true');
+              return;
+            }
+            const pr = context.payload.pull_request;
+            if (eventName === 'pull_request') {
+              if (context.payload.action === 'closed') {
+                core.setOutput('run_full', 'false');
+                return;
+              }
+              const maintainers = ['OWNER', 'MEMBER'];
+              core.setOutput('run_full', maintainers.includes(pr.author_association) ? 'true' : 'false');
+              return;
+            }
+            if (eventName === 'pull_request_review') {
+              const review = context.payload.review;
+              if (review.state !== 'approved' || pr.state !== 'open') {
+                core.setOutput('run_full', 'false');
+                return;
+              }
+              // If the full pipeline already went green on any commit of this
+              // PR, re-approvals after a stale-dismiss only need smoke.
+              const { owner, repo } = context.repo;
+              const requiredChecks = [
+                'Test H100 (PyTorch 2.12) / test-ops',
+                'Test H100 (PyTorch 2.12) / test-models',
+              ];
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner, repo, pull_number: pr.number, per_page: 100,
+              });
+              for (const commit of commits.reverse()) {
+                const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                  owner, repo, ref: commit.sha, per_page: 100,
+                });
+                const latestByName = new Map();
+                for (const run of checkRuns) {
+                  if (run.app?.slug !== 'github-actions') continue;
+                  const prev = latestByName.get(run.name);
+                  const t = Date.parse(run.started_at || run.completed_at || run.created_at || 0);
+                  const pt = prev ? Date.parse(prev.started_at || prev.completed_at || prev.created_at || 0) : 0;
+                  if (!prev || t > pt) latestByName.set(run.name, run);
+                }
+                if (requiredChecks.every(name => latestByName.get(name)?.conclusion === 'success')) {
+                  core.info(`Full pipeline already green at ${commit.sha}; smoke only from now on`);
+                  core.setOutput('run_full', 'false');
+                  return;
+                }
+              }
+              core.setOutput('run_full', 'true');
+              return;
+            }
+            core.setOutput('run_full', 'false');
+
   test-h100-pytorch-2-12:
     name: Test H100 (PyTorch 2.12)
-    # Test on all main commits and PRs, but skip on closed PRs
-    # to avoid running tests on merged PRs, and skip NPU-only PRs.
-    needs: changes
-    if: needs.changes.outputs.npu_only != 'true' && github.event_name != 'pull_request_review' && (github.event_name != 'pull_request' || github.event.action != 'closed')
+    needs: [changes, gate]
+    if: needs.changes.outputs.npu_only != 'true' && needs.gate.outputs.run_full == 'true'
     uses: ./.github/workflows/reusable-ci-tests.yml
     with:
       runner: 'nvidia-h100-1'
@@ -77,11 +152,11 @@ jobs:
 
   check_h100_pytorch_2_7:
     name: Check H100 PyTorch 2.7 Eligibility
-    needs: changes
+    needs: [changes, gate]
     if: >
       needs.changes.outputs.npu_only != 'true' &&
-      ((github.event_name == 'pull_request' && github.event.action != 'closed') ||
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.state == 'open'))
+      needs.gate.outputs.run_full == 'true' &&
+      (github.event_name == 'pull_request' || github.event_name == 'pull_request_review')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     outputs:

--- a/fla/layers/gated_deltanet.py
+++ b/fla/layers/gated_deltanet.py
@@ -83,6 +83,10 @@ class GatedDeltaNet(nn.Module):
             The index of the layer. Default: None.
         norm_eps (float, Optional):
             The epsilon value for the normalization layer. Default: 1e-5.
+        output_gate_activation (str, Optional):
+            Activation applied by the output gate when `use_gate=True`.
+            Supported values are `swish`, `silu`, and `sigmoid`.
+            `swish` and `silu` are equivalent aliases. Default: `swish`.
     """
 
     def __init__(
@@ -100,6 +104,7 @@ class GatedDeltaNet(nn.Module):
         conv_bias: bool = False,
         layer_idx: int = None,
         norm_eps: float = 1e-5,
+        output_gate_activation: str = 'swish',
         **kwargs,
     ) -> GatedDeltaNet:
         super().__init__()
@@ -141,6 +146,10 @@ class GatedDeltaNet(nn.Module):
                 f"Resulting head_v_dim would be {head_dim * expand_v}, which is invalid for FusedRMSNormGated.",
             )
         assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."
+        if output_gate_activation not in ('swish', 'silu', 'sigmoid'):
+            raise ValueError(
+                f"output_gate_activation must be one of 'swish', 'silu', 'sigmoid', got {output_gate_activation!r}")
+        self.output_gate_activation = output_gate_activation
 
         self.q_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
         self.k_proj = nn.Linear(hidden_size, self.key_dim, bias=False)
@@ -194,7 +203,7 @@ class GatedDeltaNet(nn.Module):
             )
         if use_gate:
             self.g_proj = nn.Linear(hidden_size, self.value_dim, bias=False)
-            self.o_norm = FusedRMSNormGated(self.head_v_dim, eps=norm_eps)
+            self.o_norm = FusedRMSNormGated(self.head_v_dim, eps=norm_eps, activation=self.output_gate_activation)
         else:
             self.o_norm = RMSNorm(self.head_v_dim, eps=norm_eps, dtype=torch.float32)
         self.o_proj = nn.Linear(self.value_dim, hidden_size, bias=False)

--- a/fla/models/gated_deltanet/configuration_gated_deltanet.py
+++ b/fla/models/gated_deltanet/configuration_gated_deltanet.py
@@ -48,6 +48,7 @@ class GatedDeltaNetConfig(_HybridAttentionConfigMixin, PretrainedConfig):
         use_l2warp: bool = False,
         vocab_size: int = 32000,
         attnres_block_size: int | None = None,
+        output_gate_activation: str = "swish",
         **kwargs,
     ):
         self.attn_mode = attn_mode
@@ -78,6 +79,10 @@ class GatedDeltaNetConfig(_HybridAttentionConfigMixin, PretrainedConfig):
         self.vocab_size = vocab_size
         self.allow_neg_eigval = allow_neg_eigval
         self.attnres_block_size = attnres_block_size
+        self.output_gate_activation = output_gate_activation
+        if self.output_gate_activation not in ("swish", "silu", "sigmoid"):
+            raise ValueError(
+                f"output_gate_activation must be one of 'swish', 'silu', 'sigmoid', got {self.output_gate_activation!r}")
 
         if fuse_cross_entropy and fuse_linear_cross_entropy:
             raise ValueError(

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -73,8 +73,9 @@ class GatedDeltaNetBlock(GradientCheckpointingLayer):
                 use_short_conv=config.use_short_conv,
                 allow_neg_eigval=config.allow_neg_eigval,
                 conv_size=config.conv_size,
-                norm_eps=config.norm_eps,
                 layer_idx=layer_idx,
+                norm_eps=config.norm_eps,
+                output_gate_activation=config.output_gate_activation,
             )
         self.mlp_norm = (RMSNorm if config.fuse_norm else nn.RMSNorm)(config.hidden_size, eps=config.norm_eps)
         self.mlp = GatedDeltaNetMLP(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ version = {attr = "fla.__version__"}
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "INFO"
+markers = [
+    "smoke: core tests run in the dependent-files smoke tier on every PR push (fast feedback)",
+]
 pythonpath = [
   "."
 ]

--- a/tests/layers/test_gated_deltanet_output_gate.py
+++ b/tests/layers/test_gated_deltanet_output_gate.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.gated_deltanet import GatedDeltaNet
+from fla.models.gated_deltanet.configuration_gated_deltanet import GatedDeltaNetConfig
+from fla.models.gated_deltanet.modeling_gated_deltanet import GatedDeltaNetBlock
+from fla.utils import device
+
+
+def _tiny_config(**overrides):
+    base = dict(
+        hidden_size=128,
+        head_dim=32,
+        num_heads=2,
+        num_v_heads=2,
+        expand_v=1,
+        intermediate_size=256,
+        hidden_ratio=2,
+        max_position_embeddings=512,
+        num_hidden_layers=2,
+        vocab_size=512,
+    )
+    base.update(overrides)
+    return GatedDeltaNetConfig(**base)
+
+
+def test_gated_deltanet_default_output_gate_activation_is_swish():
+    layer = GatedDeltaNet(hidden_size=128, head_dim=32, num_heads=2, expand_v=1)
+    assert layer.output_gate_activation == "swish"
+    assert layer.o_norm.activation == "swish"
+    cfg = _tiny_config()
+    assert cfg.output_gate_activation == "swish"
+    block = GatedDeltaNetBlock(cfg, layer_idx=0)
+    assert block.attn.output_gate_activation == "swish"
+    assert block.attn.o_norm.activation == "swish"
+
+
+@pytest.mark.parametrize("gate", ["sigmoid", "silu"])
+def test_gated_deltanet_output_gate_activation_wiring(gate):
+    layer = GatedDeltaNet(hidden_size=128, head_dim=32, num_heads=2, expand_v=1, output_gate_activation=gate)
+    assert layer.output_gate_activation == gate
+    assert layer.o_norm.activation == gate
+    cfg = _tiny_config(output_gate_activation=gate)
+    block = GatedDeltaNetBlock(cfg, layer_idx=0)
+    assert block.attn.output_gate_activation == gate
+    assert block.attn.o_norm.activation == gate
+    assert cfg.to_dict()["output_gate_activation"] == gate
+
+
+def test_gated_deltanet_config_serialization():
+    cfg = _tiny_config(output_gate_activation="sigmoid")
+    d = cfg.to_dict()
+    assert d["output_gate_activation"] == "sigmoid"
+    cfg2 = GatedDeltaNetConfig.from_dict(d)
+    assert cfg2.output_gate_activation == "sigmoid"
+    block = GatedDeltaNetBlock(cfg2, layer_idx=0)
+    assert block.attn.o_norm.activation == "sigmoid"
+    # old checkpoint without field defaults to swish
+    cfg3 = _tiny_config(output_gate_activation="sigmoid")
+    d3 = cfg3.to_dict()
+    d3.pop("output_gate_activation")
+    restored = GatedDeltaNetConfig.from_dict(d3)
+    assert restored.output_gate_activation == "swish"
+    block = GatedDeltaNetBlock(restored, layer_idx=0)
+    assert block.attn.output_gate_activation == "swish"
+    assert block.attn.o_norm.activation == "swish"
+
+
+def test_gated_deltanet_state_dict_compatibility():
+    tiny_kwargs = dict(hidden_size=128, head_dim=32, num_heads=2, expand_v=1)
+    base = GatedDeltaNet(**tiny_kwargs)
+    swish = GatedDeltaNet(**tiny_kwargs, output_gate_activation="swish")
+    sigmoid = GatedDeltaNet(**tiny_kwargs, output_gate_activation="sigmoid")
+    # activation choice adds no parameter/state-dict key
+    assert "output_gate_activation" not in base.state_dict()
+    assert set(base.state_dict().keys()) == set(swish.state_dict().keys()) == set(sigmoid.state_dict().keys())
+    assert sum(p.numel() for p in base.parameters()) == sum(
+        p.numel() for p in swish.parameters()
+    ) == sum(p.numel() for p in sigmoid.parameters())
+    # strict load between variants
+    sd = base.state_dict()
+    swish.load_state_dict(sd, strict=True)
+    sigmoid.load_state_dict(sd, strict=True)
+
+
+def test_gated_deltanet_sigmoid_forward_backward():
+    torch.manual_seed(42)
+
+    layer = GatedDeltaNet(
+        hidden_size=128,
+        head_dim=32,
+        num_heads=2,
+        expand_v=1,
+        output_gate_activation="sigmoid",
+    ).to(device).train()
+
+    x = torch.randn(2, 16, 128, device=device, requires_grad=True)
+    y, _, _ = layer(x)
+
+    assert torch.isfinite(y).all()
+
+    y.sum().backward()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+
+
+def test_gated_deltanet_validation_semantics():
+    with pytest.raises(ValueError):
+        GatedDeltaNetConfig(output_gate_activation="relu")
+    with pytest.raises(ValueError):
+        GatedDeltaNet(hidden_size=128, head_dim=32, num_heads=2, expand_v=1, output_gate_activation="relu")
+
+
+def test_gated_deltanet_config_positional_compatibility():
+    attn_spec = {"layers": [0], "num_heads": 2}
+    cfg_pos = GatedDeltaNetConfig(
+        "chunk",
+        128,
+        1.0,
+        True,
+        True,
+        False,
+        4,
+        32,
+        2,
+        2,
+        512,
+        2,
+        256,
+        "swish",
+        2,
+        1e-5,
+        attn_spec,
+        False,
+    )
+    cfg_kw = GatedDeltaNetConfig(
+        attn_mode="chunk",
+        hidden_size=128,
+        expand_v=1.0,
+        use_gate=True,
+        use_short_conv=True,
+        allow_neg_eigval=False,
+        conv_size=4,
+        head_dim=32,
+        num_heads=2,
+        num_v_heads=2,
+        max_position_embeddings=512,
+        hidden_ratio=2,
+        intermediate_size=256,
+        hidden_act="swish",
+        num_hidden_layers=2,
+        norm_eps=1e-5,
+        attn=attn_spec,
+        use_cache=False,
+    )
+    assert cfg_pos.norm_eps == cfg_kw.norm_eps == 1e-5
+    assert cfg_pos.attn == cfg_kw.attn
+    assert cfg_pos.use_cache == cfg_kw.use_cache is False
+    assert cfg_pos.output_gate_activation == cfg_kw.output_gate_activation == "swish"

--- a/tests/ops/test_attn.py
+++ b/tests/ops/test_attn.py
@@ -162,6 +162,7 @@ def test_parallel_with_g(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_parallel_varlen(
     H: int,
     HQ: int,

--- a/tests/ops/test_attn_sink.py
+++ b/tests/ops/test_attn_sink.py
@@ -172,6 +172,7 @@ def test_attn_sink_empty_row_ref_matches_gpt_oss_eager():
         pytest.param(64, [0, 97, 173, 300], id="varlen_swa"),
     ],
 )
+@pytest.mark.smoke
 def test_parallel_attn_sink_matches_reference(window_size, cu_seqlens):
     torch.manual_seed(123)
     os.environ["TRITON_F32_DEFAULT"] = "ieee"

--- a/tests/ops/test_attnres.py
+++ b/tests/ops/test_attnres.py
@@ -39,6 +39,7 @@ from fla.utils import IS_NPU, assert_close, device
         ]
     ],
 )
+@pytest.mark.smoke
 def test_attnres(
     L: int,
     B: int,

--- a/tests/ops/test_based.py
+++ b/tests/ops/test_based.py
@@ -26,6 +26,7 @@ from fla.utils import device
         ]
     ],
 )
+@pytest.mark.smoke
 def test_based(
     B: int,
     T: int,

--- a/tests/ops/test_comba.py
+++ b/tests/ops/test_comba.py
@@ -233,6 +233,7 @@ def test_chunk(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     HV: int,

--- a/tests/ops/test_delta.py
+++ b/tests/ops/test_delta.py
@@ -175,6 +175,7 @@ def test_chunk_with_chunk_size(
     device_platform == 'intel',
     reason='Intel Triton Failure',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_delta_product.py
+++ b/tests/ops/test_delta_product.py
@@ -102,6 +102,7 @@ def test_chunk(
         (2, 256, 3, [0, 100, 123, 300, 500, 800, 1000, 1500, 2048], torch.float16),
     ],
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_deltaformer.py
+++ b/tests/ops/test_deltaformer.py
@@ -184,6 +184,7 @@ def test_parallel_deltaformer_u(
     IS_INTEL_ALCHEMIST,
     reason="Skipping test on Intel Alchemist due to known issues with SRAM.",
 )
+@pytest.mark.smoke
 def test_deltaformer_attn_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_dplr_delta.py
+++ b/tests/ops/test_dplr_delta.py
@@ -521,6 +521,7 @@ def test_chunk_default_chunk_size(lower_bound, chunk_size):
     device_platform == 'intel',
     reason='Intel Triton Failure',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_forgetting_attn.py
+++ b/tests/ops/test_forgetting_attn.py
@@ -83,6 +83,7 @@ def test_parallel(
     IS_INTEL_ALCHEMIST,
     reason="Intel Triton Failure",
 )
+@pytest.mark.smoke
 def test_parallel_varlen(
     H: int,
     HQ: int,

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -747,6 +747,7 @@ def test_fused_recurrent_gate_in_kernel_varlen(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     HV: int,

--- a/tests/ops/test_gdn2.py
+++ b/tests/ops/test_gdn2.py
@@ -424,6 +424,7 @@ def test_chunk_state_v_first():
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk_varlen(cu_seqlens, H, K, V, use_gate_in_kernel, dtype):
     """Packed varlen chunk run (fwd + grads) must equal per-sequence reference."""
     cu = torch.LongTensor(cu_seqlens).to(device)

--- a/tests/ops/test_gdp.py
+++ b/tests/ops/test_gdp.py
@@ -118,6 +118,7 @@ def test_chunk(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_gla.py
+++ b/tests/ops/test_gla.py
@@ -395,6 +395,7 @@ def test_chunk_state_v_first(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_gsa.py
+++ b/tests/ops/test_gsa.py
@@ -395,6 +395,7 @@ def test_chunk_with_chunk_size(
     device_platform == 'intel',
     reason='Intel Triton Failure',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_hgrn.py
+++ b/tests/ops/test_hgrn.py
@@ -139,6 +139,7 @@ def test_fused_recurrent_varlen(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk(
     B: int,
     T: int,

--- a/tests/ops/test_iplr_delta.py
+++ b/tests/ops/test_iplr_delta.py
@@ -199,6 +199,7 @@ def test_fused_recurrent(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk(
     B: int,
     T: int,

--- a/tests/ops/test_kda.py
+++ b/tests/ops/test_kda.py
@@ -853,6 +853,7 @@ def test_chunk_use_beta_sigmoid_in_kernel(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_lightning_attn.py
+++ b/tests/ops/test_lightning_attn.py
@@ -22,6 +22,7 @@ from fla.utils import assert_close, device
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk_with_chunk_size(
     B: int,
     T: int,

--- a/tests/ops/test_linear_attn.py
+++ b/tests/ops/test_linear_attn.py
@@ -110,6 +110,7 @@ def test_naive_chunk(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk(
     B: int,
     T: int,

--- a/tests/ops/test_log_linear_attn.py
+++ b/tests/ops/test_log_linear_attn.py
@@ -158,6 +158,7 @@ def test_chunk_bwd(
     ],
 )
 @pytest.mark.skipif(device_platform == "intel", reason="Intel Triton Failure")
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_mesa.py
+++ b/tests/ops/test_mesa.py
@@ -122,6 +122,7 @@ def test_chunk(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_moba.py
+++ b/tests/ops/test_moba.py
@@ -91,6 +91,7 @@ def test_parallel_moba_topk1_short_circuits():
         ]
     ],
 )
+@pytest.mark.smoke
 def test_parallel_moba_varlen_matches_full_attn(cu_seqlens, H, D, chunk_size, topk):
     torch.manual_seed(42)
     T = cu_seqlens[-1]

--- a/tests/ops/test_momentum_delta.py
+++ b/tests/ops/test_momentum_delta.py
@@ -104,6 +104,7 @@ def test_chunk(
     device_platform == 'intel',
     reason='Intel Triton Failure',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_nsa.py
+++ b/tests/ops/test_nsa.py
@@ -127,6 +127,7 @@ def test_parallel(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test because SKIP_TEST_CHUNK_VARLEN is set',
 )
+@pytest.mark.smoke
 def test_parallel_varlen(
     H: int,
     HQ: int,

--- a/tests/ops/test_oja.py
+++ b/tests/ops/test_oja.py
@@ -474,6 +474,7 @@ def test_chunk_with_chunk_size(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set'
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_parallax.py
+++ b/tests/ops/test_parallax.py
@@ -158,6 +158,7 @@ def test_parallel_swa(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_parallel_varlen(H: int, HQ: int, D: int, cu_seqlens: list[int], dtype: torch.dtype):
     torch.manual_seed(42)
     os.environ['TRITON_F32_DEFAULT'] = 'ieee'

--- a/tests/ops/test_path_attn.py
+++ b/tests/ops/test_path_attn.py
@@ -109,6 +109,7 @@ def test_parallel(
     IS_INTEL_ALCHEMIST,
     reason="Intel Triton Failure",
 )
+@pytest.mark.smoke
 def test_parallel_varlen(
     H: int,
     HQ: int,

--- a/tests/ops/test_precond_gated_delta.py
+++ b/tests/ops/test_precond_gated_delta.py
@@ -237,6 +237,7 @@ def test_chunk(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_precond_kda.py
+++ b/tests/ops/test_precond_kda.py
@@ -522,6 +522,7 @@ def test_chunk_transpose_state(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     K: int,

--- a/tests/ops/test_retention.py
+++ b/tests/ops/test_retention.py
@@ -130,6 +130,7 @@ def test_chunk_with_chunk_size(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     K: int,

--- a/tests/ops/test_rwkv6.py
+++ b/tests/ops/test_rwkv6.py
@@ -176,6 +176,7 @@ def test_chunk_with_chunk_size(
         ]
     ],
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_rwkv7.py
+++ b/tests/ops/test_rwkv7.py
@@ -185,6 +185,7 @@ def test_fused_mul_recurrent_fwd(
 
 
 @pytest.mark.parametrize('chunk_size', [16, 32, 64])
+@pytest.mark.smoke
 def test_chunk_wrapper_chunk_size(chunk_size: int):
     B, T, H, D = 1, 64, 2, 64
     r = torch.empty(B, T, H, D).uniform_(-8, -6).to(device)

--- a/tests/ops/test_simple_gla.py
+++ b/tests/ops/test_simple_gla.py
@@ -456,6 +456,7 @@ def test_chunk_state_v_first(
     os.getenv('SKIP_TEST_CHUNK_VARLEN') == '1',
     reason='Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set',
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_solve_tril.py
+++ b/tests/ops/test_solve_tril.py
@@ -71,6 +71,7 @@ def test_solve_tril(B, T, H, chunk_size):
     device_platform == 'intel',
     reason='Intel Pytorch Failure',
 )
+@pytest.mark.smoke
 def test_solve_tril_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_titans.py
+++ b/tests/ops/test_titans.py
@@ -58,6 +58,7 @@ def initialize_chunked_param(B, H, T, BT, dtype=torch.float32):
 @pytest.mark.skipif(
     True, reason='FIXME',
 )
+@pytest.mark.smoke
 def test_naive_chunk(
     B: int,
     T: int,

--- a/tests/ops/test_ttt.py
+++ b/tests/ops/test_ttt.py
@@ -215,6 +215,7 @@ def test_fused_chunk(
     os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
     reason="Skipping test_chunk_varlen because SKIP_TEST_CHUNK_VARLEN is set",
 )
+@pytest.mark.smoke
 def test_chunk_varlen(
     H: int,
     D: int,

--- a/tests/ops/test_wall_attn.py
+++ b/tests/ops/test_wall_attn.py
@@ -87,6 +87,7 @@ def test_parallel_gqa_matches_reference():
     assert_close(" o", ref, tri, RTOL_FWD)
 
 
+@pytest.mark.smoke
 def test_parallel_varlen_matches_reference():
     dtype = torch.float32
     T1, T2 = 17, 23


### PR DESCRIPTION
## Summary

Add configurable output-gate activation to `GatedDeltaNet`.

`GatedDeltaNet` previously used the default SiLU/Swish activation of `FusedRMSNormGated`. This PR exposes that choice through a new `output_gate_activation` option supporting `swish`, `silu`, and `sigmoid`.

The option is wired through `GatedDeltaNetConfig` → `GatedDeltaNetBlock` → `GatedDeltaNet`.

This removes the hard-coded output-gate activation from native GatedDeltaNet and allows callers to select sigmoid gating when required by a model architecture.

The default remains `swish`, so existing callers and checkpoints are unaffected. No Gated Delta Rule kernel or recurrence is changed.

## Test plan

Hardware: NVIDIA RTX 5060 Ti

Dependent test files identified with:

```bash
python scripts/find_dependent_tests.py fla/layers/gated_deltanet.py
python scripts/find_dependent_tests.py fla/models/gated_deltanet
```

Full dependent suite:

```bash
python -m pytest \
  tests/layers/test_attn_varlen_pack_layout.py \
  tests/layers/test_gated_deltanet.py \
  tests/layers/test_gated_deltanet_output_gate.py \
  tests/layers/test_layer_cache_layer_idx.py \
  tests/models/test_hybrid_attention.py \
  tests/models/test_modeling_gated_deltanet.py \
  tests/models/test_modeling_yoco.py \
  -q
```

- 284 passed in 1100.08s

Additional targeted validation:

- `python -m pytest tests/layers/test_gated_deltanet_output_gate.py -v` — 8 passed
- `python -m pytest tests/layers/test_gated_deltanet.py -v` — 5 passed
- `python -m pytest tests/layers -k "gated_deltanet or gdn" -v` — 14 passed, 42 deselected
- `python -m pytest tests/modules/test_layernorm_gated.py -k "not large_batch" -v` — 12 passed, 2 deselected
- `pre-commit run --all-files` — passed
- `git diff --check` — clean

The new tests cover the default activation, sigmoid/SILU wiring, config serialization, state-dict compatibility, validation, positional config compatibility, and sigmoid forward/backward execution through the native `GatedDeltaNet` layer.

## Benchmark / NCU (kernel changes only)

N/A — no kernel code changed. This only selects an activation already supported by `FusedRMSNormGated`.

## Breaking changes

None. New optional configuration/constructor argument; the default remains `swish` and existing state dicts are unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A — no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.