### PR TITLE
[Perf] Avoid unused max sync in unpadding

### DIFF
--- a/fla/layers/mom.py
+++ b/fla/layers/mom.py
@@ -666,8 +666,7 @@ class MomAttention(nn.Module):
         o = self.o_proj(o)
 
         if origin_cu_seqlens is not None:
-            mask = attention_mask if attention_mask.shape[-1] == seq_len else attention_mask[:, -seq_len:]
-            indices, _ = get_unpad_indices_and_cu(mask)
+            indices, _ = get_unpad_indices_and_cu(attention_mask, seq_len)
             o = index_first_axis(rearrange(o, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
         return o, None, past_key_values, router_logits.view(-1, self.num_memories)

--- a/fla/layers/mom.py
+++ b/fla/layers/mom.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 from fla.layers.utils import (
     get_layer_cache,
     get_unpad_data,
+    get_unpad_indices_and_cu,
     index_first_axis,
     pad_input,
     repad_hidden_states,
@@ -665,7 +666,8 @@ class MomAttention(nn.Module):
         o = self.o_proj(o)
 
         if origin_cu_seqlens is not None:
-            indices, _, _ = get_unpad_data(attention_mask[:, -seq_len:])
+            mask = attention_mask if attention_mask.shape[-1] == seq_len else attention_mask[:, -seq_len:]
+            indices, _ = get_unpad_indices_and_cu(mask)
             o = index_first_axis(rearrange(o, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
         return o, None, past_key_values, router_logits.view(-1, self.num_memories)

--- a/fla/layers/precond_gated_deltanet.py
+++ b/fla/layers/precond_gated_deltanet.py
@@ -16,7 +16,13 @@ import torch.nn as nn
 from einops import rearrange
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import (
+    get_layer_cache,
+    get_unpad_indices_and_cu,
+    index_first_axis,
+    pad_input,
+    update_layer_cache,
+)
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
 from fla.ops.precond_gated_delta_rule import (
     chunk_precond_gated_delta_rule,
@@ -277,7 +283,8 @@ class PrecondGatedDeltaNet(nn.Module):
 
         cu_seqlens = kwargs.get('cu_seqlens')
         if attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+            mask = attention_mask if attention_mask.shape[-1] == q_len else attention_mask[:, -q_len:]
+            indices, cu_seqlens = get_unpad_indices_and_cu(mask)
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
         if self.use_short_conv:

--- a/fla/layers/precond_gated_deltanet.py
+++ b/fla/layers/precond_gated_deltanet.py
@@ -283,8 +283,7 @@ class PrecondGatedDeltaNet(nn.Module):
 
         cu_seqlens = kwargs.get('cu_seqlens')
         if attention_mask is not None:
-            mask = attention_mask if attention_mask.shape[-1] == q_len else attention_mask[:, -q_len:]
-            indices, cu_seqlens = get_unpad_indices_and_cu(mask)
+            indices, cu_seqlens = get_unpad_indices_and_cu(attention_mask, q_len)
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
         if self.use_short_conv:

--- a/fla/layers/precond_kda.py
+++ b/fla/layers/precond_kda.py
@@ -15,7 +15,13 @@ import torch.nn as nn
 from einops import rearrange, repeat
 from torch.nn import functional as F
 
-from fla.layers.utils import get_layer_cache, get_unpad_data, index_first_axis, pad_input, update_layer_cache
+from fla.layers.utils import (
+    get_layer_cache,
+    get_unpad_indices_and_cu,
+    index_first_axis,
+    pad_input,
+    update_layer_cache,
+)
 from fla.modules import FusedRMSNormGated, ShortConvolution
 from fla.ops.kda.gate import fused_kda_gate
 from fla.ops.precond_kda import chunk_precond_kda, fused_recurrent_precond_kda
@@ -253,7 +259,8 @@ class PrecondKDA(nn.Module):
 
         cu_seqlens = kwargs.get("cu_seqlens")
         if attention_mask is not None:
-            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+            mask = attention_mask if attention_mask.shape[-1] == q_len else attention_mask[:, -q_len:]
+            indices, cu_seqlens = get_unpad_indices_and_cu(mask)
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
         if self.use_short_conv:

--- a/fla/layers/precond_kda.py
+++ b/fla/layers/precond_kda.py
@@ -259,8 +259,7 @@ class PrecondKDA(nn.Module):
 
         cu_seqlens = kwargs.get("cu_seqlens")
         if attention_mask is not None:
-            mask = attention_mask if attention_mask.shape[-1] == q_len else attention_mask[:, -q_len:]
-            indices, cu_seqlens = get_unpad_indices_and_cu(mask)
+            indices, cu_seqlens = get_unpad_indices_and_cu(attention_mask, q_len)
             hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
 
         if self.use_short_conv:

--- a/fla/layers/utils.py
+++ b/fla/layers/utils.py
@@ -80,14 +80,32 @@ index_put_first_axis = IndexPutFirstAxis.apply
 
 
 @tensor_cache
-def get_unpad_indices_and_cu(
+def _get_unpad_indices_and_cu(
     attention_mask: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Return unpadding indices and cumulative sequence lengths."""
     lens = prepare_lens_from_mask(attention_mask)
     indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
     cu_seqlens = prepare_cu_seqlens_from_lens(lens)
     return indices, cu_seqlens
+
+
+@tensor_cache
+def _get_last_token_unpad_indices_and_cu(
+    attention_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _get_unpad_indices_and_cu(attention_mask[:, -1:])
+
+
+def get_unpad_indices_and_cu(
+    attention_mask: torch.Tensor,
+    q_len: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return unpadding indices and cumulative sequence lengths."""
+    if q_len is None or attention_mask.shape[-1] == q_len:
+        return _get_unpad_indices_and_cu(attention_mask)
+    if q_len == 1:
+        return _get_last_token_unpad_indices_and_cu(attention_mask)
+    return _get_unpad_indices_and_cu(attention_mask[:, -q_len:])
 
 
 @tensor_cache
@@ -150,8 +168,7 @@ def unpad_hidden_states(
             or the explicit value passed in when unpadding is skipped.
     """
     if cu_seqlens is None and attention_mask is not None:
-        mask = attention_mask if attention_mask.shape[-1] == q_len else attention_mask[:, -q_len:]
-        indices, cu_seqlens = get_unpad_indices_and_cu(mask)
+        indices, cu_seqlens = get_unpad_indices_and_cu(attention_mask, q_len)
         hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
         return hidden_states, indices, cu_seqlens
     return hidden_states, None, cu_seqlens

--- a/fla/layers/utils.py
+++ b/fla/layers/utils.py
@@ -10,7 +10,11 @@
 import torch
 from einops import rearrange, repeat
 
-from fla.ops.utils.index import prepare_cu_seqlens_from_mask, prepare_lens_from_mask
+from fla.ops.utils.index import (
+    prepare_cu_seqlens_from_lens,
+    prepare_cu_seqlens_from_mask,
+    prepare_lens_from_mask,
+)
 from fla.utils import tensor_cache
 
 _LAYER_IDX_REQUIRED_MSG = "{cls} requires `layer_idx` when `past_key_values` is provided."
@@ -76,6 +80,17 @@ index_put_first_axis = IndexPutFirstAxis.apply
 
 
 @tensor_cache
+def get_unpad_indices_and_cu(
+    attention_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return unpadding indices and cumulative sequence lengths."""
+    lens = prepare_lens_from_mask(attention_mask)
+    indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+    cu_seqlens = prepare_cu_seqlens_from_lens(lens)
+    return indices, cu_seqlens
+
+
+@tensor_cache
 def get_unpad_data(
     attention_mask: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, int]:
@@ -135,7 +150,8 @@ def unpad_hidden_states(
             or the explicit value passed in when unpadding is skipped.
     """
     if cu_seqlens is None and attention_mask is not None:
-        indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+        mask = attention_mask if attention_mask.shape[-1] == q_len else attention_mask[:, -q_len:]
+        indices, cu_seqlens = get_unpad_indices_and_cu(mask)
         hidden_states = index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices).unsqueeze(0)
         return hidden_states, indices, cu_seqlens
     return hidden_states, None, cu_seqlens


### PR DESCRIPTION
## Summary

- add a cached `get_unpad_indices_and_cu()` helper that does not compute `lens.max().item()`
- migrate only callers that discarded the maximum length: shared recurrent-layer unpadding, Precond GDN, Precond KDA, and MoM
- reuse the original attention-mask object when `q_len` already matches its length, restoring identity-based tensor-cache hits across layers
- cache the `q_len=1` suffix by the original attention-mask identity, so decode layers reuse the same indices and cumulative lengths
- preserve `get_unpad_data()` and all callers that need `max_seqlen_in_batch`

`torch.nonzero` can still synchronize on the first use of an uncached CUDA mask. This change removes the separate unused `max().item()` synchronization; full-length and single-token paths avoid recomputing unpadding metadata in later layers. Suffixes with `1 < q_len < mask_len` retain the existing view-based behavior.

## Test plan

- `python scripts/find_dependent_tests.py fla/layers/utils.py fla/layers/precond_gated_deltanet.py fla/layers/precond_kda.py fla/layers/mom.py`
- `python -m pytest -q tests/test_utils.py` — 6 passed
- `python -m pytest -q tests/ops/utils/test_index.py` — 93 passed
- helper equivalence checks for full, suffix, and single-token masks against `get_unpad_data()`
- PyTorch profiler assertions: the no-max path has no `aten::item`; repeated `q_len=1` calls have neither `aten::nonzero` nor `aten::item`
- `uvx pre-commit run --files fla/layers/utils.py fla/layers/precond_gated_deltanet.py fla/layers/precond_kda.py fla/layers/mom.py`

## Benchmark / NCU (kernel changes only)

No kernel code changed. CUDA helper microbenchmarks on NVIDIA RTX A1000 Laptop GPU (SM86, driver 595.84), boolean mask `[B, 2048]`, 32 consecutive layer-style calls, median of 30 repetitions, synchronized host wall time.

Isolating removal of the unused `max().item()` while forcing cache misses:

| B | old (ms) | no-max (ms) | speedup |
|---:|---:|---:|---:|
| 1 | 2.5944 | 1.8543 | 1.40x |
| 8 | 2.6819 | 1.9412 | 1.38x |
| 64 | 2.7644 | 1.9853 | 1.39x |

Full-length mask path, including restored cross-layer identity-cache hits:

| B | old (ms) | new (ms) | speedup |
|---:|---:|---:|---:|
| 1 | 2.6987 | 0.0254 | 106.05x |
| 8 | 2.7672 | 0.0408 | 67.77x |
| 64 | 2.8594 | 0.0546 | 52.33x |

Single-token decode path, comparing a new suffix view per layer with the dedicated cache keyed by the original mask:

| B | old (ms) | cached T=1 (ms) | speedup |
|---:|---:|---:|---:|
| 1 | 1.6119 | 0.0287 | 56.17x |
| 8 | 1.7242 | 0.0444 | 38.80x |
| 64 | 1.7096 | 0.0587 | 29.11x |

These are helper-path microbenchmarks, not end-to-end model latency.

## Breaking changes

None. The existing `get_unpad_data()` interface and max-length consumers are unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable.
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A: no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.