### PR TITLE
[Fix] Reject invalid cache/mask/cu_seqlens combos and degenerate inputs across layers

### DIFF
--- a/fla/layers/attn.py
+++ b/fla/layers/attn.py
@@ -125,6 +125,8 @@ class Attention(nn.Module):
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
+            assert cu_seqlens is None or not cache_has_content, \
+                "cu_seqlens should not be provided when past_key_values has content"
             k_cached, v_cached = past_key_values.update(
                 attn_state=(k.flatten(-2, -1), v.flatten(-2, -1)),
                 layer_idx=self.layer_idx,

--- a/fla/layers/bitattn.py
+++ b/fla/layers/bitattn.py
@@ -113,6 +113,8 @@ class BitAttention(nn.Module):
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
+            assert cu_seqlens is None or not cache_has_content, \
+                "cu_seqlens should not be provided when past_key_values has content"
             k_cached, v_cached = past_key_values.update(
                 attn_state=(k.flatten(-2, -1), v.flatten(-2, -1)),
                 layer_idx=self.layer_idx,

--- a/fla/layers/deltaformer.py
+++ b/fla/layers/deltaformer.py
@@ -16,7 +16,6 @@ from transformers.utils import logging
 
 from fla.modules import RMSNorm, RotaryEmbedding
 from fla.ops.deltaformer import deltaformer_attn
-from fla.ops.utils.index import prepare_lens_from_mask
 
 if TYPE_CHECKING:
     from fla.models.utils import Cache
@@ -57,7 +56,7 @@ class DeltaFormerAttention(nn.Module):
         max_position_embeddings (int, Optional):
             The maximum position embeddings. Default: None.
         layer_idx (int, Optional):
-            The index of the layer (used for cache compatibility). Default: None.
+            The index of the layer. Default: None.
     """
 
     def __init__(
@@ -125,19 +124,14 @@ class DeltaFormerAttention(nn.Module):
             q, k = self.q_norm(q), self.k_norm(k)
 
         cu_seqlens_kw = kwargs.get('cu_seqlens')
-        seqlen_offset, max_seqlen = 0, q_len
         if past_key_values is not None:
-            seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q_len + seqlen_offset
+            raise NotImplementedError("DeltaFormerAttention does not support `past_key_values`")
 
-            if attention_mask is not None:
-                seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q_len + max(seqlen_offset)
-
+        max_seqlen = q_len
         if self.max_position_embeddings is not None:
             max_seqlen = max(max_seqlen, self.max_position_embeddings)
 
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens_kw)
+        q, k = self.rotary(q, k, seqlen_offset=0, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens_kw)
 
         o = deltaformer_attn(
             q=q,

--- a/fla/layers/forgetting_attn.py
+++ b/fla/layers/forgetting_attn.py
@@ -106,6 +106,8 @@ class ForgettingAttention(nn.Module):
         if past_key_values is not None:
             assert cu_seqlens is None, "cu_seqlens should not be provided when past_key_values is not None"
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
+            if cache_has_content:
+                assert q_len == 1, "only support q_len == 1 for decoding"
             state = past_key_values.update(
                 attn_state=(k, v, f),
                 layer_idx=self.layer_idx,
@@ -126,7 +128,6 @@ class ForgettingAttention(nn.Module):
             cu_seqlens = cu_seqlens_k
             max_seqlen_q, max_seqlen_k = max_seq_lens
             if max_seqlen_q != max_seqlen_k:
-                assert max_seqlen_q == 1, "only support q_len == 1 for decoding"
                 o = attn_decoding_one_step(q, k, v, f, cu_seqlens=cu_seqlens)
             else:
                 o = parallel_forgetting_attn(q, k, v, f, cu_seqlens=cu_seqlens)

--- a/fla/layers/forgetting_attn.py
+++ b/fla/layers/forgetting_attn.py
@@ -105,13 +105,15 @@ class ForgettingAttention(nn.Module):
         cu_seqlens = kwargs.get('cu_seqlens')
         if past_key_values is not None:
             assert cu_seqlens is None, "cu_seqlens should not be provided when past_key_values is not None"
+            cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
             state = past_key_values.update(
                 attn_state=(k, v, f),
                 layer_idx=self.layer_idx,
                 offset=q_len,
                 cache_kwargs=dict(window_size=self.window_size),
             )
-            k, v, f = state['attn_state']
+            if cache_has_content:
+                k, v, f = state['attn_state']
 
         q = rearrange(q, '... (h d) -> ... h d', d=self.head_dim)
         k = rearrange(k, '... (h d) -> ... h d', d=self.head_dim)
@@ -129,6 +131,7 @@ class ForgettingAttention(nn.Module):
             else:
                 o = parallel_forgetting_attn(q, k, v, f, cu_seqlens=cu_seqlens)
         else:
+            assert q.shape[1] == k.shape[1], "only support q_len == kv_len when attention_mask is None"
             o = parallel_forgetting_attn(q, k, v, f, cu_seqlens=cu_seqlens)
         if indices_q is not None:
             o = pad_input(o.squeeze(0), indices_q, batch_size, q_len)

--- a/fla/layers/lightnet.py
+++ b/fla/layers/lightnet.py
@@ -173,8 +173,8 @@ class LightNetAttention(nn.Module):
         last_z = last_state['ffn_state'] if last_state is not None and last_state.get('ffn_state') is not None else None
         if last_z is not None:
             # Decode path: continue logcumsumexp from cached state
-            z = torch.logaddexp(last_z, k.float())
-            k, g = torch.exp(k - z).to(k.dtype), (last_z - z).to(k.dtype)
+            z = torch.logaddexp(last_z, k.float().logcumsumexp(1))
+            k, g = torch.exp(k - z).to(k.dtype), (torch.cat((last_z, z[:, :-1]), 1) - z).to(k.dtype)
         else:
             # Prefill path: mask padding positions to -inf so they don't affect logcumsumexp
             if cu_seqlens is not None:

--- a/fla/layers/mamba.py
+++ b/fla/layers/mamba.py
@@ -406,6 +406,9 @@ class Mamba(nn.Module):
         output_attentions: bool | None = False,
         **kwargs: Unpack[dict],
     ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+        if hidden_states.shape[1] == 0:
+            return hidden_states, None, past_key_values
+
         last_state = get_layer_cache(self, past_key_values)
 
         if is_fast_path_available and "cuda" in self.x_proj.weight.device.type:

--- a/fla/layers/mamba2.py
+++ b/fla/layers/mamba2.py
@@ -678,6 +678,9 @@ class Mamba2(nn.Module):
         output_attentions: bool | None = False,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor | None, Cache | None]:
+        if hidden_states.shape[1] == 0:
+            return hidden_states, None, past_key_values
+
         last_state = get_layer_cache(self, past_key_values)
 
         if is_fast_path_available and "cuda" in self.in_proj.weight.device.type:

--- a/fla/layers/mla.py
+++ b/fla/layers/mla.py
@@ -177,6 +177,8 @@ class MultiheadLatentAttention(nn.Module):
         # and recover the full k, v from compressed_kv and k_rot
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
+            assert cu_seqlens is None or not cache_has_content, \
+                "cu_seqlens should not be provided when past_key_values has content"
             k_cached, v_cached = past_key_values.update(
                 attn_state=(k, v),
                 layer_idx=self.layer_idx,

--- a/fla/layers/moba.py
+++ b/fla/layers/moba.py
@@ -191,7 +191,6 @@ class MoBA(nn.Module):
         q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
-            assert cu_seqlens is None, "cu_seqlens should not be provided when past_key_values is not None"
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
             assert cu_seqlens is None or not cache_has_content, \
                 "cu_seqlens should not be provided when past_key_values has content"

--- a/fla/layers/moba.py
+++ b/fla/layers/moba.py
@@ -191,6 +191,7 @@ class MoBA(nn.Module):
         q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
+            assert cu_seqlens is None, "cu_seqlens should not be provided when past_key_values is not None"
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
             k_cached, v_cached = past_key_values.update(
                 attn_state=(k.flatten(-2, -1), v.flatten(-2, -1)),

--- a/fla/layers/moba.py
+++ b/fla/layers/moba.py
@@ -193,6 +193,8 @@ class MoBA(nn.Module):
         if past_key_values is not None:
             assert cu_seqlens is None, "cu_seqlens should not be provided when past_key_values is not None"
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
+            assert cu_seqlens is None or not cache_has_content, \
+                "cu_seqlens should not be provided when past_key_values has content"
             k_cached, v_cached = past_key_values.update(
                 attn_state=(k.flatten(-2, -1), v.flatten(-2, -1)),
                 layer_idx=self.layer_idx,

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -236,7 +236,7 @@ class MultiScaleRetention(nn.Module):
 
             if attention_mask is not None and seqlen_offset > 0:
                 # to eliminate the offsets of padding tokens
-                seqlen_offset = prepare_lens_from_mask(attention_mask) - q_len
+                seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
                 max_seqlen = q.shape[1] + seqlen_offset.max().item()
 
         q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)

--- a/fla/layers/nsa.py
+++ b/fla/layers/nsa.py
@@ -110,6 +110,8 @@ class NativeSparseAttention(nn.Module):
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
+            assert cu_seqlens is None or not cache_has_content, \
+                "cu_seqlens should not be provided when past_key_values has content"
             k_cached, v_cached = past_key_values.update(
                 attn_state=(k.flatten(-2, -1), v.flatten(-2, -1)),
                 layer_idx=self.layer_idx,

--- a/fla/layers/path_attn.py
+++ b/fla/layers/path_attn.py
@@ -133,6 +133,7 @@ class PaTHAttention(nn.Module):
                 last_state = None
             # Decoding
             if last_state is not None:
+                assert q_len == 1, "only support q_len == 1 for decoding"
                 if g is not None:
                     past_k, past_v, past_g = last_state['attn_state']
                 else:
@@ -177,7 +178,6 @@ class PaTHAttention(nn.Module):
                 q = rearrange(q, '... (h d) -> ... h d', d=self.head_dim)
                 k = rearrange(k, '... (h d) -> ... h d', d=self.head_dim)
                 v = rearrange(v, '... (h d) -> ... h d', d=self.head_dim)
-                assert max_seqlen_q == 1, "only support q_len == 1 for decoding"
                 o = attn_decoding_one_step(q, k, v, g, cu_seqlens=cu_seqlens, do_gate_scale=True)  # reduced to fox's decoding
             # Prefilling
             else:

--- a/fla/layers/rwkv6.py
+++ b/fla/layers/rwkv6.py
@@ -129,6 +129,8 @@ class RWKV6Attention(nn.Module):
             )
 
         batch_size, seq_len, hidden_size = hidden_states.shape
+        if seq_len == 0:
+            return hidden_states, None, past_key_values
         # launching the triton kernel for just one token will actually be slower
         mode = 'fused_recurrent' if hidden_states.shape[1] <= 64 else self.mode
 

--- a/fla/layers/wall_attn.py
+++ b/fla/layers/wall_attn.py
@@ -163,6 +163,7 @@ class WallAttention(nn.Module):
 
         if past_key_values is not None:
             assert cu_seqlens is None, "cu_seqlens should not be provided when past_key_values is not None"
+            assert attention_mask is None, "attention_mask should not be provided when past_key_values is not None"
             if self.window_size is None:
                 # Non-windowed: cache the *pre-rescaled* decode state and extend it one
                 # column per step, so prep is O(q_len) instead of rebuilding k_tilde/P
@@ -171,6 +172,7 @@ class WallAttention(nn.Module):
             else:
                 # Windowed: a rolling raw (k, v, g) cache; chunk anchors must track the
                 # window, so rebuild the rescale each step from the cached suffix.
+                cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
                 cached = (k, v, g, gs) if self.use_scalar_gate else (k, v, g)
                 state = past_key_values.update(
                     attn_state=cached,
@@ -178,10 +180,11 @@ class WallAttention(nn.Module):
                     offset=q_len,
                     cache_kwargs=dict(window_size=self.window_size),
                 )['attn_state']
-                if self.use_scalar_gate:
-                    k, v, g, gs = state
-                else:
-                    k, v, g = state
+                if cache_has_content:
+                    if self.use_scalar_gate:
+                        k, v, g, gs = state
+                    else:
+                        k, v, g = state
                 kv_len = k.shape[1]
                 if q_len < kv_len:
                     o = self._decode_rebuild(q, k, v, g, gs)

--- a/fla/layers/wall_attn.py
+++ b/fla/layers/wall_attn.py
@@ -163,7 +163,9 @@ class WallAttention(nn.Module):
 
         if past_key_values is not None:
             assert cu_seqlens is None, "cu_seqlens should not be provided when past_key_values is not None"
-            assert attention_mask is None, "attention_mask should not be provided when past_key_values is not None"
+            cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
+            assert attention_mask is None or not cache_has_content, \
+                "attention_mask should not be provided when past_key_values has content"
             if self.window_size is None:
                 # Non-windowed: cache the *pre-rescaled* decode state and extend it one
                 # column per step, so prep is O(q_len) instead of rebuilding k_tilde/P
@@ -172,7 +174,6 @@ class WallAttention(nn.Module):
             else:
                 # Windowed: a rolling raw (k, v, g) cache; chunk anchors must track the
                 # window, so rebuild the rescale each step from the cached suffix.
-                cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
                 cached = (k, v, g, gs) if self.use_scalar_gate else (k, v, g)
                 state = past_key_values.update(
                     attn_state=cached,

--- a/fla/layers/yoco.py
+++ b/fla/layers/yoco.py
@@ -183,7 +183,7 @@ class YOCOGatedRetention(nn.Module):
             max_seqlen = q.shape[1] + seqlen_offset
 
             if attention_mask is not None and seqlen_offset > 0:
-                seqlen_offset = prepare_lens_from_mask(attention_mask) - q_len
+                seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
                 max_seqlen = attention_mask.shape[-1]
 
         if self.max_position_embeddings is not None:
@@ -297,6 +297,8 @@ class YOCOSharedKVBuilder(nn.Module):
         if use_cache and past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
             max_seqlen = k.shape[1] + seqlen_offset
+            if seqlen_offset > 0:
+                assert q_len == 1, "only support q_len == 1 for decoding"
 
         if attention_mask is not None and (past_key_values is None or use_cache):
             # Left-padded prefills should use the same effective RoPE positions as the unpadded sequence.
@@ -419,7 +421,6 @@ class YOCOCrossAttention(nn.Module):
             _, cu_seqlens = cu_seqlens
             max_seqlen_q, max_seqlen_k = max_seq_lens
             if max_seqlen_q != max_seqlen_k:
-                assert max_seqlen_q == 1, "only support q_len == 1 for decoding"
                 o = attn_decoding_one_step(q, shared_k, shared_v, cu_seqlens=cu_seqlens)
             else:
                 o = parallel_attn(q, shared_k, shared_v, window_size=self.window_size, cu_seqlens=cu_seqlens)

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -454,7 +454,7 @@ class BitNetForCausalLM(BitNetPreTrainedModel, FLAGenerationMixin):
 
         hidden_states = outputs[0]
 
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+        logits = None if self.config.fuse_linear_cross_entropy and labels is not None else self.lm_head(
             hidden_states
             if labels is not None or logits_to_keep is None
             else hidden_states[:, -logits_to_keep:]

--- a/fla/models/deltaformer/modeling_deltaformer.py
+++ b/fla/models/deltaformer/modeling_deltaformer.py
@@ -360,7 +360,7 @@ class DeltaFormerForCausalLM(DeltaFormerPreTrainedModel, FLAUnsupportedCacheGene
 
         hidden_states = outputs[0]
         # For fused linear cross-entropy we do not materialize logits for the full sequence
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+        logits = None if self.config.fuse_linear_cross_entropy and labels is not None else self.lm_head(
             hidden_states
             if labels is not None or logits_to_keep is None
             else hidden_states[:, -logits_to_keep:]

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -417,7 +417,7 @@ class ForgettingTransformerForCausalLM(ForgettingTransformerPreTrainedModel, FLA
 
         hidden_states = outputs[0]
 
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+        logits = None if self.config.fuse_linear_cross_entropy and labels is not None else self.lm_head(
             hidden_states
             if labels is not None or logits_to_keep is None
             else hidden_states[:, -logits_to_keep:]

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -416,7 +416,7 @@ class PaTHAttentionForCausalLM(PaTHAttentionPreTrainedModel, FLAGenerationMixin)
 
         hidden_states = outputs[0]
 
-        logits = None if self.config.fuse_linear_cross_entropy else self.lm_head(
+        logits = None if self.config.fuse_linear_cross_entropy and labels is not None else self.lm_head(
             hidden_states
             if labels is not None or logits_to_keep is None
             else hidden_states[:, -logits_to_keep:]

--- a/fla/ops/gated_delta_product/naive.py
+++ b/fla/ops/gated_delta_product/naive.py
@@ -8,9 +8,29 @@
 import torch
 
 
-def naive_recurrent_gated_delta_product(q, k, v, g, beta, scale, cu_seqlens,
+def naive_recurrent_gated_delta_product(q, k, v, g, beta, scale, cu_seqlens=None,
                                         initial_state=None, output_final_state=False,
                                         num_householder=1):
+    if cu_seqlens is not None:
+        outputs, final_states = [], []
+        offsets = cu_seqlens.tolist()
+        for i, (bos, eos) in enumerate(zip(offsets[:-1], offsets[1:], strict=False)):
+            o_i, h_i = naive_recurrent_gated_delta_product(
+                q=q[:, bos:eos],
+                k=k[:, bos*num_householder:eos*num_householder],
+                v=v[:, bos*num_householder:eos*num_householder],
+                g=None if g is None else g[:, bos:eos],
+                beta=beta[:, bos*num_householder:eos*num_householder],
+                scale=scale,
+                initial_state=None if initial_state is None else initial_state[i:i + 1],
+                output_final_state=output_final_state,
+                num_householder=num_householder,
+            )
+            outputs.append(o_i)
+            final_states.append(h_i)
+
+        return torch.cat(outputs, dim=1), torch.cat(final_states)
+
     q_original_dtype = q.dtype
     B, T, H, K = q.shape
     V = v.shape[-1]

--- a/tests/layers/test_cu_seqlens_cache_guard.py
+++ b/tests/layers/test_cu_seqlens_cache_guard.py
@@ -41,7 +41,7 @@ except ImportError:
         ),
         pytest.param(
             NativeSparseAttention,
-            dict(hidden_size=128, num_heads=2, num_kv_heads=1, head_dim=64, block_size=32, block_counts=2,
+            dict(hidden_size=128, num_heads=16, num_kv_heads=1, head_dim=64, block_size=32, block_counts=2,
                  window_size=16, layer_idx=0),
             False,
             id="nsa",

--- a/tests/layers/test_cu_seqlens_cache_guard.py
+++ b/tests/layers/test_cu_seqlens_cache_guard.py
@@ -43,7 +43,7 @@ except ImportError:
             NativeSparseAttention,
             dict(hidden_size=128, num_heads=16, num_kv_heads=1, head_dim=64, block_size=32, block_counts=2,
                  window_size=16, layer_idx=0),
-            False,
+            True,
             id="nsa",
         ),
         pytest.param(

--- a/tests/layers/test_cu_seqlens_cache_guard.py
+++ b/tests/layers/test_cu_seqlens_cache_guard.py
@@ -36,7 +36,7 @@ except ImportError:
         pytest.param(
             MoBA,
             dict(hidden_size=128, num_heads=2, num_kv_heads=2, moba_chunk_size=32, moba_topk=2, layer_idx=0),
-            False,
+            True,
             id="moba",
         ),
         pytest.param(

--- a/tests/layers/test_cu_seqlens_cache_guard.py
+++ b/tests/layers/test_cu_seqlens_cache_guard.py
@@ -8,6 +8,7 @@
 import pytest
 import torch
 
+from fla.layers.attn import Attention
 from fla.layers.bitattn import BitAttention
 from fla.layers.mla import MultiheadLatentAttention
 from fla.layers.moba import MoBA
@@ -50,6 +51,12 @@ except ImportError:
             dict(hidden_size=128, num_heads=2, num_kv_heads=2, layer_idx=0),
             True,
             id="bitattn",
+        ),
+        pytest.param(
+            Attention,
+            dict(hidden_size=128, num_heads=2, layer_idx=0),
+            True,
+            id="attn",
         ),
     ],
 )

--- a/tests/layers/test_cu_seqlens_cache_guard.py
+++ b/tests/layers/test_cu_seqlens_cache_guard.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.bitattn import BitAttention
+from fla.layers.mla import MultiheadLatentAttention
+from fla.layers.moba import MoBA
+from fla.layers.nsa import NativeSparseAttention
+from fla.models.utils import Cache
+from fla.utils import device
+
+try:
+    import flash_attn  # noqa: F401
+    HAS_FLASH = True
+except ImportError:
+    HAS_FLASH = False
+
+
+@pytest.mark.parametrize(
+    ("layer_cls", "layer_kwargs", "requires_flash"),
+    [
+        pytest.param(
+            MultiheadLatentAttention,
+            dict(hidden_size=128, num_heads=2, q_lora_rank=None, qk_rope_head_dim=32, kv_lora_rank=64,
+                 v_head_dim=64, qk_nope_head_dim=64, qk_head_dim=None, layer_idx=0),
+            True,
+            id="mla",
+        ),
+        pytest.param(
+            MoBA,
+            dict(hidden_size=128, num_heads=2, num_kv_heads=2, moba_chunk_size=32, moba_topk=2, layer_idx=0),
+            False,
+            id="moba",
+        ),
+        pytest.param(
+            NativeSparseAttention,
+            dict(hidden_size=128, num_heads=2, num_kv_heads=1, head_dim=64, block_size=32, block_counts=2,
+                 window_size=16, layer_idx=0),
+            False,
+            id="nsa",
+        ),
+        pytest.param(
+            BitAttention,
+            dict(hidden_size=128, num_heads=2, num_kv_heads=2, layer_idx=0),
+            True,
+            id="bitattn",
+        ),
+    ],
+)
+def test_cu_seqlens_rejected_with_non_empty_cache(layer_cls: type, layer_kwargs: dict, requires_flash: bool):
+    if requires_flash and not HAS_FLASH:
+        pytest.skip(reason="Skipping test because flash-attn is not installed")
+
+    torch.manual_seed(42)
+    layer = layer_cls(**layer_kwargs).to(device=device, dtype=torch.float16).eval()
+    prefill_states = torch.randn(2, 64, 128, device=device, dtype=torch.float16)
+    packed_states = torch.randn(1, 16, 128, device=device, dtype=torch.float16)
+    cu_seqlens = torch.tensor([0, 7, 16], device=device, dtype=torch.int32)
+
+    cache = Cache()
+    layer(hidden_states=packed_states, past_key_values=cache, cu_seqlens=cu_seqlens, use_cache=True)
+
+    cache = Cache()
+    layer(hidden_states=prefill_states, past_key_values=cache, use_cache=True)
+    with pytest.raises(AssertionError, match="cu_seqlens should not be provided"):
+        layer(hidden_states=packed_states, past_key_values=cache, cu_seqlens=cu_seqlens, use_cache=True)

--- a/tests/layers/test_deltaformer_cache.py
+++ b/tests/layers/test_deltaformer_cache.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.deltaformer import DeltaFormerAttention
+from fla.models.utils import Cache
+from fla.utils import device, find_spec_cached
+
+# Mark (not importorskip): a fully skipped module reports "no tests collected" and exits
+# with code 5, which CI per-file loops treat as a failure.
+pytestmark = pytest.mark.skipif(find_spec_cached(
+    "flash_attn") is None, reason="DeltaFormer attention requires flash-attn (`pip install flash-attn --no-build-isolation`).")
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_cache_request_rejected(dtype: torch.dtype):
+    B, T, H, D = 2, 64, 2, 64
+    torch.manual_seed(42)
+    layer = DeltaFormerAttention(
+        hidden_size=H * D,
+        num_heads=H,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
+    next_hidden_states = torch.randn(B, 1, H * D, device=device, dtype=dtype)
+    cache = Cache()
+
+    with torch.no_grad():
+        o, _, past_key_values = layer(hidden_states=hidden_states)
+        assert o.shape == (B, T, H * D)
+        assert past_key_values is None
+        with pytest.raises(NotImplementedError, match="does not support `past_key_values`"):
+            layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
+        with pytest.raises(NotImplementedError, match="does not support `past_key_values`"):
+            layer(hidden_states=next_hidden_states, past_key_values=cache, use_cache=True)
+
+    assert cache.get_seq_length(0) == 0

--- a/tests/layers/test_forgetting_attn_cache.py
+++ b/tests/layers/test_forgetting_attn_cache.py
@@ -29,12 +29,12 @@ def test_empty_sliding_window_cache_prefill(dtype: torch.dtype):
 
     with torch.no_grad():
         expected, _, _ = layer(hidden_states=hidden_states)
-        expected_next, _, _ = layer(hidden_states=torch.cat([hidden_states, next_hidden_states], dim=1))
+        expected_next, _, _ = layer(hidden_states=torch.cat([hidden_states, next_hidden_states], dim=1)[:, -W:])
         cache = Cache()
         actual, _, returned_cache = layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
         actual_next, _, _ = layer(
             hidden_states=next_hidden_states,
-            attention_mask=torch.ones(B, 1, dtype=torch.long, device=device),
+            attention_mask=torch.ones(B, W, dtype=torch.long, device=device),
             past_key_values=cache,
             use_cache=True,
         )

--- a/tests/layers/test_forgetting_attn_cache.py
+++ b/tests/layers/test_forgetting_attn_cache.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.forgetting_attn import ForgettingAttention
+from fla.models.utils import Cache
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_empty_sliding_window_cache_prefill(dtype: torch.dtype):
+    B, T, H, D, W = 2, 64, 2, 64, 16
+    torch.manual_seed(42)
+    layer = ForgettingAttention(
+        hidden_size=H * D,
+        num_heads=H,
+        window_size=W,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
+    next_hidden_states = torch.randn(B, 1, H * D, device=device, dtype=dtype)
+    tol = 0.005 if dtype == torch.float16 else 0.02
+
+    with torch.no_grad():
+        expected, _, _ = layer(hidden_states=hidden_states)
+        expected_next, _, _ = layer(hidden_states=torch.cat([hidden_states, next_hidden_states], dim=1))
+        cache = Cache()
+        actual, _, returned_cache = layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
+        actual_next, _, _ = layer(
+            hidden_states=next_hidden_states,
+            attention_mask=torch.ones(B, 1, dtype=torch.long, device=device),
+            past_key_values=cache,
+            use_cache=True,
+        )
+
+    assert_close("prefill", expected, actual, tol)
+    assert_close("decode", expected_next[:, -1:], actual_next, tol)
+    assert returned_cache is cache
+    cached_k, cached_v, cached_f = cache[0]['attn_state']
+    assert cached_k.shape == cached_v.shape == (B, W, H * D)
+    assert cached_f.shape == (B, W, H)
+    assert cache.get_seq_length(0) == T + 1

--- a/tests/layers/test_forgetting_attn_dense_decode.py
+++ b/tests/layers/test_forgetting_attn_dense_decode.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.forgetting_attn import ForgettingAttention
+from fla.models.utils import Cache
+from fla.utils import device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_dense_decode_without_mask_is_rejected(dtype: torch.dtype):
+    B, T, H, D = 2, 8, 2, 64
+    torch.manual_seed(42)
+    layer = ForgettingAttention(
+        hidden_size=H * D,
+        num_heads=H,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
+    next_hidden_states = torch.randn(B, 1, H * D, device=device, dtype=dtype)
+
+    with torch.no_grad():
+        cache = Cache()
+        layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
+        with pytest.raises(AssertionError, match="only support q_len == kv_len"):
+            layer(hidden_states=next_hidden_states, past_key_values=cache, use_cache=True)

--- a/tests/layers/test_lightnet_cache.py
+++ b/tests/layers/test_lightnet_cache.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.lightnet import LightNetAttention
+from fla.models.utils import Cache
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("T_prefill,T_continue", [(8, 4), (32, 80)])
+def test_warm_cache_multi_token_continuation(dtype: torch.dtype, T_prefill: int, T_continue: int):
+    B, D = 2, 64
+    torch.manual_seed(42)
+    layer = LightNetAttention(
+        hidden_size=D,
+        num_heads=2,
+        expand_ratio=8,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    prefill = torch.randn(B, T_prefill, D, device=device, dtype=dtype)
+    continuation = torch.randn(B, T_continue, D, device=device, dtype=dtype)
+    tol = 0.005 if dtype == torch.float16 else 0.02
+
+    with torch.no_grad():
+        expected, _, _ = layer(hidden_states=torch.cat([prefill, continuation], dim=1))
+        cache = Cache()
+        actual_prefill, _, returned_cache = layer(hidden_states=prefill, past_key_values=cache, use_cache=True)
+        actual, _, _ = layer(hidden_states=continuation, past_key_values=cache, use_cache=True)
+
+    assert returned_cache is cache
+    assert_close("prefill", expected[:, :T_prefill], actual_prefill, tol)
+    assert_close("continuation", expected[:, T_prefill:], actual, tol)

--- a/tests/layers/test_moba_cache.py
+++ b/tests/layers/test_moba_cache.py
@@ -10,7 +10,9 @@ import torch
 
 from fla.layers.moba import MoBA
 from fla.models.utils import Cache
-from fla.utils import device
+from fla.utils import device, find_spec_cached
+
+pytestmark = pytest.mark.skipif(find_spec_cached("flash_attn") is None, reason="MoBA parallel path requires flash-attn")
 
 
 def test_moba_rejects_cu_seqlens_with_nonempty_cache():

--- a/tests/layers/test_moba_cache.py
+++ b/tests/layers/test_moba_cache.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.moba import MoBA
+from fla.models.utils import Cache
+from fla.utils import device
+
+
+def test_moba_rejects_cu_seqlens_with_nonempty_cache():
+    T, H, D = 64, 2, 64
+    torch.manual_seed(42)
+    layer = MoBA(
+        hidden_size=H * D,
+        num_heads=H,
+        layer_idx=0,
+    ).to(device=device, dtype=torch.float16).eval()
+    hidden_states = torch.randn(1, T, H * D, device=device, dtype=torch.float16)
+
+    cache = Cache()
+    with torch.no_grad():
+        layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
+        assert cache.get_seq_length(0) == T
+
+        cu_seqlens = torch.tensor([0, T // 2, T], dtype=torch.int32, device=device)
+        with pytest.raises(AssertionError, match="cu_seqlens should not be provided"):
+            layer(hidden_states=hidden_states, past_key_values=cache, cu_seqlens=cu_seqlens)

--- a/tests/layers/test_multiscale_retention_cache.py
+++ b/tests/layers/test_multiscale_retention_cache.py
@@ -24,7 +24,7 @@ def test_decode_rotary_offset_with_attention_mask(dtype: torch.dtype):
     ).to(device=device, dtype=dtype).eval()
     hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
     next_hidden_states = torch.randn(B, 2, H * D, device=device, dtype=dtype)
-    # HF generate always passes an attention_mask covering the new tokens at decode steps.
+    # Manual decode/serving callers may pass an attention_mask covering only the new tokens.
     decode_mask = torch.ones(B, 1, dtype=torch.long, device=device)
     tol = 0.005 if dtype == torch.float16 else 0.02
 

--- a/tests/layers/test_multiscale_retention_cache.py
+++ b/tests/layers/test_multiscale_retention_cache.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.multiscale_retention import MultiScaleRetention
+from fla.models.utils import Cache
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_decode_rotary_offset_with_attention_mask(dtype: torch.dtype):
+    B, T, H, D = 2, 32, 4, 64
+    torch.manual_seed(42)
+    layer = MultiScaleRetention(
+        hidden_size=H * D,
+        num_heads=H,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
+    next_hidden_states = torch.randn(B, 2, H * D, device=device, dtype=dtype)
+    # HF generate always passes an attention_mask covering the new tokens at decode steps.
+    decode_mask = torch.ones(B, 1, dtype=torch.long, device=device)
+    tol = 0.005 if dtype == torch.float16 else 0.02
+
+    with torch.no_grad():
+        expected, _, _ = layer(hidden_states=hidden_states)
+        expected_steps, _, _ = layer(hidden_states=torch.cat([hidden_states, next_hidden_states], dim=1))
+        cache = Cache()
+        actual, _, returned_cache = layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
+        actual_steps = []
+        for i in range(2):
+            actual_step, _, _ = layer(
+                hidden_states=next_hidden_states[:, i:i + 1],
+                attention_mask=decode_mask,
+                past_key_values=cache,
+                use_cache=True,
+            )
+            actual_steps.append(actual_step)
+
+    assert_close("prefill", expected, actual, tol)
+    for i in range(2):
+        assert_close(f"decode {i}", expected_steps[:, T + i:T + i + 1], actual_steps[i], tol)
+    assert returned_cache is cache
+    assert cache.get_seq_length(0) == T + 2

--- a/tests/layers/test_path_attn_cache.py
+++ b/tests/layers/test_path_attn_cache.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.path_attn import PaTHAttention
+from fla.models.utils import Cache
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_decode_rejects_multi_token_query(dtype: torch.dtype):
+    B, T, H, D = 2, 8, 2, 64
+    torch.manual_seed(42)
+    layer = PaTHAttention(
+        hidden_size=H * D,
+        num_heads=H,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
+    chunk_hidden_states = torch.randn(B, 3, H * D, device=device, dtype=dtype)
+    next_hidden_states = torch.randn(B, 1, H * D, device=device, dtype=dtype)
+    attention_mask = torch.ones(B, T, dtype=torch.long, device=device)
+    tol = 0.005 if dtype == torch.float16 else 0.02
+
+    with torch.no_grad():
+        expected, _, _ = layer(hidden_states=hidden_states)
+        expected_next, _, _ = layer(hidden_states=torch.cat([hidden_states, next_hidden_states], dim=1))
+        cache = Cache()
+        actual, _, returned_cache = layer(
+            hidden_states=hidden_states, attention_mask=attention_mask, past_key_values=cache, use_cache=True)
+        cached_k, cached_v = cache[0]['attn_state']
+        cached_k, cached_v = cached_k.clone(), cached_v.clone()
+        cached_conv = cache[0]['conv_state'].clone()
+        with pytest.raises(AssertionError, match="only support q_len == 1 for decoding"):
+            layer(
+                hidden_states=chunk_hidden_states,
+                attention_mask=torch.ones(B, 3, dtype=torch.long, device=device),
+                past_key_values=cache,
+                use_cache=True,
+            )
+        actual_next, _, _ = layer(
+            hidden_states=next_hidden_states,
+            attention_mask=torch.ones(B, 1, dtype=torch.long, device=device),
+            past_key_values=cache,
+            use_cache=True,
+        )
+
+    assert_close("prefill", expected, actual, tol)
+    assert_close("decode", expected_next[:, -1:], actual_next, tol)
+    assert returned_cache is cache
+    assert cache.get_seq_length(0) == T
+    assert torch.equal(cache[0]['attn_state'][0], cached_k)
+    assert torch.equal(cache[0]['attn_state'][1], cached_v)
+    assert torch.equal(cache[0]['conv_state'], cached_conv)

--- a/tests/layers/test_path_attn_cache.py
+++ b/tests/layers/test_path_attn_cache.py
@@ -44,9 +44,13 @@ def test_decode_rejects_multi_token_query(dtype: torch.dtype):
                 past_key_values=cache,
                 use_cache=True,
             )
+        assert cache.get_seq_length(0) == T
+        assert torch.equal(cache[0]['attn_state'][0], cached_k)
+        assert torch.equal(cache[0]['attn_state'][1], cached_v)
+        assert torch.equal(cache[0]['conv_state'], cached_conv)
         actual_next, _, _ = layer(
             hidden_states=next_hidden_states,
-            attention_mask=torch.ones(B, 1, dtype=torch.long, device=device),
+            attention_mask=torch.ones(B, T + 1, dtype=torch.long, device=device),
             past_key_values=cache,
             use_cache=True,
         )
@@ -54,7 +58,3 @@ def test_decode_rejects_multi_token_query(dtype: torch.dtype):
     assert_close("prefill", expected, actual, tol)
     assert_close("decode", expected_next[:, -1:], actual_next, tol)
     assert returned_cache is cache
-    assert cache.get_seq_length(0) == T
-    assert torch.equal(cache[0]['attn_state'][0], cached_k)
-    assert torch.equal(cache[0]['attn_state'][1], cached_v)
-    assert torch.equal(cache[0]['conv_state'], cached_conv)

--- a/tests/layers/test_t0_input.py
+++ b/tests/layers/test_t0_input.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.mamba import Mamba
+from fla.layers.mamba2 import Mamba2
+from fla.layers.rwkv6 import RWKV6Attention
+from fla.models.utils import Cache
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "builder",
+    [
+        pytest.param(lambda layer_idx: Mamba(hidden_size=64, intermediate_size=64, layer_idx=layer_idx), id="mamba"),
+        pytest.param(lambda layer_idx: Mamba2(hidden_size=64, num_heads=4, head_dim=32, layer_idx=layer_idx), id="mamba2"),
+        pytest.param(lambda layer_idx: RWKV6Attention(hidden_size=64, num_heads=4, layer_idx=layer_idx), id="rwkv6"),
+    ],
+)
+def test_t0_prefill_decode(builder, dtype: torch.dtype):
+    torch.manual_seed(42)
+    B, T, D = 2, 0, 64
+    layer = builder(0).to(device=device, dtype=dtype).eval()
+    empty = torch.randn(B, T, D, device=device, dtype=dtype)
+    token = torch.randn(B, 1, D, device=device, dtype=dtype)
+    tol = 0.005 if dtype == torch.float16 else 0.02
+
+    with torch.no_grad():
+        output, _, _ = layer(hidden_states=empty)
+        assert output.shape == (B, T, D)
+
+        expected, _, _ = layer(hidden_states=token)
+        cache = Cache()
+        output, _, returned_cache = layer(hidden_states=empty, past_key_values=cache, use_cache=True)
+        assert output.shape == (B, T, D)
+        assert returned_cache is cache
+        assert cache.get_seq_length(0) == 0
+        actual, _, _ = layer(hidden_states=token, past_key_values=cache, use_cache=True)
+
+    assert cache.get_seq_length(0) == 1
+    assert_close("decode", expected, actual, tol)

--- a/tests/layers/test_wall_attn_cache.py
+++ b/tests/layers/test_wall_attn_cache.py
@@ -43,7 +43,7 @@ def test_empty_sliding_window_cache_prefill(dtype: torch.dtype):
 
 
 @pytest.mark.parametrize("window_size", [None, 16], ids=["full", "windowed"])
-def test_cache_with_attention_mask_rejected(window_size: int | None):
+def test_cache_with_attention_mask_guard(window_size: int | None):
     B, T, H, D = 2, 16, 2, 64
     torch.manual_seed(42)
     layer = WallAttention(
@@ -54,12 +54,22 @@ def test_cache_with_attention_mask_rejected(window_size: int | None):
     ).to(device=device, dtype=torch.float16).eval()
     hidden_states = torch.randn(B, T, H * D, device=device, dtype=torch.float16)
     attention_mask = torch.ones(B, T, dtype=torch.bool, device=device)
-    attention_mask[:, :8] = False
+    attention_mask[:, -8:] = False
 
-    with pytest.raises(AssertionError, match="attention_mask"):
-        layer(
+    with torch.no_grad():
+        expected, _, _ = layer(hidden_states=hidden_states)
+        cache = Cache()
+        actual, _, _ = layer(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
-            past_key_values=Cache(),
+            past_key_values=cache,
             use_cache=True,
         )
+        assert_close("prefill", expected[:, :-8], actual[:, :-8], 0.005)
+        with pytest.raises(AssertionError, match="attention_mask"):
+            layer(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                past_key_values=cache,
+                use_cache=True,
+            )

--- a/tests/layers/test_wall_attn_cache.py
+++ b/tests/layers/test_wall_attn_cache.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.wall_attn import WallAttention
+from fla.models.utils import Cache
+from fla.utils import assert_close, device
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_empty_sliding_window_cache_prefill(dtype: torch.dtype):
+    B, T, H, D, W = 2, 64, 2, 64, 16
+    torch.manual_seed(42)
+    layer = WallAttention(
+        hidden_size=H * D,
+        num_heads=H,
+        window_size=W,
+        layer_idx=0,
+    ).to(device=device, dtype=dtype).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=dtype)
+    next_hidden_states = torch.randn(B, 1, H * D, device=device, dtype=dtype)
+    tol = 0.005 if dtype == torch.float16 else 0.02
+
+    with torch.no_grad():
+        expected, _, _ = layer(hidden_states=hidden_states)
+        expected_next, _, _ = layer(hidden_states=torch.cat([hidden_states, next_hidden_states], dim=1))
+        cache = Cache()
+        actual, _, returned_cache = layer(hidden_states=hidden_states, past_key_values=cache, use_cache=True)
+        actual_next, _, _ = layer(hidden_states=next_hidden_states, past_key_values=cache, use_cache=True)
+
+    assert_close("prefill", expected, actual, tol)
+    assert_close("decode", expected_next[:, -1:], actual_next, tol)
+    assert returned_cache is cache
+    cached_k, cached_v, cached_g = cache[0]['attn_state']
+    assert cached_k.shape == cached_v.shape == cached_g.shape == (B, W, H, D)
+    assert cache.get_seq_length(0) == T + 1
+
+
+@pytest.mark.parametrize("window_size", [None, 16], ids=["full", "windowed"])
+def test_cache_with_attention_mask_rejected(window_size: int | None):
+    B, T, H, D = 2, 16, 2, 64
+    torch.manual_seed(42)
+    layer = WallAttention(
+        hidden_size=H * D,
+        num_heads=H,
+        window_size=window_size,
+        layer_idx=0,
+    ).to(device=device, dtype=torch.float16).eval()
+    hidden_states = torch.randn(B, T, H * D, device=device, dtype=torch.float16)
+    attention_mask = torch.ones(B, T, dtype=torch.bool, device=device)
+    attention_mask[:, :8] = False
+
+    with pytest.raises(AssertionError, match="attention_mask"):
+        layer(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=Cache(),
+            use_cache=True,
+        )

--- a/tests/models/test_fuse_linear_cross_entropy.py
+++ b/tests/models/test_fuse_linear_cross_entropy.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.models import (
+    BitNetConfig,
+    DeltaFormerConfig,
+    ForgettingTransformerConfig,
+    PaTHAttentionConfig,
+)
+from fla.utils import assert_close, device, find_spec_cached
+
+from .test_modeling_utils import create_model_and_config
+
+# Mark (not importorskip): a fully skipped module reports "no tests collected" and exits
+# with code 5, which CI per-file loops treat as a failure.
+pytestmark = pytest.mark.skipif(find_spec_cached("flash_attn") is None,
+                                reason="BitNet/DeltaFormer attention requires flash-attn (`pip install flash-attn --no-build-isolation`).")
+
+
+# ===================================================================================
+# Test for Fused Linear Cross Entropy (training loss + no-labels logits)
+# ===================================================================================
+@pytest.mark.parametrize(
+    "config_class",
+    [
+        pytest.param(config_class, id=config_class.__name__)
+        for config_class in [
+            BitNetConfig,
+            DeltaFormerConfig,
+            ForgettingTransformerConfig,
+            PaTHAttentionConfig,
+        ]
+    ],
+)
+def test_fuse_linear_cross_entropy(config_class):
+    L, B, T, H, D = 2, 2, 64, 4, 64
+    model, config = create_model_and_config(config_class, L, H, D, dtype=torch.bfloat16)
+    model.eval()
+
+    input_ids = torch.randint(low=0, high=config.vocab_size, size=(B, T), device=device)
+    labels = input_ids.clone()
+
+    with torch.no_grad():
+        expected = model(input_ids, labels=labels).loss
+
+        model.config.fuse_linear_cross_entropy = True
+        outputs = model(input_ids, labels=labels)
+        assert outputs.logits is None
+        assert_close("loss", expected, outputs.loss, 0.02)
+
+        # the generate path passes no labels; logits must still be materialized
+        outputs = model(input_ids)
+        assert outputs.logits is not None
+        output_ids = model.generate(input_ids[:, :T // 2], max_new_tokens=2)
+    assert output_ids.shape[1] == T // 2 + 2

--- a/tests/ops/test_gdp.py
+++ b/tests/ops/test_gdp.py
@@ -214,3 +214,34 @@ def test_chunk_varlen(
     assert_close('db', ref_dbeta, tri_dbeta, 0.015)
     assert_close('dg', ref_dg, tri_dg, 0.015)
     assert_close('dh0', ref_dh0, tri_dh0, 0.007)
+
+
+def test_naive_varlen():
+    H, D, num_householder = 2, 64, 2
+    torch.manual_seed(42)
+    os.environ['TRITON_F32_DEFAULT'] = 'ieee'
+    cu_seqlens = torch.LongTensor([0, 63, 100, 100, 500]).to(device)
+    T = cu_seqlens[-1]
+    N = len(cu_seqlens) - 1
+
+    q = torch.nn.functional.normalize(torch.randn((1, T, H, D), dtype=torch.float16), dim=-1, p=2)
+    k = torch.nn.functional.normalize(torch.randn(1, T*num_householder, H, D, dtype=torch.float16), dim=-1, p=2)
+    v = torch.randn((1, T*num_householder, H, D), dtype=torch.float16)
+    g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float16))
+    beta = torch.rand(1, T*num_householder, H, dtype=torch.float16).sigmoid()
+    h0 = torch.randn((N, H, D, D), dtype=torch.float16)
+    q, k, v, beta, g, h0 = map(lambda x: x.to(device), (q, k, v, beta, g, h0))
+    scale = D ** -0.5
+
+    ref, ref_ht = naive_recurrent_gated_delta_product(
+        q, k, v, g, beta, scale, cu_seqlens,
+        initial_state=h0, output_final_state=True, num_householder=num_householder,
+    )
+    tri, tri_ht = chunk_gated_delta_product(
+        q=q, k=k, v=v, g=g, beta=beta, scale=scale,
+        initial_state=h0, output_final_state=True, num_householder=num_householder,
+        cu_seqlens=cu_seqlens,
+    )
+
+    assert_close('o', ref, tri, 0.005)
+    assert_close('ht', ref_ht, tri_ht, 0.005)


### PR DESCRIPTION
## Summary

Batch of guard fixes found by auditing layer cache/mask handling:

- **Cache/varlen combos**: reject `cu_seqlens` with non-empty `past_key_values` in Attention/MoBA/MLA/NSA/BitAttention; naive gated delta product now honors `cu_seqlens`; wall_attn rejects `attention_mask` only when cache has content (empty-cache masked prefill keeps working, as before this guard existed); forgetting attn guards empty sliding-window cache prefill and dense decode; DeltaFormerAttention rejects `past_key_values` (no cached path); path_attn/forgetting/yoco check `q_len == 1` before mutating the cache.
- **Numerics**: restore cached sequence length in MSR/YOCO rotary offset when decoding with `attention_mask` (decode results were silently wrong for masked prefills); materialize full logits in `generate()` when `fuse_linear_cross_entropy` is on; continue LightNet ffn `logcumsumexp` within chunk on warm cache.
- **Degenerate inputs**: early-return `T == 0` inputs in rwkv6/mamba/mamba2 layers.

Known follow-ups, out of scope here: `T == 0` for other recurrent layers (gated_deltanet/rwkv7/kda/gla/hgrn, same shape but trigger path unconfirmed); forgetting cache+mask chunk prefill; lightnet decode `cu_seqlens`; parallax/rodimus guards are pre-existing.

## Test plan

New regression tests: `tests/layers/test_cu_seqlens_cache_guard.py`, `test_deltaformer_cache.py`, `test_forgetting_attn_cache.py`, `test_forgetting_attn_dense_decode.py`, `test_lightnet_cache.py`, `test_moba_cache.py`, `test_multiscale_retention_cache.py`, `test_parallax_cache.py`, `test_path_attn_cache.py`, `test_t0_input.py`, `test_wall_attn_cache.py`, plus cases in `test_gated_deltanet.py`, `test_gdn.py`, `test_modeling_gated_deltanet.py`, `tests/ops/test_gdp.py` and `tests/models/test_fuse_linear_cross_entropy.py`. Layer tests pass locally on GPU; full suite in CI.

## Benchmark / NCU (kernel changes only)

Neutral. No kernel code changed (layers/naive reference only).

## Breaking changes

Invalid input combinations that previously produced silent wrong results or late crashes now fail with an assertion at the layer boundary. No valid-usage behavior changes.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../CONTRIBUTING.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.