### PR TITLE
[Fix] Validate attention dimensions and grouped-query heads

### DIFF
--- a/fla/layers/abc.py
+++ b/fla/layers/abc.py
@@ -56,7 +56,7 @@ class ABCAttention(nn.Module):
         self.expand_v = expand_v
         self.num_heads = num_heads
         key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
-        self.key_dim, self.value_dim = int(key_dim), int(value_dim)
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
         assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
         assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"

--- a/fla/layers/abc.py
+++ b/fla/layers/abc.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from typing import TYPE_CHECKING
 
@@ -54,8 +55,14 @@ class ABCAttention(nn.Module):
         self.expand_k = expand_k
         self.expand_v = expand_v
         self.num_heads = num_heads
-        self.key_dim = int(self.hidden_size * self.expand_k)
-        self.value_dim = int(self.hidden_size * self.expand_v)
+        key_dim = hidden_size * expand_k
+        value_dim = hidden_size * expand_v
+        self.key_dim = int(key_dim)
+        self.value_dim = int(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
+        assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"
+        assert self.value_dim % num_heads == 0, f"value dim must be divisible by num_heads of {num_heads}"
         self.head_k_dim = self.key_dim // self.num_heads
         self.head_v_dim = self.value_dim // self.num_heads
 

--- a/fla/layers/abc.py
+++ b/fla/layers/abc.py
@@ -55,10 +55,8 @@ class ABCAttention(nn.Module):
         self.expand_k = expand_k
         self.expand_v = expand_v
         self.num_heads = num_heads
-        key_dim = hidden_size * expand_k
-        value_dim = hidden_size * expand_v
-        self.key_dim = int(key_dim)
-        self.value_dim = int(value_dim)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = int(key_dim), int(value_dim)
         assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
         assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         assert self.key_dim % num_heads == 0, f"key dim must be divisible by num_heads of {num_heads}"

--- a/fla/layers/attn.py
+++ b/fla/layers/attn.py
@@ -56,6 +56,7 @@ class Attention(nn.Module):
             self.num_kv_heads = self.num_heads
         else:
             self.num_kv_heads = num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.head_dim = self.hidden_size // self.num_heads
         self.kv_dim = self.num_kv_heads * self.head_dim

--- a/fla/layers/bitattn.py
+++ b/fla/layers/bitattn.py
@@ -55,6 +55,7 @@ class BitAttention(nn.Module):
             self.num_kv_heads = self.num_heads
         else:
             self.num_kv_heads = num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.hidden_size = hidden_size
         self.head_dim = self.hidden_size // self.num_heads

--- a/fla/layers/deltaformer.py
+++ b/fla/layers/deltaformer.py
@@ -76,6 +76,7 @@ class DeltaFormerAttention(nn.Module):
         self.hidden_size = hidden_size
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.head_dim = self.hidden_size // self.num_heads
         self.kv_dim = self.num_kv_heads * self.head_dim

--- a/fla/layers/forgetting_attn.py
+++ b/fla/layers/forgetting_attn.py
@@ -48,6 +48,7 @@ class ForgettingAttention(nn.Module):
             self.num_kv_heads = self.num_heads
         else:
             self.num_kv_heads = num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.head_dim = self.hidden_size // self.num_heads
         self.kv_dim = self.num_kv_heads * self.head_dim

--- a/fla/layers/gla.py
+++ b/fla/layers/gla.py
@@ -102,6 +102,7 @@ class GatedLinearAttention(nn.Module):
         self.expand_v = expand_v
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = self.num_heads // self.num_kv_heads
         self.feature_map_fn = ACT2FN[feature_map] if feature_map is not None else None
 

--- a/fla/layers/gsa.py
+++ b/fla/layers/gsa.py
@@ -59,6 +59,7 @@ class GatedSlotAttention(nn.Module):
         self.expand_v = expand_v
         self.num_heads = num_heads
         self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = self.num_heads // self.num_kv_heads
         self.key_dim = int(hidden_size * expand_k)
         self.value_dim = int(hidden_size * expand_v)

--- a/fla/layers/linear_attn.py
+++ b/fla/layers/linear_attn.py
@@ -50,6 +50,7 @@ class LinearAttention(nn.Module):
         self.mode = mode
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = self.num_heads // self.num_kv_heads
         self.key_dim = int(hidden_size * expand_k)
         self.value_dim = int(hidden_size * expand_v)

--- a/fla/layers/moba.py
+++ b/fla/layers/moba.py
@@ -113,6 +113,7 @@ class MoBA(nn.Module):
             self.num_kv_heads = self.num_heads
         else:
             self.num_kv_heads = num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.head_dim = self.hidden_size // self.num_heads
         self.kv_dim = self.num_kv_heads * self.head_dim

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -95,6 +95,7 @@ class MultiScaleRetention(nn.Module):
         self.expand_v = expand_v
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = self.num_heads // self.num_kv_heads
         self.feature_map_fn = ACT2FN[feature_map] if feature_map is not None else None
 

--- a/fla/layers/nsa.py
+++ b/fla/layers/nsa.py
@@ -49,6 +49,7 @@ class NativeSparseAttention(nn.Module):
             self.num_kv_heads = self.num_heads
         else:
             self.num_kv_heads = num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.head_dim = head_dim
         self.kv_dim = self.num_kv_heads * self.head_dim

--- a/fla/layers/parallax.py
+++ b/fla/layers/parallax.py
@@ -81,6 +81,7 @@ class Parallax(nn.Module):
             self.num_kv_heads = self.num_heads
         else:
             self.num_kv_heads = num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.head_dim = self.hidden_size // self.num_heads
         self.kv_dim = self.num_kv_heads * self.head_dim

--- a/fla/layers/simple_gla.py
+++ b/fla/layers/simple_gla.py
@@ -92,6 +92,7 @@ class SimpleGatedLinearAttention(nn.Module):
         self.expand_v = expand_v
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = self.num_heads // self.num_kv_heads
         self.feature_map_fn = ACT2FN[feature_map] if feature_map is not None else None
 

--- a/fla/layers/wall_attn.py
+++ b/fla/layers/wall_attn.py
@@ -87,6 +87,7 @@ class WallAttention(nn.Module):
             self.num_kv_heads = self.num_heads
         else:
             self.num_kv_heads = num_kv_heads
+        assert self.num_heads % self.num_kv_heads == 0, "num_heads must be divisible by num_kv_heads"
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.head_dim = self.hidden_size // self.num_heads
         self.kv_dim = self.num_kv_heads * self.head_dim


### PR DESCRIPTION
## Summary

- Validate ABC key/value expansion products before they reach head reshaping.
- Round mathematically integral floating-point products before checking them with `math.isclose`, so values such as `50 * 0.58` resolve to 29 instead of being truncated to 28.
- Require `num_heads` to be divisible by `num_kv_heads` before computing grouped-query head counts in all affected public layers.
- Keep the change aligned with existing layer-constructor style by using assertions and adding no extra type or positivity checks.

Affected grouped-query layers: Attention, BitAttention, DeltaFormerAttention, ForgettingAttention, GatedLinearAttention, GatedSlotAttention, LinearAttention, MoBA, MultiScaleRetention, NativeSparseAttention, Parallax, SimpleGatedLinearAttention, and WallAttention. Raven already had this validation.

## Test plan

- Unit tests added/modified: none (production-code-only change).
- Ruff checks passed for all changed files.
- Constructor smoke checks:
  - ABC accepts the floating-point representation of `50 * 0.58` and stores 29.
  - ABC rejects fractional expansion products and dimensions not divisible by `num_heads`.
  - All 13 grouped-query layers reject `(num_heads=8, num_kv_heads=3)`.
  - All 13 grouped-query layers accept `(num_heads=8, num_kv_heads=2)` and compute four groups.
- `python -m pytest tests/layers/test_attn_varlen_pack_layout.py tests/layers/test_layer_cache_layer_idx.py tests/layers/test_parallax_cache.py -q` — 43 passed, 2 skipped.
- A broader model sweep was attempted; FlashAttention-dependent cases are unavailable in the local environment, and running the remaining GPU-heavy files together exhausted CUDA memory. These failures were environmental rather than validation failures.
- Varlen / CP: no execution path changes; constructor validation only.

## Benchmark / NCU (kernel changes only)

- Neutral: no kernel or performance-sensitive code changed.

## Breaking changes

- Invalid expansion and grouped-query head configurations now fail during layer initialization instead of later in reshaping or kernels.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or limitations are documented above.
- [x] Kernel changes include same-hardware before/after benchmark numbers (N/A: no kernel changes).
- [ ] This PR is minor/cosmetic-only.