### PR TITLE
[Fix] Intel/XPU compatibility fixes for modules tests

### DIFF
--- a/fla/modules/activations.py
+++ b/fla/modules/activations.py
@@ -19,9 +19,23 @@ import triton.language as tl
 
 from fla.modules.backends import dispatch
 from fla.ops.utils.op import exp, log
-from fla.utils import IS_AMD, autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
+from fla.utils import IS_AMD, IS_INTEL, autocast_custom_bwd, autocast_custom_fwd, autotune_cache_kwargs, input_guard
 
-NUM_WARPS_AUTOTUNE = [1, 2, 4, 8, 16] if IS_AMD else [1, 2, 4, 8, 16, 32]
+
+def _activation_autotune_configs():
+    """Return autotune configs scaled to the device's scratch-space budget."""
+    if IS_INTEL:
+        # Intel/XPU has a smaller per-thread scratch space (PTSS) limit; smaller
+        # block sizes and warp counts avoid register spilling on larger D.
+        bs_list = [512, 1024]
+        nw_list = [1, 2, 4, 8]
+    elif IS_AMD:
+        bs_list = [512, 1024, 2048, 4096, 8192]
+        nw_list = [1, 2, 4, 8, 16]
+    else:
+        bs_list = [512, 1024, 2048, 4096, 8192]
+        nw_list = [1, 2, 4, 8, 16, 32]
+    return [triton.Config({'B': bs}, num_warps=nw) for bs in bs_list for nw in nw_list]
 
 
 def _get_stride(x: torch.Tensor) -> int:
@@ -90,11 +104,7 @@ def _alloc_output(x: torch.Tensor, contiguous: bool = False) -> torch.Tensor:
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -118,11 +128,7 @@ def sigmoid_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -202,11 +208,7 @@ sigmoid = SigmoidFunction.apply
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -234,11 +236,7 @@ def logsigmoid_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -329,11 +327,7 @@ def logsigmoid(x: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -357,11 +351,7 @@ def swish_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -557,11 +547,7 @@ sqrelu = SquaredReLUFunction.apply
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -590,11 +576,7 @@ def swiglu_fwd_kernel(
     'HAS_WEIGHT': lambda args: args['z'] is not None,
 })
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -756,11 +738,7 @@ def swiglu_linear(x, y, weight, bias):
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -789,11 +767,7 @@ def sigmoidglu_fwd_kernel(
     'HAS_WEIGHT': lambda args: args['z'] is not None,
 })
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -952,11 +926,7 @@ sigmoidglu_linear = SigmoidGLULinearFunction.apply
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )
@@ -994,11 +964,7 @@ def powglu_fwd_kernel(
     'HAS_WEIGHT': lambda args: args['z'] is not None,
 })
 @triton.autotune(
-    configs=[
-        triton.Config({'B': bs}, num_warps=num_warps)
-        for bs in [512, 1024, 2048, 4096, 8192]
-        for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=_activation_autotune_configs(),
     key=['D'],
     **autotune_cache_kwargs,
 )

--- a/fla/modules/fused_cross_entropy.py
+++ b/fla/modules/fused_cross_entropy.py
@@ -425,8 +425,8 @@ class FusedCrossEntropyLoss(nn.Module):
             losses: (batch,) if reduction is 'none', else (1,), dtype float
             z_loss: (batch,) if reduction is 'none', else (1,), dtype float (if self.return_z_loss)
         """
-        assert input.device.type in ('cuda', 'npu') and target.device.type in ('cuda', 'npu'), (
-            "Only support CUDA/NPU tensors"
+        assert input.device.type in ('cuda', 'npu', 'xpu') and target.device.type in ('cuda', 'npu', 'xpu'), (
+            "Only support CUDA/NPU/XPU tensors"
         )
         loss, z_loss = cross_entropy_loss(
             input,

--- a/fla/modules/grpo.py
+++ b/fla/modules/grpo.py
@@ -62,9 +62,12 @@ import triton.language as tl
 
 from fla.modules.backends import dispatch
 from fla.ops.utils.op import exp, log
-from fla.utils import IS_AMD, autotune_cache_kwargs, input_guard
+from fla.utils import IS_AMD, IS_INTEL, autotune_cache_kwargs, input_guard
 
 NUM_WARPS_AUTOTUNE = [4, 8, 16] if IS_AMD else [4, 8, 16, 32]
+# Intel/XPU Triton backend has correctness issues with multi-stage pipelining
+# when memory is cold (e.g. after empty_cache), so limit to single stage.
+NUM_STAGES_AUTOTUNE = [1] if IS_INTEL else [1, 2, 4]
 
 
 @triton.autotune(
@@ -72,7 +75,7 @@ NUM_WARPS_AUTOTUNE = [4, 8, 16] if IS_AMD else [4, 8, 16, 32]
         triton.Config({'BLOCK_SIZE': BLOCK_SIZE},  num_warps=NUM_WARPS, num_stages=NUM_STAGES)
         for BLOCK_SIZE in [1024, 2048, 4096, 8192]
         for NUM_WARPS in NUM_WARPS_AUTOTUNE
-        for NUM_STAGES in [1, 2, 4]
+        for NUM_STAGES in NUM_STAGES_AUTOTUNE
     ],
     key=['B', 'N'],
     **autotune_cache_kwargs,

--- a/fla/modules/layernorm.py
+++ b/fla/modules/layernorm.py
@@ -29,7 +29,7 @@ from torch.distributed.tensor import Replicate, Shard, distribute_module
 from torch.distributed.tensor.parallel import ParallelStyle
 
 from fla.modules.backends import dispatch
-from fla.utils import autotune_cache_kwargs, get_multiprocessor_count, input_guard
+from fla.utils import IS_INTEL, autotune_cache_kwargs, get_multiprocessor_count, input_guard
 
 try:
     from torch.distributed.tensor import DTensor
@@ -580,7 +580,9 @@ def layer_norm_fwd(
         raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
     # heuristics for number of warps
 
-    if D <= 512:
+    # Devices with limited per-thread scratch space (e.g. Intel) cannot fit the
+    # fused forward kernel when BD == 512, so fall back to the loop-based one.
+    if D <= 512 and not (D == 512 and IS_INTEL):
         NB = triton.cdiv(T, 2048)
         def grid(meta): return (triton.cdiv(T, meta['BT']), )
         layer_norm_fwd_kernel[grid](
@@ -673,7 +675,10 @@ def layer_norm_bwd(
     db = torch.empty((NS, D), dtype=torch.float, device=bias.device) if bias is not None else None
     grid = (NS,)
 
-    if D <= 512:
+    # Devices with limited per-thread scratch space (e.g. Intel) cannot fit the
+    # (BT, BD) accumulators of layer_norm_bwd_kernel when BD == 512. Fall back
+    # to the loop-based kernel in that case.
+    if D <= 512 and not (D == 512 and IS_INTEL):
         NB = triton.cdiv(T, 2048)
         layer_norm_bwd_kernel[grid](
             x,

--- a/tests/modules/test_conv.py
+++ b/tests/modules/test_conv.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from einops import rearrange
 
 from fla.modules.convolution import ShortConvolution, causal_conv1d, causal_conv1d_update
-from fla.utils import assert_close, device
+from fla.utils import IS_NVIDIA, assert_close, device
 
 try:
     from causal_conv1d import causal_conv1d_fn
@@ -147,8 +147,11 @@ def test_conv(
     dtype: torch.dtype,
     backend: str,
 ):
-    if causal_conv1d_fn is None and backend == 'cuda':
-        pytest.skip("causal_conv1d is not installed for CUDA backend")
+    if backend == 'cuda':
+        if causal_conv1d_fn is None:
+            pytest.skip("causal_conv1d is not installed for CUDA backend")
+        if not IS_NVIDIA:
+            pytest.skip("CUDA backend requires an NVIDIA GPU")
     torch.manual_seed(42)
 
     x = torch.randn(B, T, D).to(device, dtype).requires_grad_(True)
@@ -219,8 +222,11 @@ def test_conv_varlen(
     dtype: torch.dtype,
     backend: str,
 ):
-    if causal_conv1d_fn is None and backend == 'cuda':
-        pytest.skip("causal_conv1d is not installed for CUDA backend")
+    if backend == 'cuda':
+        if causal_conv1d_fn is None:
+            pytest.skip("causal_conv1d is not installed for CUDA backend")
+        if not IS_NVIDIA:
+            pytest.skip("CUDA backend requires an NVIDIA GPU")
     torch.manual_seed(42)
     cu_seqlens = torch.cat([
         torch.tensor([0], dtype=torch.long),
@@ -373,8 +379,11 @@ def test_conv_with_cache_prefill_fwd(
     dtype: torch.dtype,
     backend: str,
 ):
-    if causal_conv1d_fn is None and backend == 'cuda':
-        pytest.skip("causal_conv1d is not installed for CUDA backend")
+    if backend == 'cuda':
+        if causal_conv1d_fn is None:
+            pytest.skip("causal_conv1d is not installed for CUDA backend")
+        if not IS_NVIDIA:
+            pytest.skip("CUDA backend requires an NVIDIA GPU")
     torch.manual_seed(42)
 
     x = torch.randn(B, T, D).to(device, dtype)
@@ -448,8 +457,11 @@ def test_conv_varlen_with_cache_prefill_fwd(
     dtype: torch.dtype,
     backend: str,
 ):
-    if causal_conv1d_fn is None and backend == 'cuda':
-        pytest.skip("causal_conv1d is not installed for CUDA backend")
+    if backend == 'cuda':
+        if causal_conv1d_fn is None:
+            pytest.skip("causal_conv1d is not installed for CUDA backend")
+        if not IS_NVIDIA:
+            pytest.skip("CUDA backend requires an NVIDIA GPU")
     torch.manual_seed(42)
 
     min_len_each = max(1, T // N)
@@ -543,8 +555,11 @@ def test_conv_decoding_with_cache(
     dtype: torch.dtype,
     backend: str,
 ):
-    if causal_conv1d_fn is None and backend == 'cuda':
-        pytest.skip("causal_conv1d is not installed for CUDA backend")
+    if backend == 'cuda':
+        if causal_conv1d_fn is None:
+            pytest.skip("causal_conv1d is not installed for CUDA backend")
+        if not IS_NVIDIA:
+            pytest.skip("CUDA backend requires an NVIDIA GPU")
     torch.manual_seed(42)
 
     x = torch.randn(B, 1, D).to(device, dtype)        # (B, 1, D)
@@ -816,6 +831,8 @@ def test_fast_conv_varlen(
     torch.manual_seed(42)
     if causal_conv1d_fn is None:
         pytest.skip("causal_conv1d is not installed for CUDA backend")
+    if not IS_NVIDIA:
+        pytest.skip("fast_causal_conv1d requires an NVIDIA GPU")
     assert has_residual is False
     from fla.modules.convolution import fast_causal_conv1d_fn
     cu_seqlens = torch.cat([

--- a/tests/modules/test_grpo.py
+++ b/tests/modules/test_grpo.py
@@ -135,7 +135,8 @@ def test_fused_grpos(B: int, T: int, V: int, dtype: torch.dtype, inplace: bool, 
                     log_probs = torch.randn_like(logits_row).log_softmax(dim=-1)
                     token_log_prob = torch.gather(log_probs, dim=1, index=input_ids_row.unsqueeze(1)).squeeze(1)
                     per_token_logps.append(token_log_prob)
-                device_torch_lib.empty_cache()
+                if hasattr(device_torch_lib, 'empty_cache'):
+                    device_torch_lib.empty_cache()
                 return torch.stack(per_token_logps)
 
         logits = torch.randn(B, T + 1, V, device=device, dtype=dtype)
@@ -151,7 +152,8 @@ def test_fused_grpos(B: int, T: int, V: int, dtype: torch.dtype, inplace: bool, 
         gold_logits = logits.detach().clone().float()
         gold_logits.requires_grad_(True)
         gold_ref_logp = ref_logp.clone().float()
-        device_torch_lib.empty_cache()
+        if hasattr(device_torch_lib, 'empty_cache'):
+            device_torch_lib.empty_cache()
         y1 = fused_grpo_loss(logits, ref_logp, input_ids, advantages, beta, completion_mask, save_kl=save_kl, inplace=inplace)
         y2 = grpo_loss_torch(gold_logits, gold_ref_logp, input_ids, advantages, beta, completion_mask, save_kl)
         if save_kl:

--- a/tests/modules/test_rotary.py
+++ b/tests/modules/test_rotary.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 
 from fla.modules.rotary import RotaryEmbedding, rotary_embedding_ref
-from fla.utils import IS_NPU, assert_close, device
+from fla.utils import assert_close, device, device_torch_lib
 
 
 @pytest.mark.parametrize("B", [2])
@@ -237,10 +237,7 @@ def test_rotary_left_padding_no_uninit_leak(B: int, T: int, H: int, D: int, dtyp
     rotary = RotaryEmbedding(D).to(device)
 
     rotary(q, k, seqlen_offset=seqlen_offset, max_seqlen=T)   # warm up cos/sin cache + kernel
-    if IS_NPU:
-        torch.npu.synchronize()
-    else:
-        torch.cuda.synchronize()
+    device_torch_lib.synchronize()
     junk = [torch.full_like(q, float("nan")) for _ in range(32)]   # poison the free list
     del junk
 


### PR DESCRIPTION
## Summary
This PR makes `fla/modules/` run cleanly on Intel/XPU by limiting activation autotune configs that overflow scratch space, falling back to loop-based layernorm kernels for D=512, enabling fused cross entropy / GRPO device checks, and making the modules test suite device-aware.

## Test plan
- Unit tests added/modified: `tests/modules/test_grpo.py`, `tests/modules/test_rotary.py`, `tests/modules/test_conv.py`
- Dependent tests run: `python -m pytest tests/modules/ -v --tb=short`
- Hardware: Intel Arc B580 (XPU), PyTorch 2.13, Python 3.12
- Result: 564 passed, 32 skipped, 0 failed
- Varlen / CP / model tests: not touched by this change

## Benchmark / NCU (kernel changes only)
- Hardware: Intel Arc B580
- Workload: `pytest tests/modules/` dense shapes
- Before: tests failed with PTSS / `__name__` / CUDA synchronize errors
- After: all `tests/modules/` pass
- Conclusion: neutral (correctness/compatibility fix, no performance claim)

## Breaking changes
- None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.

### If you ticked the "minor" box above
N/A
