### PR TITLE
[Test] Fix the broken GDN-2 autotune-key test and drop its cold-autotune cost

### DIFF
--- a/fla/ops/gdn2/chunk_bwd.py
+++ b/fla/ops/gdn2/chunk_bwd.py
@@ -66,6 +66,8 @@ NUM_WARPS_WY = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
         for num_stages in [2, 3, 4]
         if not (IS_NVIDIA_HOPPER and BK == 32 and num_warps == 4)
     ],
+    # NOTE: H is excluded on purpose -- it only scales the grid (NT, B * H) and
+    # strides addressing, so it does not shape the work the BK/BV sweep tunes.
     key=['BT', 'K', 'V', 'STATE_V_FIRST'],
     **autotune_cache_kwargs,
 )

--- a/tests/ops/test_gdn2.py
+++ b/tests/ops/test_gdn2.py
@@ -25,6 +25,12 @@ from fla.ops.kda.gate import naive_kda_gate, naive_kda_lowerbound_gate
 from fla.utils import assert_close, device
 
 
+def _unwrap_autotuner(fn):
+    while not hasattr(fn, 'configs'):
+        fn = fn.fn
+    return fn
+
+
 def _activate_g(g, A_log, dt_bias, safe_gate, lower_bound):
     """Reference gate activation matching the kernel's use_gate_in_kernel path."""
     if safe_gate:
@@ -570,41 +576,23 @@ def test_layer(num_heads, num_v_heads, use_short_conv):
             assert torch.isfinite(p.grad).all(), f"{name}.grad has non-finite values"
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_chunk_bwd_autotune_key_covers_head_dims():
     """The fused WY/dqkg backward must autotune each (K, V) geometry separately.
 
-    The kernel autotunes over BK/BV tile configs, whose relative performance
-    depends on the head dimensions K and V. Backwards through two different
-    (K, V) geometries at the same chunk size must therefore leave two distinct
-    autotuner cache entries; if K/V are missing from the autotune key, the
-    second geometry cache-hits on the first geometry's winner and runs a
-    config that was never measured for its shape.
+    The kernel sweeps BK/BV tile configs whose relative performance depends on
+    the head dimensions, so K and V have to be part of the autotune key. Were
+    they missing, the first (K, V) geometry to reach the kernel in a process
+    would tune it for every other geometry sharing BT: the second geometry
+    cache-hits on the first one's winner and runs a config that was never
+    measured for its shape.
+
+    Checked against the declared key rather than by driving two backwards,
+    which would pay a cold autotune sweep per geometry on every CI run.
     """
-    import fla.ops.gdn2.chunk_bwd as chunk_bwd_mod
+    from fla.ops.gdn2.chunk_bwd import chunk_gdn2_bwd_kernel_wy_dqkg_fused
 
-    # The module symbol is Heuristics(Autotuner(JITFunction)); walk .fn down to
-    # the Autotuner, which owns the config cache.
-    tuner = chunk_bwd_mod.chunk_gdn2_bwd_kernel_wy_dqkg_fused
-    for _ in range(3):
-        if hasattr(tuner, 'cache'):
-            break
-        tuner = tuner.fn
-    assert hasattr(tuner, 'cache'), "could not locate the Autotuner on the fused kernel"
-
-    saved = dict(tuner.cache)
-    tuner.cache.clear()
-    try:
-        for K, V in [(32, 64), (64, 128)]:
-            q, k, v, g, b, w, _, _ = _rand_inputs(1, 256, 2, K, V, torch.bfloat16)
-            for t in (q, k, v, g, b, w):
-                t.requires_grad_(True)
-            o, _ = chunk_gdn2(q=q, k=k, v=v, g=g, b=b, w=w, use_qk_l2norm_in_kernel=True)
-            o.sum().backward()
-        assert len(tuner.cache) == 2, (
-            f"expected one autotune cache entry per (K, V) geometry, got {len(tuner.cache)}; "
-            f"the autotune key must include K and V"
-        )
-    finally:
-        tuner.cache.clear()
-        tuner.cache.update(saved)
+    tuner = _unwrap_autotuner(chunk_gdn2_bwd_kernel_wy_dqkg_fused)
+    assert list(tuner.keys) == ['BT', 'K', 'V', 'STATE_V_FIRST'], (
+        f"unexpected autotune key {list(tuner.keys)}; it must carry K and V, "
+        "the head dimensions that bound the swept BK/BV tiles"
+    )


### PR DESCRIPTION
## Summary

#1120 added `test_chunk_bwd_autotune_key_covers_head_dims`, which has never run green. It calls `_rand_inputs` with six positional arguments, but #1165/#1166 grew that signature to seven when `HV` was added, so on any CUDA runner it raises `TypeError: _rand_inputs() missing 1 required positional argument: 'dtype'`. It looks green only where it is skipped for want of a GPU.

It also asserted the invariant the expensive way — driving a backward through two `(K, V)` geometries and counting autotuner cache entries — which pays a full cold autotune sweep per geometry on every run.

Both points were raised in review on #1120 before merge, and the PR landed without either being applied. This PR applies them: assert the declared autotune key directly, following the `_unwrap_autotuner` precedent in `tests/ops/test_gdn.py`. That pins `K` and `V` in the key explicitly, removes the arity-sensitive call site along with the failure, and launches no kernel — so the `torch.cuda.is_available()` guard goes too, matching the precedent test, which has no CUDA guard either.

A second commit adds a two-line `NOTE:` above the key itself. #1120 added `K` and `V` and left `H` out; that omission is deliberate — `H` only scales the grid `(NT, B * H)` and strides addressing, so it does not shape the per-program work the `BK`/`BV` sweep tunes — but it is invisible, and the siblings disagree with it: the KDA ancestor `chunk_kda_bwd_kernel_wy_dqkg_fused` keys on `HV`, and `recompute_w_u_fwd_gdn2_kernel` keys on `H` (it sweeps only warps/stages, so keying on everything is cheap there). Without the note, the next person comparing those three keys cannot tell an intentional choice from a second oversight.

The kernel-side change from #1120 (`key=['BT', 'K', 'V', 'STATE_V_FIRST']`) is correct and is untouched here.

## Test plan

- Test modified: `tests/ops/test_gdn2.py::test_chunk_bwd_autotune_key_covers_head_dims`
- Dependent tests (`python scripts/find_dependent_tests.py tests/ops/test_gdn2.py`): `tests/ops/test_gdn2.py`
- Before/after on one box (NVIDIA B200, torch 2.11.0+cu130, triton 3.6.0, Python 3.12.3), same tree except this commit:
  - on `main` (a37d13af): `1 failed` — `TypeError: _rand_inputs() missing 1 required positional argument: 'dtype'` at `tests/ops/test_gdn2.py:599`
  - on this branch: `1 passed in 0.22s`
- Full `tests/ops/test_gdn2.py`: 34 passed on B200 (see comment below); the modified test also passes on AMD MI300X (torch 2.11.0+rocm7.14.0, triton 3.7.1).
- Varlen / CP / model tests: not applicable — the test launches no kernel, and the only change under `fla/` is a comment.

## Benchmark / NCU (kernel changes only)

Neutral. The only change to a kernel file is a two-line comment; no generated code changes and no config space is touched. The performance effect is on CI wall clock: the removed test version autotuned the fused WY/dqkg kernel from cold once per `(K, V)` geometry — 36 configs per geometry off Hopper (`NUM_WARPS_WY = [2, 4, 8]`, no pruning) and 18 on it. Worth noting sm100 takes the non-Hopper branch, since `IS_NVIDIA_HOPPER` matches only `'NVIDIA H'` device names or capability 9, so Blackwell pays the 36-config sweep too. The replacement reads the decorator and returns in 0.22 s.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
