### PR TITLE
[Fix] Correct HGRN state size for expansion

### DIFF
--- a/fla/layers/hgrn.py
+++ b/fla/layers/hgrn.py
@@ -177,7 +177,7 @@ class HGRNAttention(nn.Module):
         return o, None, past_key_values
 
     def state_size(self, **kwargs) -> int:
-        state_size = self.hidden_size
+        state_size = self.input_dim
         for module in self.children():
             if isinstance(module, ShortConvolution):
                 state_size += module.state_size


### PR DESCRIPTION
## Summary

Report HGRN recurrent-state size from the expanded recurrence dimension instead of the model hidden size. This fixes underestimation when `expand_ratio > 1` and overestimation when `expand_ratio < 1`, while preserving the existing ShortConvolution state accounting.

## Test plan

- Unit tests added/modified: none (production-code-only change).
- Dependent tests run: `python -m pytest tests/layers/test_layer_cache_layer_idx.py tests/models/test_hybrid_attention.py tests/models/test_modeling_hgrn.py -q` — 242 passed, 3 skipped; one HGRN numerical-tolerance case failed once and passed on isolated retry.
- Varlen / CP / model tests: HGRN model and hybrid-attention tests included; no execution-path or CP changes.

## Benchmark / NCU (kernel changes only)

- Neutral: no kernel or performance-sensitive code changed.

## Breaking changes

- None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
