### PR TITLE
[Perf] Cache Mamba3 SISO decode projection

### DIFF
--- a/fla/layers/mamba3.py
+++ b/fla/layers/mamba3.py
@@ -114,6 +114,12 @@ class Mamba3(nn.Module):
             raise ValueError(
                 f"`n_groups` ({self.n_groups}) must be a positive divisor of `num_heads` ({self.num_heads})."
             )
+        if not self.is_mimo:
+            self.register_buffer(
+                "_siso_proj",
+                torch.ones(1, self.num_heads, self.head_dim, **factory_kwargs),
+                persistent=False,
+            )
 
         if self.is_mimo and mamba3_mimo_combined is None:
             logger.warning_once(
@@ -346,10 +352,9 @@ class Mamba3(nn.Module):
             zpj = rearrange(self.mimo_z, "h r p -> r h p", p=self.head_dim).contiguous()
             outpj = rearrange(self.mimo_o, "h r p -> r h p", p=self.head_dim).contiguous()
             return xpj, zpj, outpj
-        # SISO: pass identity-style ones tensors so the kernel signature stays uniform.
-        shape = (self.mimo_rank, self.num_heads, self.head_dim)
-        xpj = torch.ones(shape, device=self.in_proj.weight.device, dtype=x_dtype)
-        zpj = torch.ones(shape, device=self.in_proj.weight.device, dtype=z_dtype)
+        # SISO reuses an identity-style ones tensor so the kernel signature stays uniform.
+        xpj = self._siso_proj.to(dtype=x_dtype)
+        zpj = xpj if z_dtype == x_dtype else self._siso_proj.to(dtype=z_dtype)
         return xpj, zpj, xpj
 
     def step(


### PR DESCRIPTION
## Summary

Cache the Mamba3 SISO identity projection as a non-persistent module buffer so cached decoding reuses it instead of allocating and filling two new CUDA tensors per token. The buffer follows normal module device/dtype conversions, while the existing `_step_mimo_projections(x_dtype, z_dtype)` interface and MIMO path remain unchanged.

## Test plan

- Unit tests added/modified: none; this PR intentionally keeps the change to production code only.
- Dependent tests: `python scripts/find_dependent_tests.py fla/layers/mamba3.py` reported no dependent tests.
- Focused check: verified the helper signature is unchanged, repeated SISO calls reuse the same storage, `.to(dtype=...)` migrates the buffer, and `_siso_proj` is absent from `state_dict()`.
- Lint/format: `uvx pre-commit run --files fla/layers/mamba3.py`.
- Model tests: `python -m pytest tests/models/test_modeling_mamba3.py -q` cannot complete in the local environment because its installed `mamba_ssm` extension is ABI-incompatible with the active PyTorch build and the CuTe decode dependency is unavailable; CI should exercise the supported kernel environment.
- Varlen / CP: N/A; only the `T=1` cached SISO decode helper changes.

## Benchmark / NCU (kernel changes only)

- Hardware: NVIDIA RTX A1000 Laptop GPU (sm86, reference-only consumer GPU), PyTorch 2.12.1+cu130.
- Workload: local decode hot-section microbenchmark, `B={1,8,64}`, `T=1`, `H=8`, SISO rank 1, head dim 64, state size 128, bf16. The timed section covers identity projection preparation, unchanged B/C view preparation, and the upstream rotary decode wrapper; it is not an end-to-end model latency claim.
- Command: `/home/cherry-cloud/miniconda3/envs/diffusion/bin/python profile/mamba3-siso-decode-opt/bench_hotpath.py --profile` (local ignored benchmark artifact).
- Before / after: B1 170.945 / 152.895 us (1.118x); B8 188.177 / 164.113 us (1.147x); B64 185.443 / 163.297 us (1.136x). Two independent repeats kept the improvement in the 1.07x-1.14x range.
- Profiler: memory events decreased from 5 to 3 and hot-section CUDA kernels from 3 to 1, removing two `aten::empty` allocation requests and two `fill_` kernels. Warm runs issued no direct `cudaMalloc` because the caching allocator served the requests.
- NCU: N/A; no kernel implementation changes.
- Conclusion: improved launch-bound SISO decode preparation. End-to-end numbers on a supported datacenter GPU remain for CI or maintainer hardware.

## Breaking changes

None. The helper signature, MIMO path, numerical behavior, and checkpoint keys are unchanged; `_siso_proj` is non-persistent.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (focused local checks and pre-commit pass; full model coverage requires the supported CI kernel environment).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A: no kernel code changed; same-hardware hot-path numbers are included above).
- [ ] This PR is minor/cosmetic-only (this is a runtime performance optimization).
