### PR TITLE
[Fix] Handle grouped Mamba3 cached decode

### DIFF
--- a/fla/layers/mamba3.py
+++ b/fla/layers/mamba3.py
@@ -110,6 +110,10 @@ class Mamba3(nn.Module):
                 f"`expand * hidden_size` ({self.intermediate_size}) must be divisible by `head_dim` ({head_dim})."
             )
         self.num_heads = self.intermediate_size // head_dim
+        if self.n_groups < 1 or self.num_heads % self.n_groups != 0:
+            raise ValueError(
+                f"`n_groups` ({self.n_groups}) must be a positive divisor of `num_heads` ({self.num_heads})."
+            )
 
         if self.is_mimo and mamba3_mimo_combined is None:
             logger.warning_once(
@@ -320,8 +324,15 @@ class Mamba3(nn.Module):
 
         B = rearrange(B, "b (r g s) -> b r g s", g=self.n_groups, r=self.mimo_rank)
         C = rearrange(C, "b (r g s) -> b r g s", g=self.n_groups, r=self.mimo_rank)
-        B = self.B_norm(B).expand(-1, -1, self.num_heads, -1)
-        C = self.C_norm(C).expand(-1, -1, self.num_heads, -1)
+        B = self.B_norm(B)
+        C = self.C_norm(C)
+        if self.n_groups not in (1, self.num_heads):
+            repeats = self.num_heads // self.n_groups
+            B = B.repeat_interleave(repeats, dim=2)
+            C = C.repeat_interleave(repeats, dim=2)
+        else:
+            B = B.expand(-1, -1, self.num_heads, -1)
+            C = C.expand(-1, -1, self.num_heads, -1)
 
         x = rearrange(x, "b (h p) -> b h p", p=self.head_dim)
         z = rearrange(z, "b (h p) -> b h p", p=self.head_dim)


### PR DESCRIPTION
## Summary

- Validate that n_groups is a positive divisor of num_heads.
- Repeat grouped B/C across their assigned heads during cached decode.
- Preserve the zero-copy expand path for n_groups=1 and n_groups=num_heads.

## Test plan

- python scripts/find_dependent_tests.py fla/layers/mamba3.py (no dependent tests reported)
- uvx pre-commit run --files fla/layers/mamba3.py
- Verified cached-decode B/C shapes and group mapping for n_groups=1, 2, and 8.
- Verified that invalid non-divisible grouping is rejected.
- python -m pytest tests/models/test_modeling_mamba3.py -q cannot complete locally because the environment does not provide the required Mamba3 SISO/MIMO kernels.

## Benchmark / NCU (kernel changes only)

N/A. No kernel code changed. The default n_groups=1 cached-decode path retains the existing zero-copy expand operation; allocation is introduced only for intermediate grouped configurations that previously failed.

## Breaking changes

None for valid configurations. Invalid non-divisible n_groups configurations now raise ValueError during initialization instead of failing later in a kernel or shape operation.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (focused local shape, mapping, and validation checks pass; full model tests require unavailable Mamba3 kernels).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A: no kernel code changed).
- [ ] This PR is minor/cosmetic-only (this is a functional cached-decode fix).