### PR TITLE
[Fix] Apply scale in naive recurrent gated delta product

### DIFF
--- a/fla/ops/gated_delta_product/naive.py
+++ b/fla/ops/gated_delta_product/naive.py
@@ -40,6 +40,7 @@ def naive_recurrent_gated_delta_product(q, k, v, g, beta, scale, cu_seqlens=None
     if g is not None:
         assert g.shape == (B, T, H)
     q, k, v, beta = map(lambda x: x.float(), (q, k, v, beta))
+    q = q * scale
 
     h = torch.zeros(B, H, K, V, dtype=torch.float32, device=q.device)
     if initial_state is not None:


### PR DESCRIPTION
## Summary

`naive_recurrent_gated_delta_product` accepted `scale` but never applied it, so the naive reference returned `1/scale` times the chunk kernel's output (8x at D=64, ratio exactly 7/8). Scale `q` up front, matching the convention in `naive_recurrent_gated_delta_rule`. Exposed on main by `tests/ops/test_gdp.py::test_naive_varlen`.

## Test plan

- Unit tests added/modified: none (fix only; the exposing test already exists on main)
- Dependent tests run: `tests/ops/test_gdp.py`, `tests/ops/test_delta_product.py` (via `scripts/find_dependent_tests.py`) — 28/28 pass on H200, torch 2.10
- Varlen / CP / model tests: `test_naive_varlen` (varlen with zero-length sequence) passes

## Benchmark / NCU (kernel changes only)

- N/A — reference (non-kernel) implementation only, no performance change

## Breaking changes

- None. Other callers use the naive only as a backward smoke reference and do not compare its values, so the corrected output does not affect existing assertions.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
