### PR TITLE
[Fix] Correct packed token shift decode detection

### DIFF
--- a/fla/modules/token_shift.py
+++ b/fla/modules/token_shift.py
@@ -130,6 +130,9 @@ def token_shift_fwd_kernel_short(
             tl.store(y + base_offset, delta, mask=m_d)
         else:
             tl.store(y + base_offset, -b_x, mask=m_d)
+        if STORE_FINAL_STATE:
+            if is_last_pos:
+                tl.store(cache_out + cache_offset, b_x, mask=m_d)
         return
 
     # Other positions: delta = prev - curr
@@ -409,7 +412,7 @@ def token_shift_fwd(
             N = B
         BD = triton.next_power_of_2(D)
         grid = (N, T)
-        IS_DECODE = T == 1 or (B == 1 and T == N)
+        IS_DECODE = T == 1
         token_shift_fwd_kernel_short[grid](
             x=x,
             y=y,

--- a/tests/modules/test_token_shift.py
+++ b/tests/modules/test_token_shift.py
@@ -140,6 +140,17 @@ def test_all_with_and_without_varlen(B, T, H, cu_seqlens, split_at):
     _check_passing_vs_whole(B, T, H, cu_seqlens, dtype, split_at)
 
 
+def test_token_shift_varlen_cache_mixed_lengths():
+    x = torch.tensor([[[1.], [2.], [3.]]], device=device)
+    cu_seqlens = torch.tensor([0, 2, 3], dtype=torch.int32, device=device)
+    cache = torch.tensor([[10.], [20.]], device=device)
+
+    output, cache_out = token_shift(x, cu_seqlens, cache=cache, output_cache=True)
+
+    assert_close("output", output, torch.tensor([[[9.], [-1.], [17.]]], device=device), 1e-3)
+    assert_close("cache", cache_out, torch.tensor([[2.], [3.]], device=device), 1e-3)
+
+
 def _packed_cu_seqlens(total_tokens: int, doc_len: int) -> torch.Tensor:
     n_docs = (total_tokens + doc_len - 1) // doc_len
     lens = torch.full((n_docs,), doc_len, device=device, dtype=torch.long)


### PR DESCRIPTION
## Summary

Fix the short `token_shift` kernel treating an ordinary packed varlen chunk as decode when the maximum sequence length happens to equal the number of packed sequences.

- Detect decode only when the maximum sequence length is one.
- Preserve `cache_out` for singleton sequences that use the normal packed path.
- Add one focused regression covering mixed lengths `[2, 1]` with initial and final cache state.

For `cu_seqlens=[0, 2, 3]`, the old condition classified the chunk as decode and produced `old_cache - current_token` for both tokens in the length-two sequence. The corrected path produces `old_cache - x0`, followed by `x0 - x1`, and stores the final token of each sequence without competing writes.

## Test plan

- `ruff check fla/modules/token_shift.py tests/modules/test_token_shift.py` — passed.
- `pytest tests/modules/test_token_shift.py::test_token_shift_varlen_cache_mixed_lengths -q` — 1 passed.
- `pytest tests/modules/test_token_shift.py -q` — 34 passed; the single largest pre-existing dense case (`B=4, T=8192, H=4096`) reached result comparison but exceeded the local 3.68 GiB GPU while allocating another 512 MiB.
- `pytest tests/layers/test_layer_cache_layer_idx.py tests/models/test_modeling_rwkv6.py tests/models/test_modeling_rwkv7.py -q` — 34 passed, 2 skipped.
- `pytest tests/context_parallel/test_cp_token_shift.py -q` — 7 skipped because the local environment has one GPU and the tests require at least two.

## Benchmark / NCU

- Neutral correctness fix. The additional store is restricted to singleton sequences when final-state output is requested; no steady-state token loop or operator math changes. The affected old path produces incorrect output or an uninitialized final state, so a before/after performance comparison is not meaningful.

## Breaking changes

- None. Only an invalid decode shortcut and an uninitialized singleton final state are corrected.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A: the affected old path is incorrect, and the required singleton final-state store does not change a valid benchmark route).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.