### PR TITLE
[Perf] Add full-BT Ascend bwd paths for chunk_bwd_dqkwg and dv_local

### DIFF
--- a/fla/ops/common/backends/triton_ascend/chunk_o.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_o.py
@@ -23,7 +23,6 @@ from fla.utils.ascend_ub_manager import (
     max_grid_axis_chunks,
 )
 
-_NUM_WARPS = 4
 _BC_CANDIDATES = (32, 16)
 _O_MEM_MULT = 6.0
 _SAFETY_MARGIN = 0.80
@@ -31,6 +30,10 @@ _FALLBACK_BK = 16
 _FALLBACK_BV = 16
 _MAX_BK = 64
 _MAX_BV = 64
+_FULL_BT_BK_CANDIDATES = (64, 32, 16)
+_FULL_BT_BV_CANDIDATES = (64, 32, 16)
+_DV_FULL_BK_CANDIDATES = (128, 64, 32, 16)
+_DV_FULL_BV_CANDIDATES = (128, 64, 32, 16)
 # Peak UB estimate for bwd_dv_local n_sub==2 path (192 KiB on typical Ascend cores).
 _UB_BYTES = 196608
 
@@ -76,6 +79,100 @@ def _get_bc(BT: int, K: int, V: int) -> int:
     return 16
 
 
+def _dv_full_peak_bytes(BT: int, BK: int, BV: int) -> int:
+    """Phased peak UB for CUDA-style full-BT dv_local (A once, then V-loop).
+
+    K-loop: A[BT,BT] fp32 + k/q bf16 + one tl.dot workspace.
+    V-loop: A_pristine + lhs copy (tl.dot clobbers) + do bf16 + dv fp32.
+    """
+    kloop = BT * BT * 4 + BT * BK * 2 * 2 + BT * max(BT, BK) * 4
+    vloop = BT * BT * 4 * 2 + BT * BV * 2 + BT * BV * 4
+    return max(kloop, vloop)
+
+
+def _get_dv_full_tiles(BT: int, K: int, V: int) -> tuple[int, int] | None:
+    """Return (BK, BV) for full-BT dv_local, or None if it cannot fit UB."""
+    ub_budget = int(_UB_BYTES * _SAFETY_MARGIN)
+    k_cap = min(128, triton.next_power_of_2(K))
+    v_cap = min(128, triton.next_power_of_2(V))
+    for BK in _DV_FULL_BK_CANDIDATES:
+        if k_cap < BK:
+            continue
+        for BV in _DV_FULL_BV_CANDIDATES:
+            if v_cap < BV:
+                continue
+            if _dv_full_peak_bytes(BT, BK, BV) <= ub_budget:
+                return BK, BV
+    return None
+
+
+def _dqkwg_full_peak_bytes(BT: int, BK: int, BV: int, use_dw: bool) -> int:
+    """Phased peak UB for full-BT dqkwg with ds hoisted out of the K loop.
+
+    ds-pass: ds fp32 + do/v + trans(v) + one tl.dot workspace.
+    per-K V-loop: ds_keep bf16 + dq/dk[/dw] fp32 + do/v[/dv]/h/dh + workspace.
+    Frobenius <h,dh> is a separate Vector kernel (see dg_hdh).
+    Epilogue: ds_keep + lhs copy, q, k, dq, dk.
+    """
+    ds_pass = (
+        BT * BT * 4
+        + BT * BV * 2 * 2
+        + BT * BV * 2
+        + BT * max(BT, BV) * 4
+    )
+    k_vloop = (
+        BT * BT * 2
+        + BT * BK * 4 * (3 if use_dw else 2)
+        + BT * BV * 2 * (3 if use_dw else 2)
+        + BV * BK * 2 * 2
+        + BT * max(BK, BV) * 4
+    )
+    epilogue = (
+        BT * BT * 2 * 2
+        + BT * BK * 4 * 2
+        + BT * BK * 2 * 2
+        + BT * 4
+    )
+    return max(ds_pass, k_vloop, epilogue)
+
+
+def _get_dqkwg_full_tiles(BT: int, K: int, V: int, use_dw: bool) -> tuple[int, int] | None:
+    """Return (BK, BV) for the full-BT dqkwg path, or None if it cannot fit UB."""
+    ub_budget = int(_UB_BYTES * _SAFETY_MARGIN)
+    k_cap = min(_MAX_BK, triton.next_power_of_2(K))
+    v_cap = min(_MAX_BV, triton.next_power_of_2(V))
+    for BK in _FULL_BT_BK_CANDIDATES:
+        if k_cap < BK:
+            continue
+        for BV in _FULL_BT_BV_CANDIDATES:
+            if v_cap < BV:
+                continue
+            if _dqkwg_full_peak_bytes(BT, BK, BV, use_dw) <= ub_budget:
+                return BK, BV
+    return None
+
+
+_HDH_BK_CANDIDATES = (256, 128, 64, 32, 16)
+_HDH_BV_CANDIDATES = (256, 128, 64, 32, 16)
+
+
+def _get_hdh_tiles(K: int, V: int) -> tuple[int, int]:
+    """Tiles for the Vector-only Frobenius <h, dh> kernel."""
+    ub_budget = int(_UB_BYTES * _SAFETY_MARGIN)
+    k_cap = min(256, triton.next_power_of_2(K))
+    v_cap = min(256, triton.next_power_of_2(V))
+    for BK in _HDH_BK_CANDIDATES:
+        if k_cap < BK:
+            continue
+        for BV in _HDH_BV_CANDIDATES:
+            if v_cap < BV:
+                continue
+            peak = 2 * BK * BV * 2 + BK * BV * 4 + BK * 4
+            if peak <= ub_budget:
+                return BK, BV
+    return 16, 16
+
+
 def _g_npu_arg(g: torch.Tensor | None, HV: int) -> tuple[torch.Tensor | None, bool]:
     """Transpose g to [B, HV, T] when HV>1 for contiguous token-axis loads."""
     if g is None or HV == 1:
@@ -91,10 +188,10 @@ def _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN: tl.constexpr):
 
 
 @triton.jit
-def _g_block_ptr(g_base, g, T, offset, BC, G_T_CONTIG: tl.constexpr, HV: tl.constexpr):
+def _g_block_ptr(g_base, T, offset, BC, G_T_CONTIG: tl.constexpr, HV: tl.constexpr):
     if G_T_CONTIG:
         return tl.make_block_ptr(g_base, (T,), (1,), (offset,), (BC,), (0,))
-    return tl.make_block_ptr(g, (T,), (HV,), (offset,), (BC,), (0,))
+    return tl.make_block_ptr(g_base, (T,), (HV,), (offset,), (BC,), (0,))
 
 
 def get_npu_properties():
@@ -306,7 +403,9 @@ def chunk_fwd_o_npu(
     return o
 
 
-def _launch_bwd_2d_kernel(kernel, *, nt: int, bh_total: int, kernel_kwargs: dict) -> None:
+def _launch_bwd_2d_kernel(
+    kernel, *, nt: int, bh_total: int, kernel_kwargs: dict,
+) -> None:
     max_nt = max_grid_axis_chunks(nt, bh_total, max_grid=ASCEND_MAX_GRID_DIM)
     for nt_off in range(0, nt, max_nt):
         nt_len = min(max_nt, nt - nt_off)
@@ -321,7 +420,7 @@ def _launch_bwd_2d_kernel(kernel, *, nt: int, bh_total: int, kernel_kwargs: dict
         for bh_off in range(0, bh_total, max_bh):
             bh_len = min(max_bh, bh_total - bh_off)
             kernel_kwargs['BH_OFFSET'] = bh_off
-            kernel[(nt_len, bh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
+            kernel[(nt_len, bh_len)](**kernel_kwargs)
 
 
 def _launch_bwd_3d_kernel(
@@ -348,11 +447,11 @@ def _launch_bwd_3d_kernel(
             for bh_off in range(0, bh_total, max_bh):
                 bh_len = min(max_bh, bh_total - bh_off)
                 kernel_kwargs['BH_OFFSET'] = bh_off
-                kernel[(1, nt_len, bh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
+                kernel[(1, nt_len, bh_len)](**kernel_kwargs)
 
 
-@triton.jit(do_not_specialize=['T'])
-def chunk_bwd_kernel_dv_local_hv1_npu(
+@triton.jit(do_not_specialize=['T', 'task_num', 'num_core'])
+def chunk_bwd_kernel_dv_local_full_npu(
     q,
     k,
     g,
@@ -363,6 +462,9 @@ def chunk_bwd_kernel_dv_local_hv1_npu(
     chunk_indices,
     scale,
     T,
+    task_num,
+    num_core,
+    B: tl.constexpr,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
@@ -372,58 +474,70 @@ def chunk_bwd_kernel_dv_local_hv1_npu(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     USE_G_GAMMA: tl.constexpr,
+    G_T_CONTIG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    NT_OFFSET: tl.constexpr,
-    BH_OFFSET: tl.constexpr,
 ):
-    """Full-BT bwd_dv_local path for HV==1."""
-    i_t = tl.program_id(0) + NT_OFFSET
-    i_bh = tl.program_id(1) + BH_OFFSET
-    i_b, i_h = i_bh // HV, i_bh % HV
+    """CUDA-style full-BT dv_local on a 1D Cube core-grid.
 
-    if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-        T = (eos - bos).to(tl.int32)
-    else:
-        bos, eos = i_b * T, i_b * T + T
+    A[BT,BT] once per (chunk, head), then V-loop A @ do. Flatten tasks so
+    large NT·B·HV does not host-split at ASCEND_MAX_GRID_DIM. Rebind local
+    pointers every task — do not in-place += kernel args.
+    """
+    core_id = tl.program_id(0)
+    bh = B * HV
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t = task_id // bh
+        i_bh = task_id % bh
+        i_b, i_h = i_bh // HV, i_bh % HV
+        T_seq = T
+        T_cur = T
 
-    q += (bos * H + i_h // (HV // H)) * K
-    k += (bos * H + i_h // (HV // H)) * K
-    do += (bos * HV + i_h) * V
-    dv += (bos * HV + i_h) * V
+        if IS_VARLEN:
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T_cur = (eos - bos).to(tl.int32)
+        else:
+            bos = tl.cast(i_b, tl.int64) * T_seq
 
-    if USE_G:
-        g += bos * HV + i_h
-        p_g = tl.make_block_ptr(g, (T,), (HV,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
-    if USE_G_GAMMA:
-        b_gamma = tl.load(g_gamma + i_h)
-        b_g = b_gamma * (tl.arange(0, BT) + 1)
+        q_ptr = q + (bos * H + i_h // (HV // H)) * K
+        k_ptr = k + (bos * H + i_h // (HV // H)) * K
+        do_ptr = do + (bos * HV + i_h) * V
+        dv_ptr = dv + (bos * HV + i_h) * V
 
-    b_A = tl.zeros([BT, BT], dtype=tl.float32)
-    for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_q = tl.make_block_ptr(q, (K, T), (1, H * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_A += tl.dot(b_k, b_q, allow_tf32=False) * scale
-    if USE_G or USE_G_GAMMA:
-        b_A *= exp2(b_g[None, :] - b_g[:, None])
+        if USE_G:
+            if G_T_CONTIG:
+                g_base = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+            else:
+                g_base = g + bos * HV + i_h
+            p_g = _g_block_ptr(g_base, T_cur, i_t * BT, BT, G_T_CONTIG, HV)
+            b_g = tl.load(p_g, boundary_check=(0,))
+        if USE_G_GAMMA:
+            b_gamma = tl.load(g_gamma + i_h)
+            b_g = b_gamma * (tl.arange(0, BT) + 1)
 
-    o_t = i_t * BT + tl.arange(0, BT)
-    m_t = o_t < T
-    m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
-    b_A = tl.where(m_A, b_A, 0)
-    b_A_pristine = b_A + 0.0
+        b_A = tl.zeros([BT, BT], dtype=tl.float32)
+        for i_k in range(tl.cdiv(K, BK)):
+            p_k = tl.make_block_ptr(k_ptr, (T_cur, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_q = tl.make_block_ptr(q_ptr, (K, T_cur), (1, H * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_A += tl.dot(b_k, b_q, allow_tf32=False) * scale
+        if USE_G or USE_G_GAMMA:
+            b_A *= exp2(b_g[None, :] - b_g[:, None])
 
-    for i_v in range(tl.cdiv(V, BV)):
-        p_do = tl.make_block_ptr(do, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_do = tl.load(p_do, boundary_check=(0, 1))
-        b_A_i = b_A_pristine + 0.0
-        b_dv = tl.dot(b_A_i.to(b_do.dtype), b_do, allow_tf32=False)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T_cur
+        m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
+        b_A = tl.where(m_A, b_A, 0)
+        b_A_pristine = b_A + 0.0
+
+        for i_v in range(tl.cdiv(V, BV)):
+            p_do = tl.make_block_ptr(do_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_dv = tl.make_block_ptr(dv_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            b_do = tl.load(p_do, boundary_check=(0, 1))
+            b_A_i = b_A_pristine + 0.0
+            b_dv = tl.dot(b_A_i.to(b_do.dtype), b_do, allow_tf32=False)
+            tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -463,7 +577,7 @@ def chunk_bwd_kernel_dv_local_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = i_b * T
 
     q += (bos * H + i_h // (HV // H)) * K
     k += (bos * H + i_h // (HV // H)) * K
@@ -491,8 +605,8 @@ def chunk_bwd_kernel_dv_local_npu(
             b_dv1 = tl.zeros([BC, BV], dtype=tl.float32)
 
             if USE_G:
-                p_g0 = _g_block_ptr(g_base, g, T, i_tc0, BC, G_T_CONTIG, HV)
-                p_g1 = _g_block_ptr(g_base, g, T, i_tc1, BC, G_T_CONTIG, HV)
+                p_g0 = _g_block_ptr(g_base, T, i_tc0, BC, G_T_CONTIG, HV)
+                p_g1 = _g_block_ptr(g_base, T, i_tc1, BC, G_T_CONTIG, HV)
                 b_g0 = tl.load(p_g0, boundary_check=(0,))
                 b_g1 = tl.load(p_g1, boundary_check=(0,))
             if USE_G_GAMMA:
@@ -546,7 +660,7 @@ def chunk_bwd_kernel_dv_local_npu(
                 b_dv = tl.zeros([BC, BV], dtype=tl.float32)
 
                 if USE_G:
-                    p_gr = _g_block_ptr(g_base, g, T, i_tc_r, BC, G_T_CONTIG, HV)
+                    p_gr = _g_block_ptr(g_base, T, i_tc_r, BC, G_T_CONTIG, HV)
                     b_g_r = tl.load(p_gr, boundary_check=(0,))
                 if USE_G_GAMMA:
                     b_g_r = b_gamma * (r * BC + o_i + 1).to(tl.float32)
@@ -563,7 +677,7 @@ def chunk_bwd_kernel_dv_local_npu(
                         b_A += tl.dot(b_k, b_q, allow_tf32=False) * scale
 
                     if USE_G:
-                        p_gc = _g_block_ptr(g_base, g, T, i_tc_c, BC, G_T_CONTIG, HV)
+                        p_gc = _g_block_ptr(g_base, T, i_tc_c, BC, G_T_CONTIG, HV)
                         b_g_c = tl.load(p_gc, boundary_check=(0,))
                         b_A = b_A * exp2(b_g_c[None, :] - b_g_r[:, None])
                     if USE_G_GAMMA:
@@ -634,11 +748,10 @@ def chunk_bwd_kernel_dqkwg_npu(
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
-        NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)
         i_tg = i_b * NT + i_t
-        bos, eos = i_b * T, i_b * T + T
+        bos = i_b * T
 
     v += (bos * HV + i_h) * V
     do += (bos * HV + i_h) * V
@@ -714,7 +827,7 @@ def chunk_bwd_kernel_dqkwg_npu(
             b_dq_r += tl.dot(b_do_r, b_h.to(b_do_r.dtype), allow_tf32=False)
 
         if USE_G:
-            p_gr = _g_block_ptr(g_base, g, T, i_tc_r, BC, G_T_CONTIG, HV)
+            p_gr = _g_block_ptr(g_base, T, i_tc_r, BC, G_T_CONTIG, HV)
             b_gr = tl.load(p_gr, boundary_check=(0,)).to(tl.float32)
             b_dq_r = b_dq_r * exp2(b_gr)[:, None] * scale
         elif USE_G_GAMMA:
@@ -736,7 +849,7 @@ def chunk_bwd_kernel_dqkwg_npu(
                 b_ds += tl.dot(b_do_r2, tl.trans(b_v_c), allow_tf32=False)
 
             if USE_G:
-                p_gc = _g_block_ptr(g_base, g, T, i_tc_c, BC, G_T_CONTIG, HV)
+                p_gc = _g_block_ptr(g_base, T, i_tc_c, BC, G_T_CONTIG, HV)
                 b_gc = tl.load(p_gc, boundary_check=(0,)).to(tl.float32)
                 b_ds = b_ds * exp2(b_gr[:, None] - b_gc[None, :]) * scale
             elif USE_G_GAMMA:
@@ -785,7 +898,7 @@ def chunk_bwd_kernel_dqkwg_npu(
             b_dk_c += tl.dot(b_v.to(tl.float32), b_dh.to(tl.float32), allow_tf32=False)
 
         if USE_G:
-            p_gc = _g_block_ptr(g_base, g, T, i_tc_c, BC, G_T_CONTIG, HV)
+            p_gc = _g_block_ptr(g_base, T, i_tc_c, BC, G_T_CONTIG, HV)
             b_gc = tl.load(p_gc, boundary_check=(0,)).to(tl.float32)
             b_dk_c = b_dk_c * tl.where(m_c, exp2(-b_gc + b_g_last), 0)[:, None]
         elif USE_G_GAMMA:
@@ -797,6 +910,248 @@ def chunk_bwd_kernel_dqkwg_npu(
         p_dk_c = tl.make_block_ptr(dk, (T, K), (HV * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
         tl.store(p_dk_c, b_dk_c.to(p_dk_c.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk_acc, b_dk_c, boundary_check=(0, 1))
+
+
+@triton.jit(do_not_specialize=['T', 'task_num', 'num_core'])
+def chunk_bwd_kernel_dqkwg_full_npu(
+    q,
+    k,
+    v,
+    g,
+    g_gamma,
+    h,
+    do,
+    dh,
+    dq,
+    dk,
+    dw,
+    dv,
+    dg,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    task_num,
+    num_core,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_DW: tl.constexpr,
+    G_T_CONTIG: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """CUDA-style full-BT dq/dk/dw[/dg row-sums], 1D Cube core-grid.
+
+    Flatten (chunk, head) into task_id; each Cube core walks the list.
+    Avoids 2D grid mapping onto 24 AIC and host-splits at 65535.
+    Rebind local pointers every task — do not in-place += kernel args.
+    Frobenius <h, dh> for last-token dg is `chunk_bwd_kernel_dg_hdh_npu`.
+    """
+    core_id = tl.program_id(0)
+    bh = B * HV
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t = task_id // bh
+        i_bh = task_id % bh
+        i_b, i_h = i_bh // HV, i_bh % HV
+        T_seq = T
+        T_cur = T
+
+        if IS_VARLEN:
+            i_tg = i_t
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T_cur = (eos - bos).to(tl.int32)
+        else:
+            NT = tl.cdiv(T_seq, BT)
+            i_tg = i_b * NT + i_t
+            bos = tl.cast(i_b, tl.int64) * T_seq
+
+        v_ptr = v + (bos * HV + i_h) * V
+        do_ptr = do + (bos * HV + i_h) * V
+        h_ptr = h + (i_tg * HV + i_h).to(tl.int64) * K * V
+        dh_ptr = dh + (i_tg * HV + i_h).to(tl.int64) * K * V
+        q_ptr = q + (bos * H + i_h // (HV // H)) * K
+        k_ptr = k + (bos * H + i_h // (HV // H)) * K
+        dq_ptr = dq + (bos * HV + i_h) * K
+        dk_ptr = dk + (bos * HV + i_h) * K
+        if USE_DW:
+            dw_ptr = dw + (bos * HV + i_h) * K
+            dv_ptr = dv + (bos * HV + i_h) * V
+
+        if USE_G:
+            dg_head = dg + bos * HV + i_h
+            last_idx = min(i_t * BT + BT, T_cur) - 1
+            if G_T_CONTIG:
+                g_base = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+                b_g_last = tl.load(g_base + last_idx).to(tl.float32)
+            else:
+                g_base = g + bos * HV + i_h
+                b_g_last = tl.load(g_base + last_idx * HV).to(tl.float32)
+            p_g = _g_block_ptr(g_base, T_cur, i_t * BT, BT, G_T_CONTIG, HV)
+            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+        if USE_G_GAMMA:
+            b_gamma = tl.load(g_gamma + i_h)
+            b_g = b_gamma * (tl.arange(0, BT) + 1).to(tl.float32)
+            b_g_last = b_gamma * min(BT, T_cur - i_t * BT)
+
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T_cur
+        m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+
+        b_ds = tl.zeros([BT, BT], dtype=tl.float32)
+        for i_v in range(tl.cdiv(V, BV)):
+            p_v = tl.make_block_ptr(v_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_do = tl.make_block_ptr(do_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            b_v = tl.load(p_v, boundary_check=(0, 1))
+            b_do = tl.load(p_do, boundary_check=(0, 1))
+            b_ds += tl.dot(b_do, tl.trans(b_v), allow_tf32=False)
+
+        if USE_G or USE_G_GAMMA:
+            b_ds = tl.where(m_A, b_ds * exp2(b_g[:, None] - b_g[None, :]), 0) * scale
+        else:
+            b_ds = b_ds * m_A.to(tl.float32) * scale
+        b_ds_keep = b_ds.to(q.dtype.element_ty)
+
+        for i_k in range(tl.cdiv(K, BK)):
+            b_dq = tl.zeros([BT, BK], dtype=tl.float32)
+            b_dk = tl.zeros([BT, BK], dtype=tl.float32)
+            if USE_DW:
+                b_dw = tl.zeros([BT, BK], dtype=tl.float32)
+
+            for i_v in range(tl.cdiv(V, BV)):
+                p_v = tl.make_block_ptr(v_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_do = tl.make_block_ptr(do_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                if STATE_V_FIRST:
+                    p_h = tl.make_block_ptr(h_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                    p_dh = tl.make_block_ptr(dh_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                else:
+                    p_h = tl.make_block_ptr(h_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                    p_dh = tl.make_block_ptr(dh_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                b_v = tl.load(p_v, boundary_check=(0, 1))
+                b_do = tl.load(p_do, boundary_check=(0, 1))
+                b_h = tl.load(p_h, boundary_check=(0, 1))
+                b_dh = tl.load(p_dh, boundary_check=(0, 1))
+                b_dq += tl.dot(b_do, b_h.to(b_do.dtype), allow_tf32=False)
+                b_dk += tl.dot(b_v, b_dh.to(b_v.dtype), allow_tf32=False)
+                if USE_DW:
+                    p_dv = tl.make_block_ptr(dv_ptr, (T_cur, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                    b_dv = tl.load(p_dv, boundary_check=(0, 1))
+                    b_dw += tl.dot(b_dv.to(b_h.dtype), b_h.to(b_h.dtype), allow_tf32=False)
+
+            if USE_DW:
+                p_dw = tl.make_block_ptr(dw_ptr, (T_cur, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+                tl.store(p_dw, -b_dw.to(p_dw.dtype.element_ty), boundary_check=(0, 1))
+
+            p_q = tl.make_block_ptr(q_ptr, (T_cur, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_k = tl.make_block_ptr(k_ptr, (T_cur, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+
+            b_ds_lhs = b_ds_keep + 0.0
+            b_ds_rhs = b_ds_keep + 0.0
+            if USE_G or USE_G_GAMMA:
+                b_dq = b_dq * exp2(b_g)[:, None] * scale
+                b_dk = b_dk * tl.where(m_t, exp2(-b_g + b_g_last), 0)[:, None]
+                if USE_G:
+                    b_dg_last = tl.sum(b_dk * b_k.to(tl.float32))
+                b_dq += tl.dot(b_ds_lhs, b_k, allow_tf32=False)
+                b_dk += tl.dot(tl.trans(b_ds_rhs), b_q, allow_tf32=False)
+            else:
+                b_dq = b_dq * scale + tl.dot(b_ds_lhs, b_k, allow_tf32=False)
+                b_dk += tl.dot(tl.trans(b_ds_rhs), b_q, allow_tf32=False)
+
+            p_dq = tl.make_block_ptr(dq_ptr, (T_cur, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_dk = tl.make_block_ptr(dk_ptr, (T_cur, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+            if USE_G:
+                b_dg = tl.sum(b_dq * b_q.to(tl.float32), axis=1) - tl.sum(b_dk * b_k.to(tl.float32), axis=1)
+                b_dg = tl.where(o_t < last_idx, b_dg, b_dg + b_dg_last)
+                dg_k = dg_head + tl.cast(i_k, tl.int64) * tl.cast(B, tl.int64) * tl.cast(T_seq, tl.int64) * HV
+                p_dg = tl.make_block_ptr(dg_k, (T_cur,), (HV,), (i_t * BT,), (BT,), (0,))
+                tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.jit(do_not_specialize=['T', 'task_num', 'num_core'])
+def chunk_bwd_kernel_dg_hdh_npu(
+    h,
+    dh,
+    g,
+    dg,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    task_num,
+    num_core,
+    B: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    G_T_CONTIG: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Vector-core Frobenius <h, dh> * exp2(g_last) added to the last token of dg.
+
+    MIX Cube cannot vectorize the 64x64 fp32 mul-sum (~22 ms). This kernel has
+    no Cube tiles so the same reduction can run on all vector cores.
+    """
+    core_id = tl.program_id(0)
+    bh = B * HV
+    for task_id in tl.range(core_id, task_num, num_core):
+        i_t = task_id // bh
+        i_bh = task_id % bh
+        i_b, i_h = i_bh // HV, i_bh % HV
+        T_seq = T
+        T_cur = T
+
+        if IS_VARLEN:
+            i_tg = i_t
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+            T_cur = (eos - bos).to(tl.int32)
+        else:
+            NT = tl.cdiv(T_seq, BT)
+            i_tg = i_b * NT + i_t
+            bos = tl.cast(i_b, tl.int64) * T_seq
+
+        h_ptr = h + (i_tg * HV + i_h).to(tl.int64) * K * V
+        dh_ptr = dh + (i_tg * HV + i_h).to(tl.int64) * K * V
+        last_idx = min(i_t * BT + BT, T_cur) - 1
+        if G_T_CONTIG:
+            g_base = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
+            b_g_last = tl.load(g_base + last_idx).to(tl.float32)
+        else:
+            g_base = g + bos * HV + i_h
+            b_g_last = tl.load(g_base + last_idx * HV).to(tl.float32)
+
+        acc = 0.0
+        for i_k in range(tl.cdiv(K, BK)):
+            for i_v in range(tl.cdiv(V, BV)):
+                if STATE_V_FIRST:
+                    p_h = tl.make_block_ptr(h_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                    p_dh = tl.make_block_ptr(dh_ptr, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                else:
+                    p_h = tl.make_block_ptr(h_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                    p_dh = tl.make_block_ptr(dh_ptr, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                b_h = tl.load(p_h, boundary_check=(0, 1)).to(tl.float32)
+                b_dh = tl.load(p_dh, boundary_check=(0, 1)).to(tl.float32)
+                acc += tl.sum(tl.sum(b_h * b_dh, axis=1))
+
+        dg_ptr = dg + bos * HV + i_h
+        p_last = dg_ptr + tl.cast(last_idx, tl.int64) * HV
+        tl.store(p_last, tl.load(p_last) + acc * exp2(b_g_last))
 
 
 @triton.jit(do_not_specialize=['T'])
@@ -836,17 +1191,16 @@ def chunk_bwd_kernel_dg_npu(
     i_b, i_h = i_bh // HV, i_bh % HV
     T_seq = T
 
-    all = B * T
+    n_tokens = B * T
     if IS_VARLEN:
         i_tg = i_t
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
-        NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)
         i_tg = i_b * NT + i_t
-        bos, eos = i_b * T, i_b * T + T
+        bos = i_b * T
 
     v += (bos * HV + i_h) * V
     h += (i_tg * HV + i_h).to(tl.int64) * K * V
@@ -855,7 +1209,7 @@ def chunk_bwd_kernel_dg_npu(
     k += (bos * H + i_h // (HV // H)) * K
     dq_f32 += (bos * HV + i_h) * K
     dk_f32 += (bos * HV + i_h) * K
-    dg += i_k * all * HV
+    dg += i_k * n_tokens * HV
     dg += bos * HV + i_h
     if G_T_CONTIG:
         g_base = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
@@ -901,7 +1255,7 @@ def chunk_bwd_kernel_dg_npu(
 
         p_k_c = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc_c, i_k * BK), (BC, BK), (1, 0))
         b_k_c = tl.load(p_k_c, boundary_check=(0, 1))
-        p_gc = _g_block_ptr(g_base, g, T, i_tc_c, BC, G_T_CONTIG, HV)
+        p_gc = _g_block_ptr(g_base, T, i_tc_c, BC, G_T_CONTIG, HV)
         b_gc = tl.load(p_gc, boundary_check=(0,)).to(tl.float32)
         b_dk_pre = b_dk_pre * tl.where(m_c, exp2(-b_gc + b_g_last), 0)[:, None]
         b_dg_last += tl.sum(b_dk_pre * b_k_c.to(tl.float32))
@@ -944,12 +1298,19 @@ def chunk_bwd_dv_local_npu(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    BC = _get_bc(BT, K, V)
-    BK = _get_bk(K, BC)
-    BV = _get_bv(V, BC)
     use_g = g is not None
     use_g_gamma = g_gamma is not None
-    if not use_g and not use_g_gamma:
+    full_tiles = _get_dv_full_tiles(BT, K, V)
+    use_full = full_tiles is not None
+    if use_full:
+        BK, BV = full_tiles
+        bwd_kernel = chunk_bwd_kernel_dv_local_full_npu
+    else:
+        BC = _get_bc(BT, K, V)
+        BK = _get_bk(K, BC)
+        BV = _get_bv(V, BC)
+        bwd_kernel = chunk_bwd_kernel_dv_local_npu
+    if not use_g and not use_g_gamma and not use_full:
         g_arg = torch.zeros(B, T, HV, dtype=torch.float32, device=q.device)
         use_g = True
         g_t_contig = False
@@ -960,7 +1321,6 @@ def chunk_bwd_dv_local_npu(
         g_t_contig = False
 
     dv = torch.empty_like(do)
-    bwd_kernel = chunk_bwd_kernel_dv_local_hv1_npu if HV == 1 else chunk_bwd_kernel_dv_local_npu
     kernel_kwargs = {
         'q': q,
         'k': k,
@@ -981,19 +1341,25 @@ def chunk_bwd_dv_local_npu(
         'BV': BV,
         'USE_G': use_g,
         'USE_G_GAMMA': use_g_gamma,
+        'G_T_CONTIG': g_t_contig,
         'IS_VARLEN': cu_seqlens is not None,
-        'NT_OFFSET': 0,
-        'BH_OFFSET': 0,
     }
-    if HV != 1:
+    if use_full:
+        kernel_kwargs['B'] = B
+        num_core = get_npu_properties()["num_aicore"]
+        kernel_kwargs['task_num'] = NT * B * HV
+        kernel_kwargs['num_core'] = num_core
+        bwd_kernel[(num_core,)](**kernel_kwargs)
+    else:
         kernel_kwargs['BC'] = BC
-        kernel_kwargs['G_T_CONTIG'] = g_t_contig
-    _launch_bwd_2d_kernel(
-        bwd_kernel,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs=kernel_kwargs,
-    )
+        kernel_kwargs['NT_OFFSET'] = 0
+        kernel_kwargs['BH_OFFSET'] = 0
+        _launch_bwd_2d_kernel(
+            bwd_kernel,
+            nt=NT,
+            bh_total=B * HV,
+            kernel_kwargs=kernel_kwargs,
+        )
     return dv
 
 
@@ -1023,9 +1389,21 @@ def chunk_bwd_dqkwg_npu(
     if scale is None:
         scale = K ** -0.5
 
-    BC = _get_bc(BT, K, V)
-    BK = _get_bk(K, BC)
-    BV = _get_bv(V, BC)
+    use_dw = w is not None
+    # Ungated full-BT hits Triton-Ascend `tl.trans` cc→cc copy on Cube-resident
+    # ds[BT,BT]. Gated paths flush ds via exp2 (vector) and compile cleanly.
+    full_tiles = _get_dqkwg_full_tiles(BT, K, V, use_dw)
+    use_full = full_tiles is not None and (g is not None or g_gamma is not None)
+    if use_full:
+        BK, BV = full_tiles
+        dqkwg_kernel = chunk_bwd_kernel_dqkwg_full_npu
+    else:
+        BC = _get_bc(BT, K, V)
+        BK = _get_bk(K, BC)
+        BV = _get_bv(V, BC)
+        dqkwg_kernel = chunk_bwd_kernel_dqkwg_npu
+        dq_f32 = torch.empty(B, T, HV, K, dtype=torch.float32, device=q.device)
+        dk_f32 = torch.empty(B, T, HV, K, dtype=torch.float32, device=q.device)
     NK = triton.cdiv(K, BK)
     if g is not None:
         g_arg, g_t_contig = _g_npu_arg(g, HV)
@@ -1034,56 +1412,63 @@ def chunk_bwd_dqkwg_npu(
         g_t_contig = False
     dq = q.new_empty(B, T, HV, K)
     dk = k.new_empty(B, T, HV, K)
-    dq_f32 = torch.empty(B, T, HV, K, dtype=torch.float32, device=q.device)
-    dk_f32 = torch.empty(B, T, HV, K, dtype=torch.float32, device=q.device)
     dg = torch.empty(NK, *g.shape, dtype=torch.float32, device=g.device) if g is not None else None
-    dw = torch.empty_like(w) if w is not None else None
+    dw = torch.empty_like(w) if use_dw else None
 
-    _launch_bwd_3d_kernel(
-        chunk_bwd_kernel_dqkwg_npu,
-        nk=NK,
-        nt=NT,
-        bh_total=B * HV,
-        kernel_kwargs={
-            'q': q,
-            'k': k,
-            'v': v,
-            'g': g_arg,
-            'g_gamma': g_gamma,
-            'h': h,
-            'do': do,
-            'dh': dh,
-            'dw': dw,
-            'dq': dq,
-            'dk': dk,
-            'dq_f32': dq_f32,
-            'dk_f32': dk_f32,
-            'dv': dv,
-            'cu_seqlens': cu_seqlens,
-            'chunk_indices': chunk_indices,
-            'scale': scale,
-            'T': T,
-            'H': H,
-            'HV': HV,
-            'K': K,
-            'V': V,
-            'BT': BT,
-            'BC': BC,
-            'BK': BK,
-            'BV': BV,
-            'USE_G': g is not None,
-            'USE_G_GAMMA': g_gamma is not None,
-            'USE_DW': w is not None,
-            'G_T_CONTIG': g_t_contig,
-            'STATE_V_FIRST': state_v_first,
-            'IS_VARLEN': cu_seqlens is not None,
-            'K_OFFSET': 0,
-            'NT_OFFSET': 0,
-            'BH_OFFSET': 0,
-        },
-    )
+    dqkwg_kwargs = {
+        'q': q,
+        'k': k,
+        'v': v,
+        'g': g_arg,
+        'g_gamma': g_gamma,
+        'h': h,
+        'do': do,
+        'dh': dh,
+        'dw': dw,
+        'dq': dq,
+        'dk': dk,
+        'dv': dv,
+        'cu_seqlens': cu_seqlens,
+        'chunk_indices': chunk_indices,
+        'scale': scale,
+        'T': T,
+        'H': H,
+        'HV': HV,
+        'K': K,
+        'V': V,
+        'BT': BT,
+        'BK': BK,
+        'BV': BV,
+        'USE_G': g is not None,
+        'USE_G_GAMMA': g_gamma is not None,
+        'USE_DW': use_dw,
+        'G_T_CONTIG': g_t_contig,
+        'STATE_V_FIRST': state_v_first,
+        'IS_VARLEN': cu_seqlens is not None,
+    }
+    if use_full:
+        dqkwg_kwargs['dg'] = dg if dg is not None else dq
+        dqkwg_kwargs['B'] = B
+        num_core = get_npu_properties()["num_aicore"]
+        dqkwg_kwargs['task_num'] = NT * B * HV
+        dqkwg_kwargs['num_core'] = num_core
+        dqkwg_kernel[(num_core,)](**dqkwg_kwargs)
+    else:
+        dqkwg_kwargs['dq_f32'] = dq_f32
+        dqkwg_kwargs['dk_f32'] = dk_f32
+        dqkwg_kwargs['BC'] = BC
+        dqkwg_kwargs['K_OFFSET'] = 0
+        dqkwg_kwargs['NT_OFFSET'] = 0
+        dqkwg_kwargs['BH_OFFSET'] = 0
+        _launch_bwd_3d_kernel(
+            dqkwg_kernel,
+            nk=NK,
+            nt=NT,
+            bh_total=B * HV,
+            kernel_kwargs=dqkwg_kwargs,
+        )
 
-    if dg is not None:
+    if dg is not None and not use_full:
         _launch_bwd_3d_kernel(
             chunk_bwd_kernel_dg_npu,
             nk=NK,
@@ -1125,4 +1510,28 @@ def chunk_bwd_dqkwg_npu(
         dk = dk.view(B, T, H, HV // H, K).sum(3)
     if dg is not None:
         dg = dg.sum(0)
+        if use_full:
+            hdh_bk, hdh_bv = _get_hdh_tiles(K, V)
+            num_vec = get_npu_properties()["num_vectorcore"]
+            chunk_bwd_kernel_dg_hdh_npu[(num_vec,)](
+                h=h,
+                dh=dh,
+                g=g_arg,
+                dg=dg,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                T=T,
+                task_num=NT * B * HV,
+                num_core=num_vec,
+                B=B,
+                HV=HV,
+                K=K,
+                V=V,
+                BT=BT,
+                BK=hdh_bk,
+                BV=hdh_bv,
+                G_T_CONTIG=g_t_contig,
+                STATE_V_FIRST=state_v_first,
+                IS_VARLEN=cu_seqlens is not None,
+            )
     return dq, dk, dw, dg


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->
Add CUDA-style full-BT kernels for the Ascend (`triton_ascend`) backward ops `chunk_bwd_dqkwg_npu` and `chunk_bwd_dv_local_npu`. The previous BC-tiled loops were scalar-bound (Cube ~20%) because they split `ds`/`A` into `BC=32` sub-blocks and recomputed small gemms. Public API is unchanged; GPU path is untouched. UB-tight or ungated `dqkwg` still falls back to the BC kernels.
**1. Full-BT `chunk_bwd_kernel_dqkwg_full_npu` (gated, UB-safe)**
- Keep `ds[BT,BT] = do @ v.T` in UB, hoist it out of the K loop, then V-loop `do@h` / `v@dh` / `dv@h`.
- Fuse dg row-sums (`sum(dq·q) - sum(dk·k)` + last-token `dg_last`) so the separate BC-tiled `chunk_bwd_kernel_dg_npu` is not launched and `dq_f32`/`dk_f32` scratch is not allocated.
- Split Frobenius `⟨h, dh⟩` to Vector-only `chunk_bwd_kernel_dg_hdh_npu`: MIX Cube cannot vectorize the 64×64 fp32 mul-sum (~22 ms).
- Ungated full-BT is skipped: Triton-Ascend `tl.trans` cc→cc copy on Cube-resident `ds[BT,BT]` does not compile cleanly; gated `exp2` flushes `ds` to Vector first.
**2. Full-BT `chunk_bwd_kernel_dv_local_full_npu` (any HV)**
- Compute `A[BT,BT] = k@q` once per (chunk, head), then V-loop `A @ do`. Replaces the HV==1-only full-BT kernel and the BC path that recomputed `k@q` per V-tile.
- Tile pick via phased UB model (`BK`/`BV` up to 128).
**3. Launch / UB**
- Flatten `(chunk, head)` onto a 1D Cube core-grid (`grid=(num_aicore,)`, `task_num=NT·B·HV`) so large `NT·B·HV` does not host-split at `ASCEND_MAX_GRID_DIM`. Rebind local pointers every task.
- Drop hardcoded `num_warps`. `_g_block_ptr` always uses `g_base`.


## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->
hardware: Atlas 800T A3(X86)
FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules tests/ops/utils tests/ops/test_gdn_kernels.py tests/ops/test_gdn.py tests/ops/test_kda.py tests/ops/test_attnres.py tests/ops/test_solve_tril.py tests/ops/test_gla.py
<img width="1205" height="485" alt="image" src="https://github.com/user-attachments/assets/ea68d5e9-4a4d-4b75-9370-14f0e7b77456" />


## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
<img width="1135" height="682" alt="image" src="https://github.com/user-attachments/assets/b4e04714-4a09-4113-8e3a-467e2b49642d" />


## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->
None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [x] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.

### If you ticked the "minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
Justify here why yours is worth a maintainer's review time — minor PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
