### PR TITLE
[Fix] Cast Ascend kernel indices to int64 before stride multiply

### DIFF
--- a/fla/modules/backends/triton_ascend/fused_cross_entropy.py
+++ b/fla/modules/backends/triton_ascend/fused_cross_entropy.py
@@ -54,7 +54,7 @@ def cross_entropy_fwd_kernel(
     row_idx = tl.program_id(0)
     abs_row_idx = row_idx + ROW_OFFSET
     col_block_idx = tl.program_id(1)
-    logits_ptr = logits_ptr + row_idx * logits_row_stride.to(tl.int64)
+    logits_ptr = logits_ptr + tl.cast(row_idx, tl.int64) * logits_row_stride
     col_offsets = col_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     label_idx = tl.load(labels_ptr + row_idx)
     logits = tl.load(logits_ptr + col_offsets, mask=col_offsets < n_cols, other=-float("inf"))
@@ -129,8 +129,8 @@ def cross_entropy_bwd_kernel(
     row_idx = tl.program_id(0)
     abs_row_idx = row_idx + ROW_OFFSET
     col_block_idx = tl.program_id(1)
-    logits_ptr = logits_ptr + row_idx * logits_row_stride.to(tl.int64)
-    dlogits_ptr = dlogits_ptr + row_idx * dlogits_row_stride.to(tl.int64)
+    logits_ptr = logits_ptr + tl.cast(row_idx, tl.int64) * logits_row_stride
+    dlogits_ptr = dlogits_ptr + tl.cast(row_idx, tl.int64) * dlogits_row_stride
     col_offsets = col_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     label_idx = tl.load(labels_ptr + row_idx)
     if label_idx != ignore_index:

--- a/fla/modules/backends/triton_ascend/fused_norm_gate.py
+++ b/fla/modules/backends/triton_ascend/fused_norm_gate.py
@@ -186,7 +186,7 @@ def layer_norm_gated_fwd_kernel(
 
     NT = tl.cdiv(T, BT)
     for i_t in range(i_s, NT, NS):
-        rows = i_t * BT + tl.arange(0, BT)
+        rows = tl.cast(i_t, tl.int64) * BT + tl.arange(0, BT)
         row_mask = rows < T
         mask = row_mask[:, None] & col_mask[None, :]
         row_off = rows[:, None] * D + cols[None, :]
@@ -269,7 +269,7 @@ def layer_norm_gated_bwd_kernel(
 
     NT = tl.cdiv(T, BT)
     for i_t in range(i_s, NT, NS):
-        rows = i_t * BT + tl.arange(0, BT)
+        rows = tl.cast(i_t, tl.int64) * BT + tl.arange(0, BT)
         row_mask = rows < T
         mask = row_mask[:, None] & col_mask[None, :]
         row_off = rows[:, None] * D + cols[None, :]

--- a/fla/modules/backends/triton_ascend/l2norm.py
+++ b/fla/modules/backends/triton_ascend/l2norm.py
@@ -73,7 +73,7 @@ def l2norm_fwd_kernel(
     BT: tl.constexpr,
 ):
     i_t = tl.program_id(0) + T_OFFSET
-    rows = i_t * BT + tl.arange(0, BT)
+    rows = tl.cast(i_t, tl.int64) * BT + tl.arange(0, BT)
     cols = tl.arange(0, BD)
     mask = (rows[:, None] < T) & (cols[None, :] < D)
 
@@ -98,7 +98,7 @@ def l2norm_bwd_kernel(
     BT: tl.constexpr,
 ):
     i_t = tl.program_id(0) + T_OFFSET
-    rows = i_t * BT + tl.arange(0, BT)
+    rows = tl.cast(i_t, tl.int64) * BT + tl.arange(0, BT)
     cols = tl.arange(0, BD)
     mask = (rows[:, None] < T) & (cols[None, :] < D)
 

--- a/fla/modules/backends/triton_ascend/layernorm.py
+++ b/fla/modules/backends/triton_ascend/layernorm.py
@@ -66,12 +66,12 @@ def layer_norm_fwd_kernel1(
     i_t = tl.program_id(0)
     i_g = i_t % G
 
-    x += i_t * D
-    y += i_t * D
+    x += tl.cast(i_t, tl.int64) * D
+    y += tl.cast(i_t, tl.int64) * D
     if HAS_RESIDUAL:
-        res += i_t * D
+        res += tl.cast(i_t, tl.int64) * D
     if STORE_RESIDUAL_OUT:
-        res_out += i_t * D
+        res_out += tl.cast(i_t, tl.int64) * D
 
     o_d = tl.arange(0, BD)
     m_d = o_d < D
@@ -148,8 +148,8 @@ def layer_norm_bwd_kernel1(
         b_db = tl.zeros((BD,), dtype=tl.float32)
 
     for i_t in range(i_sg * BS * G + i_g, min((i_sg * BS + BS) * G + i_g, T), G):
-        b_x = tl.load(x + i_t * D + o_d, mask=mask, other=0).to(tl.float32)
-        b_dy = tl.load(dy + i_t * D + o_d, mask=mask, other=0).to(tl.float32)
+        b_x = tl.load(x + tl.cast(i_t, tl.int64) * D + o_d, mask=mask, other=0).to(tl.float32)
+        b_dy = tl.load(dy + tl.cast(i_t, tl.int64) * D + o_d, mask=mask, other=0).to(tl.float32)
 
         if not IS_RMS_NORM:
             b_mean = tl.load(mean + i_t)
@@ -160,7 +160,7 @@ def layer_norm_bwd_kernel1(
             b_y = b_xhat * b_w if HAS_WEIGHT else b_xhat
             if HAS_BIAS:
                 b_y = b_y + b_b
-            tl.store(y + i_t * D + o_d, b_y, mask=mask)
+            tl.store(y + tl.cast(i_t, tl.int64) * D + o_d, b_y, mask=mask)
         b_wdy = b_dy
         if HAS_WEIGHT:
             b_wdy = b_dy * b_w
@@ -175,12 +175,12 @@ def layer_norm_bwd_kernel1(
             b_c1 = tl.sum(b_xhat * b_wdy, axis=0) / D
             b_dx = (b_wdy - b_xhat * b_c1) * b_rstd
         if HAS_DRESIDUAL:
-            b_dres = tl.load(dres + i_t * D + o_d, mask=mask, other=0).to(tl.float32)
+            b_dres = tl.load(dres + tl.cast(i_t, tl.int64) * D + o_d, mask=mask, other=0).to(tl.float32)
             b_dx += b_dres
         b_dx = tl.cast(b_dx, dtype=dx.dtype.element_ty, fp_downcast_rounding='rtne')
         if STORE_DRESIDUAL:
-            tl.store(dres_in + i_t * D + o_d, b_dx, mask=mask)
-        tl.store(dx + i_t * D + o_d, b_dx, mask=mask)
+            tl.store(dres_in + tl.cast(i_t, tl.int64) * D + o_d, b_dx, mask=mask)
+        tl.store(dx + tl.cast(i_t, tl.int64) * D + o_d, b_dx, mask=mask)
 
     if HAS_WEIGHT:
         tl.store(dw + i_s * D + o_d, b_dw, mask=mask)

--- a/fla/modules/backends/triton_ascend/rotary.py
+++ b/fla/modules/backends/triton_ascend/rotary.py
@@ -66,14 +66,14 @@ def rotary_embedding_kernel(
 
     if IS_VARLEN:
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
-        bos, eos = tl.load(cu_seqlens + i_n), tl.load(cu_seqlens + i_n + 1)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
         x = x + bos * H*D + i_h * D
         y = y + bos * H*D + i_h * D
     else:
         i_n = i_b
-        x = x + i_n * T*H*D + i_h * D
-        y = y + i_n * T*H*D + i_h * D
+        x = x + tl.cast(i_n, tl.int64) * T * H * D + i_h * D
+        y = y + tl.cast(i_n, tl.int64) * T * H * D + i_h * D
 
     if i_t * BT >= T:
         return

--- a/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_delta_h.py
@@ -232,27 +232,27 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu(
             NT = tl.cdiv(T, BT)
             boh = tl.load(chunk_offsets + i_n).to(tl.int64)
         else:
-            bos = i_n * T
+            bos = tl.cast(i_n, tl.int64) * T
             NT = tl.cdiv(T, BT)
-            boh = i_n * NT
+            boh = tl.cast(i_n, tl.int64) * NT
 
         v_start = i_v * BV
         # Rebind GM bases each task; do not in-place ``ptr +=`` across ``i_t``
         # (Ascend MTE OOB). ``h`` rebases each chunk via ``i_t * DH_CS``.
-        w_base = w + (bos * HV + i_h).to(tl.int64) * K
-        k_base = k + (bos * H + i_h // (HV // H)).to(tl.int64) * K
-        v_base = v + (bos * HV + i_h).to(tl.int64) * V
+        w_base = w + (bos * HV + i_h) * K
+        k_base = k + (bos * H + i_h // (HV // H)) * K
+        v_base = v + (bos * HV + i_h) * V
         if SAVE_NEW_VALUE:
-            v_new_base = v_new + (bos * HV + i_h).to(tl.int64) * V
-        h_nh = h + (boh * HV + i_h).to(tl.int64) * K * V
+            v_new_base = v_new + (bos * HV + i_h) * V
+        h_nh = h + (boh * HV + i_h) * K * V
 
         if USE_G:
             if USE_G_PRECOMP:
-                g_ratio_ptr = g_ratio + (i_n * HV + i_h).to(tl.int64) * T_max
-                g_last_exp_ptr = g_last_exp + (i_n * HV + i_h).to(tl.int64) * NT
+                g_ratio_ptr = g_ratio + (tl.cast(i_n, tl.int64) * HV + i_h) * T_max
+                g_last_exp_ptr = g_last_exp + (tl.cast(i_n, tl.int64) * HV + i_h) * NT
         if USE_GK:
             if USE_GK_PRECOMP:
-                gk_last_exp_nh = gk_last_exp + (i_n * HV + i_h).to(tl.int64) * NT * K
+                gk_last_exp_nh = gk_last_exp + (tl.cast(i_n, tl.int64) * HV + i_h) * NT * K
 
         # b_h shape: [BK, BV] (default) or [BV, BK] (STATE_V_FIRST)
         if STATE_V_FIRST:
@@ -372,7 +372,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu(
                     if IS_VARLEN:
                         g_ptr = g + bos + i_h * T_max
                     else:
-                        g_ptr = g + i_n * HV * T_max + i_h * T_max
+                        g_ptr = g + tl.cast(i_n, tl.int64) * HV * T_max + i_h * T_max
                     b_g_last = tl.load(g_ptr + last_idx).to(tl.float32)
                     p_g = tl.make_block_ptr(g_ptr, (T,), (1,), (i_t * BT,), (BT,), (0,))
                     b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
@@ -559,21 +559,21 @@ def chunk_gated_delta_rule_fwd_kernel_h_oneslab_npu(
     for task_id in tl.range(core_id, task_num, num_core):
         i_v, i_nh = task_id % NV, (task_id // NV).to(tl.int64)
         i_n, i_h = i_nh // HV, i_nh % HV
-        bos = i_n * T
+        bos = tl.cast(i_n, tl.int64) * T
         v_start = i_v * BV
 
-        w_base = w + (bos * HV + i_h).to(tl.int64) * K
-        k_base = k + (bos * H + i_h // (HV // H)).to(tl.int64) * K
-        v_base = v + (bos * HV + i_h).to(tl.int64) * V
+        w_base = w + (bos * HV + i_h) * K
+        k_base = k + (bos * H + i_h // (HV // H)) * K
+        v_base = v + (bos * HV + i_h) * V
         if SAVE_NEW_VALUE:
-            v_new_base = v_new + (bos * HV + i_h).to(tl.int64) * V
-        h_nh = h + (i_n * NT * HV + i_h).to(tl.int64) * K * V
+            v_new_base = v_new + (bos * HV + i_h) * V
+        h_nh = h + (tl.cast(i_n, tl.int64) * NT * HV + i_h) * K * V
 
         if USE_G:
-            g_ratio_ptr = g_ratio + (i_n * HV + i_h).to(tl.int64) * T
-            g_last_exp_ptr = g_last_exp + (i_n * HV + i_h).to(tl.int64) * NT
+            g_ratio_ptr = g_ratio + (tl.cast(i_n, tl.int64) * HV + i_h) * T
+            g_last_exp_ptr = g_last_exp + (tl.cast(i_n, tl.int64) * HV + i_h) * NT
         if USE_GK:
-            gk_last_exp_nh = gk_last_exp + (i_n * HV + i_h).to(tl.int64) * NT * K
+            gk_last_exp_nh = gk_last_exp + (tl.cast(i_n, tl.int64) * HV + i_h) * NT * K
 
         b_h1 = tl.zeros([BK, BV], dtype=tl.float32)
         if USE_INITIAL_STATE:
@@ -818,36 +818,37 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64_npu(
             NT = tl.cdiv(T, BT)
             boh = tl.load(chunk_offsets + i_n).to(tl.int64)
         else:
-            bos, eos = i_n * T_max, i_n * T_max + T_max
+            bos = tl.cast(i_n, tl.int64) * T_max
+            eos = bos + T_max
             NT = tl.cdiv(T, BT)
-            boh = i_n * NT
+            boh = tl.cast(i_n, tl.int64) * NT
 
         stride_v = HV * V
         stride_k = H * K
         stride_w = HV * K
 
-        q_base = q + (bos * H + i_h // (HV // H)).to(tl.int64) * K
-        k_base = k + (bos * H + i_h // (HV // H)).to(tl.int64) * K
-        w_base = w + (bos * HV + i_h).to(tl.int64) * K
-        do_base = do + (bos * HV + i_h).to(tl.int64) * V
-        dv_base = dv + (bos * HV + i_h).to(tl.int64) * V
-        dv2_base = dv2 + (bos * HV + i_h).to(tl.int64) * V
-        dh_base = dh + (boh * HV + i_h).to(tl.int64) * K * V
+        q_base = q + (bos * H + i_h // (HV // H)) * K
+        k_base = k + (bos * H + i_h // (HV // H)) * K
+        w_base = w + (bos * HV + i_h) * K
+        do_base = do + (bos * HV + i_h) * V
+        dv_base = dv + (bos * HV + i_h) * V
+        dv2_base = dv2 + (bos * HV + i_h) * V
+        dh_base = dh + (boh * HV + i_h) * K * V
         if USE_GK:
-            gk_base = gk + (bos * HV + i_h).to(tl.int64) * K
+            gk_base = gk + (bos * HV + i_h) * K
         if USE_G:
             if USE_G_PRECOMP:
-                g_exp_base = g_exp + (i_n * HV + i_h).to(tl.int64) * T_max
-                g_ratio_base = g_ratio + (i_n * HV + i_h).to(tl.int64) * T_max
-                g_last_exp_base = g_last_exp + (i_n * HV + i_h).to(tl.int64) * NT
+                g_exp_base = g_exp + (tl.cast(i_n, tl.int64) * HV + i_h) * T_max
+                g_ratio_base = g_ratio + (tl.cast(i_n, tl.int64) * HV + i_h) * T_max
+                g_last_exp_base = g_last_exp + (tl.cast(i_n, tl.int64) * HV + i_h) * NT
                 g_base = g
             elif IS_VARLEN:
-                g_base = g + (bos + i_h * T_max).to(tl.int64)
+                g_base = g + (bos + tl.cast(i_h, tl.int64) * T_max)
                 g_exp_base = g_exp
                 g_ratio_base = g_ratio
                 g_last_exp_base = g_last_exp
             else:
-                g_base = g + (i_n * HV + i_h).to(tl.int64) * T_max
+                g_base = g + (tl.cast(i_n, tl.int64) * HV + i_h) * T_max
                 g_exp_base = g_exp
                 g_ratio_base = g_ratio
                 g_last_exp_base = g_last_exp

--- a/fla/ops/common/backends/triton_ascend/chunk_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_h.py
@@ -58,8 +58,8 @@ def chunk_fwd_kernel_h_npu(
     i_v = tl.program_id(1) + V_OFFSET
     i_nh = tl.program_id(2).to(tl.int64) + NH_OFFSET
     i_n, i_h = i_nh // H, i_nh % H
-    bos = (i_n * T).to(tl.int64)
-    boh = (i_n * tl.cdiv(T, BS)).to(tl.int64)
+    bos = tl.cast(i_n, tl.int64) * T
+    boh = tl.cast(i_n, tl.int64) * tl.cdiv(T, BS)
     NTS = BS // BT
 
     if USE_G_GAMMA:
@@ -70,7 +70,7 @@ def chunk_fwd_kernel_h_npu(
     o_k = i_k * BK + tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
     if USE_INITIAL_STATE:
-        h0_base = (i_nh * K * V).to(tl.int64)
+        h0_base = (i_nh * K * V)
         if STATE_V_FIRST:
             p_h0 = h0 + h0_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             b_h = tl.trans(tl.load(p_h0, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
@@ -82,11 +82,11 @@ def chunk_fwd_kernel_h_npu(
         i_s = i_t // NTS
         o_t = (i_t * BT + tl.arange(0, BT)).to(tl.int64)
         m_t = o_t < T
-        kv_base = (bos * H + i_h).to(tl.int64) * K
+        kv_base = (bos * H + i_h) * K
         p_k = k + kv_base + o_k[:, None] + o_t[None, :] * (H * K)
-        p_v = v + (bos * H + i_h).to(tl.int64) * V + o_t[:, None] * (H * V) + o_v[None, :]
+        p_v = v + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
 
-        o_h = ((boh + i_s.to(tl.int64)) * H + i_h).to(tl.int64) * K * V
+        o_h = ((boh + i_s) * H + i_h) * K * V
         if STATE_V_FIRST:
             p_h = h + o_h + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             m_h = (o_v[:, None] < V) & (o_k[None, :] < K)
@@ -123,7 +123,7 @@ def chunk_fwd_kernel_h_npu(
             b_k = b_k * exp2(b_gk_last[:, None] - b_gk)
 
         if USE_GV:
-            p_gv = gv + (bos * H + i_h).to(tl.int64) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_gv = gv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
             p_gv_last = gv + (bos + last_idx.to(tl.int64)) * (H * V) + i_h * V + i_v * BV + tl.arange(0, BV)
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.).to(tl.float32)
             b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
@@ -133,7 +133,7 @@ def chunk_fwd_kernel_h_npu(
         b_h += tl.dot(b_k, b_v)
 
     if STORE_FINAL_STATE:
-        ht_base = (i_nh * K * V).to(tl.int64)
+        ht_base = (i_nh * K * V)
         if STATE_V_FIRST:
             p_ht = ht + ht_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             tl.store(p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))
@@ -162,8 +162,8 @@ def chunk_bwd_kernel_dh_npu(
     i_nh = tl.program_id(2).to(tl.int64) + NH_OFFSET
     i_n, i_hq = i_nh // HQ, i_nh % HQ
     i_h = i_hq // NG
-    bos = (i_n * T).to(tl.int64)
-    boh = (i_n * tl.cdiv(T, BS)).to(tl.int64)
+    bos = tl.cast(i_n, tl.int64) * T
+    boh = tl.cast(i_n, tl.int64) * tl.cdiv(T, BS)
 
     if USE_G_GAMMA:
         b_gamma = tl.load(g_gamma + i_h)
@@ -173,7 +173,7 @@ def chunk_bwd_kernel_dh_npu(
     o_k = i_k * BK + tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
     if USE_FINAL_STATE_GRADIENT:
-        dht_base = (i_nh * K * V).to(tl.int64)
+        dht_base = (i_nh * K * V)
         if STATE_V_FIRST:
             p_dht = dht + dht_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             b_dh += tl.trans(tl.load(p_dht, mask=(o_v[:, None] < V) & (o_k[None, :] < K), other=0.0)).to(tl.float32)
@@ -184,7 +184,7 @@ def chunk_bwd_kernel_dh_npu(
     for step in tl.static_range(NT):
         i_t = NT - 1 - step
         i_s = i_t // (BS // BT)
-        o_dh = ((boh + i_s.to(tl.int64)) * H + i_h).to(tl.int64) * K * V
+        o_dh = ((boh + i_s) * H + i_h) * K * V
         if STATE_V_FIRST:
             p_dh = dh + o_dh + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             m_dh = (o_v[:, None] < V) & (o_k[None, :] < K)
@@ -198,7 +198,7 @@ def chunk_bwd_kernel_dh_npu(
         last_idx = min(i_t * BT + BT, T) - 1
         o_t = (i_t * BT + tl.arange(0, BT)).to(tl.int64)
         m_t = o_t < T
-        qv_base = (bos * HQ + i_hq).to(tl.int64)
+        qv_base = bos * HQ + i_hq
         p_q = q + qv_base * K + o_k[:, None] + o_t[None, :] * (HQ * K)
         p_do = do + qv_base * V + o_t[:, None] * (HQ * V) + o_v[None, :]
         b_q = tl.load(p_q, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32) * scale
@@ -217,7 +217,7 @@ def chunk_bwd_kernel_dh_npu(
             b_dh *= exp2(b_g_last)
 
         if USE_GK:
-            kv_base = (bos * H + i_h).to(tl.int64) * K
+            kv_base = (bos * H + i_h) * K
             p_gk = gk + kv_base + o_k[:, None] + o_t[None, :] * (H * K)
             p_gk_last = gk + (bos + last_idx.to(tl.int64)) * (H * K) + i_h * K + i_k * BK + tl.arange(0, BK)
             b_gk = tl.load(p_gk, mask=(o_k[:, None] < K) & m_t[None, :], other=0.0).to(tl.float32)
@@ -226,7 +226,7 @@ def chunk_bwd_kernel_dh_npu(
             b_dh *= exp2(b_gk_last)[:, None]
 
         if USE_GV:
-            p_gv = gv + (bos * H + i_h).to(tl.int64) * V + o_t[:, None] * (H * V) + o_v[None, :]
+            p_gv = gv + (bos * H + i_h) * V + o_t[:, None] * (H * V) + o_v[None, :]
             p_gv_last = gv + (bos + last_idx.to(tl.int64)) * (H * V) + i_h * V + i_v * BV + tl.arange(0, BV)
             b_gv = tl.load(p_gv, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0).to(tl.float32)
             b_gv_last = tl.load(p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.).to(tl.float32)
@@ -236,7 +236,7 @@ def chunk_bwd_kernel_dh_npu(
         b_dh += tl.dot(b_q, b_do)
 
     if STORE_INITIAL_STATE_GRADIENT:
-        dh0_base = (i_nh * K * V).to(tl.int64)
+        dh0_base = (i_nh * K * V)
         if STATE_V_FIRST:
             p_dh0 = dh0 + dh0_base + o_v[:, None].to(tl.int64) * K + o_k[None, :]
             tl.store(p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), mask=(o_v[:, None] < V) & (o_k[None, :] < K))

--- a/fla/ops/common/backends/triton_ascend/chunk_o.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_o.py
@@ -184,7 +184,7 @@ def _g_npu_arg(g: torch.Tensor | None, HV: int) -> tuple[torch.Tensor | None, bo
 def _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN: tl.constexpr):
     if IS_VARLEN:
         return g + bos + i_h * T_seq
-    return g + i_b * HV * T_seq + i_h * T_seq
+    return g + tl.cast(i_b, tl.int64) * HV * T_seq + i_h * T_seq
 
 
 @triton.jit
@@ -266,7 +266,7 @@ def chunk_fwd_kernel_o_npu(
             NT = tl.cdiv(T, BT)
             i_n = global_t // NT
             i_t = global_t % NT
-            bos = i_n * T
+            bos = tl.cast(i_n, tl.int64) * T
             i_tg = global_t
 
         # offset calculation (use local pointers to avoid in-place += accumulation across iterations)
@@ -274,7 +274,7 @@ def chunk_fwd_kernel_o_npu(
         k_ptr = k + (bos * H + i_h // (HV // H)) * K
         v_ptr = v + (bos * HV + i_h) * V
         o_ptr = o + (bos * HV + i_h) * V
-        h_base = h + (i_tg * HV + i_h).to(tl.int64) * K * V
+        h_base = h + (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
 
         b_o = tl.zeros([BT, BV], dtype=tl.float32)
         b_A = tl.zeros([BT, BT], dtype=tl.float32)
@@ -305,12 +305,12 @@ def chunk_fwd_kernel_o_npu(
 
         if USE_G:
             # g is transposed to [B, HV, T] in wrapper for contiguous T-load.
-            # Non-varlen: g_ptr = g + i_n * HV * T + i_h * T (i_n is batch index)
+            # Non-varlen: g_ptr = g + tl.cast(i_n, tl.int64) * HV * T + i_h * T (i_n is batch index)
             # Varlen (B=1): g_ptr = g + bos + i_h * T (bos is absolute token offset)
             if IS_VARLEN:
                 g_ptr = g + bos + i_h * T
             else:
-                g_ptr = g + i_n * HV * T + i_h * T
+                g_ptr = g + tl.cast(i_n, tl.int64) * HV * T + i_h * T
             p_g = tl.make_block_ptr(g_ptr, (T_cur,), (1,), (i_t * BT,), (BT,), (0,))
             b_g = tl.load(p_g, boundary_check=(0,))
 
@@ -577,7 +577,7 @@ def chunk_bwd_kernel_dv_local_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos = i_b * T
+        bos = tl.cast(i_b, tl.int64) * T
 
     q += (bos * H + i_h // (HV // H)) * K
     k += (bos * H + i_h // (HV // H)) * K
@@ -750,13 +750,13 @@ def chunk_bwd_kernel_dqkwg_npu(
         T = (eos - bos).to(tl.int32)
     else:
         NT = tl.cdiv(T, BT)
-        i_tg = i_b * NT + i_t
-        bos = i_b * T
+        i_tg = tl.cast(i_b, tl.int64) * NT + i_t
+        bos = tl.cast(i_b, tl.int64) * T
 
     v += (bos * HV + i_h) * V
     do += (bos * HV + i_h) * V
-    h += (i_tg * HV + i_h).to(tl.int64) * K * V
-    dh += (i_tg * HV + i_h).to(tl.int64) * K * V
+    h += (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
+    dh += (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
     q += (bos * H + i_h // (HV // H)) * K
     k += (bos * H + i_h // (HV // H)) * K
     dq += (bos * HV + i_h) * K
@@ -971,13 +971,13 @@ def chunk_bwd_kernel_dqkwg_full_npu(
             T_cur = (eos - bos).to(tl.int32)
         else:
             NT = tl.cdiv(T_seq, BT)
-            i_tg = i_b * NT + i_t
+            i_tg = tl.cast(i_b, tl.int64) * NT + i_t
             bos = tl.cast(i_b, tl.int64) * T_seq
 
         v_ptr = v + (bos * HV + i_h) * V
         do_ptr = do + (bos * HV + i_h) * V
-        h_ptr = h + (i_tg * HV + i_h).to(tl.int64) * K * V
-        dh_ptr = dh + (i_tg * HV + i_h).to(tl.int64) * K * V
+        h_ptr = h + (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
+        dh_ptr = dh + (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
         q_ptr = q + (bos * H + i_h // (HV // H)) * K
         k_ptr = k + (bos * H + i_h // (HV // H)) * K
         dq_ptr = dq + (bos * HV + i_h) * K
@@ -1123,11 +1123,11 @@ def chunk_bwd_kernel_dg_hdh_npu(
             T_cur = (eos - bos).to(tl.int32)
         else:
             NT = tl.cdiv(T_seq, BT)
-            i_tg = i_b * NT + i_t
+            i_tg = tl.cast(i_b, tl.int64) * NT + i_t
             bos = tl.cast(i_b, tl.int64) * T_seq
 
-        h_ptr = h + (i_tg * HV + i_h).to(tl.int64) * K * V
-        dh_ptr = dh + (i_tg * HV + i_h).to(tl.int64) * K * V
+        h_ptr = h + (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
+        dh_ptr = dh + (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
         last_idx = min(i_t * BT + BT, T_cur) - 1
         if G_T_CONTIG:
             g_base = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
@@ -1199,12 +1199,12 @@ def chunk_bwd_kernel_dg_npu(
         T = (eos - bos).to(tl.int32)
     else:
         NT = tl.cdiv(T, BT)
-        i_tg = i_b * NT + i_t
-        bos = i_b * T
+        i_tg = tl.cast(i_b, tl.int64) * NT + i_t
+        bos = tl.cast(i_b, tl.int64) * T
 
     v += (bos * HV + i_h) * V
-    h += (i_tg * HV + i_h).to(tl.int64) * K * V
-    dh += (i_tg * HV + i_h).to(tl.int64) * K * V
+    h += (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
+    dh += (tl.cast(i_tg, tl.int64) * HV + i_h) * K * V
     q += (bos * H + i_h // (HV // H)) * K
     k += (bos * H + i_h // (HV // H)) * K
     dq_f32 += (bos * HV + i_h) * K

--- a/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_scaled_dot_kkt.py
@@ -80,7 +80,7 @@ def chunk_scaled_dot_kkt_fwd_kernel_npu(
             bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
             T = eos - bos
         else:
-            bos = i_b * T
+            bos = tl.cast(i_b, tl.int64) * T
         o_t = i_t * BT + o_i
         m_t = o_t < T
         m_A = m_causal & (m_t[:, None] & m_t)

--- a/fla/ops/gated_delta_rule/backends/triton_ascend/gate.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/gate.py
@@ -151,7 +151,8 @@ def gdn_gate_chunk_cumsum_scalar_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
     p_o = tl.make_block_ptr(o + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))

--- a/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/gated_delta_rule/backends/triton_ascend/wy_fast.py
@@ -71,23 +71,11 @@ def _bwd_col_tile(BT: int, dim: int, mem_mult: float, max_tile: int) -> int:
     )
 
 
-def _get_bwd_k_tile(BT: int, K: int) -> int:
-    return _bwd_col_tile(BT, K, _PREPARE_BWD_K_MEM_MULT, _MAX_TILE_BWD)
-
-
-def _get_bwd_kv_tiles(BT: int, K: int, V: int) -> tuple[int, int]:
-    """Minimize K/V slab trips under the kv-stage UB budget (larger than finalize)."""
-    return (
-        _bwd_col_tile(BT, K, _PREPARE_BWD_KV_MEM_MULT, _MAX_TILE_BWD_KV),
-        _bwd_col_tile(BT, V, _PREPARE_BWD_KV_MEM_MULT, _MAX_TILE_BWD_KV),
-    )
-
-
 @triton.jit
 def _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN: tl.constexpr):
     if IS_VARLEN:
         return g + bos + i_h * T_seq
-    return g + i_b * HV * T_seq + i_h * T_seq
+    return g + tl.cast(i_b, tl.int64) * HV * T_seq + i_h * T_seq
 
 
 @triton.jit
@@ -168,8 +156,9 @@ def recompute_w_u_fwd_kernel_npu(
             bos_bh = bos
         else:
             i_t = i_t_o
-            bos, eos = i_b * T, i_b * T + T
-            bos_bh = i_b * HV * T_max
+            bos = tl.cast(i_b, tl.int64) * T
+            eos = bos + T
+            bos_bh = tl.cast(i_b, tl.int64) * HV * T_max
 
         offs_t = tl.arange(0, BT)
         global_offs_t = i_t * BT + offs_t
@@ -385,7 +374,8 @@ def prepare_wy_repr_bwd_da_mask_dot1_npu(
         ).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     p_A = tl.make_block_ptr(
         A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1),
@@ -422,7 +412,8 @@ def prepare_wy_repr_bwd_da_dot2_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     p_A = tl.make_block_ptr(A + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
     p_in = tl.make_block_ptr(dA_mid + (bos * HV + i_h) * BT, (BT, T), (1, HV * BT), (0, i_t * BT), (BT, BT), (0, 1))
@@ -458,7 +449,7 @@ def prepare_wy_repr_bwd_da_gate_npu(
         ).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos = i_b * T
+        bos = tl.cast(i_b, tl.int64) * T
 
     if G_T_CONTIG:
         g_ptr = _g_contig_base(g, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
@@ -503,7 +494,7 @@ def prepare_wy_repr_bwd_finalize_k_npu(
             T = (eos - bos).to(tl.int32)
         else:
             i_t = i_t_o
-            bos = i_b * T_seq
+            bos = tl.cast(i_b, tl.int64) * T_seq
 
         if BETA_T_CONTIG:
             beta_ptr = _g_contig_base(beta, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
@@ -563,7 +554,7 @@ def prepare_wy_repr_bwd_finalize_a2_dg_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos = i_b * T
+        bos = tl.cast(i_b, tl.int64) * T
 
     if BETA_T_CONTIG:
         beta_ptr = _g_contig_base(beta, bos, i_b, i_h, T_seq, HV, IS_VARLEN)
@@ -667,8 +658,9 @@ def prepare_wy_repr_bwd_npu(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
-    BK, BV = _get_bwd_kv_tiles(BT, K, V)
-    BK_FIN = _get_bwd_k_tile(BT, K)
+    BK, BV = _bwd_col_tile(BT, K, _PREPARE_BWD_KV_MEM_MULT, _MAX_TILE_BWD_KV), _bwd_col_tile(
+        BT, V, _PREPARE_BWD_KV_MEM_MULT, _MAX_TILE_BWD_KV)
+    BK_FIN = _bwd_col_tile(BT, K, _PREPARE_BWD_K_MEM_MULT, _MAX_TILE_BWD)
     use_g = g is not None
     is_varlen = cu_seqlens is not None
 

--- a/fla/ops/gla/backends/triton_ascend/chunk.py
+++ b/fla/ops/gla/backends/triton_ascend/chunk.py
@@ -56,7 +56,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_inter_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     if i_t * BT + i_i * BC >= T:
         return
@@ -112,7 +113,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     if i_t * BT + i_i * BC >= T:
         return
@@ -178,7 +180,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_split_npu(
         all = T
         T = eos - bos
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
         all = B * T
 
     if i_t * BT + i_i * BC >= T:
@@ -240,7 +243,8 @@ def chunk_gla_fwd_A_kernel_intra_sub_intra_merge_npu(
         all = T
         T = eos - bos
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
         all = B * T
 
     if i_t * BT + i_c * BC >= T:
@@ -378,7 +382,7 @@ def chunk_gla_fwd_kernel_o_npu(
         g_ptr = g + (bos * HV + i_hv) * K
         v_ptr = v + (bos * HV + i_hv) * V
         o_ptr = o + (bos * HV + i_hv) * V
-        h_base = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        h_base = h + (i_tg * HV + i_hv) * K * V
         a_ptr = A + (bos * HV + i_hv) * BT
 
         b_o = tl.zeros([BT, BV], dtype=tl.float32)
@@ -497,7 +501,8 @@ def chunk_gla_bwd_kernel_dA_npu(
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
     T = eos - bos
 
     if i_t * BT >= T:
@@ -579,8 +584,9 @@ def chunk_gla_bwd_kernel_dv_npu(
         NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)
-        i_tg = i_b * NT + i_t
-        bos, eos = i_b * T, i_b * T + T
+        i_tg = tl.cast(i_b, tl.int64) * NT + i_t
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     if i_t * BT >= T:
         return
@@ -688,7 +694,8 @@ def chunk_gla_bwd_kernel_intra_npu(
         i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
     T = eos - bos
     if i_t * BT + i_i * BC >= T:
         return
@@ -857,8 +864,9 @@ def chunk_gla_bwd_kernel_inter_npu(
         NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)
-        i_tg = i_b * NT + i_t
-        bos, eos = i_b * T, i_b * T + T
+        i_tg = tl.cast(i_b, tl.int64) * NT + i_t
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     if i_t * BT >= T:
         return

--- a/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_bwd.py
@@ -80,7 +80,8 @@ def chunk_kda_bwd_kernel_dAv_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     v += (bos * HV + i_hv) * V
     do += (bos * HV + i_hv) * V
@@ -376,16 +377,16 @@ def chunk_kda_bwd_kernel_wy_k_part_npu(
             T = (eos - bos).to(tl.int32)
             i_tg = tl.load(chunk_offsets + i_n).to(tl.int64) + i_t.to(tl.int64)
         else:
-            i_tg = (i_b * tl.cdiv(T, BT) + i_t).to(tl.int64)
+            i_tg = tl.cast(i_b, tl.int64) * tl.cdiv(T, BT) + i_t
             bos, eos = tl.cast(i_b, tl.int64) * T, tl.cast(i_b, tl.int64) * T + T
 
         q_ptr = q + (bos * H + i_h) * K
         k_ptr = k + (bos * H + i_h) * K
         v_new_ptr = v_new + (bos * HV + i_hv) * V
         g_ptr = g + (bos * HV + i_hv) * K
-        h_ptr = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        h_ptr = h + (i_tg * HV + i_hv) * K * V
         do_ptr = do + (bos * HV + i_hv) * V
-        dh_ptr = dh + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        dh_ptr = dh + (i_tg * HV + i_hv) * K * V
         dq_ptr = dq + (bos * HV + i_hv) * K
         dk_ptr = dk + (bos * HV + i_hv) * K
         dg_ptr = dg + (bos * HV + i_hv) * K
@@ -522,7 +523,7 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
             T = (eos - bos).to(tl.int32)
             i_tg = tl.load(chunk_offsets + i_n).to(tl.int64) + i_t.to(tl.int64)
         else:
-            i_tg = (i_b * tl.cdiv(T, BT) + i_t).to(tl.int64)
+            i_tg = tl.cast(i_b, tl.int64) * tl.cdiv(T, BT) + i_t
             bos, eos = tl.cast(i_b, tl.int64) * T, tl.cast(i_b, tl.int64) * T + T
 
         if K_T_CONTIG:
@@ -561,7 +562,7 @@ def chunk_kda_bwd_kernel_wy_dw_part_npu(
             dv_stride_t = HV * V
             beta_stride = HV
 
-        h_ptr = h + (i_tg * HV + i_hv).to(tl.int64) * K * V
+        h_ptr = h + (i_tg * HV + i_hv) * K * V
         dA_ptr = dA_acc + (bos * HV + i_hv) * BT
         db_ptr = db_acc + bos * HV + i_hv
         dg_ptr = dg + (bos * HV + i_hv) * K

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra.py
@@ -178,7 +178,7 @@ def chunk_kda_fwd_kernel_diag_solve_npu(
     if i_ti >= T:
         return
 
-    Akkd = Akkd + (bos * HV + i_hv).to(tl.int64) * BC
+    Akkd = Akkd + (bos * HV + i_hv) * BC
     o_i = tl.arange(0, BC)
     m_A = o_i[:, None] > o_i[None, :]
     m_I = o_i[:, None] == o_i[None, :]
@@ -239,12 +239,12 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_npu(
     o_c = i_ti + tl.arange(0, BC)
     m_c = o_c < T
 
-    q = q + (bos * H + i_h).to(tl.int64) * K
-    k = k + (bos * H + i_h).to(tl.int64) * K
-    g = g + (bos * HV + i_hv).to(tl.int64) * K
-    beta = beta + (bos * HV + i_hv).to(tl.int64)
-    Aqk = Aqk + (bos * HV + i_hv).to(tl.int64) * BT
-    Akk = Akk + (bos * HV + i_hv).to(tl.int64) * BC
+    q = q + (bos * H + i_h) * K
+    k = k + (bos * H + i_h) * K
+    g = g + (bos * HV + i_hv) * K
+    beta = beta + (bos * HV + i_hv)
+    Aqk = Aqk + (bos * HV + i_hv) * BT
+    Akk = Akk + (bos * HV + i_hv) * BC
 
     p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
     p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
@@ -330,12 +330,12 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     i_tc2 = i_t * BT + 2 * BC
     i_tc3 = i_t * BT + 3 * BC
 
-    q += (bos * H + i_h).to(tl.int64) * K
-    k += (bos * H + i_h).to(tl.int64) * K
-    g += (bos * HV + i_hv).to(tl.int64) * K
-    Aqk += (bos * HV + i_hv).to(tl.int64) * BT
-    Akk += (bos * HV + i_hv).to(tl.int64) * BT
-    Akkd += (bos * HV + i_hv).to(tl.int64) * BC
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    Aqk += (bos * HV + i_hv) * BT
+    Akk += (bos * HV + i_hv) * BT
+    Akkd += (bos * HV + i_hv) * BC
 
     o_i = tl.arange(0, BC)
     m_tc1 = (i_tc1 + o_i) < T
@@ -428,7 +428,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
     p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
     tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-    p_b1 = tl.make_block_ptr(beta + (bos * HV + i_hv).to(tl.int64), (T,), (HV,), (i_tc1,), (BC,), (0,))
+    p_b1 = tl.make_block_ptr(beta + (bos * HV + i_hv), (T,), (HV,), (i_tc1,), (BC,), (0,))
     b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
     b_Akk10 = b_Akk10 * b_b1[:, None]
     if NC >= 3:
@@ -437,7 +437,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_b2 = tl.make_block_ptr(beta + (bos * HV + i_hv).to(tl.int64), (T,), (HV,), (i_tc2,), (BC,), (0,))
+        p_b2 = tl.make_block_ptr(beta + (bos * HV + i_hv), (T,), (HV,), (i_tc2,), (BC,), (0,))
         b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
         b_Akk20 = b_Akk20 * b_b2[:, None]
         b_Akk21 = b_Akk21 * b_b2[:, None]
@@ -449,7 +449,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused_npu(
         tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
-        p_b3 = tl.make_block_ptr(beta + (bos * HV + i_hv).to(tl.int64), (T,), (HV,), (i_tc3,), (BC,), (0,))
+        p_b3 = tl.make_block_ptr(beta + (bos * HV + i_hv), (T,), (HV,), (i_tc3,), (BC,), (0,))
         b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
         b_Akk30 = b_Akk30 * b_b3[:, None]
         b_Akk31 = b_Akk31 * b_b3[:, None]
@@ -751,7 +751,7 @@ def _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN: tl.constexp
         if IS_VARLEN:
             return beta + (bos + i_hv.to(tl.int64) * T_seq)
         return beta + (tl.cast(i_b, tl.int64) * HV + i_hv) * T_seq
-    return beta + (bos * HV + i_hv).to(tl.int64)
+    return beta + (bos * HV + i_hv)
 
 
 @triton.jit
@@ -765,9 +765,9 @@ def _bwd_intra_beta_row_stride(BETA_T_CONTIG: tl.constexpr, HV: tl.constexpr):
 def _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN: tl.constexpr, G_T_CONTIG: tl.constexpr):
     if G_T_CONTIG:
         if IS_VARLEN:
-            return g + (bos * K).to(tl.int64) + i_hv.to(tl.int64) * T_seq * K
+            return g + (bos * K) + i_hv.to(tl.int64) * T_seq * K
         return g + tl.cast(i_b, tl.int64) * HV * T_seq * K + i_hv.to(tl.int64) * T_seq * K
-    return g + (bos * HV + i_hv).to(tl.int64) * K
+    return g + (bos * HV + i_hv) * K
 
 
 @triton.jit
@@ -815,19 +815,19 @@ def chunk_kda_bwd_kernel_intra_dq_db_npu(
         i_ti = i_t * BT + i_i * BC
         if i_ti < T_cur:
             all = tl.cast(B, tl.int64) * T
-            q_ptr = q + (bos * H + i_h).to(tl.int64) * K
-            k_ptr = k + (bos * H + i_h).to(tl.int64) * K
+            q_ptr = q + (bos * H + i_h) * K
+            k_ptr = k + (bos * H + i_h) * K
             g_base = _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN, G_T_CONTIG)
             beta_base = _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN, BETA_T_CONTIG)
-            dAqk_ptr = dAqk + (bos * HV + i_hv).to(tl.int64) * BT
-            dAkk_ptr = dAkk + (bos * HV + i_hv).to(tl.int64) * BT
-            dq_ptr = dq + (bos * HV + i_hv).to(tl.int64) * K
-            dq2_ptr = dq2 + (bos * HV + i_hv).to(tl.int64) * K
-            dk2_ptr = dk2 + (bos * HV + i_hv).to(tl.int64) * K
-            dg2_ptr = dg2 + (bos * HV + i_hv).to(tl.int64) * K
+            dAqk_ptr = dAqk + (bos * HV + i_hv) * BT
+            dAkk_ptr = dAkk + (bos * HV + i_hv) * BT
+            dq_ptr = dq + (bos * HV + i_hv) * K
+            dq2_ptr = dq2 + (bos * HV + i_hv) * K
+            dk2_ptr = dk2 + (bos * HV + i_hv) * K
+            dg2_ptr = dg2 + (bos * HV + i_hv) * K
             o_k = i_k * BK + tl.arange(0, BK)
             m_k = o_k < K
-            db_ptr = db + (i_k * all + bos).to(tl.int64) * HV + i_hv
+            db_ptr = db + (tl.cast(i_k, tl.int64) * all + bos) * HV + i_hv
             p_g = _bwd_intra_g_block_ptr(g_base, T_cur, i_ti, i_k * BK, BC, BK, g_row_stride, K)
             b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
             p_b = tl.make_block_ptr(beta_base, (T_cur,), (beta_row_stride,), (i_ti,), (BC,), (0,))
@@ -938,13 +938,13 @@ def chunk_kda_bwd_kernel_intra_dkt_future_npu(
         T_cur = (eos - bos).to(tl.int32)
         i_ti = i_t * BT + i_i * BC
         if i_ti < T_cur:
-            q_ptr = q + (bos * H + i_h).to(tl.int64) * K
-            k_ptr = k + (bos * H + i_h).to(tl.int64) * K
+            q_ptr = q + (bos * H + i_h) * K
+            k_ptr = k + (bos * H + i_h) * K
             g_base = _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN, G_T_CONTIG)
             beta_base = _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN, BETA_T_CONTIG)
-            dAqk_ptr = dAqk + (bos * HV + i_hv).to(tl.int64) * BT
-            dAkk_ptr = dAkk + (bos * HV + i_hv).to(tl.int64) * BT
-            dkt_part_ptr = dkt_part + (bos * HV + i_hv).to(tl.int64) * K
+            dAqk_ptr = dAqk + (bos * HV + i_hv) * BT
+            dAkk_ptr = dAkk + (bos * HV + i_hv) * BT
+            dkt_part_ptr = dkt_part + (bos * HV + i_hv) * K
             nc_eff = min(NC, tl.cdiv(T_cur - i_t * BT, BC))
             o_k = i_k * BK + tl.arange(0, BK)
             m_k = o_k < K
@@ -1012,17 +1012,17 @@ def chunk_kda_bwd_kernel_intra_dk_dg_npu(
         T_cur = (eos - bos).to(tl.int32)
         i_ti = i_t * BT + i_i * BC
         if i_ti < T_cur:
-            q_ptr = q + (bos * H + i_h).to(tl.int64) * K
-            k_ptr = k + (bos * H + i_h).to(tl.int64) * K
+            q_ptr = q + (bos * H + i_h) * K
+            k_ptr = k + (bos * H + i_h) * K
             g_base = _bwd_intra_g_base(g, bos, i_b, i_hv, T_seq, K, HV, IS_VARLEN, G_T_CONTIG)
             beta_base = _bwd_intra_beta_base(beta, bos, i_b, i_hv, T_seq, HV, IS_VARLEN, BETA_T_CONTIG)
-            dAqk_ptr = dAqk + (bos * HV + i_hv).to(tl.int64) * BT
-            dAkk_ptr = dAkk + (bos * HV + i_hv).to(tl.int64) * BT
-            dk_ptr = dk + (bos * HV + i_hv).to(tl.int64) * K
-            dk2_ptr = dk2 + (bos * HV + i_hv).to(tl.int64) * K
-            dg_ptr = dg + (bos * HV + i_hv).to(tl.int64) * K
-            dg2_ptr = dg2 + (bos * HV + i_hv).to(tl.int64) * K
-            dkt_part_ptr = dkt_part + (bos * HV + i_hv).to(tl.int64) * K
+            dAqk_ptr = dAqk + (bos * HV + i_hv) * BT
+            dAkk_ptr = dAkk + (bos * HV + i_hv) * BT
+            dk_ptr = dk + (bos * HV + i_hv) * K
+            dk2_ptr = dk2 + (bos * HV + i_hv) * K
+            dg_ptr = dg + (bos * HV + i_hv) * K
+            dg2_ptr = dg2 + (bos * HV + i_hv) * K
+            dkt_part_ptr = dkt_part + (bos * HV + i_hv) * K
             o_k = i_k * BK + tl.arange(0, BK)
             m_k = o_k < K
             p_g = _bwd_intra_g_block_ptr(g_base, T_cur, i_ti, i_k * BK, BC, BK, g_row_stride, K)

--- a/fla/ops/kda/backends/triton_ascend/chunk_intra_token_parallel.py
+++ b/fla/ops/kda/backends/triton_ascend/chunk_intra_token_parallel.py
@@ -88,7 +88,7 @@ def chunk_kda_fwd_kernel_intra_token_parallel_npu(
         T = (eos - bos).to(tl.int32)
         i_t = i_tg - bos
     else:
-        bos = (i_tg // T) * T
+        bos = tl.cast(i_tg // T, tl.int64) * T
         i_t = i_tg % T
 
     if i_t >= T:

--- a/fla/ops/kda/backends/triton_ascend/fused_recurrent.py
+++ b/fla/ops/kda/backends/triton_ascend/fused_recurrent.py
@@ -119,15 +119,15 @@ def fused_recurrent_kda_fwd_kernel_npu(
         )
         T_cur = (eos - bos).to(tl.int32)
     else:
-        bos = (i_n * T).to(tl.int64)
+        bos = tl.cast(i_n, tl.int64) * T
         T_cur = T
 
     if T_cur > 0:
         o_k = i_k * BK + tl.arange(0, BK)
         o_v = i_v * BV + tl.arange(0, BV)
 
-        base_qk = (bos * H + i_h).to(tl.int64) * K
-        base_hv = (bos * HV + i_hv).to(tl.int64)
+        base_qk = (bos * H + i_h) * K
+        base_hv = (bos * HV + i_hv)
 
         p_q = q + base_qk + o_k
         p_k = k + base_qk + o_k
@@ -170,7 +170,7 @@ def fused_recurrent_kda_fwd_kernel_npu(
                 )
                 p_h0 = h0 + state_base + i_hv * K * V
             else:
-                p_h0 = h0 + (i_n * HV + i_hv).to(tl.int64) * K * V
+                p_h0 = h0 + (tl.cast(i_n, tl.int64) * HV + i_hv) * K * V
             if STATE_V_FIRST:
                 p_h0 = p_h0 + o_v[:, None] * K + o_k[None, :]
             else:
@@ -239,7 +239,7 @@ def fused_recurrent_kda_fwd_kernel_npu(
                     )
                     p_ht = ht + state_base + i_hv * K * V
                 else:
-                    p_ht = ht + (bos + i_t).to(tl.int64) * stride_final_state_token + i_hv * K * V
+                    p_ht = ht + (bos + i_t) * stride_final_state_token + i_hv * K * V
                 if STATE_V_FIRST:
                     p_ht = p_ht + o_v[:, None] * K + o_k[None, :]
                 else:
@@ -258,7 +258,7 @@ def fused_recurrent_kda_fwd_kernel_npu(
 
         if not IS_CONTINUOUS_BATCHING:
             if STORE_FINAL_STATE:
-                p_ht = ht + (i_n * HV + i_hv).to(tl.int64) * K * V
+                p_ht = ht + (tl.cast(i_n, tl.int64) * HV + i_hv) * K * V
                 if STATE_V_FIRST:
                     p_ht = p_ht + o_v[:, None] * K + o_k[None, :]
                 else:

--- a/fla/ops/kda/backends/triton_ascend/gate.py
+++ b/fla/ops/kda/backends/triton_ascend/gate.py
@@ -300,7 +300,8 @@ def kda_gate_chunk_cumsum_vector_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H * S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
     p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H * S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))

--- a/fla/ops/kda/backends/triton_ascend/wy_fast.py
+++ b/fla/ops/kda/backends/triton_ascend/wy_fast.py
@@ -161,9 +161,9 @@ def recompute_w_u_fwd_kda_kernel_npu(
         else:
             i_b = i_bh // HV
             i_t = i_t_o
-            bos = (i_b * T).to(tl.int64)
-            beta_bh = (i_b * HV + i_hv).to(tl.int64) * T_max
-            gk_bh = (i_b * HV + i_hv).to(tl.int64) * T_max * K
+            bos = tl.cast(i_b, tl.int64) * T
+            beta_bh = (tl.cast(i_b, tl.int64) * HV + i_hv) * T_max
+            gk_bh = (tl.cast(i_b, tl.int64) * HV + i_hv) * T_max * K
 
         k_ptr = k + (bos * H + i_h) * K
         v_ptr = v + (bos * HV + i_hv) * V

--- a/fla/ops/utils/backends/triton_ascend/cumsum.py
+++ b/fla/ops/utils/backends/triton_ascend/cumsum.py
@@ -174,7 +174,8 @@ def chunk_local_cumsum_scalar_kernel_npu(
             )
             T = eos - bos
         else:
-            bos, eos = i_b * T, i_b * T + T
+            bos = tl.cast(i_b, tl.int64) * T
+            eos = bos + T
 
         o_t = i_t * BT + tl.arange(0, BT)
         m_t = o_t < T
@@ -221,7 +222,8 @@ def chunk_local_cumsum_vector_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     p_s = tl.make_block_ptr(s + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
     p_o = tl.make_block_ptr(o + (bos * H + i_h) * S, (T, S), (H*S, 1), (i_t * BT, i_s * BS), (BT, BS), (1, 0))
@@ -260,7 +262,8 @@ def chunk_global_cumsum_scalar_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_n * T, i_n * T + T
+        bos = tl.cast(i_n, tl.int64) * T
+        eos = bos + T
 
     b_z = tl.zeros([], dtype=tl.float32)
     NT = tl.cdiv(T, BT)
@@ -309,7 +312,8 @@ def chunk_global_cumsum_vector_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_n * T, i_n * T + T
+        bos = tl.cast(i_n, tl.int64) * T
+        eos = bos + T
 
     b_z = tl.zeros([BS], dtype=tl.float32)
     NT = tl.cdiv(T, BT)

--- a/fla/ops/utils/backends/triton_ascend/solve_tril.py
+++ b/fla/ops/utils/backends/triton_ascend/solve_tril.py
@@ -59,7 +59,8 @@ def solve_tril_16x16_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     o_i = tl.arange(0, 16)
     m_A = o_i[:, None] > o_i[None, :]
@@ -106,7 +107,8 @@ def merge_16x16_to_32x32_inverse_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     o_i = tl.arange(0, 16)
     m_A = o_i[:, None] > o_i[None, :]
@@ -172,7 +174,8 @@ def merge_16x16_to_64x64_inverse_kernel_npu(
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = (eos - bos).to(tl.int32)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = tl.cast(i_b, tl.int64) * T
+        eos = bos + T
 
     o_i = tl.arange(0, 16)
     m_A = o_i[:, None] > o_i[None, :]


### PR DESCRIPTION
## Summary

<!-- What changed and why, at a high level. Link the issue this PR resolves, e.g. "Fixes #1234". -->
Triton-Ascend kernels were overflowing int32 when building GM addresses on long sequences.
Program IDs and grid-derived indices (`i_b`, `i_t`, `i_n`, `NT`, `bos`) are int32. Products like `i_b * T`, `i_tg * HV * K * V`, or `bos * HV` wrap past 2³¹ **before** a trailing `.to(tl.int64)`. That pattern also fails to compile when the index is specialized (`constexpr` has no `.to()`).
Typical wrap points:
- state layout `HV * K * V` with K=V=128, HV=64, BT=64 → overflow at NT > 2048 (T > 131K)
- packed `offset * D` with D=4096 → overflow at T > 524K
- varlen `cu_seqlens` loaded as int32, then `(bos * HV + i_h) * V` (HV=32, V=4096 → safe `bos` ≈ 16K)
This PR casts the **index** to int64 first, then multiplies:
- `tl.cast(i_b, tl.int64) * T` instead of `(i_b * T).to(tl.int64)`
- load `cu_seqlens` as `tl.int64`; keep `T_cur = (eos - bos).to(tl.int32)`
- keep `make_block_ptr` offsets/block_shape as int32 (`i_t * BT`)
Touched 20 `triton_ascend` files: modules (fused CE, layernorm, l2norm, rotary, fused_norm_gate) and ops (chunk_h / chunk_o / chunk_delta_h, GDN wy_fast/gate, GLA chunk, KDA, cumsum, solve_tril).


## Test plan

<!-- How you verified it: commands run, hardware used.
     Identify dependent tests first: `python scripts/find_dependent_tests.py <changed_file_or_dir>` -->

hardware: Atlas 800T A3(X86)
FLA_NPU_XDIST=1 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 pytest --exitfirst -n 8 --dist load tests/modules tests/ops/utils tests/ops/test_gdn_kernels.py tests/ops/test_gdn.py tests/ops/test_kda.py tests/ops/test_attnres.py tests/ops/test_solve_tril.py tests/ops/test_gla.py
<img width="1163" height="380" alt="image" src="https://github.com/user-attachments/assets/2f3880d4-aa16-48ad-aa39-288b9bdc77a0" />

## Benchmark / NCU (kernel changes only)

<!-- Same-hardware before/after numbers, with workload shape (batch, seq_len, heads, dims, dtype).
     State "neutral" if the change is not performance-related. -->
Not involved

## Breaking changes

<!-- None / list any API or behavior changes and the migration path. -->
None

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.

### If you ticked the "minor" box above

Standalone minor PRs are normally not accepted (see [No busywork PRs](../CONTRIBUTING.md#submit-pull-requests)).
Justify here why yours is worth a maintainer's review time — minor PRs without a justification may be closed without review:

<!-- justification, or delete this section if not applicable -->
