### PR TITLE
[Fix] Guard GSA inference final state stores

### DIFF
--- a/fla/ops/gsa/fused_recurrent.py
+++ b/fla/ops/gsa/fused_recurrent.py
@@ -14,6 +14,9 @@ from fla.ops.utils.op import exp
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
 
+@triton.heuristics({
+    'STORE_FINAL_STATE': lambda args: args['hkt'] is not None,
+})
 @triton.jit
 def fused_recurrent_gsa_inference_kernel(
     q,
@@ -33,6 +36,7 @@ def fused_recurrent_gsa_inference_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     NG: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
 ):
     i_bh = tl.program_id(0).to(tl.int64)
     i_bg = i_bh // NG
@@ -58,9 +62,10 @@ def fused_recurrent_gsa_inference_kernel(
         b_hk = b_hk * b_g[:, None] + b_k[None, :] * b_s[:, None]
         b_ok += tl.sum(b_hk * b_q[None, :], axis=1)
 
-        if i_bh % NG == 0:
-            p_hkt = hkt + i_bg * K * M + o_k[None, :] * M + tl.arange(0, M)[:, None]
-            tl.store(p_hkt, b_hk.to(p_hkt.dtype.element_ty), mask=mask_hk)
+        if STORE_FINAL_STATE:
+            if i_bh % NG == 0:
+                p_hkt = hkt + i_bg * K * M + o_k[None, :] * M + tl.arange(0, M)[:, None]
+                tl.store(p_hkt, b_hk.to(p_hkt.dtype.element_ty), mask=mask_hk)
 
     b_qv = tl.softmax(b_ok)
     for i_v in range(tl.cdiv(V, BV)):
@@ -80,9 +85,10 @@ def fused_recurrent_gsa_inference_kernel(
 
         tl.store(o + i_bh * V + o_v, b_ov.to(o.dtype.element_ty), mask=mask_v)
 
-        if i_bh % NG == 0:
-            p_hvt = hvt + i_bg * M * V + tl.arange(0, M)[None, :] * V + o_v[:, None]
-            tl.store(p_hvt, b_hv.to(p_hvt.dtype.element_ty), mask=mask_hv)
+        if STORE_FINAL_STATE:
+            if i_bh % NG == 0:
+                p_hvt = hvt + i_bg * M * V + tl.arange(0, M)[None, :] * V + o_v[:, None]
+                tl.store(p_hvt, b_hv.to(p_hvt.dtype.element_ty), mask=mask_hv)
 
 
 def fused_recurrent_gsa_inference(
@@ -107,10 +113,7 @@ def fused_recurrent_gsa_inference(
 
     hkt, hvt = None, None
     if output_final_state:
-        if NG == 1:
-            hkt, hvt = hk0, hv0
-        else:
-            hkt, hvt = q.new_empty(B, H, K, M, dtype=torch.float), q.new_empty(B, H, M, V, dtype=torch.float)
+        hkt, hvt = q.new_empty(B, H, K, M, dtype=torch.float), q.new_empty(B, H, M, V, dtype=torch.float)
 
     o = v.new_empty(B, T, HQ, V)
     grid = (B * HQ,)

--- a/tests/ops/test_gsa.py
+++ b/tests/ops/test_gsa.py
@@ -523,3 +523,68 @@ def test_inference(
         tri[:, i] = o.squeeze(1)
         assert_close(f'o{i}', ref[:, i], tri[:, i], 0.005)
         h0 = ht
+
+
+@pytest.mark.parametrize(
+    ('has_initial_state', 'output_final_state'),
+    [
+        (False, False),
+        (False, True),
+        (True, False),
+        (True, True),
+    ],
+)
+@pytest.mark.skipif(
+    device_platform == 'intel',
+    reason='Intel Triton Failure',
+)
+def test_inference_state_contract(has_initial_state: bool, output_final_state: bool):
+    torch.manual_seed(42)
+    B, T, H, D, M = 2, 1, 2, 16, 8
+    q = torch.randn(B, T, H, D, device=device)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    s = torch.randn(B, T, H, M, device=device)
+    g = F.logsigmoid(torch.randn_like(s))
+    initial_state = None
+    initial_state_before = None
+    if has_initial_state:
+        initial_state = (
+            torch.randn(B, H, D, M, device=device),
+            torch.randn(B, H, M, D, device=device),
+        )
+        initial_state_before = tuple(state.clone() for state in initial_state)
+
+    ref, ref_state = naive_recurrent_gsa(
+        q=q,
+        k=k,
+        v=v,
+        s=s,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+    )
+    with torch.no_grad():
+        tri, tri_state = fused_recurrent_gsa(
+            q=q,
+            k=k,
+            v=v,
+            s=s,
+            g=g,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+        )
+
+    assert_close('o', ref, tri, 0.005)
+    if output_final_state:
+        assert_close('hkt', ref_state[0], tri_state[0], 0.005)
+        assert_close('hvt', ref_state[1], tri_state[1], 0.005)
+    else:
+        assert tri_state == [None, None]
+
+    if has_initial_state:
+        torch.testing.assert_close(initial_state[0], initial_state_before[0], rtol=0, atol=0)
+        torch.testing.assert_close(initial_state[1], initial_state_before[1], rtol=0, atol=0)
+        if output_final_state:
+            assert tri_state[0].data_ptr() != initial_state[0].data_ptr()
+            assert tri_state[1].data_ptr() != initial_state[1].data_ptr()


### PR DESCRIPTION
## Summary

Fix the single-token no-grad GSA inference shortcut when `output_final_state=False` by compile-time guarding final-state pointer arithmetic and stores. Also allocate fresh final-state tensors for `NG == 1` so the shortcut no longer mutates caller-provided initial states.

## Test plan

- Dependent tests identified with `python scripts/find_dependent_tests.py fla/ops/gsa/fused_recurrent.py`.
- `python -m pytest -q tests/ops/test_gsa.py::test_inference tests/ops/test_gsa.py::test_inference_state_contract` (`7 passed`).
- `uvx pre-commit run --files fla/ops/gsa/fused_recurrent.py tests/ops/test_gsa.py`.
- Exercised both `output_final_state` specializations under `torch.cuda.set_sync_debug_mode("error")`; neither triggered a host synchronization.
- The general dense and varlen recurrent kernels are unchanged; the modified shortcut is selected only for no-grad `T == 1` inference.

## Benchmark / NCU (kernel changes only)

- Hardware: NVIDIA RTX A1000 Laptop GPU (sm86; reference-only hardware).
- Workload: `B=2, T=1, H=8, K=V=M=64, float16, NG=1`, FP32 initial states, `output_final_state=True`; `triton.testing.do_bench`, 100 warmup iterations, 1000 measured iterations, five runs.
- Before: `9.216 us` median.
- After: `9.216 us` median.
- Conclusion: neutral within measurement resolution. The `output_final_state=False` baseline cannot be benchmarked because it fails Triton compilation; the fixed path passes the synchronization probe.
- NCU: a `--set full` capture was attempted for `fused_recurrent_gsa_inference_kernel`, but metric replay did not complete on the local sm86 system and no report was produced.

## Breaking changes

None. This removes accidental mutation of caller-provided initial states and restores the out-of-place semantics used by the general recurrent path.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
