### PR TITLE
[Fix] Gate decode shortcuts and validate dims across layers

### DIFF
--- a/fla/layers/delta_net.py
+++ b/fla/layers/delta_net.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from typing import TYPE_CHECKING
 
@@ -115,8 +116,10 @@ class DeltaNet(nn.Module):
         self.conv_bias = conv_bias
         self.allow_neg_eigval = allow_neg_eigval
 
-        self.key_dim = int(hidden_size * expand_k)
-        self.value_dim = int(hidden_size * expand_v)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         self.head_k_dim = self.key_dim // num_heads
         self.head_v_dim = self.value_dim // num_heads
         self.layer_idx = layer_idx

--- a/fla/layers/gla.py
+++ b/fla/layers/gla.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -110,8 +111,10 @@ class GatedLinearAttention(nn.Module):
         self.conv_bias = conv_bias
         self.use_output_gate = use_output_gate
 
-        self.key_dim = int(hidden_size * expand_k)
-        self.value_dim = int(hidden_size * expand_v)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         self.key_dim_per_group = self.key_dim // self.num_kv_groups
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
         self.clamp_min = clamp_min

--- a/fla/layers/gsa.py
+++ b/fla/layers/gsa.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from typing import TYPE_CHECKING
 
@@ -60,8 +61,10 @@ class GatedSlotAttention(nn.Module):
         self.num_heads = num_heads
         self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
         self.num_kv_groups = self.num_heads // self.num_kv_heads
-        self.key_dim = int(hidden_size * expand_k)
-        self.value_dim = int(hidden_size * expand_v)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         self.key_dim_per_group = self.key_dim // self.num_kv_groups
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
         self.head_k_dim = self.key_dim // self.num_heads

--- a/fla/layers/hgrn2.py
+++ b/fla/layers/hgrn2.py
@@ -212,3 +212,10 @@ class HGRN2Attention(nn.Module):
         o = repad_hidden_states(o, indices, batch_size, q_len)
 
         return o, None, past_key_values
+
+    def state_size(self, **kwargs) -> int:
+        state_size = self.input_dim * self.expand_ratio
+        for module in self.children():
+            if isinstance(module, ShortConvolution):
+                state_size += module.state_size
+        return state_size

--- a/fla/layers/linear_attn.py
+++ b/fla/layers/linear_attn.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -51,8 +52,10 @@ class LinearAttention(nn.Module):
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
         self.num_kv_groups = self.num_heads // self.num_kv_heads
-        self.key_dim = int(hidden_size * expand_k)
-        self.value_dim = int(hidden_size * expand_v)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         self.key_dim_per_group = self.key_dim // self.num_kv_groups
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
 

--- a/fla/layers/mamba2.py
+++ b/fla/layers/mamba2.py
@@ -160,6 +160,11 @@ class Mamba2(nn.Module):
                 )
             self.num_heads = num_heads
 
+        if self.num_heads % n_groups != 0:
+            raise ValueError(
+                f"`num_heads` ({self.num_heads}) must be divisible by `n_groups` ({n_groups})."
+            )
+
         self.conv_kernel_size = conv_kernel
         self.conv_init = conv_init
         self.use_conv_bias = use_conv_bias

--- a/fla/layers/mom.py
+++ b/fla/layers/mom.py
@@ -332,9 +332,11 @@ class MomAttention(nn.Module):
         self.num_heads = num_heads
 
         self.key_dim = int(self.num_heads * self.head_dim)
-        self.value_dim = int(self.key_dim * self.expand_v)
+        value_dim, head_v_dim = self.key_dim * self.expand_v, head_dim * self.expand_v
+        self.value_dim, self.head_v_dim = round(value_dim), round(head_v_dim)
+        assert math.isclose(value_dim, self.value_dim), f"`key_dim * expand_v` must be an integer, got {value_dim}."
+        assert math.isclose(head_v_dim, self.head_v_dim), f"`head_dim * expand_v` must be an integer, got {head_v_dim}."
         self.head_qk_dim = head_dim
-        self.head_v_dim = int(head_dim * self.expand_v)
         self.layer_idx = layer_idx
         self.silu = nn.SiLU()
 

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -103,8 +104,10 @@ class MultiScaleRetention(nn.Module):
         self.conv_bias = conv_bias
         self.use_output_gate = use_output_gate
 
-        self.key_dim = int(hidden_size * expand_k)
-        self.value_dim = int(hidden_size * expand_v)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         self.key_dim_per_group = self.key_dim // self.num_kv_groups
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
         self.layer_idx = layer_idx

--- a/fla/layers/raven.py
+++ b/fla/layers/raven.py
@@ -246,7 +246,8 @@ class Raven(nn.Module):
         seqlen_offset, max_seqlen = 0, q_len
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q_len + _max_offset(seqlen_offset)
+            if self.use_rope:
+                max_seqlen = q_len + _max_offset(seqlen_offset)
 
         cu_seqlens = kwargs.get('cu_seqlens')
         hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
@@ -254,7 +255,7 @@ class Raven(nn.Module):
         # top of cached tokens. During prefill the unpadded tokens are already packed
         # contiguously per `cu_seqlens`, so positions start at 0; adding `lens - mask_len`
         # there would push them negative.
-        if indices is not None and _max_offset(seqlen_offset) > 0:
+        if self.use_rope and indices is not None and _max_offset(seqlen_offset) > 0:
             seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
             max_seqlen = q_len + _max_offset(seqlen_offset)
 

--- a/fla/layers/raven.py
+++ b/fla/layers/raven.py
@@ -104,8 +104,8 @@ class Raven(nn.Module):
         self.num_kv_groups = self.num_heads // self.num_kv_heads
         key_dim = hidden_size * expand_k
         value_dim = hidden_size * expand_v
-        self.key_dim = int(key_dim)
-        self.value_dim = int(value_dim)
+        self.key_dim = round(key_dim)
+        self.value_dim = round(value_dim)
         if not math.isclose(key_dim, self.key_dim):
             raise ValueError(f"`hidden_size * expand_k` must be an integer, got {key_dim}.")
         if not math.isclose(value_dim, self.value_dim):

--- a/fla/layers/rwkv6.py
+++ b/fla/layers/rwkv6.py
@@ -55,8 +55,10 @@ class RWKV6Attention(nn.Module):
         self.proj_low_rank_dim = proj_low_rank_dim
         self.gate_low_rank_dim = gate_low_rank_dim
 
-        self.key_dim = int(hidden_size * expand_k)
-        self.value_dim = int(hidden_size * expand_v)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         self.layer_idx = layer_idx
 
         assert mode in ['chunk', 'fused_recurrent'], f"Not supported mode `{mode}`."

--- a/fla/layers/rwkv7.py
+++ b/fla/layers/rwkv7.py
@@ -60,12 +60,15 @@ class RWKV7Attention(nn.Module):
         if head_dim is None and num_heads is None:
             raise ValueError("Either `head_dim` or `num_heads` must be specified.")
         elif head_dim is not None:
+            assert hidden_size % head_dim == 0, f"`hidden_size` must be divisible by `head_dim`, got {hidden_size} and {head_dim}."
             self.head_dim = head_dim
-            self.num_heads = int(hidden_size // head_dim)
+            self.num_heads = hidden_size // head_dim
         elif num_heads is not None:
-            self.head_dim = int(hidden_size // num_heads)
+            assert hidden_size % num_heads == 0, f"`hidden_size` must be divisible by `num_heads`, got {hidden_size} and {num_heads}."
+            self.head_dim = hidden_size // num_heads
             self.num_heads = num_heads
-        self.head_v_dim = int(self.value_dim // self.num_heads)
+        assert self.value_dim % self.num_heads == 0, f"`value_dim` must be divisible by `num_heads`, got {self.value_dim} and {self.num_heads}."
+        self.head_v_dim = self.value_dim // self.num_heads
 
         # Increase lora dimension for headdim>64
         factor = self.head_dim / 64

--- a/fla/layers/simple_gla.py
+++ b/fla/layers/simple_gla.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -99,8 +100,10 @@ class SimpleGatedLinearAttention(nn.Module):
         self.conv_size = conv_size
         self.conv_bias = conv_bias
 
-        self.key_dim = int(hidden_size * expand_k)
-        self.value_dim = int(hidden_size * expand_v)
+        key_dim, value_dim = hidden_size * expand_k, hidden_size * expand_v
+        self.key_dim, self.value_dim = round(key_dim), round(value_dim)
+        assert math.isclose(key_dim, self.key_dim), f"`hidden_size * expand_k` must be an integer, got {key_dim}."
+        assert math.isclose(value_dim, self.value_dim), f"`hidden_size * expand_v` must be an integer, got {value_dim}."
         self.key_dim_per_group = self.key_dim // self.num_kv_groups
         self.value_dim_per_group = self.value_dim // self.num_kv_groups
         self.layer_idx = layer_idx

--- a/fla/modules/conv/short_conv.py
+++ b/fla/modules/conv/short_conv.py
@@ -160,7 +160,9 @@ class ShortConvolution(nn.Conv1d):
             x = x.mul_(mask.unsqueeze(-1))
 
         # in decoding phase, the cache (if provided) is updated inplace
-        if B * T == N:
+        # For packed varlen inputs, decode only when every sequence has exactly one token:
+        # a zero-length or multi-token sequence makes the shape check misfire.
+        if B * T == N and (cu_seqlens is None or bool((cu_seqlens.diff() == 1).all())):
             y, cache = self.step(
                 x=x,
                 residual=residual,

--- a/fla/ops/gsa/fused_recurrent.py
+++ b/fla/ops/gsa/fused_recurrent.py
@@ -374,7 +374,9 @@ class FusedRecurrentGSAFunction(torch.autograd.Function):
         cu_seqlens: torch.LongTensor | None = None,
     ) -> tuple[torch.Tensor, tuple[torch.Tensor]]:
         T = q.shape[1]
-        if T == 1 and not q.requires_grad:
+        # The inference shortcut treats the input as a single dense batch; it is only
+        # valid without cu_seqlens (a packed batch would read seq0's state and misshape the output).
+        if T == 1 and not q.requires_grad and cu_seqlens is None:
             o, (hkt, hvt) = fused_recurrent_gsa_inference(
                 q=q,
                 k=k,

--- a/fla/ops/rwkv7/fused_recurrent.py
+++ b/fla/ops/rwkv7/fused_recurrent.py
@@ -147,7 +147,9 @@ def fused_recurrent_rwkv7_fwd(
     B, T, H, K, V = *k.shape, v.shape[-1]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK = triton.next_power_of_2(K)
-    IS_DECODE = (T == 1)
+    # For packed varlen inputs, decode only when every sequence has exactly one token:
+    # a zero-length sequence would otherwise read/write out of bounds in the decode branch.
+    IS_DECODE = (T == 1) and (cu_seqlens is None or bool((cu_seqlens.diff() == 1).all()))
 
     h0 = initial_state
     if not output_final_state:

--- a/tests/layers/test_layer_dim_validation.py
+++ b/tests/layers/test_layer_dim_validation.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+
+from fla.layers.delta_net import DeltaNet
+from fla.layers.gla import GatedLinearAttention
+from fla.layers.gsa import GatedSlotAttention
+from fla.layers.hgrn2 import HGRN2Attention
+from fla.layers.linear_attn import LinearAttention
+from fla.layers.mamba2 import Mamba2
+from fla.layers.multiscale_retention import MultiScaleRetention
+from fla.layers.rwkv6 import RWKV6Attention
+from fla.layers.rwkv7 import RWKV7Attention
+from fla.layers.simple_gla import SimpleGatedLinearAttention
+
+# hidden_size * expand is an integer only in floating-point representation
+_EXPAND_LAYERS = [
+    GatedLinearAttention, GatedSlotAttention, LinearAttention,
+    SimpleGatedLinearAttention, MultiScaleRetention, DeltaNet, RWKV6Attention,
+]
+
+
+@pytest.mark.parametrize("layer_cls", _EXPAND_LAYERS)
+def test_expand_dim_rounding(layer_cls):
+    """`hidden_size * expand` that is an integer up to fp error must round, not truncate."""
+    # 100 * 0.58 == 57.999...: must round to 58 (truncating to 57 was the bug)
+    layer = layer_cls(hidden_size=100, expand_k=0.58, expand_v=0.5, num_heads=1)
+    assert layer.key_dim == 58
+
+
+@pytest.mark.parametrize("layer_cls", _EXPAND_LAYERS)
+def test_expand_dim_rejects_non_integer(layer_cls):
+    """A truly non-integer `hidden_size * expand` must fail loudly instead of being used silently."""
+    # 101 * 0.58 == 58.58: not an integer
+    with pytest.raises(AssertionError):
+        layer_cls(hidden_size=101, expand_k=0.58, expand_v=0.5, num_heads=1)
+
+
+def test_rwkv7_head_dim_divisibility():
+    RWKV7Attention(hidden_size=1000, head_dim=None, num_heads=5)
+    with pytest.raises(AssertionError):
+        RWKV7Attention(hidden_size=1000, head_dim=None, num_heads=6)
+    RWKV7Attention(hidden_size=1000, head_dim=100)
+    with pytest.raises(AssertionError):
+        RWKV7Attention(hidden_size=1000, head_dim=64)
+
+
+def test_mamba2_n_groups_divisibility():
+    Mamba2(hidden_size=512, n_groups=4)
+    with pytest.raises(ValueError, match="n_groups"):
+        Mamba2(hidden_size=512, n_groups=3)
+
+
+def test_hgrn2_state_size():
+    layer = HGRN2Attention(hidden_size=64, expand_ratio=2, use_short_conv=False)
+    assert layer.state_size() == 128

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -1538,3 +1538,44 @@ def test_conv_non_contiguous_dy(B, T, D, W, activation, dtype):
     assert_close(" dx", x_ones.grad, x_sum.grad, 1e-3)
     assert_close(" dw", weight_ones.grad, weight_sum.grad, 1e-3)
     assert_close("dh0", h0_ones.grad, h0_sum.grad, 1e-3)
+
+
+def test_conv_varlen_decode_detection_with_zero_len_seq():
+    """A packed batch with a zero-length sequence must not be misdetected as a decode step."""
+    torch.manual_seed(42)
+    D, W = 16, 4
+    dtype = torch.float32
+    # lens [0, 2]: B*T == N would misfire into the decode shortcut, which ignores cu_seqlens.
+    cu_seqlens = torch.tensor([0, 0, 2], device=device, dtype=torch.int32)
+    N, T = 2, 2
+    x = torch.randn(1, T, D).to(device, dtype)
+
+    conv = ShortConvolution(
+        hidden_size=D,
+        kernel_size=W,
+        bias=False,
+        activation='silu',
+        device=device,
+        dtype=dtype,
+    )
+
+    cache = torch.randn(N, D, W - 1).to(device, dtype)
+    # reference: only the real sequence (index 1) is processed
+    xi = x[:, 0:2, :].transpose(1, 2)
+    ci = cache[1:2]
+    ref = causal_conv1d_ref_torch(
+        x=xi,
+        weight=rearrange(conv.weight, "d 1 w -> d w"),
+        bias=conv.bias,
+        initial_state=ci,
+        activation='silu',
+    ).transpose(1, 2)
+
+    zero_pad = torch.zeros(N, D, 1, device=device, dtype=dtype)
+    tri, _ = conv(
+        x,
+        cache=torch.cat([zero_pad, cache], dim=-1).clone(),
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+    )
+    assert_close("varlen zero-len y", ref, tri, 1e-3)


### PR DESCRIPTION
## Summary

Batch of small, independent safety fixes found by auditing the codebase for the same bug classes as recent community fix PRs:

- **Decode shortcuts misfire on packed varlen** (`short_conv.py`, `ops/rwkv7/fused_recurrent.py`, `ops/gsa/fused_recurrent.py`): shape-equality decode checks (`B*T==N`, `T==1`) are wrong when a packed batch has zero-length or multi-token sequences — short_conv misaligns tokens to cache rows, rwkv7 reads/writes out of bounds, GSA treats a packed batch as dense. Gate shortcuts on every sequence having exactly one token.
- **Expanded dims not validated at layer construction** (7 layers + mom/raven/rwkv7): `int(hidden_size * expand)` truncates fp-representable integers (50*0.58→28) and silently uses non-integer dims. Round first and reject true non-integers with `math.isclose`, and assert divisibility for head dims — the convention already used in abc/raven/kda layers. Also fixes raven's false reject of valid expand values (isclose was checked after int-truncation).
- **Mamba2 `num_heads % n_groups`**: fail fast instead of a cryptic late reshape error in decode.
- **HGRN2 `state_size`**: implement as `input_dim * expand_ratio` (GLA recurrent state shape).
- **raven seqlen max**: compute only when RoPE is used (default path skips two device syncs).

## Test plan

- Unit tests added/modified: `tests/layers/test_layer_dim_validation.py` (17 constructor-validation cases, CPU), `tests/modules/test_conv.py::test_conv_varlen_decode_detection_with_zero_len_seq`
- Dependent tests run: `tests/layers/test_layer_dim_validation.py` 17/17 pass locally; ruff and compileall clean
- Varlen / CP / model tests: the short_conv test covers a packed varlen batch with a zero-length sequence and cache; GPU-dependent suites run in CI

## Benchmark / NCU (kernel changes only)

- N/A — no kernel code changed (validation guards, decode-shortcut gating, one sync-avoidance refactor)

## Breaking changes

- Invalid layer configs that were silently truncated or floored now fail loudly at construction; valid configs are bit-identical. The GSA inference shortcut no longer applies to packed varlen inputs (previously wrong for them); dense decode is unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
