### PR TITLE
[Fix] Handle empty Parallax sliding-window cache

### DIFF
--- a/fla/layers/parallax.py
+++ b/fla/layers/parallax.py
@@ -150,16 +150,16 @@ class Parallax(nn.Module):
         r, _ = self.rotary(r, r, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
-            # Decode / cached prefill. `r` is regenerated each step (like `q`), so only
-            # `(k, v)` are cached; the new queries attend to the full cached KV.
+            cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
             k_cached, v_cached = past_key_values.update(
                 attn_state=(k.flatten(-2, -1), v.flatten(-2, -1)),
                 layer_idx=self.layer_idx,
                 offset=q_len,
                 cache_kwargs=dict(window_size=self.window_size),
             )['attn_state']
-            k = rearrange(k_cached, '... (h d) -> ... h d', d=self.head_dim)
-            v = rearrange(v_cached, '... (h d) -> ... h d', d=self.head_dim)
+            if cache_has_content:
+                k = rearrange(k_cached, '... (h d) -> ... h d', d=self.head_dim)
+                v = rearrange(v_cached, '... (h d) -> ... h d', d=self.head_dim)
             # left-padding: the first `kv_len - valid_len` cached keys are padding.
             cache_start = None
             if attention_mask is not None:

--- a/fla/ops/parallax/decode.py
+++ b/fla/ops/parallax/decode.py
@@ -167,6 +167,7 @@ def parallax_decode(
     """
     B, Sq, HQ, K = q.shape
     Skv, H = k.shape[1], k.shape[2]
+    assert Skv >= Sq, f"Cached KV length must cover query length, got Skv={Skv} and Sq={Sq}"
     G = HQ // H
     if scale is None:
         scale = K ** -0.5

--- a/tests/layers/test_parallax_cache.py
+++ b/tests/layers/test_parallax_cache.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.parallax import Parallax
+from fla.models.utils import Cache
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_empty_sliding_window_cache_prefill(dtype: torch.dtype):
+    B, T, H, D, W = 2, 64, 2, 64, 16
+    torch.manual_seed(42)
+    layer = Parallax(
+        hidden_size=H * D,
+        num_heads=H,
+        window_size=W,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
+    next_hidden_states = torch.randn(B, 1, H * D, device=device, dtype=dtype)
+    tol = 0.005 if dtype == torch.float16 else 0.02
+
+    with torch.no_grad():
+        expected, _, _ = layer(hidden_states=hidden_states)
+        expected_next, _, _ = layer(hidden_states=torch.cat([hidden_states, next_hidden_states], dim=1))
+        cache = Cache()
+        actual, _, returned_cache = layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
+        actual_next, _, _ = layer(hidden_states=next_hidden_states, past_key_values=cache, use_cache=True)
+
+    assert_close("prefill", expected, actual, tol)
+    assert_close("decode", expected_next[:, -1:], actual_next, tol)
+    assert returned_cache is cache
+    cached_k, cached_v = cache[0]['attn_state']
+    assert cached_k.shape == cached_v.shape == (B, W, H * D)
+    assert cache.get_seq_length(0) == T + 1

--- a/tests/ops/test_parallax.py
+++ b/tests/ops/test_parallax.py
@@ -279,6 +279,7 @@ def _decode_ref(q, r, k, v, scale, window_size=None):
             (2, 1, 300, 2, 2, 100, 64),      # windowed decode, non-pow2 D
             (2, 64, 64, 2, 2, 64, None),     # full prefill == training causal
             (3, 200, 200, 2, 8, 64, 32),     # windowed prefill (GQA)
+            (2, 64, 32, 2, 2, 64, 16),       # cached KV shorter than query
         ]
     ],
 )
@@ -292,6 +293,11 @@ def test_decode(B: int, Sq: int, Skv: int, H: int, HQ: int, D: int, W, dtype: to
     r = torch.randn((B, Sq, HQ, D), dtype=dtype, device=device)
     k = torch.randn((B, Skv, H, D), dtype=dtype, device=device)
     v = torch.randn((B, Skv, H, D), dtype=dtype, device=device)
+
+    if Skv < Sq:
+        with pytest.raises(AssertionError, match="Cached KV length must cover query length"):
+            parallax_decode(q, r, k, v, window_size=W)
+        return
 
     ref = _decode_ref(q, r, k, v, scale=D ** -0.5, window_size=W)
     tri = parallax_decode(q, r, k, v, window_size=W)


### PR DESCRIPTION
## Summary

Fix Parallax forward with an empty sliding-window cache when the initial prompt is longer than the window.

The cache still stores only the window tail, while the first prefill uses the complete local K/V tensors. Subsequent cached calls continue to use the K/V tensors returned by the cache. This prevents `parallax_decode` from receiving `Skv < Sq` and computing a negative KV offset.

The decode entry point now also asserts its `Skv >= Sq` contract instead of silently producing invalid output.

## Test plan

Dependent tests identified with `python scripts/find_dependent_tests.py fla/layers/parallax.py fla/ops/parallax/decode.py`:

- `tests/layers/test_parallax_cache.py`
- `tests/models/test_modeling_parallax.py`
- `tests/ops/test_parallax.py`

Commands run on an NVIDIA RTX A1000 Laptop GPU:

- `uvx pre-commit run --files fla/layers/parallax.py fla/ops/parallax/decode.py tests/layers/test_parallax_cache.py tests/ops/test_parallax.py`
- `python -m pytest -q tests/layers/test_parallax_cache.py tests/ops/test_parallax.py -k 'empty_sliding_window_cache_prefill or test_decode'` (`32 passed`)
- `python -m pytest -q 'tests/models/test_modeling_parallax.py::test_generation[L2-B4-T2000-H8-D64-torch.float16]'` (`1 passed`)

## Benchmark / NCU (kernel changes only)

Neutral. No kernel code or performance behavior changed.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A: no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks).
