### PR TITLE
[Rotary] Separate varlen lengths from cache capacity

### DIFF
--- a/fla/layers/attn.py
+++ b/fla/layers/attn.py
@@ -17,6 +17,7 @@ from transformers.utils import logging
 
 from fla.layers.utils import pad_input, unpad_input
 from fla.modules import RMSNorm, RotaryEmbedding
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.utils.index import prepare_lens_from_mask
 
 if TYPE_CHECKING:
@@ -109,20 +110,21 @@ class Attention(nn.Module):
 
         # equivalent to cu_seqlens in `flash_attn`
         cu_seqlens = kwargs.get('cu_seqlens')
+        batch_max_seqlen = q_len if cu_seqlens is None else get_max_seqlen(cu_seqlens, kwargs.get('cu_seqlens_cpu'))
 
-        seqlen_offset, max_seqlen = 0, q_len
+        seqlen_offset, rope_cache_length = 0, batch_max_seqlen
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None:
                 # to eliminate the offsets of padding tokens
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q.shape[1] + max(seqlen_offset)
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
+        q, k = self.rotary(
+            q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
@@ -163,8 +165,8 @@ class Attention(nn.Module):
                 rearrange(v, 'b l ... -> (b l) ...').contiguous(),
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_k=cu_seqlens,
-                max_seqlen_q=max_seqlen,
-                max_seqlen_k=max_seqlen,
+                max_seqlen_q=batch_max_seqlen,
+                max_seqlen_k=batch_max_seqlen,
                 causal=True,
                 window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0),
             )

--- a/fla/layers/bitattn.py
+++ b/fla/layers/bitattn.py
@@ -18,6 +18,7 @@ from transformers.utils import logging
 from fla.layers.utils import pad_input, unpad_input
 from fla.modules import RotaryEmbedding
 from fla.modules.fused_bitlinear import FusedBitLinear
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.utils.index import prepare_lens_from_mask
 
 if TYPE_CHECKING:
@@ -97,20 +98,21 @@ class BitAttention(nn.Module):
 
         # equivalent to cu_seqlens in `flash_attn`
         cu_seqlens = kwargs.get('cu_seqlens')
+        batch_max_seqlen = q_len if cu_seqlens is None else get_max_seqlen(cu_seqlens, kwargs.get('cu_seqlens_cpu'))
 
-        seqlen_offset, max_seqlen = 0, q_len
+        seqlen_offset, rope_cache_length = 0, batch_max_seqlen
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None:
                 # to eliminate the offsets of padding tokens
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q.shape[1] + max(seqlen_offset)
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
+        q, k = self.rotary(
+            q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
@@ -150,8 +152,8 @@ class BitAttention(nn.Module):
                 q.squeeze(0), k.squeeze(0), v.squeeze(0),
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_k=cu_seqlens,
-                max_seqlen_q=max_seqlen,
-                max_seqlen_k=max_seqlen,
+                max_seqlen_q=batch_max_seqlen,
+                max_seqlen_k=batch_max_seqlen,
                 causal=True,
                 window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0),
             ).unsqueeze(0)

--- a/fla/layers/deltaformer.py
+++ b/fla/layers/deltaformer.py
@@ -15,6 +15,7 @@ from einops import rearrange
 from transformers.utils import logging
 
 from fla.modules import RMSNorm, RotaryEmbedding
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.deltaformer import deltaformer_attn
 
 if TYPE_CHECKING:
@@ -128,11 +129,9 @@ class DeltaFormerAttention(nn.Module):
         if past_key_values is not None:
             raise NotImplementedError("DeltaFormerAttention does not support `past_key_values`")
 
-        max_seqlen = q_len
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
-
-        q, k = self.rotary(q, k, seqlen_offset=0, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens_kw)
+        rope_cache_length = q_len if cu_seqlens_kw is None else get_max_seqlen(
+            cu_seqlens_kw, kwargs.get('cu_seqlens_cpu'))
+        q, k = self.rotary(q, k, seqlen_offset=0, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens_kw)
 
         o = deltaformer_attn(
             q=q,
@@ -141,6 +140,7 @@ class DeltaFormerAttention(nn.Module):
             beta=beta,
             attention_mask=attention_mask,
             cu_seqlens=cu_seqlens_kw,
+            max_seqlen=rope_cache_length,
         )
 
         o = o.reshape(batch_size, q_len, -1)

--- a/fla/layers/mla.py
+++ b/fla/layers/mla.py
@@ -24,6 +24,7 @@ from transformers.utils import logging
 
 from fla.layers.utils import pad_input, unpad_input
 from fla.modules import RMSNorm, RotaryEmbedding
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.utils.index import prepare_lens_from_mask
 
 if TYPE_CHECKING:
@@ -126,7 +127,7 @@ class MultiheadLatentAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: torch.Tensor | None,
+        attention_mask: torch.Tensor | None = None,
         past_key_values: Cache | None = None,
         output_attentions: bool = False,
         use_cache: bool = False,
@@ -153,20 +154,20 @@ class MultiheadLatentAttention(nn.Module):
         k_pass, v = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
 
         # apply rotary position embedding
-        seqlen_offset, max_seqlen = 0, q_len
+        cu_seqlens = kwargs.get("cu_seqlens")
+        batch_max_seqlen = q_len if cu_seqlens is None else get_max_seqlen(cu_seqlens, kwargs.get('cu_seqlens_cpu'))
+        seqlen_offset, rope_cache_length = 0, batch_max_seqlen
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q_len + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None:
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q_len + max(seqlen_offset)
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
-        cu_seqlens = kwargs.get("cu_seqlens")
+        if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
         q_rot, k_rot = self.rotary(
-            q_rot, k_rot, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens,
+            q_rot, k_rot, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens,
         )
 
         k_rot = repeat(k_rot, 'b t 1 d -> b t h d', h=self.num_heads)
@@ -213,8 +214,8 @@ class MultiheadLatentAttention(nn.Module):
                 q.squeeze(0), k.squeeze(0), v.squeeze(0),
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_k=cu_seqlens,
-                max_seqlen_q=max_seqlen,
-                max_seqlen_k=max_seqlen,
+                max_seqlen_q=batch_max_seqlen,
+                max_seqlen_k=batch_max_seqlen,
                 causal=True,
                 window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0),
             ).unsqueeze(0)

--- a/fla/layers/moba.py
+++ b/fla/layers/moba.py
@@ -16,6 +16,7 @@ from transformers.utils import logging
 
 from fla.layers.utils import pad_input, unpad_input
 from fla.modules import FusedRMSNormGated, RMSNorm, RotaryEmbedding
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.moba import parallel_moba
 from fla.ops.utils.index import prepare_lens_from_mask
 
@@ -176,20 +177,24 @@ class MoBA(nn.Module):
 
         # equivalent to cu_seqlens in `flash_attn`
         cu_seqlens = kwargs.get('cu_seqlens')
+        cu_seqlens_q = cu_seqlens[0] if isinstance(cu_seqlens, (tuple, list)) else cu_seqlens
+        cu_seqlens_cpu = kwargs.get('cu_seqlens_cpu')
+        cu_seqlens_cpu = cu_seqlens_cpu[0] if isinstance(cu_seqlens_cpu, (tuple, list)) else cu_seqlens_cpu
+        batch_max_seqlen = q_len if cu_seqlens_q is None else get_max_seqlen(cu_seqlens_q, cu_seqlens_cpu)
 
-        seqlen_offset, max_seqlen = 0, q_len
+        seqlen_offset, rope_cache_length = 0, batch_max_seqlen
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None:
                 # to eliminate the offsets of padding tokens
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q.shape[1] + max(seqlen_offset)
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        if past_key_values is not None and cu_seqlens_q is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
+        q, k = self.rotary(
+            q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens_q)
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0
@@ -280,11 +285,8 @@ class MoBA(nn.Module):
             k_packed = rearrange(k, 'b s h d -> 1 (b s) h d').contiguous()
             v_packed = rearrange(v, 'b s h d -> 1 (b s) h d').contiguous()
 
-            offsets = torch.arange(batch_size + 1, dtype=torch.int32, device=hidden_states.device)
-            if isinstance(cu_seqlens, (tuple, list)):
-                cu_seqlens_q, _ = cu_seqlens
-            else:
-                cu_seqlens_q = offsets * q_len if cu_seqlens is None else cu_seqlens
+            if cu_seqlens_q is None:
+                cu_seqlens_q = torch.arange(batch_size + 1, dtype=torch.int32, device=hidden_states.device) * q_len
 
             if self.use_flash_moba:
                 o = flash_moba_varlen_func(
@@ -293,8 +295,8 @@ class MoBA(nn.Module):
                     v=v_packed.squeeze(0),
                     cu_seqlens_q=cu_seqlens_q,
                     cu_seqlens_k=cu_seqlens_q,
-                    max_seqlen_q=q_len,
-                    max_seqlen_k=q_len,
+                    max_seqlen_q=batch_max_seqlen,
+                    max_seqlen_k=batch_max_seqlen,
                     moba_chunk_size=self.moba_chunk_size,
                     moba_topk=self.moba_topk,
                     causal=True,
@@ -305,7 +307,7 @@ class MoBA(nn.Module):
                     k_packed,
                     v_packed,
                     cu_seqlens=cu_seqlens_q,
-                    max_seqlen=max_seqlen,
+                    max_seqlen=batch_max_seqlen,
                     chunk_size=self.moba_chunk_size,
                     topk=self.moba_topk,
                 ).squeeze(0)

--- a/fla/layers/multiscale_retention.py
+++ b/fla/layers/multiscale_retention.py
@@ -17,7 +17,7 @@ from transformers.activations import ACT2FN
 
 from fla.layers.utils import get_layer_cache, repad_hidden_states, unpad_hidden_states, update_layer_cache
 from fla.modules import FusedRMSNormGated, RMSNorm, ShortConvolution
-from fla.modules.rotary import RotaryEmbedding
+from fla.modules.rotary import RotaryEmbedding, get_max_seqlen
 from fla.ops.retention import chunk_retention, fused_chunk_retention, fused_recurrent_retention, parallel_retention
 from fla.ops.utils.index import prepare_lens_from_mask
 
@@ -233,17 +233,19 @@ class MultiScaleRetention(nn.Module):
         if self.feature_map_fn is not None:
             q, k = map(self.feature_map_fn, (q, k))
 
-        seqlen_offset, max_seqlen = 0, q.shape[1]
+        rope_cache_length = q_len if cu_seqlens is None else get_max_seqlen(
+            cu_seqlens, kwargs.get('cu_seqlens_cpu'))
+        seqlen_offset = 0
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None and seqlen_offset > 0:
                 # to eliminate the offsets of padding tokens
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q.shape[1] + seqlen_offset.max().item()
 
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        q, k = self.rotary(
+            q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         if self.num_kv_groups > 1:
             k = repeat(k, '... h d -> ... (h g) d', g=self.num_kv_groups)

--- a/fla/layers/nsa.py
+++ b/fla/layers/nsa.py
@@ -16,6 +16,7 @@ from transformers.utils import logging
 
 from fla.layers.utils import pad_input, unpad_input
 from fla.modules import RotaryEmbedding
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.nsa.parallel import parallel_nsa
 from fla.ops.utils.index import prepare_lens_from_mask
 
@@ -94,20 +95,21 @@ class NativeSparseAttention(nn.Module):
         g = rearrange(self.g_proj(hidden_states), '... (h d) -> ... h d', d=3)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-
-        seqlen_offset, max_seqlen = 0, q_len
+        rope_cache_length = q_len if cu_seqlens is None else get_max_seqlen(
+            cu_seqlens, kwargs.get('cu_seqlens_cpu'))
+        seqlen_offset = 0
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None:
                 # to eliminate the offsets of padding tokens
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q.shape[1] + max(seqlen_offset)
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
+        q, k = self.rotary(
+            q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0

--- a/fla/layers/parallax.py
+++ b/fla/layers/parallax.py
@@ -19,6 +19,7 @@ from transformers.utils import logging
 
 from fla.layers.utils import pad_input, unpad_input
 from fla.modules import RMSNorm, RotaryEmbedding
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.parallax import parallel_parallax
 from fla.ops.parallax.decode import parallax_decode, parallax_decode_one_step
 from fla.ops.utils.index import prepare_lens_from_mask
@@ -136,19 +137,22 @@ class Parallax(nn.Module):
         # equivalent to cu_seqlens in `flash_attn`
         cu_seqlens = kwargs.get('cu_seqlens')
 
-        seqlen_offset, max_seqlen = 0, q_len
+        rope_cache_length = q_len if cu_seqlens is None else get_max_seqlen(
+            cu_seqlens, kwargs.get('cu_seqlens_cpu'))
+        seqlen_offset = 0
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q_len + seqlen_offset
+            rope_cache_length += seqlen_offset
             if attention_mask is not None:
                 # account for left-padding when indexing rotary positions
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = q_len + seqlen_offset.max().item()
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
+        if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
         # rope on q, k and r; `r` shares q's positions (same cos/sin), then is rotated alone.
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
-        r, _ = self.rotary(r, r, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        q, k = self.rotary(
+            q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
+        r, _ = self.rotary(
+            r, r, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
             cache_has_content = past_key_values.get_seq_length(self.layer_idx) > 0

--- a/fla/layers/raven.py
+++ b/fla/layers/raven.py
@@ -24,6 +24,7 @@ from fla.modules import FusedRMSNormGated, RMSNorm, RotaryEmbedding
 from fla.modules.activations import ACT2FN
 from fla.modules.feature_map import ReLUFeatureMap, SwishFeatureMap, T2RFeatureMap
 from fla.modules.layernorm import rms_norm_linear
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.gsa import chunk_gsa, fused_recurrent_gsa
 from fla.ops.utils.index import prepare_lens_from_mask
 
@@ -31,12 +32,6 @@ if TYPE_CHECKING:
     from transformers.processing_utils import Unpack
 
     from fla.models.utils import Cache
-
-
-def _max_offset(seqlen_offset: int | torch.Tensor) -> int:
-    if isinstance(seqlen_offset, int):
-        return seqlen_offset
-    return int(seqlen_offset.max().item())
 
 
 class Raven(nn.Module):
@@ -243,21 +238,23 @@ class Raven(nn.Module):
         mode = 'fused_recurrent' if hidden_states.shape[1] <= 64 else self.mode
 
         last_state = get_layer_cache(self, past_key_values)
-        seqlen_offset, max_seqlen = 0, q_len
+        seqlen_offset, rope_cache_length = 0, q_len
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
             if self.use_rope:
-                max_seqlen = q_len + _max_offset(seqlen_offset)
+                rope_cache_length = q_len + seqlen_offset
 
         cu_seqlens = kwargs.get('cu_seqlens')
         hidden_states, indices, cu_seqlens = unpad_hidden_states(hidden_states, cu_seqlens, attention_mask, q_len)
+        if self.use_rope and cu_seqlens is not None:
+            rope_cache_length = get_max_seqlen(
+                cu_seqlens, kwargs.get('cu_seqlens_cpu')) + seqlen_offset
         # Shift RoPE positions by each sequence's left padding only when decoding on
         # top of cached tokens. During prefill the unpadded tokens are already packed
         # contiguously per `cu_seqlens`, so positions start at 0; adding `lens - mask_len`
         # there would push them negative.
-        if self.use_rope and indices is not None and _max_offset(seqlen_offset) > 0:
+        if self.use_rope and indices is not None and seqlen_offset > 0:
             seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-            max_seqlen = q_len + _max_offset(seqlen_offset)
 
         q = rearrange(self.q_proj(hidden_states), '... (h d) -> ... h d', d=self.head_k_dim)
         k = rearrange(self.k_proj(hidden_states), '... (h d) -> ... h d', d=self.head_k_dim)
@@ -274,9 +271,10 @@ class Raven(nn.Module):
         q, k = self.q_norm(q), self.k_norm(k)
 
         if self.use_rope:
-            if self.max_position_embeddings is not None:
-                max_seqlen = max(max_seqlen, self.max_position_embeddings)
-            q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+            if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+                rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
+            q, k = self.rotary(
+                q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         v = self.gate_fn(v)
 

--- a/fla/layers/rodimus.py
+++ b/fla/layers/rodimus.py
@@ -28,6 +28,7 @@ from fla.layers.utils import (
 )
 from fla.modules import RMSNorm, RotaryEmbedding, ShortConvolution
 from fla.modules.layernorm_gated import RMSNormGated
+from fla.modules.rotary import get_max_seqlen
 from fla.ops.gla import chunk_gla, fused_recurrent_gla
 
 if TYPE_CHECKING:
@@ -303,21 +304,22 @@ class SlidingWindowSharedKeyAttention(nn.Module):
 
         # equivalent to cu_seqlens in `flash_attn`
         cu_seqlens = kwargs.get('cu_seqlens')
+        batch_max_seqlen = q_len if cu_seqlens is None else get_max_seqlen(cu_seqlens, kwargs.get('cu_seqlens_cpu'))
 
         layer_idx = require_cache_layer_idx(self, past_key_values)
-        seqlen_offset, max_seqlen = 0, q.shape[1]
+        seqlen_offset, rope_cache_length = 0, batch_max_seqlen
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(layer_idx)
-            max_seqlen = q.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None:
                 # to eliminate the offsets of padding tokens
                 seqlen_offset = seqlen_offset + attention_mask.sum(-1) - attention_mask.shape[-1]
-                max_seqlen = q.shape[1] + max(seqlen_offset)
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
-        q, k = self.rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
+        q, k = self.rotary(
+            q, k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         if past_key_values is not None:
             if rodimus_caches is not None:
@@ -369,8 +371,8 @@ class SlidingWindowSharedKeyAttention(nn.Module):
                 q.squeeze(0), k.squeeze(0), v.squeeze(0),
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_k=cu_seqlens,
-                max_seqlen_q=max_seqlen,
-                max_seqlen_k=max_seqlen,
+                max_seqlen_q=batch_max_seqlen,
+                max_seqlen_k=batch_max_seqlen,
                 causal=True,
                 window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0),
             ).unsqueeze(0)

--- a/fla/layers/yoco.py
+++ b/fla/layers/yoco.py
@@ -25,7 +25,7 @@ from fla.layers.utils import (
 )
 from fla.modules import FusedRMSNormGated, RMSNorm, RotaryEmbedding
 from fla.modules.activations import swiglu
-from fla.modules.rotary import rotary_embedding
+from fla.modules.rotary import get_max_seqlen, rotary_embedding
 from fla.ops.attn.decoding import attn_decoding_one_step
 from fla.ops.attn.parallel import parallel_attn
 from fla.ops.simple_gla import chunk_simple_gla, fused_recurrent_simple_gla
@@ -177,20 +177,23 @@ class YOCOGatedRetention(nn.Module):
         g = self.g_proj(hidden_states)
         gk = F.logsigmoid(self.gk_proj(hidden_states)) / self.gate_logit_normalizer
 
-        seqlen_offset, max_seqlen = 0, q.shape[1]
+        rope_cache_length = q_len if cu_seqlens is None else get_max_seqlen(
+            cu_seqlens, kwargs.get('cu_seqlens_cpu'))
+        seqlen_offset = 0
         if past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = q.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
 
             if attention_mask is not None and seqlen_offset > 0:
                 seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-                max_seqlen = attention_mask.shape[-1]
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
+        if past_key_values is not None and cu_seqlens is None and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
 
-        q = self.rotary.forward(q, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
-        k = self.rotary.forward(k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        q = self.rotary.forward(
+            q, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
+        k = self.rotary.forward(
+            k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         recurrent_state = last_state['recurrent_state'] if last_state is not None else None
         if mode == 'chunk':
@@ -293,22 +296,30 @@ class YOCOSharedKVBuilder(nn.Module):
 
         cu_seqlens = kwargs.get('cu_seqlens')
 
-        seqlen_offset, max_seqlen = 0, q_len
+        rope_cache_length = q_len if cu_seqlens is None else get_max_seqlen(
+            cu_seqlens, kwargs.get('cu_seqlens_cpu'))
+        seqlen_offset = 0
         if use_cache and past_key_values is not None:
             seqlen_offset = past_key_values.get_seq_length(self.layer_idx)
-            max_seqlen = k.shape[1] + seqlen_offset
+            rope_cache_length += seqlen_offset
             if seqlen_offset > 0:
                 assert q_len == 1, "only support q_len == 1 for decoding"
 
         if attention_mask is not None and (past_key_values is None or use_cache):
             # Left-padded prefills should use the same effective RoPE positions as the unpadded sequence.
             seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-            max_seqlen = attention_mask.shape[-1]
+            rope_cache_length = max(rope_cache_length, attention_mask.shape[-1])
 
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
+        if (
+            use_cache
+            and past_key_values is not None
+            and cu_seqlens is None
+            and self.max_position_embeddings is not None
+        ):
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
 
-        k = self.rotary.forward(k, seqlen_offset=seqlen_offset, max_seqlen=max_seqlen, cu_seqlens=cu_seqlens)
+        k = self.rotary.forward(
+            k, seqlen_offset=seqlen_offset, max_seqlen=rope_cache_length, cu_seqlens=cu_seqlens)
 
         if use_cache and past_key_values is not None:
             cache_state = past_key_values.update(
@@ -393,21 +404,21 @@ class YOCOCrossAttention(nn.Module):
             q = self.q_norm(q)
 
         cu_seqlens = kwargs.get('cu_seqlens')
-        rotary_cu_seqlens = cu_seqlens
         seqlen_offset = shared_k.shape[1] - q_len
-        max_seqlen = shared_k.shape[1]
+        rope_cache_length = shared_k.shape[1] if cu_seqlens is None else (
+            get_max_seqlen(cu_seqlens, kwargs.get('cu_seqlens_cpu')) + seqlen_offset)
 
         if attention_mask is not None:
             seqlen_offset = seqlen_offset + prepare_lens_from_mask(attention_mask) - attention_mask.shape[-1]
-            max_seqlen = max(max_seqlen, attention_mask.shape[-1])
-        if self.max_position_embeddings is not None:
-            max_seqlen = max(max_seqlen, self.max_position_embeddings)
+            rope_cache_length = max(rope_cache_length, attention_mask.shape[-1])
+        if cu_seqlens is None and shared_k.shape[1] != q_len and self.max_position_embeddings is not None:
+            rope_cache_length = max(rope_cache_length, self.max_position_embeddings)
 
         q = self.rotary.forward(
             q,
             seqlen_offset=seqlen_offset,
-            max_seqlen=max_seqlen,
-            cu_seqlens=rotary_cu_seqlens,
+            max_seqlen=rope_cache_length,
+            cu_seqlens=cu_seqlens,
         )
 
         if attention_mask is not None:

--- a/fla/modules/backends/triton_ascend/rotary.py
+++ b/fla/modules/backends/triton_ascend/rotary.py
@@ -11,7 +11,7 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.utils import prepare_chunk_indices
+from fla.ops.utils import prepare_chunk_indices, prepare_lens
 from fla.utils import autotune_cache_kwargs, get_multiprocessor_count
 from fla.utils.ascend_ub_manager import (
     ASCEND_MAX_GRID_DIM,
@@ -155,10 +155,15 @@ def rotary_embedding_fwdbwd_npu(
     if isinstance(seqlen_offsets, torch.Tensor):
         assert seqlen_offsets.shape == (N,)
         assert seqlen_offsets.dtype in [torch.int32, torch.int64]
-        sequence_lengths = T if not is_varlen else cu_seqlens[1:] - cu_seqlens[:-1]
+        sequence_lengths = T if not is_varlen else prepare_lens(cu_seqlens)
         torch._assert_async(
             torch.all(sequence_lengths + seqlen_offsets <= TR),
             f"Rotary cache is too short for tensor offsets, got {TR} positions",
+        )
+    elif is_varlen:
+        torch._assert_async(
+            torch.all(prepare_lens(cu_seqlens) + seqlen_offsets <= TR),
+            f"Rotary cache is too short for scalar offset {seqlen_offsets}, got {TR} positions",
         )
     else:
         assert seqlen_offsets + T <= TR
@@ -179,7 +184,9 @@ def rotary_embedding_fwdbwd_npu(
         min_block=1,
     )
     BT = min(bt_cap, desired_bt)
-    BT = compute_grid_limited_tile_size(T, B * H, BT, max_grid=ASCEND_MAX_GRID_DIM)
+    grid_batch = 1 if is_varlen else B
+    BH = grid_batch * H
+    BT = compute_grid_limited_tile_size(T, BH, BT, max_grid=ASCEND_MAX_GRID_DIM)
     if chunk_indices is None and is_varlen:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = len(chunk_indices) if is_varlen else triton.cdiv(T, BT)
@@ -205,7 +212,7 @@ def rotary_embedding_fwdbwd_npu(
         INTERLEAVED=interleaved,
         CONJUGATE=conjugate,
     )
-    max_nt = max_grid_axis_chunks(NT, B * H, max_grid=ASCEND_MAX_GRID_DIM)
+    max_nt = max_grid_axis_chunks(NT, BH, max_grid=ASCEND_MAX_GRID_DIM)
     for nt_off in range(0, NT, max_nt):
         nt_len = min(max_nt, NT - nt_off)
         if is_varlen:
@@ -214,5 +221,5 @@ def rotary_embedding_fwdbwd_npu(
         else:
             kernel_kwargs['chunk_indices'] = chunk_indices
             kernel_kwargs['NT_OFFSET'] = nt_off
-        rotary_embedding_kernel[(nt_len, B, H)](**kernel_kwargs)
+        rotary_embedding_kernel[(nt_len, grid_batch, H)](**kernel_kwargs)
     return y

--- a/fla/modules/rotary.py
+++ b/fla/modules/rotary.py
@@ -12,10 +12,19 @@ import triton.language as tl
 from einops import rearrange, repeat
 
 from fla.modules.backends import dispatch
-from fla.ops.utils import prepare_chunk_indices
-from fla.utils import IS_AMD, autotune_cache_kwargs, get_multiprocessor_count, input_guard
+from fla.ops.utils import prepare_chunk_indices, prepare_lens
+from fla.utils import IS_AMD, autotune_cache_kwargs, get_multiprocessor_count, input_guard, tensor_cache
 
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [2, 4, 8, 16, 32]
+
+
+@tensor_cache
+def get_max_seqlen(
+    cu_seqlens: torch.LongTensor,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+) -> int:
+    src = cu_seqlens_cpu if cu_seqlens_cpu is not None else cu_seqlens
+    return prepare_lens(src).max().item()
 
 
 def rotate_half(x, interleaved=False):
@@ -179,10 +188,15 @@ def rotary_embedding_fwdbwd(
     if isinstance(seqlen_offsets, torch.Tensor):
         assert seqlen_offsets.shape == (N,)
         assert seqlen_offsets.dtype in [torch.int32, torch.int64]
-        sequence_lengths = T if not is_varlen else cu_seqlens[1:] - cu_seqlens[:-1]
+        sequence_lengths = T if not is_varlen else prepare_lens(cu_seqlens)
         torch._assert_async(
             torch.all(sequence_lengths + seqlen_offsets <= TR),
             f"Rotary cache is too short for tensor offsets, got {TR} positions",
+        )
+    elif is_varlen:
+        torch._assert_async(
+            torch.all(prepare_lens(cu_seqlens) + seqlen_offsets <= TR),
+            f"Rotary cache is too short for scalar offset {seqlen_offsets}, got {TR} positions",
         )
     else:
         assert seqlen_offsets + T <= TR
@@ -198,7 +212,7 @@ def rotary_embedding_fwdbwd(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = len(chunk_indices) if is_varlen else triton.cdiv(T, BT)
 
-    grid = (NT, B, H)
+    grid = (NT, 1 if is_varlen else B, H)
     rotary_embedding_kernel[grid](
         x,
         cos,

--- a/fla/ops/deltaformer/parallel.py
+++ b/fla/ops/deltaformer/parallel.py
@@ -724,6 +724,7 @@ def deltaformer_attn(
     attention_mask: torch.LongTensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     C: int = BLOCK_SIZE_C,
+    max_seqlen: int | None = None,
 ) -> torch.Tensor:
     if flash_attn_func is None:
         raise ImportError("Please install Flash Attention via `pip install flash-attn --no-build-isolation` first")
@@ -754,7 +755,8 @@ def deltaformer_attn(
         )
         o = pad_input(o, indices_q, B, T)
     elif cu_seqlens is not None:
-        max_seqlen = int((cu_seqlens[1:] - cu_seqlens[:-1]).max().item())
+        if max_seqlen is None:
+            max_seqlen = int((cu_seqlens[1:] - cu_seqlens[:-1]).max().item())
         o = flash_attn_varlen_func(
             q.squeeze(0), k.squeeze(0), u.squeeze(0),
             cu_seqlens_q=cu_seqlens,


### PR DESCRIPTION
## Summary

Packed varlen used one max_seqlen value for RoPE cache capacity, the logical batch maximum, and the configured context limit. A 4K/32K packed batch could therefore allocate and launch as if it were 256K.

This PR keeps those lengths separate, validates scalar rotary offsets per segment, avoids per-layer left-padding scalar synchronization, and removes the redundant physical batch axis from CUDA and Ascend varlen rotary grids. The cached maximum-length helper now lives in the already affected rotary module, so the shared ops index remains untouched.

The branch is rebased onto the latest main. No test files are added or modified.

## Test plan

Hardware: NVIDIA RTX A1000 Laptop GPU (4 GiB), PyTorch 2.13.0+cu130, CUDA 13.x.

- Unit tests added/modified: none
- Existing dependent layer and rotary tests: 134 passed
- Small DeltaFormer packed-varlen forward/backward case: 1 passed
- Cached maximum-length helper: CUDA and CPU-mirror paths passed
- Dependent-test selection: reduced from 65 files to 10 files
- pre-commit run --files <all changed files>: all hooks passed
- Ascend execution: previous A2 CI revision passed; the rebased revision is pending CI

The full naive-reference DeltaFormer configurations exceed this GPU's 4 GiB capacity.

## Benchmark / NCU (kernel changes only)

Hardware: NVIDIA RTX A1000 Laptop GPU. NCU was not collected.

Packed prefill, BF16, rotary dim 128, eight 4K segments, 32K packed tokens, configured context 256K:

| Metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| RoPE cache | 64.0 MiB | 1.0 MiB | -98.4% |
| Peak allocated memory | 233.251 MiB | 57.253 MiB | -75.5% |
| FlashAttention max length | 262144 | 4096 | 64x smaller |
| Cold elapsed time | 430.68 ms | 442.69 ms | within compilation/startup noise |

Left-padded decode, real FlashAttention, FP16, 8 Attention layers, hidden size 128, 128-token prefill, 64 measured decode steps:

| Batch | Baseline median | This PR median | Latency reduction | Throughput increase |
|---:|---:|---:|---:|---:|
| 1 | 4.2032 ms | 3.9178 ms | 6.8% | 7.3% |
| 8 | 4.7711 ms | 3.8538 ms | 19.2% | 23.8% |
| 32 | 6.4738 ms | 4.0056 ms | 38.1% | 61.6% |

## Breaking changes

None. The DeltaFormer maximum-length argument is optional, and the MLA attention_mask default remains backward-compatible.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.