### PR TITLE
[Fix] Stabilize DeltaNet sum normalization

### DIFF
--- a/fla/layers/delta_net.py
+++ b/fla/layers/delta_net.py
@@ -30,7 +30,7 @@ def elu_p1(x):
 
 
 def sum_norm(x):
-    return (x / x.sum(-1, keepdim=True)).to(x)
+    return F.normalize(x, p=1, dim=-1, eps=1e-6).to(x)
 
 
 class DeltaNet(nn.Module):


### PR DESCRIPTION
## Summary

- Replace algebraic-sum normalization with stable L1 normalization for DeltaNet qk_norm=sum.
- Keep the existing behavior for nonnegative feature maps while supporting signed identity and SiLU features without cancellation-induced Inf or NaN.
- Use an explicit epsilon that remains representable in FP16.

## Test plan

- python scripts/find_dependent_tests.py fla/layers/delta_net.py
- Focused local regression checks covered all-zero and nonzero zero-sum inputs in FP32, BF16, and FP16, all four supported Q/K activations, and fused-recurrent plus chunk execution. The temporary regression test file was not included in this production-only PR.
- Existing DeltaNet cache and varlen dependent tests pass.
- uvx pre-commit run --files fla/layers/delta_net.py

## Benchmark / NCU (kernel changes only)

N/A. No kernel code changed.

## Breaking changes

For signed identity and SiLU feature maps, qk_norm=sum now normalizes by the sum of magnitudes instead of the algebraic sum. Nonnegative ReLU and ELU feature maps retain the same normalization semantics, with finite handling for a zero denominator.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (focused local regression checks pass; test code is intentionally excluded from this production-only PR).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A: no kernel code changed).
- [ ] This PR is minor/cosmetic-only (this is a functional numerical-stability fix).