### PR TITLE
[Feat] Support platform-graph capture and replay for KDA chunk

### DIFF
--- a/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
@@ -687,6 +687,7 @@ def chunk_gated_delta_rule_fwd_h_npu(
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    chunk_offsets: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     B, T, H, K, V, HV = *k.shape, u.shape[-1], u.shape[2]
     BT = chunk_size
@@ -697,7 +698,9 @@ def chunk_gated_delta_rule_fwd_h_npu(
     if cu_seqlens is None:
         N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
     else:
-        N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
+        N, NT = len(cu_seqlens) - 1, len(chunk_indices)
+        if chunk_offsets is None:
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
     if state_v_first:
@@ -1175,6 +1178,7 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    chunk_offsets: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V, HV = *q.shape, do.shape[-1], do.shape[2]
     BT = chunk_size
@@ -1185,7 +1189,9 @@ def chunk_gated_delta_rule_bwd_dhu_npu(
     if cu_seqlens is None:
         N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
     else:
-        N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
+        N, NT = len(cu_seqlens) - 1, len(chunk_indices)
+        if chunk_offsets is None:
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
 
     if state_v_first:
         dh = q.new_empty(B, NT, HV, V, K)

--- a/fla/ops/common/chunk_delta_h.py
+++ b/fla/ops/common/chunk_delta_h.py
@@ -12,6 +12,7 @@ import triton.language as tl
 from fla.ops.backends import dispatch
 from fla.ops.utils import prepare_chunk_indices, prepare_chunk_offsets
 from fla.ops.utils.cache import fla_cache_autotune
+from fla.ops.utils.graph import get_static_buffer
 from fla.ops.utils.op import exp2
 from fla.utils import (
     IS_INTEL,
@@ -698,6 +699,7 @@ def chunk_gated_delta_rule_fwd_h(
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    chunk_offsets: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     B, T, H, K, V, HV = *k.shape, u.shape[-1], u.shape[2]
     BT = chunk_size
@@ -708,7 +710,9 @@ def chunk_gated_delta_rule_fwd_h(
     if cu_seqlens is None:
         N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
     else:
-        N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
+        N, NT = len(cu_seqlens) - 1, len(chunk_indices)
+        if chunk_offsets is None:
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
     if state_v_first:
@@ -759,6 +763,8 @@ def chunk_gated_delta_rule_bwd_dhu(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    chunk_offsets: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V, HV = *q.shape, do.shape[-1], do.shape[2]
     # N: the actual number of sequences in the batch with either equal or variable lengths
@@ -770,14 +776,24 @@ def chunk_gated_delta_rule_bwd_dhu(
     if cu_seqlens is None:
         N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
     else:
-        N, NT, chunk_offsets = len(cu_seqlens) - 1, len(chunk_indices), prepare_chunk_offsets(cu_seqlens, BT)
+        N, NT = len(cu_seqlens) - 1, len(chunk_indices)
+        if chunk_offsets is None:
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
 
-    if state_v_first:
-        dh = q.new_empty(B, NT, HV, V, K)
+    if use_graph:
+        if state_v_first:
+            dh = get_static_buffer("dhu_dh_vf", (B, NT, HV, V, K), q.dtype, q.device)
+        else:
+            dh = get_static_buffer("dhu_dh", (B, NT, HV, K, V), q.dtype, q.device)
+        dh0 = get_static_buffer("dhu_dh0", tuple(h0.shape), torch.float32, h0.device) if h0 is not None else None
+        dv2 = get_static_buffer("dhu_dv2", tuple(dv.shape), dv.dtype, dv.device)
     else:
-        dh = q.new_empty(B, NT, HV, K, V)
-    dh0 = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
-    dv2 = torch.empty_like(dv)
+        if state_v_first:
+            dh = q.new_empty(B, NT, HV, V, K)
+        else:
+            dh = q.new_empty(B, NT, HV, K, V)
+        dh0 = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
+        dv2 = torch.empty_like(dv)
 
     def grid(meta): return (triton.cdiv(V, meta['BV']) * N * HV, )
     chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64[grid](

--- a/fla/ops/common/intracard_cp.py
+++ b/fla/ops/common/intracard_cp.py
@@ -352,6 +352,7 @@ def intracard_merge(
         init_offsets=init_offsets,
         h0_seq_ids=h0_seq_ids,
         h0=initial_state,
+        h_seq_idx=None,
         HV=HV,
         K=K,
         V=V,

--- a/fla/ops/cp/chunk_delta_h.py
+++ b/fla/ops/cp/chunk_delta_h.py
@@ -319,6 +319,7 @@ def pre_process_fwd_kernel_merged(
 
 @triton.heuristics({
     'HAS_H0': lambda args: args['h0'] is not None,
+    'HAS_H_SEQ_IDX': lambda args: args['h_seq_idx'] is not None,
 })
 @triton.autotune(
     configs=[
@@ -340,6 +341,7 @@ def merge_fwd_bwd_kernel(
     init_offsets,        # None for CP, [num_split_seqs+1] for intracard
     h0_seq_ids,          # None for CP, [num_split_seqs] for intracard
     h0,                  # None or [N_orig, HV, K, V] for intracard (or [V, K] when transposed)
+    h_seq_idx,           # None, or a device scalar selecting the target sequence row of h (graph replay)
     HV: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -349,8 +351,10 @@ def merge_fwd_bwd_kernel(
     INTRACARD_MODE: tl.constexpr,          # True: intracard mode, False: CP mode
     NUM_SEQ_ENTRIES,         # num_split_seqs for intracard
     HAS_H0: tl.constexpr,                  # Heuristic: whether h0 is provided
+    HAS_H_SEQ_IDX: tl.constexpr,           # Heuristic: whether h_seq_idx is provided
     STATE_V_FIRST: tl.constexpr = False,  # When True, h0/h use [V, K] layout; ag_hm always [K, V+K]
     AFFINE_CHAIN_PRECISION: tl.constexpr = None,  # input_precision for M@h in the state update (h' = M @ h + he)
+    NUM_RANKS_ON_DEVICE: tl.constexpr = False,  # CP mode: load pre_or_post_num_ranks from a device tensor
 ):
     """
     Unified merge kernel for both CP and Intra-card modes.
@@ -434,7 +438,12 @@ def merge_fwd_bwd_kernel(
     else:
         # CP mode
         i_h = tl.program_id(1)
-        num_ranks = pre_or_post_num_ranks.to(tl.int32)
+        if HAS_H_SEQ_IDX:
+            h += tl.load(h_seq_idx).to(tl.int64) * HV * K * V
+        if NUM_RANKS_ON_DEVICE:
+            num_ranks = tl.load(pre_or_post_num_ranks).to(tl.int32)
+        else:
+            num_ranks = pre_or_post_num_ranks.to(tl.int32)
         h += i_h * K * V
         ag_hm += i_h * K * (K + V)
         stride = HV * K * (K + V)
@@ -764,6 +773,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
     cu_seqlens: torch.LongTensor | None = None,
     initial_state: torch.Tensor | None = None,
     context: FLACPContext = None,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if context is None or context.group is None:
         return initial_state
@@ -792,7 +802,16 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
         initial_state = k.new_zeros(N, HV, V, K, dtype=torch.float32)
     else:
         initial_state = k.new_zeros(N, HV, K, V, dtype=torch.float32)
-    if not context.is_last_rank:
+    cu_last = cu_seqlens[-2:]
+    if use_graph:
+        assert context.pre_num_ranks_dev is not None, "use_graph with CP requires context.pre_num_ranks_dev"
+        # last non-empty sequence window, on-device; zero-length tail padding would
+        # otherwise make cu_seqlens[-2:] point at a padding sequence
+        i_last = (cu_seqlens[1:] > cu_seqlens[:-1]).sum() - 1
+        cu_last = cu_seqlens.index_select(0, torch.stack((i_last, i_last + 1)))
+    # graph mode always launches: a last rank's hm is never read, but the all-gather
+    # needs every rank, and host-side flags are frozen at capture
+    if use_graph or not context.is_last_rank:
         BLOCK_SIZE = 32 if K <= 64 else 64
         grid = (triton.cdiv(V, BLOCK_SIZE) + triton.cdiv(K, BLOCK_SIZE), HV)
         # For DPLR, v provides the original v for computing h contributions,
@@ -806,7 +825,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
             bg=bg,
             u=u,
             hm=hm,
-            cu_seqlens=cu_seqlens[-2:],
+            cu_seqlens=cu_last,
             T=T,
             H=H,
             HV=HV,
@@ -822,17 +841,19 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
             ),
         )
     ag_hm, _ = all_gather_into_tensor(hm, group=context.group)
-    if not context.is_first_rank:
+    # a zero num_ranks merge just re-stores the zeros initial_state[0] already holds
+    if use_graph or not context.is_first_rank:
         def grid(meta): return (triton.cdiv(V, meta['BV']), HV)
         merge_fwd_bwd_kernel[grid](
             h=initial_state[0],
             ag_hm=ag_hm,
-            pre_or_post_num_ranks=context.pre_num_ranks,
+            pre_or_post_num_ranks=context.pre_num_ranks_dev if use_graph else context.pre_num_ranks,
             rank=rank,
             seq_offsets=None,
             init_offsets=None,
             h0_seq_ids=None,
             h0=None,
+            h_seq_idx=None,
             HV=HV,
             K=K,
             V=V,
@@ -845,6 +866,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process(
                 "tf32x3" if use_tf32x3_affine_chain and IS_TF32_SUPPORTED
                 else ("ieee" if not IS_TF32_SUPPORTED else None)
             ),
+            NUM_RANKS_ON_DEVICE=use_graph,
         )
     return initial_state
 
@@ -865,6 +887,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
     initial_state: torch.Tensor | None = None,
     context: FLACPContext | None = None,
     chunk_size: int = 64,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if context is None or context.group is None:
         return dht, initial_state
@@ -894,7 +917,9 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
     else:
         dht = q.new_zeros(N, HV, K, V, dtype=torch.float32)
 
-    if not context.is_first_rank:
+    # graph mode always launches: a first rank's dhm is never read, but the all-gather
+    # needs every rank, and host-side flags are frozen at capture
+    if use_graph or not context.is_first_rank:
         BLOCK_SIZE = 32 if K <= 64 else 64
         grid = (triton.cdiv(V, BLOCK_SIZE) + triton.cdiv(K, BLOCK_SIZE), HV)
         pre_process_bwd_kernel_merged[grid](
@@ -925,17 +950,28 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
 
     ag_dhm, _ = all_gather_into_tensor(dhm, group=context.group)
 
-    if not context.is_last_rank:
+    # a zero num_ranks merge just re-stores the zeros dht already holds
+    if use_graph or not context.is_last_rank:
+        h_seq_idx = None
+        h = dht[-1]
+        if use_graph:
+            assert context.post_num_ranks_dev is not None, "use_graph with CP requires context.post_num_ranks_dev"
+            # merge target is the last non-empty sequence; zero-length tail padding
+            # would otherwise make dht[-1] a padding row
+            h_seq_idx = (cu_seqlens[1:] > cu_seqlens[:-1]).sum() - 1
+            h = dht
+
         def grid(meta): return (triton.cdiv(V, meta['BV']), HV)
         merge_fwd_bwd_kernel[grid](
-            h=dht[-1],
+            h=h,
             ag_hm=ag_dhm,
-            pre_or_post_num_ranks=context.post_num_ranks,
+            pre_or_post_num_ranks=context.post_num_ranks_dev if use_graph else context.post_num_ranks,
             rank=rank,
             seq_offsets=None,
             init_offsets=None,
             h0_seq_ids=None,
             h0=None,
+            h_seq_idx=h_seq_idx,
             HV=HV,
             K=K,
             V=V,
@@ -948,6 +984,7 @@ def chunk_gated_delta_rule_bwd_dhu_pre_process(
                 "tf32x3" if use_tf32x3_affine_chain and IS_TF32_SUPPORTED
                 else ("ieee" if not IS_TF32_SUPPORTED else None)
             ),
+            NUM_RANKS_ON_DEVICE=use_graph,
         )
 
     # initial_state is None in the CP mode

--- a/fla/ops/cp/context.py
+++ b/fla/ops/cp/context.py
@@ -32,6 +32,11 @@ class FLACPContext:
     conv1d_kernel_size: int | None = None
     pre_num_conv_tokens: int | None = None
     use_tf32x3_affine_chain: bool = False
+    # Device-resident copies of pre/post_num_ranks for graph replay: kernel scalar
+    # arguments are frozen at capture, so graph mode reads them via tl.load instead.
+    # Persistent int32 tensors the caller refreshes in place before each replay.
+    pre_num_ranks_dev: torch.Tensor | None = None
+    post_num_ranks_dev: torch.Tensor | None = None
 
     def copy_for_backward(self) -> FLACPContext:
         """Create a copy for backward pass (useful when PP_SIZE > 1)."""
@@ -46,6 +51,8 @@ class FLACPContext:
             conv1d_kernel_size=self.conv1d_kernel_size,
             pre_num_conv_tokens=self.pre_num_conv_tokens,
             use_tf32x3_affine_chain=self.use_tf32x3_affine_chain,
+            pre_num_ranks_dev=self.pre_num_ranks_dev,
+            post_num_ranks_dev=self.post_num_ranks_dev,
         )
 
     @property

--- a/fla/ops/gla/backends/triton_ascend/chunk.py
+++ b/fla/ops/gla/backends/triton_ascend/chunk.py
@@ -425,7 +425,10 @@ def chunk_gla_fwd_o_gk_npu(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ):
+    if use_graph:
+        raise NotImplementedError("use_graph is not supported on the Ascend NPU backend")
     B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
     BT = chunk_size
 

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -371,9 +371,8 @@ def chunk_gla_fwd_kernel_o(
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -363,13 +363,18 @@ def chunk_gla_fwd_kernel_o(
     BV: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
         NT = tl.cdiv(T, BT)
@@ -973,6 +978,7 @@ def chunk_gla_fwd_o_gk(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ):
     B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
     BT = chunk_size
@@ -1001,6 +1007,7 @@ def chunk_gla_fwd_o_gk(
         V=V,
         BT=BT,
         STATE_V_FIRST=state_v_first,
+        USE_GRAPH=use_graph,
     )
     return o
 

--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -123,7 +123,10 @@ def chunk_kda_bwd_dAv_npu(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if use_graph:
+        raise NotImplementedError("use_graph is not supported on the Ascend NPU backend")
     B, T, HV, V = k.shape[0], k.shape[1], do.shape[2], do.shape[-1]
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
@@ -731,7 +734,11 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    chunk_offsets: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ):
+    if use_graph:
+        raise NotImplementedError("use_graph is not supported on the Ascend NPU backend")
     B, T, H, K, HV, V = *k.shape, v.shape[2], v.shape[-1]
     BT = chunk_size
     if BT % _BC != 0:
@@ -754,7 +761,8 @@ def chunk_kda_bwd_wy_dqkg_fused_npu(
     BV = _get_bv(V)
     NK = triton.cdiv(K, BK)
     is_varlen = cu_seqlens is not None
-    chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT) if is_varlen else g.new_zeros(1, dtype=torch.int64)
+    if chunk_offsets is None:
+        chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT) if is_varlen else g.new_zeros(1, dtype=torch.int64)
 
     v_arg, g_t_contig = _t_contig_arg(v, HV)
     beta_arg = _t_contig_arg(beta, HV)[0]

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra.py
@@ -554,7 +554,10 @@ def chunk_kda_fwd_intra_npu(
     chunk_indices: torch.LongTensor | None = None,
     safe_gate: bool = False,
     disable_recompute: bool = False,
+    use_graph: bool = False,
 ):
+    if use_graph:
+        raise NotImplementedError("use_graph is not supported on the Ascend NPU backend")
     B, T, H, K, HV = *k.shape, gk.shape[2]
     BT = chunk_size
     if BT not in (32, 64):
@@ -1102,7 +1105,10 @@ def chunk_kda_bwd_intra_npu(
     chunk_indices: torch.LongTensor | None = None,
     chunk_size: int = 64,
     safe_gate: bool = False,
+    use_graph: bool = False,
 ):
+    if use_graph:
+        raise NotImplementedError("use_graph is not supported on the Ascend NPU backend")
     B, T, H, K, HV = *k.shape, g.shape[2]
     BT = chunk_size
     BC = min(_BWD_INTRA_BC, BT)

--- a/fla/ops/kda/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/kda/backends/triton_ascend/wy_fast.py
@@ -244,7 +244,10 @@ def recompute_w_u_fwd_kda_npu(
     q: torch.Tensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    if use_graph:
+        raise NotImplementedError("use_graph is not supported on the Ascend NPU backend")
     B, T, H, K, V = *k.shape, v.shape[-1]
     HV = v.shape[2]
     BT = A.shape[-1]

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -310,9 +310,19 @@ def chunk_kda(
             - ``initial_state`` and the incoming ``dht`` gradient (when used) shaped
               ``[max_num_seqs, ...]``.
             - the captured step warmed up eagerly beforehand so that kernel autotuning
-              happens outside the graph.
+              (and, with ``cp_context``, NCCL communicator setup) happens outside the graph.
 
-            ``cp_context`` and ``disable_recompute=True`` are not supported. Default: ``False``.
+            With ``cp_context``, the cross-rank state all-gathers are recorded into the
+            graph, which additionally requires:
+
+            - a graph-capturable (non-blocking) NCCL communicator, with all ranks
+              capturing and replaying the same collectives in the same order;
+            - ``cp_context.cu_seqlens`` being the persistent padded buffer, refreshed
+              in place before each replay;
+            - ``cp_context.pre_num_ranks_dev``/``post_num_ranks_dev``, persistent int32
+              device scalars refreshed in place before each replay.
+
+            ``disable_recompute=True`` is not supported. Default: ``False``.
         max_num_seqs (Optional[int]):
             Static upper bound of the sequence count used together with ``use_graph``.
             Defaults to ``cu_seqlens.shape[0] - 1``. Default: ``None``.

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -17,7 +17,7 @@ from fla.ops.common.gate import fused_beta_sigmoid, fused_beta_sigmoid_bwd
 from fla.ops.cp import FLACPContext
 from fla.ops.kda.chunk_bwd import chunk_kda_bwd
 from fla.ops.kda.chunk_fwd import chunk_kda_fwd
-from fla.ops.utils.index import prepare_chunk_indices
+from fla.ops.utils.index import prepare_chunk_indices, prepare_chunk_indices_static
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
 
@@ -50,6 +50,8 @@ class ChunkKDAFunction(torch.autograd.Function):
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         cp_context: FLACPContext | None = None,
+        use_graph: bool = False,
+        max_num_seqs: int | None = None,
     ):
         # Apply l2norm
         q_rstd, k_rstd = None, None
@@ -61,13 +63,22 @@ class ChunkKDAFunction(torch.autograd.Function):
         if use_beta_sigmoid_in_kernel:
             beta = fused_beta_sigmoid(beta_raw, scale=2.0 if allow_neg_eigval else 1.0)
 
-        chunk_indices = None
+        chunk_indices, chunk_offsets = None, None
         if cu_seqlens is not None:
-            chunk_indices = prepare_chunk_indices(
-                cu_seqlens,
-                chunk_size,
-                cu_seqlens_cpu=cu_seqlens_cpu,
-            )
+            if use_graph:
+                if max_num_seqs is None:
+                    max_num_seqs = cu_seqlens.shape[0] - 1
+                assert cu_seqlens.shape[0] - 1 <= max_num_seqs, (
+                    f"cu_seqlens has {cu_seqlens.shape[0] - 1} sequences but max_num_seqs is {max_num_seqs}"
+                )
+                nt_max = (q.shape[1] + chunk_size - 1) // chunk_size + max_num_seqs - 1
+                chunk_indices, chunk_offsets = prepare_chunk_indices_static(cu_seqlens, chunk_size, nt_max)
+            else:
+                chunk_indices = prepare_chunk_indices(
+                    cu_seqlens,
+                    chunk_size,
+                    cu_seqlens_cpu=cu_seqlens_cpu,
+                )
 
         g_input = g
 
@@ -93,6 +104,8 @@ class ChunkKDAFunction(torch.autograd.Function):
             return_intermediate_states=return_intermediate_states,
             cp_context=cp_context,
             state_v_first=state_v_first,
+            use_graph=use_graph,
+            chunk_offsets=chunk_offsets,
         )
 
         if return_intermediate_states:
@@ -103,8 +116,9 @@ class ChunkKDAFunction(torch.autograd.Function):
         ctx.save_for_backward(
             q, q_rstd, k, k_rstd, v, g_cumsum, g_input, beta_raw, beta, A_log, dt_bias, Aqk, Akk,
             w, u, qg, kg, v_new, h,
-            initial_state, cu_seqlens, chunk_indices
+            initial_state, cu_seqlens, chunk_indices, chunk_offsets
         )
+        ctx.use_graph = use_graph
         ctx.chunk_size = chunk_size
         ctx.safe_gate = safe_gate
         ctx.scale = scale
@@ -128,7 +142,7 @@ class ChunkKDAFunction(torch.autograd.Function):
     ):
         (q, q_rstd, k, k_rstd, v, g_cumsum, g_input, beta_raw, beta, A_log, dt_bias, Aqk, Akk,
          w, u, qg, kg, v_new, h,
-         initial_state, cu_seqlens, chunk_indices) = (
+         initial_state, cu_seqlens, chunk_indices, chunk_offsets) = (
             ctx.saved_tensors
         )
 
@@ -162,6 +176,8 @@ class ChunkKDAFunction(torch.autograd.Function):
             kg=kg,
             v_new=v_new,
             h=h,
+            use_graph=ctx.use_graph,
+            chunk_offsets=chunk_offsets,
         )
         if ctx.use_qk_l2norm_in_kernel:
             dq = l2norm_bwd(q, q_rstd, dq)
@@ -170,7 +186,8 @@ class ChunkKDAFunction(torch.autograd.Function):
             db = fused_beta_sigmoid_bwd(beta_raw, db, scale=2.0 if ctx.allow_neg_eigval else 1.0)
 
         return (dq.to(q), dk.to(k), dv.to(v), dg.to(g_input), db.to(beta_raw), dA, dbias, None, dh0,
-                None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+                None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+                None, None)
 
 
 @torch.compiler.disable
@@ -196,6 +213,8 @@ def chunk_kda(
     cu_seqlens: torch.LongTensor | None = None,
     cu_seqlens_cpu: torch.LongTensor | None = None,
     cp_context: FLACPContext = None,
+    use_graph: bool = False,
+    max_num_seqs: int | None = None,
     **kwargs,
 ):
     r"""
@@ -277,6 +296,16 @@ def chunk_kda(
             Context parallel context for distributed training across multiple devices.
             When provided, ``initial_state`` and ``output_final_state`` are not supported,
             and ``cu_seqlens`` will be overridden by the context. Default: ``None``.
+        use_graph (bool):
+            Whether to build the varlen chunk list on-device at a fixed shape so the
+            forward/backward can be recorded by a platform graph (CUDA graph, NPU graph)
+            and replayed after only the contents of ``cu_seqlens`` change. Requires
+            ``cu_seqlens`` padded with zero-length tail sequences up to ``max_num_seqs + 1``
+            entries; kernels return immediately on sentinel rows (segment id < 0).
+            ``cp_context`` and ``disable_recompute=True`` are not supported. Default: ``False``.
+        max_num_seqs (Optional[int]):
+            Static upper bound of the sequence count used together with ``use_graph``.
+            Defaults to ``cu_seqlens.shape[0] - 1``. Default: ``None``.
 
     Returns:
         - Normal mode (return_intermediate_states=False): A tuple (o, final_state)
@@ -440,4 +469,6 @@ def chunk_kda(
         disable_recompute,
         return_intermediate_states,
         cp_context,
+        use_graph,
+        max_num_seqs,
     )

--- a/fla/ops/kda/chunk.py
+++ b/fla/ops/kda/chunk.py
@@ -68,8 +68,10 @@ class ChunkKDAFunction(torch.autograd.Function):
             if use_graph:
                 if max_num_seqs is None:
                     max_num_seqs = cu_seqlens.shape[0] - 1
-                assert cu_seqlens.shape[0] - 1 <= max_num_seqs, (
-                    f"cu_seqlens has {cu_seqlens.shape[0] - 1} sequences but max_num_seqs is {max_num_seqs}"
+                assert cu_seqlens.shape[0] - 1 == max_num_seqs, (
+                    f"cu_seqlens must be padded with zero-length tail sequences to exactly "
+                    f"max_num_seqs + 1 entries, got {cu_seqlens.shape[0] - 1} sequences "
+                    f"with max_num_seqs={max_num_seqs}"
                 )
                 nt_max = (q.shape[1] + chunk_size - 1) // chunk_size + max_num_seqs - 1
                 chunk_indices, chunk_offsets = prepare_chunk_indices_static(cu_seqlens, chunk_size, nt_max)
@@ -299,9 +301,17 @@ def chunk_kda(
         use_graph (bool):
             Whether to build the varlen chunk list on-device at a fixed shape so the
             forward/backward can be recorded by a platform graph (CUDA graph, NPU graph)
-            and replayed after only the contents of ``cu_seqlens`` change. Requires
-            ``cu_seqlens`` padded with zero-length tail sequences up to ``max_num_seqs + 1``
-            entries; kernels return immediately on sentinel rows (segment id < 0).
+            and replayed after only the contents of ``cu_seqlens`` change. Requires:
+
+            - ``cu_seqlens`` padded with zero-length tail sequences up to exactly
+              ``max_num_seqs + 1`` entries; kernels return immediately on sentinel rows
+              (segment id < 0), so output/gradient rows not covered by real tokens
+              are left undefined.
+            - ``initial_state`` and the incoming ``dht`` gradient (when used) shaped
+              ``[max_num_seqs, ...]``.
+            - the captured step warmed up eagerly beforehand so that kernel autotuning
+              happens outside the graph.
+
             ``cp_context`` and ``disable_recompute=True`` are not supported. Default: ``False``.
         max_num_seqs (Optional[int]):
             Static upper bound of the sequence count used together with ``use_graph``.

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -568,6 +568,7 @@ def chunk_kda_bwd(
             context=cp_context,
             chunk_size=chunk_size,
             state_v_first=state_v_first,
+            use_graph=use_graph,
         )
 
     dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -68,9 +68,8 @@ def chunk_kda_bwd_kernel_dAv(
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
@@ -177,9 +176,8 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)

--- a/fla/ops/kda/chunk_bwd.py
+++ b/fla/ops/kda/chunk_bwd.py
@@ -19,6 +19,7 @@ from fla.ops.kda.wy_fast import recompute_w_u_fwd
 from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.constant import RCP_LN2
+from fla.ops.utils.graph import get_static_buffer
 from fla.ops.utils.op import exp2
 from fla.utils import IS_NVIDIA_HOPPER, IS_NVIDIA_SM100, autotune_cache_kwargs, check_shared_mem
 
@@ -60,12 +61,17 @@ def chunk_kda_bwd_kernel_dAv(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -162,6 +168,7 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     BV: tl.constexpr,
     STATE_V_FIRST: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
     i_b, i_hv = i_bh // HV, i_bh % HV
@@ -169,7 +176,11 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
 
     if IS_VARLEN:
         i_tg = i_t.to(tl.int64)
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         NT = tl.cdiv(T, BT)
@@ -322,6 +333,7 @@ def chunk_kda_bwd_dAv(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, HV, V = *k.shape, do.shape[2], do.shape[-1]
     BT = chunk_size
@@ -338,8 +350,12 @@ def chunk_kda_bwd_dAv(
     BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    dA = v.new_empty(B, T, HV, BT, dtype=torch.float)
-    dv = torch.empty_like(do)
+    if use_graph:
+        dA = get_static_buffer("dAv_dA", (B, T, HV, BT), torch.float, v.device)
+        dv = get_static_buffer("dAv_dv", tuple(do.shape), do.dtype, do.device)
+    else:
+        dA = v.new_empty(B, T, HV, BT, dtype=torch.float)
+        dv = torch.empty_like(do)
     grid = (NT, B * HV)
     chunk_kda_bwd_kernel_dAv[grid](
         q=q,
@@ -360,6 +376,7 @@ def chunk_kda_bwd_dAv(
         BT=BT,
         BK=BK,
         BV=BV,
+        USE_GRAPH=use_graph,
     )
     return dA, dv
 
@@ -382,6 +399,7 @@ def chunk_kda_bwd_wy_dqkg_fused(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ):
     B, T, H, K, HV, V = *k.shape, v.shape[2], v.shape[-1]
     BT = chunk_size
@@ -391,12 +409,20 @@ def chunk_kda_bwd_wy_dqkg_fused(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
     # dq, dk are allocated at HV dimension; caller reduces to H if GVA
-    dq = g.new_empty(B, T, HV, K, dtype=torch.float)
-    dk = g.new_empty(B, T, HV, K, dtype=torch.float)
-    dv2 = torch.empty_like(v)
-    dg = torch.empty_like(g, dtype=torch.float)
-    db = torch.empty_like(beta, dtype=torch.float)
-    dA = torch.empty_like(A, dtype=torch.float)
+    if use_graph:
+        dq = get_static_buffer("wy_dq", (B, T, HV, K), torch.float, q.device)
+        dk = get_static_buffer("wy_dk", (B, T, HV, K), torch.float, q.device)
+        dv2 = get_static_buffer("wy_dv2", tuple(v.shape), v.dtype, v.device)
+        dg = get_static_buffer("wy_dg", tuple(g.shape), torch.float, g.device)
+        db = get_static_buffer("wy_db", tuple(beta.shape), torch.float, beta.device)
+        dA = get_static_buffer("wy_dA", tuple(A.shape), torch.float, A.device)
+    else:
+        dq = g.new_empty(B, T, HV, K, dtype=torch.float)
+        dk = g.new_empty(B, T, HV, K, dtype=torch.float)
+        dv2 = torch.empty_like(v)
+        dg = torch.empty_like(g, dtype=torch.float)
+        db = torch.empty_like(beta, dtype=torch.float)
+        dA = torch.empty_like(A, dtype=torch.float)
 
     grid = (NT, B * HV)
     chunk_kda_bwd_kernel_wy_dqkg_fused[grid](
@@ -427,6 +453,7 @@ def chunk_kda_bwd_wy_dqkg_fused(
         V=V,
         BT=BT,
         STATE_V_FIRST=state_v_first,
+        USE_GRAPH=use_graph,
     )
     dv = dv2
     return dq, dk, dv, db, dg, dA
@@ -456,6 +483,8 @@ def chunk_kda_bwd(
     dt_bias: torch.Tensor | None = None,
     disable_recompute: bool = False,
     cp_context: FLACPContext | None = None,
+    use_graph: bool = False,
+    chunk_offsets: torch.LongTensor | None = None,
     **kwargs,
 ):
     H, HV = q.shape[2], v.shape[2]
@@ -471,7 +500,8 @@ def chunk_kda_bwd(
                 chunk_size=chunk_size,
                 cu_seqlens=cu_seqlens,
                 chunk_indices=chunk_indices,
-                lower_bound=lower_bound
+                lower_bound=lower_bound,
+                use_graph=use_graph,
             )
         w, u, qg, kg = recompute_w_u_fwd(
             q=q,
@@ -482,6 +512,7 @@ def chunk_kda_bwd(
             gk=g,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
+            use_graph=use_graph,
         )
         if cp_context is not None:
             # Restore the full initial_state tensor from the compressed version.
@@ -496,6 +527,7 @@ def chunk_kda_bwd(
             output_final_state=False,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
+            chunk_offsets=chunk_offsets,
             chunk_size=chunk_size,
             state_v_first=state_v_first,
         )
@@ -518,6 +550,7 @@ def chunk_kda_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        use_graph=use_graph,
     )
 
     if cp_context is not None:
@@ -552,6 +585,7 @@ def chunk_kda_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
         state_v_first=state_v_first,
     )
 
@@ -572,6 +606,7 @@ def chunk_kda_bwd(
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         state_v_first=state_v_first,
+        use_graph=use_graph,
     )
 
     dq, dk, db, dg = chunk_kda_bwd_intra(
@@ -588,7 +623,8 @@ def chunk_kda_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        safe_gate=safe_gate
+        safe_gate=safe_gate,
+        use_graph=use_graph,
     )
 
     # For GVA, reduce dq and dk from [B, T, HV, K] back to [B, T, H, K]
@@ -603,6 +639,7 @@ def chunk_kda_bwd(
         reverse=True,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        use_graph=use_graph,
     )
     if use_gate_in_kernel:
         dg, dA, dbias = kda_gate_bwd(
@@ -610,7 +647,7 @@ def chunk_kda_bwd(
             A_log=A_log,
             dt_bias=dt_bias,
             dyg=dg,
-            lower_bound=lower_bound
+            lower_bound=lower_bound,
         )
 
     return dq, dk, dv, db, dg, dh0, dA, dbias

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -94,6 +94,7 @@ def chunk_kda_fwd(
             context=cp_context,
             chunk_size=chunk_size,
             state_v_first=state_v_first,
+            use_graph=use_graph,
         )
 
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(

--- a/fla/ops/kda/chunk_fwd.py
+++ b/fla/ops/kda/chunk_fwd.py
@@ -39,6 +39,8 @@ def chunk_kda_fwd(
     disable_recompute: bool = False,
     return_intermediate_states: bool = False,
     cp_context: FLACPContext | None = None,
+    use_graph: bool = False,
+    chunk_offsets: torch.LongTensor | None = None,
 ):
     # Apply gate activation
     g_org = None
@@ -53,6 +55,7 @@ def chunk_kda_fwd(
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             lower_bound=lower_bound,
+            use_graph=use_graph,
         )
     else:
         g = chunk_local_cumsum(
@@ -60,7 +63,8 @@ def chunk_kda_fwd(
             scale=RCP_LN2,
             chunk_size=chunk_size,
             cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices
+            chunk_indices=chunk_indices,
+            use_graph=use_graph,
         )
 
     # qg = None if disable_recompute is False
@@ -75,7 +79,8 @@ def chunk_kda_fwd(
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         safe_gate=safe_gate,
-        disable_recompute=disable_recompute
+        disable_recompute=disable_recompute,
+        use_graph=use_graph,
     )
 
     if cp_context is not None:
@@ -101,6 +106,7 @@ def chunk_kda_fwd(
         cu_seqlens=cu_seqlens,
         cu_seqlens_cpu=cu_seqlens_cpu,
         chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
         chunk_size=chunk_size,
         state_v_first=state_v_first,
     )
@@ -123,6 +129,7 @@ def chunk_kda_fwd(
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         state_v_first=state_v_first,
+        use_graph=use_graph,
     )
     if disable_recompute is False:
         # Delete to save memory

--- a/fla/ops/kda/chunk_intra.py
+++ b/fla/ops/kda/chunk_intra.py
@@ -14,6 +14,7 @@ from fla.ops.kda.chunk_intra_token_parallel import chunk_kda_fwd_intra_token_par
 from fla.ops.kda.wy_fast import recompute_w_u_fwd
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
+from fla.ops.utils.graph import get_static_buffer
 from fla.ops.utils.op import exp2, gather
 from fla.utils import IS_GATHER_SUPPORTED, IS_TF32_SUPPORTED, autotune_cache_kwargs
 
@@ -61,6 +62,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_SAFE_GATE: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     """
     Fused kernel: compute inter-subchunk Akk + solve_tril in one pass.
@@ -79,7 +81,10 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH and (i_n < 0):
+            return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -420,6 +425,7 @@ def chunk_kda_bwd_kernel_intra(
     IS_VARLEN: tl.constexpr,
     SAFE_GATE: tl.constexpr,
     USE_GATHER: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_hv = i_bh // HV, i_bh % HV
@@ -428,7 +434,10 @@ def chunk_kda_bwd_kernel_intra(
 
     all = B * T
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH and (i_n < 0):
+            return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     else:
         bos, eos = i_b * T, i_b * T + T
@@ -699,13 +708,17 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_GATHER: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2).to(tl.int64)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH and (i_n < 0):
+            return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -803,6 +816,7 @@ def chunk_kda_fwd_intra(
     chunk_indices: torch.LongTensor | None = None,
     safe_gate: bool = False,
     disable_recompute: bool = False,
+    use_graph: bool = False,
 ):
     B, T, H, K, HV = *k.shape, gk.shape[2]
     BT = chunk_size
@@ -843,6 +857,7 @@ def chunk_kda_fwd_intra(
             BC=BC,
             BK=BK,
             USE_GATHER=IS_GATHER_SUPPORTED,
+            USE_GRAPH=use_graph,
         )
     else:
         Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
@@ -879,6 +894,7 @@ def chunk_kda_fwd_intra(
         BC=BC,
         NC=NC,
         USE_SAFE_GATE=safe_gate,
+        USE_GRAPH=use_graph,
     )
     w, u, qg, kg = recompute_w_u_fwd(
         k=k,
@@ -889,6 +905,7 @@ def chunk_kda_fwd_intra(
         gk=gk,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        use_graph=use_graph,
     )
     return w, u, qg, kg, Aqk, Akk
 
@@ -909,6 +926,7 @@ def chunk_kda_bwd_intra(
     chunk_indices: torch.LongTensor | None = None,
     chunk_size: int = 64,
     safe_gate: bool = False,
+    use_graph: bool = False,
 ):
     B, T, H, K, HV = *k.shape, g.shape[2]
     BT = chunk_size
@@ -921,10 +939,16 @@ def chunk_kda_bwd_intra(
     NC = triton.cdiv(BT, BC)
     NK = triton.cdiv(K, BK)
 
-    dq2 = torch.empty_like(dq)
-    dk2 = torch.empty_like(dk)
-    db2 = beta.new_empty(NK, *beta.shape, dtype=torch.float)
-    dg2 = torch.empty_like(dg, dtype=torch.float)
+    if use_graph:
+        dq2 = get_static_buffer("intra_dq2", tuple(dq.shape), dq.dtype, dq.device)
+        dk2 = get_static_buffer("intra_dk2", tuple(dk.shape), dk.dtype, dk.device)
+        db2 = get_static_buffer("intra_db2", (NK, *beta.shape), torch.float, beta.device)
+        dg2 = get_static_buffer("intra_dg2", tuple(dg.shape), torch.float, dg.device)
+    else:
+        dq2 = torch.empty_like(dq)
+        dk2 = torch.empty_like(dk)
+        db2 = beta.new_empty(NK, *beta.shape, dtype=torch.float)
+        dg2 = torch.empty_like(dg, dtype=torch.float)
     grid = (NK * NC, NT, B * HV)
     chunk_kda_bwd_kernel_intra[grid](
         q=q,
@@ -953,6 +977,7 @@ def chunk_kda_bwd_intra(
         NC=NC,
         SAFE_GATE=safe_gate,
         USE_GATHER=IS_GATHER_SUPPORTED,
+        USE_GRAPH=use_graph,
     )
     dq = dq2
     dk = dk2

--- a/fla/ops/kda/chunk_intra.py
+++ b/fla/ops/kda/chunk_intra.py
@@ -82,7 +82,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
 
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH and (i_n < 0):
+        if USE_GRAPH and i_n < 0:
             return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -435,7 +435,7 @@ def chunk_kda_bwd_kernel_intra(
     all = B * T
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH and (i_n < 0):
+        if USE_GRAPH and i_n < 0:
             return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -716,7 +716,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk(
 
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH and (i_n < 0):
+        if USE_GRAPH and i_n < 0:
             return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
@@ -871,6 +871,7 @@ def chunk_kda_fwd_intra(
             cu_seqlens=cu_seqlens,
             chunk_size=BT,
             sub_chunk_size=BC,
+            use_graph=use_graph,
         )
 
     # Step 2: Fused inter + solve_tril (works for both fixed-len and varlen)

--- a/fla/ops/kda/chunk_intra_token_parallel.py
+++ b/fla/ops/kda/chunk_intra_token_parallel.py
@@ -49,10 +49,14 @@ def chunk_kda_fwd_kernel_intra_token_parallel(
     BC: tl.constexpr,
     BH: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_tg, i_hg = tl.program_id(0).to(tl.int64), tl.program_id(1)
 
     if IS_VARLEN:
+        # static T may exceed the covered tokens; i_n would converge to N and read OOB
+        if USE_GRAPH and i_tg >= tl.load(cu_seqlens + N).to(tl.int32):
+            return
         i_n = 0
         left, right = 0, N
 
@@ -135,6 +139,7 @@ def chunk_kda_fwd_intra_token_parallel(
     cu_seqlens: torch.LongTensor | None = None,
     chunk_size: int = 64,
     sub_chunk_size: int = 16,
+    use_graph: bool = False,
 ) -> None:
     """
     Token-parallel implementation: each token gets its own thread block.
@@ -178,5 +183,6 @@ def chunk_kda_fwd_intra_token_parallel(
         BK=BK,
         BT=BT,
         BC=BC,
+        USE_GRAPH=use_graph,
     )
     return Aqk, Akk

--- a/fla/ops/kda/gate.py
+++ b/fla/ops/kda/gate.py
@@ -430,9 +430,8 @@ def kda_gate_chunk_cumsum_vector_kernel(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos

--- a/fla/ops/kda/gate.py
+++ b/fla/ops/kda/gate.py
@@ -424,11 +424,16 @@ def kda_gate_chunk_cumsum_vector_kernel(
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -477,6 +482,7 @@ def kda_gate_chunk_cumsum(
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
     lower_bound: float | None = None,
+    use_graph: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     if cu_seqlens is not None:
@@ -505,5 +511,6 @@ def kda_gate_chunk_cumsum(
         S=S,
         BT=BT,
         REVERSE=False,
+        USE_GRAPH=use_graph,
     )
     return g

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -62,9 +62,8 @@ def recompute_w_u_fwd_kda_kernel(
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
@@ -179,9 +178,8 @@ def prepare_wy_repr_bwd_kda_kernel(
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos

--- a/fla/ops/kda/wy_fast.py
+++ b/fla/ops/kda/wy_fast.py
@@ -55,12 +55,17 @@ def recompute_w_u_fwd_kda_kernel(
     STORE_QG: tl.constexpr,
     STORE_KG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -167,12 +172,17 @@ def prepare_wy_repr_bwd_kda_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_hv = i_bh // HV, i_bh % HV
     i_h = i_hv // (HV // H)
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -270,6 +280,7 @@ def recompute_w_u_fwd(
     q: torch.Tensor | None = None,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     HV = v.shape[2]
@@ -306,6 +317,7 @@ def recompute_w_u_fwd(
         BT=BT,
         BK=BK,
         BV=BV,
+        USE_GRAPH=use_graph,
     )
     return w, u, qg, kg
 
@@ -322,6 +334,7 @@ def prepare_wy_repr_bwd(
     dg: torch.Tensor,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     HV = v.shape[2]
@@ -363,6 +376,7 @@ def prepare_wy_repr_bwd(
         BT=BT,
         BK=BK,
         BV=BV,
+        USE_GRAPH=use_graph,
     )
     dk = dk2
     dg = dg2

--- a/fla/ops/utils/__init__.py
+++ b/fla/ops/utils/__init__.py
@@ -17,6 +17,7 @@ from .cumsum import (
 from .index import (
     get_max_num_splits,
     prepare_chunk_indices,
+    prepare_chunk_indices_static,
     prepare_chunk_offsets,
     prepare_cu_seqlens_from_lens,
     prepare_cu_seqlens_from_mask,
@@ -49,6 +50,7 @@ __all__ = [
     "pack_sequence",
     "prepare_block_csr",
     "prepare_chunk_indices",
+    "prepare_chunk_indices_static",
     "prepare_chunk_offsets",
     "prepare_cu_seqlens_from_lens",
     "prepare_cu_seqlens_from_mask",

--- a/fla/ops/utils/backends/triton_ascend/cumsum.py
+++ b/fla/ops/utils/backends/triton_ascend/cumsum.py
@@ -336,6 +336,7 @@ def chunk_local_cumsum_scalar_npu(
     cu_seqlens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     if 'head_first' in kwargs:
@@ -347,7 +348,8 @@ def chunk_local_cumsum_scalar_npu(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     num_blocks = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, chunk_size)
-    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+    # graph 模式下未覆盖行须为 0：kda_gate_bwd 对输出做全量归约，脏行会污染 dA/dbias
+    g_org, g = g, (torch.zeros_like if use_graph else torch.empty_like)(g, dtype=output_dtype or g.dtype)
 
     num_core = get_multiprocessor_count()
     task_num = num_blocks * B * H
@@ -377,6 +379,7 @@ def chunk_local_cumsum_vector_npu(
     cu_seqlens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     if 'head_first' in kwargs:
@@ -397,7 +400,8 @@ def chunk_local_cumsum_vector_npu(
         BS,
         max_grid=ASCEND_MAX_GRID_DIM,
     )
-    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+    # graph 模式下未覆盖行须为 0：kda_gate_bwd 对输出做全量归约，脏行会污染 dA/dbias
+    g_org, g = g, (torch.zeros_like if use_graph else torch.empty_like)(g, dtype=output_dtype or g.dtype)
     _launch_local_cumsum_vector(
         g_org=g_org,
         g=g,
@@ -547,6 +551,7 @@ def chunk_local_cumsum_npu(
     cu_seqlens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     if 'head_first' in kwargs:
@@ -564,6 +569,7 @@ def chunk_local_cumsum_npu(
             cu_seqlens=cu_seqlens,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
+            use_graph=use_graph,
         )
     if len(g.shape) == 4:
         return chunk_local_cumsum_vector_npu(
@@ -574,6 +580,7 @@ def chunk_local_cumsum_npu(
             cu_seqlens=cu_seqlens,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
+            use_graph=use_graph,
         )
     raise ValueError(
         f"Unsupported input shape {g.shape}, "

--- a/fla/ops/utils/cumsum.py
+++ b/fla/ops/utils/cumsum.py
@@ -269,7 +269,8 @@ def chunk_local_cumsum_scalar(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
-    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+    # graph 模式下未覆盖行须为 0：kda_gate_bwd 对输出做全量归约，脏行会污染 dA/dbias
+    g_org, g = g, (torch.zeros_like if use_graph else torch.empty_like)(g, dtype=output_dtype or g.dtype)
     grid = (NT, B * H)
     chunk_local_cumsum_scalar_kernel[grid](
         s=g_org,
@@ -309,7 +310,8 @@ def chunk_local_cumsum_vector(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     assert chunk_size == 2**(chunk_size.bit_length()-1), "chunk_size must be a power of 2"
 
-    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+    # graph 模式下未覆盖行须为 0：kda_gate_bwd 对输出做全量归约，脏行会污染 dA/dbias
+    g_org, g = g, (torch.zeros_like if use_graph else torch.empty_like)(g, dtype=output_dtype or g.dtype)
     def grid(meta): return (triton.cdiv(meta['S'], meta['BS']), NT, B * H)
     # keep cummulative normalizer in fp32
     # this kernel is equivalent to

--- a/fla/ops/utils/cumsum.py
+++ b/fla/ops/utils/cumsum.py
@@ -43,11 +43,16 @@ def chunk_local_cumsum_scalar_kernel(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -97,11 +102,16 @@ def chunk_local_cumsum_vector_kernel(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_GRAPH: tl.constexpr = False,
 ):
     i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        if USE_GRAPH:
+            if i_n < 0:
+                return
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
@@ -248,6 +258,7 @@ def chunk_local_cumsum_scalar(
     cu_seqlens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     if 'head_first' in kwargs:
@@ -273,6 +284,7 @@ def chunk_local_cumsum_scalar(
         H=H,
         BT=BT,
         REVERSE=reverse,
+        USE_GRAPH=use_graph,
     )
     return g
 
@@ -285,6 +297,7 @@ def chunk_local_cumsum_vector(
     cu_seqlens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     if 'head_first' in kwargs:
@@ -315,6 +328,7 @@ def chunk_local_cumsum_vector(
         S=S,
         BT=BT,
         REVERSE=reverse,
+        USE_GRAPH=use_graph,
     )
     return g
 
@@ -433,6 +447,7 @@ def chunk_local_cumsum(
     cu_seqlens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = torch.float,
     chunk_indices: torch.LongTensor | None = None,
+    use_graph: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     if 'head_first' in kwargs:
@@ -450,6 +465,7 @@ def chunk_local_cumsum(
             cu_seqlens=cu_seqlens,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
+            use_graph=use_graph,
         )
     elif len(g.shape) == 4:
         return chunk_local_cumsum_vector(
@@ -460,6 +476,7 @@ def chunk_local_cumsum(
             cu_seqlens=cu_seqlens,
             output_dtype=output_dtype,
             chunk_indices=chunk_indices,
+            use_graph=use_graph,
         )
     else:
         raise ValueError(

--- a/fla/ops/utils/cumsum.py
+++ b/fla/ops/utils/cumsum.py
@@ -49,9 +49,8 @@ def chunk_local_cumsum_scalar_kernel(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
@@ -108,9 +107,8 @@ def chunk_local_cumsum_vector_kernel(
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
-        if USE_GRAPH:
-            if i_n < 0:
-                return
+        if USE_GRAPH and i_n < 0:
+            return
         i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos

--- a/fla/ops/utils/graph.py
+++ b/fla/ops/utils/graph.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Static buffer management for platform graph capture (CUDA graph, NPU graph).
+
+Buffers are allocated on first use, kept for the process lifetime, and shared by all
+graphs with the same (name, shape, dtype, device) key; interleaved replay of graphs
+with identical keys is not supported.
+"""
+
+import torch
+
+_BUFFERS: dict[tuple, torch.Tensor] = {}
+
+
+def get_static_buffer(name: str, shape: tuple, dtype: torch.dtype, device: torch.device | str) -> torch.Tensor:
+    """Return the persistent buffer for the given key, allocated on first use and reused after."""
+    key = (name, tuple(shape), dtype, str(device))
+    buf = _BUFFERS.get(key)
+    if buf is None:
+        buf = torch.empty(shape, dtype=dtype, device=device)
+        _BUFFERS[key] = buf
+    return buf

--- a/fla/ops/utils/index.py
+++ b/fla/ops/utils/index.py
@@ -181,3 +181,31 @@ def get_max_num_splits(
     if cu_seqlens_cpu is not None:
         return triton.cdiv(int(max(prepare_lens(cu_seqlens_cpu))), chunk_size)
     return triton.cdiv(int(max(prepare_lens(cu_seqlens))), chunk_size)
+
+
+def prepare_chunk_indices_static(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int,
+    nt_max: int,
+) -> tuple[torch.LongTensor, torch.LongTensor]:
+    """Device-side, fixed-shape chunk-index construction for graph capture.
+
+    Builds ``chunk_indices`` of shape ``[nt_max, 2]`` and ``chunk_offsets`` of shape
+    ``[N_max + 1]`` with on-device ops, so their construction can be recorded in a
+    platform graph. ``cu_seqlens`` must be padded with zero-length tail sequences up to
+    ``N_max + 1`` entries. Rows beyond the real chunk count carry the sentinel
+    ``i_n = -1``; kernels must return immediately on a negative segment id.
+    Not cached: the construction runs (and is recorded) on every call.
+
+    Returns both tensors with the same dtype as ``cu_seqlens``.
+    """
+    lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks = (lens + (chunk_size - 1)).div(chunk_size, rounding_mode='floor')
+    chunk_offsets = F.pad(chunks.cumsum(0), (1, 0))
+    slots = torch.arange(nt_max, device=cu_seqlens.device, dtype=chunk_offsets.dtype)
+    i_n = torch.searchsorted(chunk_offsets, slots, right=True) - 1
+    i_t = slots - chunk_offsets[i_n]
+    valid = slots < chunk_offsets[-1]
+    i_n = torch.where(valid, i_n, torch.full_like(i_n, -1))
+    i_t = torch.where(valid, i_t, torch.zeros_like(i_t))
+    return torch.stack([i_n, i_t], 1).to(cu_seqlens), chunk_offsets.to(cu_seqlens)

--- a/tests/context_parallel/test_cp_kda_graph.py
+++ b/tests/context_parallel/test_cp_kda_graph.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""
+Test for Context Parallel (CP) KDA with platform graph capture/replay.
+
+Each rank captures a fwd+bwd step (cp_context + use_graph) once, replays it with
+several cu_seqlens layouts (different splits and zero-length tail padding), and
+compares against the eager CP path on the same shard. The recorded region includes
+the cross-rank state all-gathers, so all ranks must capture and replay in lockstep.
+"""
+
+import logging
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+from fla.ops.cp import FLACPContext, build_cp_context
+from fla.ops.kda import chunk_kda
+from fla.utils import assert_close
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+T = 1024
+H = 4
+D = 64
+MAX_NUM_SEQS = 4
+
+# (tag, cu_seqlens) -- all cover [0, T]; trailing repeats are zero-length padding sequences
+CONFIGS = [
+    ("4seq", [0, 300, 600, 900, 1024]),
+    ("2seq_zerotail", [0, 512, 1024, 1024, 1024]),
+    ("4seq_alt", [0, 100, 400, 700, 1024]),
+    ("1seq_zerotail", [0, 1024, 1024, 1024, 1024]),
+]
+
+TOK_NAMES = ["q", "k", "v", "g", "beta"]
+NAMES = TOK_NAMES + ["A_log", "dt_bias"]
+OUT_NAMES = ["o", "dq", "dk", "dv", "dg", "db", "dA", "dbias"]
+
+
+def rand_global(seed, device):
+    """Same seed on every rank reproduces one logical global batch; ranks slice their shard."""
+    g = torch.Generator(device).manual_seed(seed)
+    dt = torch.bfloat16
+    hv = H
+    q = torch.randn(1, T, H, D, dtype=dt, device=device, generator=g)
+    k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32, device=device, generator=g), p=2, dim=-1).to(dt)
+    v = torch.randn(1, T, hv, D, dtype=dt, device=device, generator=g)
+    gg = torch.randn(1, T, hv, D, dtype=dt, device=device, generator=g)
+    A_log = torch.log(torch.empty(1, 1, hv, 1, device=device).uniform_(1, 16, generator=g))
+    dt_bias = torch.randn(hv * D, dtype=torch.float32, device=device, generator=g)
+    beta = torch.rand(1, T, hv, dtype=dt, device=device, generator=g).sigmoid()
+    do = torch.randn(1, T, hv, D, dtype=dt, device=device, generator=g)
+    return dict(q=q, k=k, v=v, g=gg, beta=beta, A_log=A_log, dt_bias=dt_bias, do=do)
+
+
+def init_distributed(rank, world_size):
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '29631'
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
+
+
+def run_cp_graph_worker(rank, world_size):
+    init_distributed(rank, world_size)
+    device = torch.device('cuda', rank)
+    part = T // world_size
+    lo, hi = rank * part, (rank + 1) * part
+    group = dist.group.WORLD
+
+    cu_static = torch.zeros(MAX_NUM_SEQS + 1, dtype=torch.long, device=device)
+    pre_dev = torch.zeros(1, dtype=torch.int32, device=device)
+    post_dev = torch.zeros(1, dtype=torch.int32, device=device)
+
+    def refresh(base):
+        local = base.cu_seqlens
+        cu_static[: len(local)] = local
+        cu_static[len(local):] = local[-1]
+        pre_dev.fill_(base.pre_num_ranks)
+        post_dev.fill_(base.post_num_ranks)
+
+    # one persistent context around the static buffers; host fields are only read eagerly
+    base0 = build_cp_context(torch.tensor(CONFIGS[0][1], dtype=torch.long, device=device), group=group)
+    refresh(base0)
+    ctx = FLACPContext(
+        group=group,
+        cu_seqlens=cu_static,
+        cu_seqlens_cpu=None,
+        is_last_rank=base0.is_last_rank,
+        pre_num_ranks=base0.pre_num_ranks,
+        is_first_rank=base0.is_first_rank,
+        post_num_ranks=base0.post_num_ranks,
+        pre_num_ranks_dev=pre_dev,
+        post_num_ranks_dev=post_dev,
+    )
+
+    def shard_leaves(inp):
+        leaves = {n: inp[n][:, lo:hi].detach().clone().requires_grad_() for n in TOK_NAMES}
+        for n in ("A_log", "dt_bias"):
+            leaves[n] = inp[n].detach().clone().requires_grad_()
+        return leaves
+
+    inp0 = rand_global(0, device)
+    leaves = shard_leaves(inp0)
+    do = inp0["do"][:, lo:hi].detach().clone()
+
+    def step():
+        for t in leaves.values():
+            if t.grad is not None:
+                t.grad.zero_()
+        o, _ = chunk_kda(
+            q=leaves["q"], k=leaves["k"], v=leaves["v"], g=leaves["g"], beta=leaves["beta"],
+            cp_context=ctx, use_gate_in_kernel=True,
+            A_log=leaves["A_log"], dt_bias=leaves["dt_bias"],
+            use_graph=True, max_num_seqs=MAX_NUM_SEQS,
+        )
+        (o * do).sum().backward()
+        return o
+
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            step()
+    torch.cuda.current_stream().wait_stream(s)
+    dist.barrier()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        cap_o = step()
+
+    for seed, (tag, cucfg) in enumerate(CONFIGS, start=1):
+        inp = rand_global(seed * 17, device)
+        for n in TOK_NAMES:
+            leaves[n].data.copy_(inp[n][:, lo:hi])
+        for n in ("A_log", "dt_bias"):
+            leaves[n].data.copy_(inp[n])
+        do.copy_(inp["do"][:, lo:hi])
+        cu = torch.tensor(cucfg, dtype=torch.long, device=device)
+        refresh(build_cp_context(cu, group=group))
+
+        dist.barrier()
+        graph.replay()
+        torch.cuda.synchronize()
+        got = [cap_o.clone()] + [leaves[n].grad.clone() for n in NAMES]
+        dist.barrier()
+
+        # eager CP reference on the same shard
+        ref_leaves = shard_leaves(inp)
+        o, _ = chunk_kda(
+            q=ref_leaves["q"], k=ref_leaves["k"], v=ref_leaves["v"], g=ref_leaves["g"], beta=ref_leaves["beta"],
+            cp_context=build_cp_context(cu, group=group), use_gate_in_kernel=True,
+            A_log=ref_leaves["A_log"], dt_bias=ref_leaves["dt_bias"],
+        )
+        (o * inp["do"][:, lo:hi]).sum().backward()
+        ref = [o.detach()] + [ref_leaves[n].grad for n in NAMES]
+        dist.barrier()
+
+        for name, r, g in zip(OUT_NAMES, ref, got):
+            assert_close(f"{tag}::{name}", r, g, ratio=8e-3)
+
+    # no destroy_process_group: tearing down a communicator recorded in a CUDA graph
+    # can hang; process exit reaps it
+    dist.barrier()
+
+
+def test_cp2_graph_replay_matches_eager():
+    if torch.cuda.device_count() < 2:
+        pytest.skip("At least 2 GPUs required")
+    mp.start_processes(run_cp_graph_worker, args=(2,), nprocs=2, join=True, start_method='spawn')

--- a/tests/ops/test_kda_graph.py
+++ b/tests/ops/test_kda_graph.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Graph capture/replay tests for KDA chunk training (fwd + bwd).
+
+Captures a fwd+bwd step once, replays it with different ``cu_seqlens`` contents
+(different splits and zero-length tail padding), and compares against the eager
+(``use_graph=False``) path. Requires CUDA + CUDAGraph.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from fla.ops.kda import chunk_kda
+from fla.utils import assert_close, device
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not hasattr(torch.cuda, "CUDAGraph"),
+    reason="graph capture tests require a CUDA device with CUDAGraph support",
+)
+
+# static capture capacity
+T = 1024
+H = 4
+D = 64
+MAX_NUM_SEQS = 4
+
+# (tag, cu_seqlens) -- all cover [0, T]; trailing repeats are zero-length padding sequences
+_VARLEN_CONFIGS = [
+    ("4seq", [0, 300, 600, 900, 1024]),
+    ("2seq_zerotail", [0, 512, 1024, 1024, 1024]),
+    ("4seq_alt", [0, 100, 400, 700, 1024]),
+    ("1seq_zerotail", [0, 1024, 1024, 1024, 1024]),
+]
+
+_OUT_NAMES = ["o", "ht", "dq", "dk", "dv", "dg", "db", "dh0", "dA", "dbias"]
+
+
+def _rand_inputs(seed, gate, safe_gate, hv=H):
+    # q/k carry H heads; v/g/beta/state carry HV heads (HV>H exercises GVA).
+    g = torch.Generator(device).manual_seed(seed)
+    dt = torch.bfloat16
+    q = torch.randn(1, T, H, D, dtype=dt, device=device, generator=g)
+    k = F.normalize(torch.randn(1, T, H, D, dtype=torch.float32, device=device, generator=g), p=2, dim=-1).to(dt)
+    v = torch.randn(1, T, hv, D, dtype=dt, device=device, generator=g)
+    if gate:
+        gg = torch.randn(1, T, hv, D, dtype=dt, device=device, generator=g)
+        A_log = torch.log(torch.empty(1, 1, hv, 1, device=device).uniform_(1, 16, generator=g))
+        dt_bias = torch.randn(hv * D, dtype=torch.float32, device=device, generator=g)
+    else:
+        gg = F.logsigmoid(torch.randn(1, T, hv, D, dtype=torch.float32, device=device, generator=g))
+        if safe_gate:
+            gg = gg.clamp(-5, 0)
+        A_log = dt_bias = None
+    beta = torch.rand(1, T, hv, dtype=dt, device=device, generator=g).sigmoid()
+    h0 = torch.randn(MAX_NUM_SEQS, hv, D, D, dtype=torch.float32, device=device, generator=g)
+    do = torch.randn(1, T, hv, D, dtype=dt, device=device, generator=g)
+    dht = torch.randn(MAX_NUM_SEQS, hv, D, D, dtype=torch.float32, device=device, generator=g)
+    return dict(q=q, k=k, v=v, g=gg, beta=beta, h0=h0, A_log=A_log, dt_bias=dt_bias, do=do, dht=dht)
+
+
+def _eager(inp, cu, gate, safe_gate):
+    leaves = {n: inp[n].detach().clone().requires_grad_() for n in ("q", "k", "v", "g", "beta", "h0")}
+    extra = {}
+    if gate:
+        leaves["A_log"] = inp["A_log"].detach().clone().requires_grad_()
+        leaves["dt_bias"] = inp["dt_bias"].detach().clone().requires_grad_()
+        extra = dict(A_log=leaves["A_log"], dt_bias=leaves["dt_bias"])
+    o, ht = chunk_kda(
+        q=leaves["q"],
+        k=leaves["k"],
+        v=leaves["v"],
+        g=leaves["g"],
+        beta=leaves["beta"],
+        initial_state=leaves["h0"],
+        output_final_state=True,
+        cu_seqlens=cu,
+        use_gate_in_kernel=gate,
+        safe_gate=safe_gate,
+        lower_bound=(-5 if safe_gate else None),
+        **extra,
+    )
+    ((o * inp["do"]).sum() + (ht * inp["dht"]).sum()).backward()
+    out = [
+        o.detach(),
+        ht.detach(),
+        leaves["q"].grad,
+        leaves["k"].grad,
+        leaves["v"].grad,
+        leaves["g"].grad,
+        leaves["beta"].grad,
+        leaves["h0"].grad,
+    ]
+    out += [leaves["A_log"].grad, leaves["dt_bias"].grad] if gate else [None, None]
+    return out
+
+
+def _make_graphed(inp, cu, gate, safe_gate):
+    """Build static leaf buffers and capture a fwd+bwd step. Returns (graph, leaves, do, dht, cap_o, cap_ht)."""
+    leaves = {n: inp[n].detach().clone().requires_grad_() for n in ("q", "k", "v", "g", "beta", "h0")}
+    extra = {}
+    if gate:
+        leaves["A_log"] = inp["A_log"].detach().clone().requires_grad_()
+        leaves["dt_bias"] = inp["dt_bias"].detach().clone().requires_grad_()
+        extra = dict(A_log=leaves["A_log"], dt_bias=leaves["dt_bias"])
+    do = inp["do"].detach().clone()
+    dht = inp["dht"].detach().clone()
+    grad_leaves = [leaves[n] for n in leaves]
+
+    def step():
+        for t in grad_leaves:
+            if t.grad is not None:
+                t.grad.zero_()
+        o, ht = chunk_kda(
+            q=leaves["q"],
+            k=leaves["k"],
+            v=leaves["v"],
+            g=leaves["g"],
+            beta=leaves["beta"],
+            initial_state=leaves["h0"],
+            output_final_state=True,
+            cu_seqlens=cu,
+            use_gate_in_kernel=gate,
+            safe_gate=safe_gate,
+            lower_bound=(-5 if safe_gate else None),
+            use_graph=True,
+            max_num_seqs=MAX_NUM_SEQS,
+            **extra,
+        )
+        ((o * do).sum() + (ht * dht).sum()).backward()
+        return o.detach().clone(), ht.detach().clone()
+
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            step()
+    torch.cuda.current_stream().wait_stream(s)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        cap_o, cap_ht = step()
+    return graph, leaves, do, dht, cap_o, cap_ht
+
+
+def _graphed_outputs(leaves, gate, cap_o, cap_ht):
+    out = [
+        cap_o,
+        cap_ht,
+        leaves["q"].grad,
+        leaves["k"].grad,
+        leaves["v"].grad,
+        leaves["g"].grad,
+        leaves["beta"].grad,
+        leaves["h0"].grad,
+    ]
+    out += [leaves["A_log"].grad, leaves["dt_bias"].grad] if gate else [None, None]
+    return out
+
+
+# (gate, safe_gate, hv) covering every chunk_kda config axis incl. GVA (hv > H).
+_CFG = [
+    pytest.param(False, False, H, id="default"),
+    pytest.param(False, True, H, id="safe_gate"),
+    pytest.param(True, False, H, id="gate_in_kernel"),
+    pytest.param(True, True, H, id="gate+safe_gate"),
+    pytest.param(False, False, 2 * H, id="gva_default"),
+    pytest.param(True, True, 2 * H, id="gva_gate+safe"),
+]
+
+
+@pytest.mark.parametrize(("gate", "safe_gate", "hv"), _CFG)
+def test_chunk_kda_graph_replay_matches_eager(gate, safe_gate, hv):
+    """Capture fwd+bwd, replay with the captured inputs, and compare to the eager path."""
+    cu = torch.tensor(_VARLEN_CONFIGS[0][1], dtype=torch.long, device=device)
+    inp = _rand_inputs(seed=0, gate=gate, safe_gate=safe_gate, hv=hv)
+
+    graph, leaves, _do, _dht, cap_o, cap_ht = _make_graphed(inp, cu, gate, safe_gate)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    got = _graphed_outputs(leaves, gate, cap_o, cap_ht)
+    ref = _eager(inp, cu, gate, safe_gate)
+    for name, r, g in zip(_OUT_NAMES, ref, got):
+        if r is None:
+            continue
+        assert_close(f"graph::{name}", r, g, 2e-3)
+
+
+@pytest.mark.parametrize(("gate", "safe_gate", "hv"), _CFG)
+def test_chunk_kda_graph_multi_replay_varlen(gate, safe_gate, hv):
+    """Capture once, then replay against several different cu_seqlens layouts.
+
+    Each replay copies fresh inputs + a new cu_seqlens content into the static buffers and
+    must match an independent eager run on that same data -- proving the in-graph device-side
+    chunk-index rebuild recomputes correctly from the live cu_seqlens on every replay.
+    """
+    cu = torch.tensor(_VARLEN_CONFIGS[0][1], dtype=torch.long, device=device)
+    inp0 = _rand_inputs(seed=0, gate=gate, safe_gate=safe_gate, hv=hv)
+    graph, leaves, _do, _dht, cap_o, cap_ht = _make_graphed(inp0, cu, gate, safe_gate)
+
+    update_names = ["q", "k", "v", "g", "beta", "h0"] + (["A_log", "dt_bias"] if gate else [])
+    for seed, (tag, cucfg) in enumerate(_VARLEN_CONFIGS, start=1):
+        inp = _rand_inputs(seed=seed * 17, gate=gate, safe_gate=safe_gate, hv=hv)
+        for n in update_names:
+            leaves[n].data.copy_(inp[n])
+        _do.copy_(inp["do"])
+        _dht.copy_(inp["dht"])
+        cu.copy_(torch.tensor(cucfg, dtype=torch.long, device=device))
+
+        graph.replay()
+        torch.cuda.synchronize()
+
+        got = _graphed_outputs(leaves, gate, cap_o, cap_ht)
+        ref = _eager(inp, torch.tensor(cucfg, dtype=torch.long, device=device), gate, safe_gate)
+        for name, r, g in zip(_OUT_NAMES, ref, got):
+            if r is None:
+                continue
+            assert_close(f"{tag}::{name}", r, g, 2e-3)

--- a/tests/ops/test_kda_graph.py
+++ b/tests/ops/test_kda_graph.py
@@ -8,14 +8,19 @@
 """Graph capture/replay tests for KDA chunk training (fwd + bwd).
 
 Captures a fwd+bwd step once, replays it with different ``cu_seqlens`` contents
-(different splits and zero-length tail padding), and compares against the eager
-(``use_graph=False``) path. Requires CUDA + CUDAGraph.
+(different splits, zero-length tail padding, and total_tokens below the static
+capacity), and compares against the eager (``use_graph=False``) path.
+Requires CUDA + CUDAGraph.
 """
+
+import os
 
 import pytest
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 
+from fla.ops.cp import FLACPContext, build_cp_context
 from fla.ops.kda import chunk_kda
 from fla.utils import assert_close, device
 
@@ -36,6 +41,12 @@ _VARLEN_CONFIGS = [
     ("2seq_zerotail", [0, 512, 1024, 1024, 1024]),
     ("4seq_alt", [0, 100, 400, 700, 1024]),
     ("1seq_zerotail", [0, 1024, 1024, 1024, 1024]),
+]
+
+# (tag, cu_seqlens) -- total_tokens < T; rows above cu[-1] are padding and must stay inert
+_PARTIAL_CONFIGS = [
+    ("half", [0, 512, 512, 512, 512]),
+    ("quarter_2seq", [0, 128, 384, 384, 384]),
 ]
 
 _OUT_NAMES = ["o", "ht", "dq", "dk", "dv", "dg", "db", "dh0", "dA", "dbias"]
@@ -222,3 +233,154 @@ def test_chunk_kda_graph_multi_replay_varlen(gate, safe_gate, hv):
             if r is None:
                 continue
             assert_close(f"{tag}::{name}", r, g, 2e-3)
+
+
+@pytest.mark.parametrize(("safe_gate", "hv"), [
+    pytest.param(False, H, id="gate_in_kernel"),
+    pytest.param(True, H, id="gate+safe_gate"),
+    pytest.param(True, 2 * H, id="gva_gate+safe"),
+])
+def test_chunk_kda_graph_partial_tokens(safe_gate, hv):
+    """Replay with total_tokens < T_static: padding rows must not pollute dA/dbias.
+
+    The capture config covers all T rows, so on a partial replay the padding rows
+    of intermediate buffers hold stale nonzero values. Full-tensor reductions in
+    kda_gate_bwd (dA/dbias) must still match the eager path run on real tokens only.
+    """
+    gate = True
+    cu = torch.tensor(_VARLEN_CONFIGS[0][1], dtype=torch.long, device=device)
+    inp0 = _rand_inputs(seed=0, gate=gate, safe_gate=safe_gate, hv=hv)
+    graph, leaves, _do, _dht, cap_o, cap_ht = _make_graphed(inp0, cu, gate, safe_gate)
+
+    update_names = ["q", "k", "v", "g", "beta", "h0", "A_log", "dt_bias"]
+    for seed, (tag, cucfg) in enumerate(_PARTIAL_CONFIGS, start=1):
+        n = cucfg[-1]
+        inp = _rand_inputs(seed=seed * 17, gate=gate, safe_gate=safe_gate, hv=hv)
+        for name in update_names:
+            leaves[name].data.copy_(inp[name])
+        _do.copy_(inp["do"])
+        _dht.copy_(inp["dht"])
+        cu.copy_(torch.tensor(cucfg, dtype=torch.long, device=device))
+
+        graph.replay()
+        torch.cuda.synchronize()
+
+        got = _graphed_outputs(leaves, gate, cap_o, cap_ht)
+        sliced = {k: v[:, :n] if k in ("q", "k", "v", "g", "beta", "do") else v for k, v in inp.items()}
+        ref = _eager(sliced, torch.tensor(cucfg, dtype=torch.long, device=device), gate, safe_gate)
+        for name, r, g in zip(_OUT_NAMES, ref, got):
+            if r is None:
+                continue
+            if name in ("o", "dq", "dk", "dv", "dg", "db"):
+                g = g[:, :n]
+            assert_close(f"partial::{tag}::{name}", r, g, 2e-3)
+
+
+def _eager_cp(inp, cucfg, gate):
+    """Eager CP reference: world_size=1 crosses no rank, so only real tokens matter."""
+    leaves = {n: inp[n].detach().clone().requires_grad_() for n in ("q", "k", "v", "g", "beta")}
+    extra = {}
+    if gate:
+        leaves["A_log"] = inp["A_log"].detach().clone().requires_grad_()
+        leaves["dt_bias"] = inp["dt_bias"].detach().clone().requires_grad_()
+        extra = dict(A_log=leaves["A_log"], dt_bias=leaves["dt_bias"])
+    cu = torch.tensor(cucfg, dtype=torch.long, device=device)
+    o, _ = chunk_kda(
+        q=leaves["q"],
+        k=leaves["k"],
+        v=leaves["v"],
+        g=leaves["g"],
+        beta=leaves["beta"],
+        cp_context=build_cp_context(cu, group=dist.group.WORLD),
+        use_gate_in_kernel=gate,
+        **extra,
+    )
+    (o * inp["do"]).sum().backward()
+    out = [o.detach(), leaves["q"].grad, leaves["k"].grad, leaves["v"].grad, leaves["g"].grad, leaves["beta"].grad]
+    out += [leaves["A_log"].grad, leaves["dt_bias"].grad] if gate else [None, None]
+    return out
+
+
+@pytest.mark.skipif(not dist.is_available(), reason="requires torch.distributed")
+def test_chunk_kda_graph_cp_world1():
+    """world_size=1 CP + graph: exercises the recorded all-gather and device-side CP metadata.
+
+    A single rank is both first and last (pre/post_num_ranks = 0), so no state crosses
+    ranks and the graph-mode CP branch must match the eager CP branch. The context is
+    built once around the persistent buffers: rebuilding it per step would D2H-sync,
+    which capture forbids. Multi-rank numerics are covered by tests/context_parallel.
+    """
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29617")
+    dist.init_process_group(backend="nccl", rank=0, world_size=1)
+    try:
+        gate = True
+        cu = torch.tensor(_VARLEN_CONFIGS[0][1], dtype=torch.long, device=device)
+        pre_dev = torch.zeros(1, dtype=torch.int32, device=device)
+        post_dev = torch.zeros(1, dtype=torch.int32, device=device)
+        base = build_cp_context(cu, group=dist.group.WORLD)
+        ctx = FLACPContext(
+            group=dist.group.WORLD,
+            cu_seqlens=cu,
+            cu_seqlens_cpu=base.cu_seqlens_cpu,
+            is_last_rank=base.is_last_rank,
+            pre_num_ranks=base.pre_num_ranks,
+            is_first_rank=base.is_first_rank,
+            post_num_ranks=base.post_num_ranks,
+            pre_num_ranks_dev=pre_dev,
+            post_num_ranks_dev=post_dev,
+        )
+
+        inp0 = _rand_inputs(seed=0, gate=gate, safe_gate=False)
+        names = ["q", "k", "v", "g", "beta", "A_log", "dt_bias"]
+        leaves = {n: inp0[n].detach().clone().requires_grad_() for n in names}
+        do = inp0["do"].detach().clone()
+
+        def step():
+            for t in leaves.values():
+                if t.grad is not None:
+                    t.grad.zero_()
+            o, _ = chunk_kda(
+                q=leaves["q"],
+                k=leaves["k"],
+                v=leaves["v"],
+                g=leaves["g"],
+                beta=leaves["beta"],
+                cp_context=ctx,
+                use_gate_in_kernel=gate,
+                A_log=leaves["A_log"],
+                dt_bias=leaves["dt_bias"],
+                use_graph=True,
+                max_num_seqs=MAX_NUM_SEQS,
+            )
+            (o * do).sum().backward()
+            return o.detach().clone()
+
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                step()
+        torch.cuda.current_stream().wait_stream(s)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            cap_o = step()
+
+        names_out = ["o", "dq", "dk", "dv", "dg", "db", "dA", "dbias"]
+        for seed, (tag, cucfg) in enumerate(_VARLEN_CONFIGS, start=1):
+            inp = _rand_inputs(seed=seed * 17, gate=gate, safe_gate=False)
+            for n in names:
+                leaves[n].data.copy_(inp[n])
+            do.copy_(inp["do"])
+            cu.copy_(torch.tensor(cucfg, dtype=torch.long, device=device))
+
+            graph.replay()
+            torch.cuda.synchronize()
+
+            got = [cap_o] + [leaves[n].grad for n in names]
+            ref = _eager_cp(inp, cucfg, gate)
+            for name, r, g in zip(names_out, ref, got):
+                assert_close(f"cp_world1::{tag}::{name}", r, g, 2e-3)
+    finally:
+        dist.destroy_process_group()


### PR DESCRIPTION
## Summary

Add `use_graph` + `max_num_seqs` to `chunk_kda` so the forward and backward can be captured in a platform graph (CUDA graph). The varlen chunk list is built on-device at a static shape via `prepare_chunk_indices_static`, kernels early-return on sentinel rows, and backward intermediates come from persistent buffers via `get_static_buffer`. The eager path (`use_graph=False`) is unchanged.

Also supports `cp_context` (context parallelism) in graph capture/replay: FLACPContext gains device scalars for pre/post num_ranks, the merge kernel handles NUM_RANKS_ON_DEVICE, and the pre_process wrapper always launches.

NPU backends explicitly reject `use_graph=True` with `NotImplementedError`.

## Changes

- **`fla/ops/utils/graph.py`** (new, 27 lines): `get_static_buffer` hands out persistent intermediates whose addresses stay valid for the graph's lifetime.
- **`fla/ops/utils/index.py`**: `prepare_chunk_indices_static` builds chunk_indices/chunk_offsets with on-device ops at a fixed shape for graph recording.
- **`fla/ops/kda/chunk.py`**: `use_graph` + `max_num_seqs` entry point; varlen chunk list built on-device; eager path unchanged.
- **`fla/ops/kda/chunk_fwd.py` / `chunk_bwd.py`**: kernels early-return on sentinel rows; backward intermediates from persistent buffers.
- **`fla/ops/kda/chunk_intra.py` / `chunk_intra_token_parallel.py`**: `use_graph` guard for tokens beyond `cu_seqlens[-1]`.
- **`fla/ops/common/chunk_delta_h.py`**: `use_graph` support in the shared delta-rule state recurrence.
- **`fla/ops/cp/chunk_delta_h.py` / `context.py`**: CP graph capture/replay support.
- **`fla/ops/utils/cumsum.py`**: `zeros_like` under `use_graph` so dA/dbias are not polluted by dirty padding rows.
- **NPU backends**: explicit `NotImplementedError` on `use_graph=True`; `chunk_offsets` no longer recomputed when provided; `zeros_like` parity.

## Tests

- `tests/ops/test_kda_graph.py` (386 lines): 16 tests covering fwd/bwd graph capture, varlen, state, gate, partial tokens.
- `tests/context_parallel/test_cp_kda_graph.py` (179 lines): CP graph capture/replay with world=2, 64/64 checks pass.

## Related

- RFC: #1155 (tracking issue for CUDA graph support across fla)


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
