### PR TITLE
[Fix] Preserve full logits when computing CausalLM loss

### DIFF
--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -410,7 +410,11 @@ class ABCForCausalLM(ABCPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -454,7 +454,11 @@ class BitNetForCausalLM(BitNetPreTrainedModel, FLAGenerationMixin):
 
         hidden_states = outputs[0]
 
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
+        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+            hidden_states
+            if labels is not None or logits_to_keep is None
+            else hidden_states[:, -logits_to_keep:]
+        )
 
         loss = None
         if labels is not None:

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -421,7 +421,11 @@ class CombaForCausalLM(CombaPreTrainedModel, FLAUnsupportedCacheGenerationMixin)
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -410,7 +410,11 @@ class DeltaNetForCausalLM(DeltaNetPreTrainedModel, FLAUnsupportedCacheGeneration
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/deltaformer/modeling_deltaformer.py
+++ b/fla/models/deltaformer/modeling_deltaformer.py
@@ -360,7 +360,11 @@ class DeltaFormerForCausalLM(DeltaFormerPreTrainedModel, FLAUnsupportedCacheGene
 
         hidden_states = outputs[0]
         # For fused linear cross-entropy we do not materialize logits for the full sequence
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
+        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+            hidden_states
+            if labels is not None or logits_to_keep is None
+            else hidden_states[:, -logits_to_keep:]
+        )
 
         loss = None
         if labels is not None:

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -417,7 +417,11 @@ class ForgettingTransformerForCausalLM(ForgettingTransformerPreTrainedModel, FLA
 
         hidden_states = outputs[0]
 
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
+        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+            hidden_states
+            if labels is not None or logits_to_keep is None
+            else hidden_states[:, -logits_to_keep:]
+        )
 
         loss = None
         if labels is not None:

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -422,7 +422,11 @@ class GatedDeltaNetForCausalLM(GatedDeltaNetPreTrainedModel, FLAUnsupportedCache
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -412,7 +412,11 @@ class GatedDeltaProductForCausalLM(GatedDeltaProductPreTrainedModel, FLAUnsuppor
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -412,7 +412,11 @@ class GLAForCausalLM(GLAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -414,7 +414,11 @@ class GSAForCausalLM(GSAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -414,7 +414,11 @@ class HGRNForCausalLM(HGRNPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -415,7 +415,11 @@ class HGRN2ForCausalLM(HGRN2PreTrainedModel, FLAUnsupportedCacheGenerationMixin)
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/kda/modeling_kda.py
+++ b/fla/models/kda/modeling_kda.py
@@ -438,7 +438,11 @@ class KDAForCausalLM(KDAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, "criterion", None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -405,7 +405,11 @@ class LightNetForCausalLM(LightNetPreTrainedModel, FLAUnsupportedCacheGeneration
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -411,7 +411,11 @@ class LinearAttentionForCausalLM(LinearAttentionPreTrainedModel, FLAUnsupportedC
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
+++ b/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
@@ -467,7 +467,7 @@ class LogLinearMamba2ForCausalLM(LogLinearMamba2PreTrainedModel):
         if not fuse_linear_and_cross_entropy or labels is None:
             logits = self.lm_head(
                 hidden_states
-                if logits_to_keep is None
+                if labels is not None or logits_to_keep is None
                 else hidden_states[:, -logits_to_keep:],
             )
         if labels is not None:

--- a/fla/models/mamba/modeling_mamba.py
+++ b/fla/models/mamba/modeling_mamba.py
@@ -317,7 +317,11 @@ class MambaForCausalLM(MambaPreTrainedModel, FLAGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -386,7 +386,11 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel, FLAGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/mamba3/modeling_mamba3.py
+++ b/fla/models/mamba3/modeling_mamba3.py
@@ -301,7 +301,11 @@ class Mamba3ForCausalLM(Mamba3PreTrainedModel, FLAGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -408,7 +408,11 @@ class MesaNetForCausalLM(MesaNetPreTrainedModel, FLAUnsupportedCacheGenerationMi
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/mla/modeling_mla.py
+++ b/fla/models/mla/modeling_mla.py
@@ -394,7 +394,11 @@ class MLAForCausalLM(MLAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/moba/modeling_moba.py
+++ b/fla/models/moba/modeling_moba.py
@@ -377,7 +377,11 @@ class MoBAForCausalLM(MoBAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -514,7 +514,11 @@ class MomForCausalLM(MomPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         hidden_states = outputs[0]
         fuse_linear_and_cross_entropy = self.config.fuse_cross_entropy and self.training
-        logits = None if fuse_linear_and_cross_entropy else self.lm_head(hidden_states[:, -num_logits_to_keep:])
+        logits = None if fuse_linear_and_cross_entropy else self.lm_head(
+            hidden_states
+            if labels is not None or num_logits_to_keep is None
+            else hidden_states[:, -num_logits_to_keep:]
+        )
 
         loss = None
         aux_loss = None

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -412,7 +412,11 @@ class NSAForCausalLM(NSAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/parallax/modeling_parallax.py
+++ b/fla/models/parallax/modeling_parallax.py
@@ -396,7 +396,11 @@ class ParallaxForCausalLM(ParallaxPreTrainedModel, FLAGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -416,7 +416,11 @@ class PaTHAttentionForCausalLM(PaTHAttentionPreTrainedModel, FLAGenerationMixin)
 
         hidden_states = outputs[0]
 
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(hidden_states[:, -logits_to_keep:])
+        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+            hidden_states
+            if labels is not None or logits_to_keep is None
+            else hidden_states[:, -logits_to_keep:]
+        )
 
         loss = None
         if labels is not None:

--- a/fla/models/precond_gated_deltanet/modeling_precond_gated_deltanet.py
+++ b/fla/models/precond_gated_deltanet/modeling_precond_gated_deltanet.py
@@ -378,7 +378,11 @@ class PrecondGatedDeltaNetForCausalLM(PrecondGatedDeltaNetPreTrainedModel, FLAGe
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/precond_kda/modeling_precond_kda.py
+++ b/fla/models/precond_kda/modeling_precond_kda.py
@@ -371,7 +371,11 @@ class PrecondKDAForCausalLM(PrecondKDAPreTrainedModel, FLAGenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, "criterion", None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/fla/models/raven/modeling_raven.py
+++ b/fla/models/raven/modeling_raven.py
@@ -423,7 +423,11 @@ class RavenForCausalLM(RavenPreTrainedModel, FLAUnsupportedCacheGenerationMixin)
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -415,7 +415,11 @@ class RetNetForCausalLM(RetNetPreTrainedModel, FLAUnsupportedCacheGenerationMixi
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/rodimus/modeling_rodimus.py
+++ b/fla/models/rodimus/modeling_rodimus.py
@@ -522,7 +522,11 @@ class RodimusForCausalLM(RodimusPreTrainedModel, FLAUnsupportedCacheGenerationMi
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -409,7 +409,11 @@ class RWKV6ForCausalLM(RWKV6PreTrainedModel, FLAUnsupportedCacheGenerationMixin)
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -505,7 +505,11 @@ class RWKV7ForCausalLM(RWKV7PreTrainedModel, FLAUnsupportedCacheGenerationMixin)
         loss, logits = None, None
         has_labels = (labels is not None) or (shift_labels is not None)
         if not (self.config.fuse_linear_cross_entropy and has_labels):
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if has_labels or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if has_labels:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -411,7 +411,11 @@ class SambaForCausalLM(SambaPreTrainedModel, FLAGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -412,7 +412,11 @@ class TransformerForCausalLM(TransformerPreTrainedModel, FLAGenerationMixin):
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/wall_transformer/modeling_wall_transformer.py
+++ b/fla/models/wall_transformer/modeling_wall_transformer.py
@@ -426,7 +426,11 @@ class WallTransformerForCausalLM(WallTransformerPreTrainedModel, FLAGenerationMi
 
         loss, logits = None, None
         if not self.config.fuse_linear_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if self.config.fuse_linear_cross_entropy:

--- a/fla/models/yoco/modeling_yoco.py
+++ b/fla/models/yoco/modeling_yoco.py
@@ -712,7 +712,11 @@ class YOCOForCausalLM(YOCOPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
         loss, logits = None, None
         if not fuse_linear_and_cross_entropy or labels is None:
-            logits = self.lm_head(hidden_states if logits_to_keep is None else hidden_states[:, -logits_to_keep:])
+            logits = self.lm_head(
+                hidden_states
+                if labels is not None or logits_to_keep is None
+                else hidden_states[:, -logits_to_keep:]
+            )
         if labels is not None:
             if getattr(self, 'criterion', None) is None:
                 if fuse_linear_and_cross_entropy:

--- a/tests/models/test_modeling_gated_deltanet.py
+++ b/tests/models/test_modeling_gated_deltanet.py
@@ -8,7 +8,8 @@
 import pytest
 import torch
 
-from fla.models import GatedDeltaNetConfig
+from fla.models import GatedDeltaNetConfig, GatedDeltaNetForCausalLM
+from fla.utils import assert_close, device
 
 from .test_modeling_base import (
     run_test_generate_matches_forward,
@@ -96,3 +97,28 @@ def test_generate_prefill(
     dtype: torch.dtype,
 ):
     run_test_generate_matches_forward(L, B, T, H, D, GatedDeltaNetConfig, dtype)
+
+
+@torch.no_grad()
+def test_logits_to_keep_with_labels():
+    B, T, H, D, V = 2, 8, 2, 8, 32
+    config = GatedDeltaNetConfig(
+        hidden_size=H * D,
+        num_hidden_layers=1,
+        num_heads=H,
+        head_dim=D,
+        expand_v=1,
+        vocab_size=V,
+        fuse_cross_entropy=False,
+    )
+    model = GatedDeltaNetForCausalLM(config).eval().to(device)
+    input_ids = torch.randint(V, (B, T), device=device)
+
+    expected = model(input_ids, labels=input_ids)
+    actual = model(input_ids, labels=input_ids, logits_to_keep=1)
+    inference = model(input_ids, logits_to_keep=1)
+
+    assert actual.logits.shape == expected.logits.shape == (B, T, V)
+    assert inference.logits.shape == (B, 1, V)
+    assert torch.isfinite(actual.loss)
+    assert_close('loss', expected.loss, actual.loss, 1e-6)


### PR DESCRIPTION
## Summary

Fix CausalLM loss paths that applied a positive `logits_to_keep` even when labels were supplied, leaving logits shorter than labels and causing reshape failures or incorrect loss shapes. Calls with labels now materialize full-sequence logits, while inference-only calls retain logits slicing.

Affected scope: non-fused CausalLM loss calls using labels together with a positive `logits_to_keep` across the affected model implementations, on all supported dtypes and backends. There are no API or checkpoint compatibility changes.

## Test plan

- Unit test added: `tests/models/test_modeling_gated_deltanet.py::test_logits_to_keep_with_labels`
- Dependent-test discovery: `python scripts/find_dependent_tests.py <changed model files>` identified the touched model suites; the focused regression covers their shared CausalLM loss pattern.
- Passed: `/home/cherry-cloud/miniconda3/envs/cherry/bin/python -m pytest -q tests/models/test_modeling_gated_deltanet.py::test_logits_to_keep_with_labels`
- Passed: `uvx pre-commit run --files <changed files>`
- Varlen / CP tests: N/A; this change only affects CausalLM logits selection.

## Benchmark / NCU (kernel changes only)

Neutral. No kernel or performance-sensitive operator code changed.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.