### PR TITLE
[Fix] Correct packed loss boundaries and cache defaults

### DIFF
--- a/fla/models/abc/modeling_abc.py
+++ b/fla/models/abc/modeling_abc.py
@@ -22,7 +22,7 @@ from fla.layers.abc import ABCAttention
 from fla.layers.attn import Attention
 from fla.models.abc.configuration_abc import ABCConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as ABCMLP
 from fla.modules.l2warp import l2_warp
@@ -426,7 +426,7 @@ class ABCForCausalLM(ABCPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/bitnet/modeling_bitnet.py
+++ b/fla/models/bitnet/modeling_bitnet.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.bitattn import BitAttention
 from fla.models.bitnet.configuration_bitnet import BitNetConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules.activations import swiglu
 from fla.modules.fused_bitlinear import FusedBitLinear
@@ -473,7 +473,7 @@ class BitNetForCausalLM(BitNetPreTrainedModel, FLAGenerationMixin):
                 criterion = self.criterion
 
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/comba/modeling_comba.py
+++ b/fla/models/comba/modeling_comba.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.comba import Comba
 from fla.models.comba.configuration_comba import CombaConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as CombaMLP
 from fla.modules.l2warp import l2_warp
@@ -437,7 +437,7 @@ class CombaForCausalLM(CombaPreTrainedModel, FLAUnsupportedCacheGenerationMixin)
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/delta_net/modeling_delta_net.py
+++ b/fla/models/delta_net/modeling_delta_net.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.delta_net import DeltaNet
 from fla.models.delta_net.configuration_delta_net import DeltaNetConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as DeltaNetMLP
 from fla.modules.l2warp import l2_warp
@@ -426,7 +426,7 @@ class DeltaNetForCausalLM(DeltaNetPreTrainedModel, FLAUnsupportedCacheGeneration
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/deltaformer/configuration_deltaformer.py
+++ b/fla/models/deltaformer/configuration_deltaformer.py
@@ -36,7 +36,7 @@ class DeltaFormerConfig(_HybridAttentionConfigMixin, PretrainedConfig):
         rope_theta: float = 10000.,
         rope_max_position_embeddings: int | None = None,
         attn: HybridAttentionConfig = None,
-        use_cache: bool = True,
+        use_cache: bool = False,
         pad_token_id: int | None = None,
         bos_token_id: int = 1,
         eos_token_id: int = 2,

--- a/fla/models/deltaformer/modeling_deltaformer.py
+++ b/fla/models/deltaformer/modeling_deltaformer.py
@@ -19,7 +19,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.deltaformer import DeltaFormerAttention
 from fla.models.deltaformer.configuration_deltaformer import DeltaFormerConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as DeltaFormerMLP
 from fla.modules.l2warp import l2_warp
@@ -378,7 +378,7 @@ class DeltaFormerForCausalLM(DeltaFormerPreTrainedModel, FLAUnsupportedCacheGene
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
+++ b/fla/models/forgetting_transformer/modeling_forgetting_transformer.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.forgetting_attn import ForgettingAttention
 from fla.models.forgetting_transformer.configuration_forgetting_transformer import ForgettingTransformerConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as ForgettingTransformerMLP
 from fla.modules.l2warp import l2_warp
@@ -436,7 +436,7 @@ class ForgettingTransformerForCausalLM(ForgettingTransformerPreTrainedModel, FLA
                 criterion = self.criterion
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/gated_deltanet/modeling_gated_deltanet.py
+++ b/fla/models/gated_deltanet/modeling_gated_deltanet.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.gated_deltanet import GatedDeltaNet
 from fla.models.gated_deltanet.configuration_gated_deltanet import GatedDeltaNetConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaNetMLP
 from fla.modules.l2warp import l2_warp
@@ -438,7 +438,7 @@ class GatedDeltaNetForCausalLM(GatedDeltaNetPreTrainedModel, FLAUnsupportedCache
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
+++ b/fla/models/gated_deltaproduct/modeling_gated_deltaproduct.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.gated_deltaproduct import GatedDeltaProduct
 from fla.models.gated_deltaproduct.configuration_gated_deltaproduct import GatedDeltaProductConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GatedDeltaProductMLP
 from fla.modules.l2warp import l2_warp
@@ -428,7 +428,7 @@ class GatedDeltaProductForCausalLM(GatedDeltaProductPreTrainedModel, FLAUnsuppor
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.gla import GatedLinearAttention
 from fla.models.gla.configuration_gla import GLAConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GLAMLP
 from fla.modules.l2warp import l2_warp
@@ -428,7 +428,7 @@ class GLAForCausalLM(GLAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/gsa/modeling_gsa.py
+++ b/fla/models/gsa/modeling_gsa.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.gsa import GatedSlotAttention
 from fla.models.gsa.configuration_gsa import GSAConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as GSAMLP
 from fla.modules.l2warp import l2_warp
@@ -431,7 +431,7 @@ class GSAForCausalLM(GSAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
                 criterion = self.criterion
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/hgrn/modeling_hgrn.py
+++ b/fla/models/hgrn/modeling_hgrn.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.hgrn import HGRNAttention
 from fla.models.hgrn.configuration_hgrn import HGRNConfig
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRNMLP
 from fla.modules.l2warp import l2_warp
@@ -430,7 +430,7 @@ class HGRNForCausalLM(HGRNPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/hgrn2/modeling_hgrn2.py
+++ b/fla/models/hgrn2/modeling_hgrn2.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.hgrn2 import HGRN2Attention
 from fla.models.hgrn2.configuration_hgrn2 import HGRN2Config
 from fla.models.hybrid import get_hybrid_attention_spec
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as HGRN2MLP
 from fla.modules.l2warp import l2_warp
@@ -431,7 +431,7 @@ class HGRN2ForCausalLM(HGRN2PreTrainedModel, FLAUnsupportedCacheGenerationMixin)
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/kda/modeling_kda.py
+++ b/fla/models/kda/modeling_kda.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.kda import KimiDeltaAttention
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.kda.configuration_kda import KDAConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as KDAMLP
 from fla.modules.l2warp import l2_warp
@@ -454,7 +454,7 @@ class KDAForCausalLM(KDAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if fuse_linear_and_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/lightnet/modeling_lightnet.py
+++ b/fla/models/lightnet/modeling_lightnet.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.lightnet import LightNetAttention
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.lightnet.configuration_lightnet import LightNetConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as LightNetMLP
 from fla.modules.l2warp import l2_warp
@@ -421,7 +421,7 @@ class LightNetForCausalLM(LightNetPreTrainedModel, FLAUnsupportedCacheGeneration
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/linear_attn/modeling_linear_attn.py
+++ b/fla/models/linear_attn/modeling_linear_attn.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.linear_attn import LinearAttention
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.linear_attn.configuration_linear_attn import LinearAttentionConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as LinearAttentionMLP
 from fla.modules.l2warp import l2_warp
@@ -427,7 +427,7 @@ class LinearAttentionForCausalLM(LinearAttentionPreTrainedModel, FLAUnsupportedC
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
+++ b/fla/models/log_linear_mamba2/modeling_log_linear_mamba2.py
@@ -16,7 +16,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.log_linear_mamba2 import LogLinearMamba2
 from fla.models.log_linear_mamba2.configuration_log_linear_mamba2 import LogLinearMamba2Config
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, GatedMLP, RMSNorm
 from fla.ops.attnres import fused_attnres
 
@@ -481,13 +481,7 @@ class LogLinearMamba2ForCausalLM(LogLinearMamba2PreTrainedModel):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat(
-                (
-                    labels[..., 1:],
-                    torch.full_like(labels[:, :1], criterion.ignore_index),
-                ),
-                1,
-            )
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if fuse_linear_and_cross_entropy:
                 loss = criterion(
                     hidden_states, labels, self.lm_head.weight, self.lm_head.bias,

--- a/fla/models/mamba/modeling_mamba.py
+++ b/fla/models/mamba/modeling_mamba.py
@@ -30,7 +30,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.mamba import Mamba
 from fla.models.mamba.configuration_mamba import MambaConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules.l2warp import l2_warp
 
@@ -333,7 +333,7 @@ class MambaForCausalLM(MambaPreTrainedModel, FLAGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -33,7 +33,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.mamba2 import Mamba2
 from fla.models.mamba2.configuration_mamba2 import Mamba2Config
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules.l2warp import l2_warp
 
@@ -402,7 +402,7 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel, FLAGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/mamba3/modeling_mamba3.py
+++ b/fla/models/mamba3/modeling_mamba3.py
@@ -16,7 +16,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.mamba3 import Mamba3
 from fla.models.mamba3.configuration_mamba3 import Mamba3Config
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules.l2warp import l2_warp
 
@@ -317,7 +317,7 @@ class Mamba3ForCausalLM(Mamba3PreTrainedModel, FLAGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/mesa_net/modeling_mesa_net.py
+++ b/fla/models/mesa_net/modeling_mesa_net.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.mesa_net import MesaNet
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.mesa_net.configuration_mesa_net import MesaNetConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MesaNetMLP
 from fla.modules.l2warp import l2_warp
@@ -424,7 +424,7 @@ class MesaNetForCausalLM(MesaNetPreTrainedModel, FLAUnsupportedCacheGenerationMi
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/mla/modeling_mla.py
+++ b/fla/models/mla/modeling_mla.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.mla import MultiheadLatentAttention
 from fla.models.mla.configuration_mla import MLAConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MLAMLP
 from fla.modules.l2warp import l2_warp
@@ -410,7 +410,7 @@ class MLAForCausalLM(MLAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/moba/modeling_moba.py
+++ b/fla/models/moba/modeling_moba.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.moba import MoBA
 from fla.models.moba.configuration_moba import MoBAConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MoBAMLP
 from fla.modules.l2warp import l2_warp
@@ -393,7 +393,7 @@ class MoBAForCausalLM(MoBAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/mom/modeling_mom.py
+++ b/fla/models/mom/modeling_mom.py
@@ -22,7 +22,7 @@ from fla.layers import MomAttention
 from fla.layers.attn import Attention
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.mom.configuration_mom import MomConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as MomMLP
 from fla.ops.attnres import fused_attnres
@@ -532,7 +532,7 @@ class MomForCausalLM(MomPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
                 loss_fct = nn.CrossEntropyLoss()
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], loss_fct.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, loss_fct.ignore_index, kwargs.get("cu_seqlens"))
             if fuse_linear_and_cross_entropy:
                 loss = loss_fct(hidden_states.view(-1, self.config.hidden_size),
                                 labels.view(-1),

--- a/fla/models/nsa/modeling_nsa.py
+++ b/fla/models/nsa/modeling_nsa.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.nsa import NativeSparseAttention
 from fla.models.nsa.configuration_nsa import NSAConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as NSAMLP
 from fla.modules.l2warp import l2_warp
@@ -428,7 +428,7 @@ class NSAForCausalLM(NSAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/parallax/modeling_parallax.py
+++ b/fla/models/parallax/modeling_parallax.py
@@ -23,7 +23,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.parallax import Parallax
 from fla.models.parallax.configuration_parallax import ParallaxConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as ParallaxMLP
 from fla.modules.l2warp import l2_warp
@@ -413,7 +413,7 @@ class ParallaxForCausalLM(ParallaxPreTrainedModel, FLAGenerationMixin):
                 criterion = self.criterion
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/path_attn/modeling_path_attention.py
+++ b/fla/models/path_attn/modeling_path_attention.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.path_attn import PaTHAttention
 from fla.models.path_attn.configuration_path_attention import PaTHAttentionConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as PaTHAttentionMLP
 from fla.modules.l2warp import l2_warp
@@ -277,6 +277,8 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         use_cache = use_cache if use_cache is not None else (self.config.use_cache if not self.training else False)
+        if kwargs.get('cu_seqlens') is not None:
+            use_cache = False
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         # retrieve input_ids and inputs_embeds
@@ -293,6 +295,12 @@ class PaTHAttentionModel(PaTHAttentionPreTrainedModel):
 
         # embed positions
         hidden_states = inputs_embeds
+        if use_cache and attention_mask is None:
+            past_length = past_key_values.get_seq_length() if past_key_values is not None else 0
+            attention_mask = hidden_states.new_ones(
+                (hidden_states.shape[0], past_length + hidden_states.shape[1]),
+                dtype=torch.bool,
+            )
 
         # list of completed block summaries (kept as separate tensors so
         # `fused_attnres` can ingest them via its pointer-table API
@@ -435,7 +443,7 @@ class PaTHAttentionForCausalLM(PaTHAttentionPreTrainedModel, FLAGenerationMixin)
                 criterion = self.criterion
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/precond_gated_deltanet/modeling_precond_gated_deltanet.py
+++ b/fla/models/precond_gated_deltanet/modeling_precond_gated_deltanet.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.precond_gated_deltanet import PrecondGatedDeltaNet
 from fla.models.precond_gated_deltanet.configuration_precond_gated_deltanet import PrecondGatedDeltaNetConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as PrecondGatedDeltaNetMLP
 from fla.modules.l2warp import l2_warp
@@ -394,7 +394,7 @@ class PrecondGatedDeltaNetForCausalLM(PrecondGatedDeltaNetPreTrainedModel, FLAGe
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/precond_kda/modeling_precond_kda.py
+++ b/fla/models/precond_kda/modeling_precond_kda.py
@@ -21,7 +21,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.precond_kda import PrecondKDA
 from fla.models.precond_kda.configuration_precond_kda import PrecondKDAConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as PrecondKDAMLP
 from fla.modules.l2warp import l2_warp
@@ -387,7 +387,7 @@ class PrecondKDAForCausalLM(PrecondKDAPreTrainedModel, FLAGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if fuse_linear_and_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/raven/modeling_raven.py
+++ b/fla/models/raven/modeling_raven.py
@@ -25,7 +25,7 @@ from fla.layers.attn import Attention
 from fla.layers.raven import Raven
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.raven.configuration_raven import RavenConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as RavenMLP
 from fla.modules.l2warp import l2_warp
@@ -440,7 +440,7 @@ class RavenForCausalLM(RavenPreTrainedModel, FLAUnsupportedCacheGenerationMixin)
                 criterion = self.criterion
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/retnet/modeling_retnet.py
+++ b/fla/models/retnet/modeling_retnet.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.multiscale_retention import MultiScaleRetention
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.retnet.configuration_retnet import RetNetConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as RetNetMLP
 from fla.modules.l2warp import l2_warp
@@ -431,7 +431,7 @@ class RetNetForCausalLM(RetNetPreTrainedModel, FLAUnsupportedCacheGenerationMixi
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/rodimus/modeling_rodimus.py
+++ b/fla/models/rodimus/modeling_rodimus.py
@@ -23,7 +23,7 @@ from fla.layers.attn import Attention
 from fla.layers.rodimus import RodimusAttention, SlidingWindowSharedKeyAttention, align_multiple
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.rodimus.configuration_rodimus import RodimusConfig
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as RodimusMLP
 from fla.modules.l2warp import l2_warp
@@ -538,7 +538,7 @@ class RodimusForCausalLM(RodimusPreTrainedModel, FLAUnsupportedCacheGenerationMi
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/rwkv6/modeling_rwkv6.py
+++ b/fla/models/rwkv6/modeling_rwkv6.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.rwkv6 import LerpLinear, RWKV6Attention
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.rwkv6.configuration_rwkv6 import RWKV6Config
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
 from fla.modules.activations import ACT2FN
 from fla.modules.l2warp import l2_warp
@@ -425,7 +425,7 @@ class RWKV6ForCausalLM(RWKV6PreTrainedModel, FLAUnsupportedCacheGenerationMixin)
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/rwkv7/modeling_rwkv7.py
+++ b/fla/models/rwkv7/modeling_rwkv7.py
@@ -22,7 +22,7 @@ from fla.layers.attn import Attention
 from fla.layers.rwkv7 import RWKV7Attention
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.rwkv7.configuration_rwkv7 import RWKV7Config
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, LayerNorm
 from fla.modules.activations import ACT2FN
 from fla.modules.l2warp import l2_warp
@@ -523,7 +523,7 @@ class RWKV7ForCausalLM(RWKV7PreTrainedModel, FLAUnsupportedCacheGenerationMixin)
 
             # shift_labels: See https://github.com/huggingface/transformers/pull/36607/files.
             if shift_labels is None:
-                shift_labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+                shift_labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             shift_labels = shift_labels.to(hidden_states.device)
 
             if self.config.fuse_linear_cross_entropy:

--- a/fla/models/samba/modeling_samba.py
+++ b/fla/models/samba/modeling_samba.py
@@ -21,7 +21,7 @@ from fla.layers.attn import Attention
 from fla.layers.mamba import Mamba
 from fla.models.hybrid import get_hybrid_attention_spec
 from fla.models.samba.configuration_samba import SambaConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as SambaMLP
 from fla.modules.l2warp import l2_warp
@@ -427,7 +427,7 @@ class SambaForCausalLM(SambaPreTrainedModel, FLAGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/transformer/modeling_transformer.py
+++ b/fla/models/transformer/modeling_transformer.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.attn import Attention
 from fla.models.transformer.configuration_transformer import TransformerConfig
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as TransformerMLP
 from fla.modules.l2warp import l2_warp
@@ -429,7 +429,7 @@ class TransformerForCausalLM(TransformerPreTrainedModel, FLAGenerationMixin):
                 criterion = self.criterion
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/utils.py
+++ b/fla/models/utils.py
@@ -21,6 +21,25 @@ _TF_VERSION = transformers.__version__
 _NEED_NEW = "4.53.3"
 _IS_TRANSFORMERS_4_56_PLUS = version.parse(_TF_VERSION) >= version.parse("4.56.0")
 
+
+def prepare_causal_lm_labels(
+    labels: torch.Tensor,
+    ignore_index: int,
+    cu_seqlens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    labels = torch.cat(
+        (labels[..., 1:], torch.full_like(labels[..., :1], ignore_index)),
+        dim=-1,
+    )
+    if cu_seqlens is not None:
+        if labels.shape[0] != 1:
+            raise ValueError("Packed `cu_seqlens` loss currently requires batch size 1.")
+        starts, ends = cu_seqlens[:-1], cu_seqlens[1:]
+        last_token_indices = ends[ends > starts].to(device=labels.device, dtype=torch.long) - 1
+        labels.view(-1).index_fill_(0, last_token_indices, ignore_index)
+    return labels
+
+
 if version.parse(_TF_VERSION) > version.parse(_NEED_NEW):
     from transformers.cache_utils import CacheLayerMixin
 else:

--- a/fla/models/wall_transformer/modeling_wall_transformer.py
+++ b/fla/models/wall_transformer/modeling_wall_transformer.py
@@ -21,7 +21,7 @@ from transformers.utils import logging
 from transformers.utils.deprecation import deprecate_kwarg
 
 from fla.layers.wall_attn import WallAttention
-from fla.models.utils import Cache, FLAGenerationMixin
+from fla.models.utils import Cache, FLAGenerationMixin, prepare_causal_lm_labels
 from fla.models.wall_transformer.configuration_wall_transformer import WallTransformerConfig
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as WallTransformerMLP
@@ -443,7 +443,7 @@ class WallTransformerForCausalLM(WallTransformerPreTrainedModel, FLAGenerationMi
                 criterion = self.criterion
             # Enable model parallelism
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if self.config.fuse_linear_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:

--- a/fla/models/yoco/modeling_yoco.py
+++ b/fla/models/yoco/modeling_yoco.py
@@ -20,7 +20,7 @@ from transformers.utils.deprecation import deprecate_kwarg
 from fla.layers.attn import Attention
 from fla.layers.gated_deltanet import GatedDeltaNet
 from fla.layers.yoco import YOCOCrossAttention, YOCOGatedRetention, YOCOSharedKVBuilder
-from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin
+from fla.models.utils import Cache, FLAUnsupportedCacheGenerationMixin, prepare_causal_lm_labels
 from fla.models.yoco.configuration_yoco import YOCOConfig
 from fla.modules import FusedCrossEntropyLoss, FusedLinearCrossEntropyLoss, RMSNorm
 from fla.modules import GatedMLP as YOCOMLP
@@ -728,7 +728,7 @@ class YOCOForCausalLM(YOCOPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
             else:
                 criterion = self.criterion
             labels = labels.to(hidden_states.device)
-            labels = torch.cat((labels[..., 1:], torch.full_like(labels[:, :1], criterion.ignore_index)), 1)
+            labels = prepare_causal_lm_labels(labels, criterion.ignore_index, kwargs.get("cu_seqlens"))
             if fuse_linear_and_cross_entropy:
                 loss = criterion(hidden_states, labels, self.lm_head.weight, self.lm_head.bias)
             else:


### PR DESCRIPTION
## Summary

- add a shared causal LM label preparation helper that masks the last token of each non-empty packed sequence when `cu_seqlens` is provided
- use the helper across all 37 CausalLM implementations so packed training never predicts across sequence boundaries
- preserve the existing non-packed shift behavior, existing ignore labels, and safely handle zero-length packed sequences
- preserve supported `[B, T]` inputs with `B > 1` and `cu_seqlens`; shift packed labels in flattened token order so sequences spanning batch rows keep all valid prediction targets, then restore the original label shape
- disable cache by default for DeltaFormer, whose attention layer does not implement `past_key_values`
- make PaTH synthesize an all-valid attention mask for unpadded cache calls and disable cache for packed `cu_seqlens`

## Test plan

- `pre-commit run --files <all changed production files>`
- `python -m compileall -q fla/models`
- added `tests/models/test_modeling_transformer.py::test_packed_loss`: 9 cases covering flattened, batched, and cross-row layouts with all three cross-entropy implementations, comparing loss and parameter gradients and checking that final-hidden-state gradients are nonzero at valid targets and zero at ignored targets and sequence boundaries
- `pytest -q tests/models/test_modeling_transformer.py::test_packed_loss tests/layers/test_attn_varlen_pack_layout.py::test_attention_varlen_accepts_batched_layout_with_cu_seqlens`: 11 passed on an RTX A1000 Laptop GPU
- verified the batched cases fail with the previous batch-size guard and all three cross-row cases fail with the previous row-wise packed shift; six temporary mutation checks confirm that missing boundary masking and row-wise packed shifting are caught even with `FLA_CI_ENV=1`
- temporary local CUDA validation:
  - checked ordinary packed sequences, multiple short sequences, zero-length sequences, existing `-100` SFT labels, CPU/GPU `cu_seqlens`, non-contiguous labels, and unchanged input labels; the follow-up helper audit passed all 72 cases, including cross-row layouts
  - compared packed vs per-sequence loss and gradients for `CrossEntropyLoss`, `FusedCrossEntropyLoss`, and `FusedLinearCrossEntropyLoss`; sequence-final gradients are zero
  - compared packed vs per-sequence GatedDeltaNet loss, parameter gradients, and input embedding gradients for all three loss implementations
- verified the helper under `torch.compile(..., fullgraph=True)` with both eager and default Inductor backends during the initial validation; the cross-row follow-up additionally confirmed capture and execution of a full graph with a custom eager backend
- follow-up validation: 93 cases passed in total (11 committed model/layer cases, 72 temporary helper cases, six mutation checks, three additional cross-row model comparisons, and one fullgraph capture check)
- temporary PaTH cache validation: no-mask prefill/decode matches a no-cache full-sequence reference, while packed eval returns no cache
- `pytest -q tests/models/test_modeling_gated_deltanet.py tests/models/test_fuse_linear_cross_entropy.py`: all 11 targeted cases pass after rerunning the two previously failing cache cases
- `pytest -q tests/models/test_modeling_path_attn.py tests/models/test_modeling_deltaformer.py`: 9 passed, 3 skipped

## Benchmark / NCU (kernel changes only)

Neutral. No kernel code changed.

## Breaking changes

None. Packed causal LM loss now intentionally ignores targets at sequence boundaries. DeltaFormer now defaults cache off because its attention layer does not support cache state.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
