### PR TITLE
[Perf] Remove host syncs from fused linear CE and KL divergence

### DIFF
--- a/fla/modules/backends/triton_ascend/__init__.py
+++ b/fla/modules/backends/triton_ascend/__init__.py
@@ -105,7 +105,7 @@ class TritonAscendBackend(BaseBackend):
         from fla.modules.backends.triton_ascend.fused_linear_cross_entropy import (
             logsumexp_fwd_npu,
         )
-        return logsumexp_fwd_npu(x, scale=scale, softcapping=softcapping, dtype=dtype)
+        return logsumexp_fwd_npu(x=x, scale=scale, softcapping=softcapping, dtype=dtype)
 
     def fused_linear_cross_entropy_forward(
         self,
@@ -127,19 +127,19 @@ class TritonAscendBackend(BaseBackend):
             fused_linear_cross_entropy_forward_npu,
         )
         return fused_linear_cross_entropy_forward_npu(
-            x,
-            target,
-            weight,
-            bias,
-            ignore_index,
-            label_smoothing,
-            logit_scale,
-            logit_softcapping,
-            num_chunks,
-            reduction,
-            use_l2warp,
-            l2_penalty_factor,
-            accumulate_grad_in_fp32,
+            x=x,
+            target=target,
+            weight=weight,
+            bias=bias,
+            ignore_index=ignore_index,
+            label_smoothing=label_smoothing,
+            logit_scale=logit_scale,
+            logit_softcapping=logit_softcapping,
+            num_chunks=num_chunks,
+            reduction=reduction,
+            use_l2warp=use_l2warp,
+            l2_penalty_factor=l2_penalty_factor,
+            accumulate_grad_in_fp32=accumulate_grad_in_fp32,
         )
 
     def fused_linear_cross_entropy_backward(
@@ -152,7 +152,7 @@ class TritonAscendBackend(BaseBackend):
         from fla.modules.backends.triton_ascend.fused_linear_cross_entropy import (
             fused_linear_cross_entropy_backward_npu,
         )
-        return fused_linear_cross_entropy_backward_npu(do, dx, dw, db)
+        return fused_linear_cross_entropy_backward_npu(do=do, dx=dx, dw=dw, db=db)
 
     def sigmoid_fwd(self, x, output_contiguous=False):
         from fla.modules.backends.triton_ascend.activations import sigmoid_fwd_npu
@@ -215,17 +215,17 @@ class TritonAscendBackend(BaseBackend):
     ):
         from fla.modules.backends.triton_ascend.fused_kl_div import fused_kl_div_forward_npu
         return fused_kl_div_forward_npu(
-            x,
-            target_x,
-            weight,
-            target_weight,
-            reduction,
-            accumulate_grad_in_fp32,
+            x=x,
+            target_x=target_x,
+            weight=weight,
+            target_weight=target_weight,
+            reduction=reduction,
+            accumulate_grad_in_fp32=accumulate_grad_in_fp32,
         )
 
     def fused_kl_div_backward(self, do, dx, dw):
         from fla.modules.backends.triton_ascend.fused_kl_div import fused_kl_div_backward_npu
-        return fused_kl_div_backward_npu(do, dx, dw)
+        return fused_kl_div_backward_npu(do=do, dx=dx, dw=dw)
 
     def l2norm_fwd(
         self,

--- a/fla/modules/backends/triton_ascend/fused_kl_div.py
+++ b/fla/modules/backends/triton_ascend/fused_kl_div.py
@@ -164,7 +164,6 @@ def fused_kl_div_backward_npu(
     dx: torch.Tensor,
     dw: torch.Tensor,
 ):
-    # keep the unit-gradient fast path on device to avoid a host synchronization
     N, H = dx.shape
     B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
 

--- a/fla/modules/backends/triton_ascend/fused_kl_div.py
+++ b/fla/modules/backends/triton_ascend/fused_kl_div.py
@@ -89,6 +89,8 @@ def elementwise_mul_kernel(
     o_x = i_x * B + tl.arange(0, B)
 
     b_g = tl.load(g)
+    if b_g == 1.0:
+        return
     b_x = tl.load(x + o_x, mask=o_x < N)
     tl.store(x + o_x, b_x * b_g, mask=o_x < N)
 
@@ -162,27 +164,27 @@ def fused_kl_div_backward_npu(
     dx: torch.Tensor,
     dw: torch.Tensor,
 ):
-    if torch.ne(do, torch.tensor(1.0, device=do.device)):
-        N, H = dx.shape
-        B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
+    # keep the unit-gradient fast path on device to avoid a host synchronization
+    N, H = dx.shape
+    B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
 
-        elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
-            x=dx,
+    elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
+        x=dx,
+        g=do,
+        N=N*H,
+        B=B,
+        num_warps=STATIC_WARPS,
+    )
+
+    if dw is not None:
+        V, H = dw.shape
+        B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
+        elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
+            x=dw,
             g=do,
-            N=N*H,
-            B=B,
+            N=V*H,
+            B=B_dw,
             num_warps=STATIC_WARPS,
         )
-
-        if dw is not None:
-            V, H = dw.shape
-            B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
-            elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
-                x=dw,
-                g=do,
-                N=V*H,
-                B=B_dw,
-                num_warps=STATIC_WARPS,
-            )
 
     return dx, dw

--- a/fla/modules/backends/triton_ascend/fused_kl_div.py
+++ b/fla/modules/backends/triton_ascend/fused_kl_div.py
@@ -96,7 +96,7 @@ def elementwise_mul_kernel(
 
 
 def _npu_vocab_block_size(vocab_size: int, num_rows: int) -> int:
-    return compute_vocab_block_size(vocab_size, num_rows, _KLD_FWD_MEM_MULT)
+    return compute_vocab_block_size(vocab_size=vocab_size, num_rows=num_rows, memory_multiplier=_KLD_FWD_MEM_MULT)
 
 
 def fused_kl_div_forward_npu(
@@ -110,7 +110,7 @@ def fused_kl_div_forward_npu(
     device = x.device
 
     N, H, V = *x.shape, weight.shape[0]
-    BV = _npu_vocab_block_size(V, N)
+    BV = _npu_vocab_block_size(vocab_size=V, num_rows=N)
     NC = min(8, triton.cdiv(V, H))
     C = min(triton.next_power_of_2(triton.cdiv(N, NC)), ASCEND_MAX_GRID_DIM)
     NC = triton.cdiv(N, C)
@@ -165,7 +165,7 @@ def fused_kl_div_backward_npu(
     dw: torch.Tensor,
 ):
     N, H = dx.shape
-    B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
+    B = compute_elementwise_block_size(n_elements=N * H, memory_multiplier=_ELEMENTWISE_MEM_MULT)
 
     elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
         x=dx,
@@ -177,12 +177,12 @@ def fused_kl_div_backward_npu(
 
     if dw is not None:
         V, H = dw.shape
-        B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
-        elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
+        B = compute_elementwise_block_size(n_elements=V * H, memory_multiplier=_ELEMENTWISE_MEM_MULT)
+        elementwise_mul_kernel[(triton.cdiv(V * H, B),)](
             x=dw,
             g=do,
             N=V*H,
-            B=B_dw,
+            B=B,
             num_warps=STATIC_WARPS,
         )
 

--- a/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
+++ b/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
@@ -104,7 +104,7 @@ def cross_entropy_kernel(
         return
 
     if reduction == "mean":
-        b_total = tl.maximum(tl.load(total), 1)
+        b_total = tl.load(total)
 
     b_l = tl.load(logits + b_y).to(tl.float32) * logit_scale
     if HAS_SOFTCAPPING:
@@ -324,6 +324,7 @@ def fused_linear_cross_entropy_backward_npu(
         g=do,
         N=N*H,
         B=B,
+        num_warps=STATIC_WARPS,
     )
 
     if dw is not None:
@@ -334,6 +335,7 @@ def fused_linear_cross_entropy_backward_npu(
             g=do,
             N=V*H,
             B=B_dw,
+            num_warps=STATIC_WARPS,
         )
 
     if db is not None:
@@ -344,5 +346,6 @@ def fused_linear_cross_entropy_backward_npu(
             g=do,
             N=V,
             B=B_db,
+            num_warps=STATIC_WARPS,
         )
     return dx, dw, db

--- a/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
+++ b/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
@@ -103,6 +103,9 @@ def cross_entropy_kernel(
             tl.store(logits + o_v, 0.0, mask=o_v < V)
         return
 
+    if reduction == "mean":
+        b_total = tl.maximum(tl.load(total), 1)
+
     b_l = tl.load(logits + b_y).to(tl.float32) * logit_scale
     if HAS_SOFTCAPPING:
         b_t_y = tanh(b_l / logit_softcapping)
@@ -128,7 +131,7 @@ def cross_entropy_kernel(
         if HAS_SOFTCAPPING:
             b_p = b_p * (1.0 - b_t * b_t)
         if reduction == "mean":
-            b_p = b_p / total
+            b_p = b_p / b_total
         tl.store(logits + o_v, b_p, mask=o_v < V)
 
     if label_smoothing > 0:
@@ -142,8 +145,8 @@ def cross_entropy_kernel(
         b_sc_factor = 1.0
 
     if reduction == 'mean':
-        b_loss = b_loss / total
-        b_l += (label_smoothing - 1) / total * logit_scale * b_sc_factor
+        b_loss = b_loss / b_total
+        b_l += (label_smoothing - 1) / b_total * logit_scale * b_sc_factor
     else:
         b_l += (label_smoothing - 1) * logit_scale * b_sc_factor
 
@@ -162,6 +165,8 @@ def elementwise_mul_kernel(
     o_x = i_x * B + tl.arange(0, B)
 
     b_g = tl.load(g)
+    if b_g == 1.0:
+        return
     b_x = tl.load(x + o_x, mask=o_x < N)
     tl.store(x + o_x, b_x * b_g, mask=o_x < N)
 
@@ -236,7 +241,7 @@ def fused_linear_cross_entropy_forward_npu(
     db = torch.zeros_like(bias, device=device, dtype=bias_grad_dtype) if bias is not None else None
     loss = torch.zeros(N, device=device, dtype=torch.float)
 
-    total = target.ne(ignore_index).sum().item()
+    total = target.ne(ignore_index).sum()
 
     for ic in range(NC):
         start, end = ic * C, min((ic + 1) * C, N)
@@ -311,37 +316,33 @@ def fused_linear_cross_entropy_backward_npu(
     dw: torch.Tensor,
     db: torch.Tensor,
 ):
-    if torch.ne(do, torch.tensor(1.0, device=do.device)):
-        N, H = dx.shape
-        B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
+    N, H = dx.shape
+    B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
 
-        elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
-            x=dx,
+    elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
+        x=dx,
+        g=do,
+        N=N*H,
+        B=B,
+    )
+
+    if dw is not None:
+        V, H = dw.shape
+        B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
+        elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
+            x=dw,
             g=do,
-            N=N*H,
-            B=B,
-            num_warps=STATIC_WARPS,
+            N=V*H,
+            B=B_dw,
         )
 
-        if dw is not None:
-            V, H = dw.shape
-            B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
-            elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
-                x=dw,
-                g=do,
-                N=V*H,
-                B=B_dw,
-                num_warps=STATIC_WARPS,
-            )
-
-        if db is not None:
-            V = db.shape[0]
-            B_db = compute_elementwise_block_size(V, _ELEMENTWISE_MEM_MULT)
-            elementwise_mul_kernel[(triton.cdiv(V, B_db),)](
-                x=db,
-                g=do,
-                N=V,
-                B=B_db,
-                num_warps=STATIC_WARPS,
-            )
+    if db is not None:
+        V = db.shape[0]
+        B_db = compute_elementwise_block_size(V, _ELEMENTWISE_MEM_MULT)
+        elementwise_mul_kernel[(triton.cdiv(V, B_db),)](
+            x=db,
+            g=do,
+            N=V,
+            B=B_db,
+        )
     return dx, dw, db

--- a/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
+++ b/fla/modules/backends/triton_ascend/fused_linear_cross_entropy.py
@@ -173,7 +173,7 @@ def elementwise_mul_kernel(
 
 def _npu_vocab_block_size(vocab_size: int, num_rows: int, is_backward: bool = True) -> int:
     memory_multiplier = _LCE_BWD_MEM_MULT if is_backward else _LCE_FWD_MEM_MULT
-    return compute_vocab_block_size(vocab_size, num_rows, memory_multiplier)
+    return compute_vocab_block_size(vocab_size=vocab_size, num_rows=num_rows, memory_multiplier=memory_multiplier)
 
 
 def logsumexp_fwd_npu(
@@ -185,12 +185,12 @@ def logsumexp_fwd_npu(
     shape = x.shape
     x = x.view(-1, shape[-1])
     N, D = x.shape
-    B = _npu_vocab_block_size(D, N, is_backward=False)
+    B = _npu_vocab_block_size(vocab_size=D, num_rows=N, is_backward=False)
     has_softcapping = softcapping is not None
     softcap_val = float(softcapping) if has_softcapping else 0.0
 
     z = x.new_empty(N, dtype=torch.float)
-    for row_off, row_len in iter_axis_launch_chunks(N, 1, max_grid=ASCEND_MAX_GRID_DIM):
+    for row_off, row_len in iter_axis_launch_chunks(axis_size=N, other_grid_product=1, max_grid=ASCEND_MAX_GRID_DIM):
         logsumexp_fwd_kernel[(row_len,)](
             x=x[row_off:row_off + row_len],
             z=z[row_off:row_off + row_len],
@@ -224,7 +224,7 @@ def fused_linear_cross_entropy_forward_npu(
 ):
     device = x.device
     N, H, V = *x.shape, weight.shape[0]
-    BV = _npu_vocab_block_size(V, N)
+    BV = _npu_vocab_block_size(vocab_size=V, num_rows=N)
     has_softcapping = logit_softcapping is not None
     softcap_val = float(logit_softcapping) if has_softcapping else 0.0
     NC = min(num_chunks, triton.cdiv(V, H))
@@ -250,7 +250,7 @@ def fused_linear_cross_entropy_forward_npu(
         if weight is not None and c_x.dtype != grad_dtype:
             c_x = c_x.to(dtype=grad_dtype)
         c_target = target[start:end]
-        c_lse = logsumexp_fwd_npu(c_logits, scale=logit_scale, softcapping=logit_softcapping, dtype=torch.float)
+        c_lse = logsumexp_fwd_npu(x=c_logits, scale=logit_scale, softcapping=logit_softcapping, dtype=torch.float)
 
         c_loss = loss[start:end]
         if use_l2warp:
@@ -317,7 +317,7 @@ def fused_linear_cross_entropy_backward_npu(
     db: torch.Tensor,
 ):
     N, H = dx.shape
-    B = compute_elementwise_block_size(N * H, _ELEMENTWISE_MEM_MULT)
+    B = compute_elementwise_block_size(n_elements=N * H, memory_multiplier=_ELEMENTWISE_MEM_MULT)
 
     elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
         x=dx,
@@ -329,23 +329,23 @@ def fused_linear_cross_entropy_backward_npu(
 
     if dw is not None:
         V, H = dw.shape
-        B_dw = compute_elementwise_block_size(V * H, _ELEMENTWISE_MEM_MULT)
-        elementwise_mul_kernel[(triton.cdiv(V * H, B_dw),)](
+        B = compute_elementwise_block_size(n_elements=V * H, memory_multiplier=_ELEMENTWISE_MEM_MULT)
+        elementwise_mul_kernel[(triton.cdiv(V * H, B),)](
             x=dw,
             g=do,
             N=V*H,
-            B=B_dw,
+            B=B,
             num_warps=STATIC_WARPS,
         )
 
     if db is not None:
         V = db.shape[0]
-        B_db = compute_elementwise_block_size(V, _ELEMENTWISE_MEM_MULT)
-        elementwise_mul_kernel[(triton.cdiv(V, B_db),)](
+        B = compute_elementwise_block_size(n_elements=V, memory_multiplier=_ELEMENTWISE_MEM_MULT)
+        elementwise_mul_kernel[(triton.cdiv(V, B),)](
             x=db,
             g=do,
             N=V,
-            B=B_db,
+            B=B,
             num_warps=STATIC_WARPS,
         )
     return dx, dw, db

--- a/fla/modules/fused_kl_div.py
+++ b/fla/modules/fused_kl_div.py
@@ -211,7 +211,6 @@ def fused_kl_div_backward(
     dx: torch.Tensor,
     dw: torch.Tensor,
 ):
-    # keep the unit-gradient fast path on device to avoid a host synchronization
     # We use a Triton kernel instead of a PyTorch operation because modifying inputs in-place
     # for gradient storage and backward multiple times causes anomalies with PyTorch but not with Triton.
     N, H = dx.shape

--- a/fla/modules/fused_kl_div.py
+++ b/fla/modules/fused_kl_div.py
@@ -116,6 +116,8 @@ def elementwise_mul_kernel(
 
     # Load the gradient output value
     b_g = tl.load(g)
+    if b_g == 1.0:
+        return
     b_x = tl.load(x + o_x, mask=o_x < N)
     tl.store(x + o_x, b_x * b_g, mask=o_x < N)
 
@@ -209,31 +211,30 @@ def fused_kl_div_backward(
     dx: torch.Tensor,
     dw: torch.Tensor,
 ):
-    # If cross entropy is the last layer, do is 1.0. Skip the mul to save time
-    if torch.ne(do, torch.tensor(1.0, device=do.device)):
-        # We use a Triton kernel instead of a PyTorch operation because modifying inputs in-place
-        # for gradient storage and backward multiple times causes anomalies with PyTorch but not with Triton.
-        N, H = dx.shape
-        B = min(MAX_FUSED_SIZE, triton.next_power_of_2(H))
+    # keep the unit-gradient fast path on device to avoid a host synchronization
+    # We use a Triton kernel instead of a PyTorch operation because modifying inputs in-place
+    # for gradient storage and backward multiple times causes anomalies with PyTorch but not with Triton.
+    N, H = dx.shape
+    B = min(MAX_FUSED_SIZE, triton.next_power_of_2(H))
 
-        elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
-            x=dx,
+    elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
+        x=dx,
+        g=do,
+        N=N*H,
+        B=B,
+        num_warps=STATIC_WARPS,
+    )
+
+    # handle dw
+    if dw is not None:
+        V, H = dw.shape
+        elementwise_mul_kernel[(triton.cdiv(V * H, B),)](
+            x=dw,
             g=do,
-            N=N*H,
+            N=V*H,
             B=B,
             num_warps=STATIC_WARPS,
         )
-
-        # handle dw
-        if dw is not None:
-            V, H = dw.shape
-            elementwise_mul_kernel[(triton.cdiv(V * H, B),)](
-                x=dw,
-                g=do,
-                N=V*H,
-                B=B,
-                num_warps=STATIC_WARPS,
-            )
 
     return dx, dw
 

--- a/fla/modules/fused_kl_div.py
+++ b/fla/modules/fused_kl_div.py
@@ -266,7 +266,7 @@ class FusedKLDivLossFunction(torch.autograd.Function):
     @input_guard
     def backward(ctx, do):
         dx, dw = ctx.saved_tensors
-        dx, dw = fused_kl_div_backward(do, dx, dw)
+        dx, dw = fused_kl_div_backward(do=do, dx=dx, dw=dw)
         return dx, None, dw, None, None, None
 
 

--- a/fla/modules/fused_linear_cross_entropy.py
+++ b/fla/modules/fused_linear_cross_entropy.py
@@ -154,7 +154,7 @@ def cross_entropy_kernel(
         return
 
     if reduction == "mean":
-        b_total = tl.maximum(tl.load(total), 1)
+        b_total = tl.load(total)
 
     # Online softmax: 2 loads + 1 store (compared with 3 loads + 1 store for the safe softmax)
     # Refer to Algorithm 3 in the paper: https://arxiv.org/pdf/1805.02867

--- a/fla/modules/fused_linear_cross_entropy.py
+++ b/fla/modules/fused_linear_cross_entropy.py
@@ -123,8 +123,8 @@ def cross_entropy_kernel(
             Pointer to tensor to store the loss.
         V (int):
             The number of columns in the input tensor.
-        total (int):
-            The number of non-ignored classes.
+        total:
+            Pointer to the number of non-ignored elements.
         ignore_index (int):
             The index to ignore in the target.
         label_smoothing (float):
@@ -152,6 +152,9 @@ def cross_entropy_kernel(
             o_v = i + tl.arange(0, BV)
             tl.store(logits + o_v, 0.0, mask=o_v < V)
         return
+
+    if reduction == "mean":
+        b_total = tl.maximum(tl.load(total), 1)
 
     # Online softmax: 2 loads + 1 store (compared with 3 loads + 1 store for the safe softmax)
     # Refer to Algorithm 3 in the paper: https://arxiv.org/pdf/1805.02867
@@ -203,7 +206,7 @@ def cross_entropy_kernel(
         if logit_softcapping is not None:
             b_p = b_p * (1.0 - b_t * b_t)
         if reduction == "mean":
-            b_p = b_p / total
+            b_p = b_p / b_total
         tl.store(logits + o_v, b_p, mask=o_v < V)
 
         tl.debug_barrier()
@@ -232,8 +235,8 @@ def cross_entropy_kernel(
 
     # Normalize the loss by the number of non-ignored elements if reduction is "mean"
     if reduction == 'mean':
-        b_loss = b_loss / total
-        b_l += (label_smoothing - 1) / total * logit_scale * b_sc_factor
+        b_loss = b_loss / b_total
+        b_l += (label_smoothing - 1) / b_total * logit_scale * b_sc_factor
     else:
         b_l += (label_smoothing - 1) * logit_scale * b_sc_factor
 
@@ -269,6 +272,8 @@ def elementwise_mul_kernel(
 
     # Load the gradient output value
     b_g = tl.load(g)
+    if b_g == 1.0:
+        return
     b_x = tl.load(x + o_x, mask=o_x < N)
     tl.store(x + o_x, b_x * b_g, mask=o_x < N)
 
@@ -322,7 +327,7 @@ def fused_linear_cross_entropy_forward(
     # [N]
     loss = torch.zeros(N, device=device, dtype=torch.float)
 
-    total = target.ne(ignore_index).sum().item()
+    total = target.ne(ignore_index).sum()
 
     for ic in range(NC):
         start, end = ic * C, min((ic + 1) * C, N)
@@ -417,41 +422,39 @@ def fused_linear_cross_entropy_backward(
     dw: torch.Tensor,
     db: torch.Tensor,
 ):
-    # If cross entropy is the last layer, do is 1.0. Skip the mul to save time
-    if torch.ne(do, torch.tensor(1.0, device=do.device)):
-        # We use a Triton kernel instead of a PyTorch operation because modifying inputs in-place
-        # for gradient storage and backward multiple times causes anomalies with PyTorch but not with Triton.
-        N, H = dx.shape
-        B = min(MAX_FUSED_SIZE, triton.next_power_of_2(H))
+    # We use a Triton kernel instead of a PyTorch operation because modifying inputs in-place
+    # for gradient storage and backward multiple times causes anomalies with PyTorch but not with Triton.
+    N, H = dx.shape
+    B = min(MAX_FUSED_SIZE, triton.next_power_of_2(H))
 
-        elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
-            x=dx,
+    elementwise_mul_kernel[(triton.cdiv(N * H, B),)](
+        x=dx,
+        g=do,
+        N=N*H,
+        B=B,
+        num_warps=STATIC_WARPS,
+    )
+
+    # handle dw
+    if dw is not None:
+        V, H = dw.shape
+        elementwise_mul_kernel[(triton.cdiv(V * H, B),)](
+            x=dw,
             g=do,
-            N=N*H,
+            N=V*H,
             B=B,
             num_warps=STATIC_WARPS,
         )
 
-        # handle dw
-        if dw is not None:
-            V, H = dw.shape
-            elementwise_mul_kernel[(triton.cdiv(V * H, B),)](
-                x=dw,
-                g=do,
-                N=V*H,
-                B=B,
-                num_warps=STATIC_WARPS,
-            )
-
-        if db is not None:
-            V = db.shape[0]
-            elementwise_mul_kernel[(triton.cdiv(V, B),)](
-                x=db,
-                g=do,
-                N=V,
-                B=B,
-                num_warps=STATIC_WARPS,
-            )
+    if db is not None:
+        V = db.shape[0]
+        elementwise_mul_kernel[(triton.cdiv(V, B),)](
+            x=db,
+            g=do,
+            N=V,
+            B=B,
+            num_warps=STATIC_WARPS,
+        )
     return dx, dw, db
 
 

--- a/fla/modules/fused_linear_cross_entropy.py
+++ b/fla/modules/fused_linear_cross_entropy.py
@@ -341,7 +341,7 @@ def fused_linear_cross_entropy_forward(
         c_target = target[start:end]
         # [C]
         # keep lse in fp32 to maintain precision
-        c_lse = logsumexp_fwd(c_logits, scale=logit_scale, softcapping=logit_softcapping, dtype=torch.float)
+        c_lse = logsumexp_fwd(x=c_logits, scale=logit_scale, softcapping=logit_softcapping, dtype=torch.float)
 
         # unreduced loss
         c_loss = loss[start:end]
@@ -522,19 +522,19 @@ class FusedLinearCrossEntropyFunction(torch.autograd.Function):
             back to the parameter dtype. Default: True
         """
         loss, dx, dw, db = fused_linear_cross_entropy_forward(
-            x,
-            target,
-            weight,
-            bias,
-            ignore_index,
-            label_smoothing,
-            logit_scale,
-            logit_softcapping,
-            num_chunks,
-            reduction,
-            use_l2warp,
-            l2_penalty_factor,
-            accumulate_grad_in_fp32,
+            x=x,
+            target=target,
+            weight=weight,
+            bias=bias,
+            ignore_index=ignore_index,
+            label_smoothing=label_smoothing,
+            logit_scale=logit_scale,
+            logit_softcapping=logit_softcapping,
+            num_chunks=num_chunks,
+            reduction=reduction,
+            use_l2warp=use_l2warp,
+            l2_penalty_factor=l2_penalty_factor,
+            accumulate_grad_in_fp32=accumulate_grad_in_fp32,
         )
         # downcast to dtype and store for backward
         ctx.save_for_backward(
@@ -548,7 +548,7 @@ class FusedLinearCrossEntropyFunction(torch.autograd.Function):
     @input_guard
     def backward(ctx, do):
         dx, dw, db = ctx.saved_tensors
-        dx, dw, db = fused_linear_cross_entropy_backward(do, dx, dw, db)
+        dx, dw, db = fused_linear_cross_entropy_backward(do=do, dx=dx, dw=dw, db=db)
         return dx, None, dw, db, None, None, None, None, None, None, None, None, None
 
 
@@ -700,8 +700,8 @@ class FusedLinearCrossEntropyLoss(nn.Module):
             loss
         """
         loss = fused_linear_cross_entropy_loss(
-            x.view(-1, x.shape[-1]),
-            target.view(-1),
+            x=x.view(-1, x.shape[-1]),
+            target=target.view(-1),
             weight=weight,
             bias=bias,
             ignore_index=self.ignore_index,

--- a/tests/modules/test_kl_div.py
+++ b/tests/modules/test_kl_div.py
@@ -8,18 +8,9 @@
 import pytest
 import torch
 import torch.nn.functional as F
-from torch.utils._python_dispatch import TorchDispatchMode
 
 from fla.modules import FusedKLDivLoss
 from fla.utils import assert_close, device, device_platform
-
-
-class RejectScalarExtraction(TorchDispatchMode):
-
-    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
-        if func is torch.ops.aten._local_scalar_dense.default:
-            raise AssertionError("Fused KL divergence must not extract a host scalar")
-        return func(*args, **(kwargs or {}))
 
 
 @pytest.mark.parametrize("B", [2])
@@ -65,34 +56,6 @@ def test_fused(
     tri.backward(do)
     tri_dx, x.grad = x.grad.clone(), None
     tri_dw, x_weight.grad = x_weight.grad.clone(), None
-
-    assert_close("  o", ref, tri, 1e-2)
-    assert_close(" dx", ref_dx, tri_dx, 1e-2)
-    assert_close(" dw", ref_dw, tri_dw, 1e-2)
-
-
-@pytest.mark.parametrize("grad_scale", [1.0, 0.375, 0.0, -1.0])
-@pytest.mark.parametrize("accumulate_grad_in_fp32", [False, True])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-@pytest.mark.skipif(device_platform == 'intel', reason="Intel Triton Failure")
-def test_fused_no_host_sync(grad_scale: float, accumulate_grad_in_fp32: bool, dtype: torch.dtype):
-    torch.manual_seed(42)
-    x = torch.randn(17, 32, device=device, dtype=dtype).requires_grad_()
-    weight = torch.randn(67, 32, device=device, dtype=dtype).requires_grad_()
-    target_x = torch.randn_like(x)
-    target_weight = torch.randn_like(weight)
-    do = torch.tensor(grad_scale, device=device, dtype=torch.float32)
-
-    ref = F.kl_div(
-        F.linear(x, weight).log_softmax(-1),
-        F.linear(target_x, target_weight).softmax(-1),
-        reduction='batchmean',
-    )
-    ref_dx, ref_dw = torch.autograd.grad(ref, (x, weight), grad_outputs=do)
-
-    with RejectScalarExtraction():
-        tri = FusedKLDivLoss(accumulate_grad_in_fp32=accumulate_grad_in_fp32)(x, target_x, weight, target_weight)
-        tri_dx, tri_dw = torch.autograd.grad(tri, (x, weight), grad_outputs=do)
 
     assert_close("  o", ref, tri, 1e-2)
     assert_close(" dx", ref_dx, tri_dx, 1e-2)

--- a/tests/modules/test_kl_div.py
+++ b/tests/modules/test_kl_div.py
@@ -8,9 +8,18 @@
 import pytest
 import torch
 import torch.nn.functional as F
+from torch.utils._python_dispatch import TorchDispatchMode
 
 from fla.modules import FusedKLDivLoss
 from fla.utils import assert_close, device, device_platform
+
+
+class RejectScalarExtraction(TorchDispatchMode):
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if func is torch.ops.aten._local_scalar_dense.default:
+            raise AssertionError("Fused KL divergence must not extract a host scalar")
+        return func(*args, **(kwargs or {}))
 
 
 @pytest.mark.parametrize("B", [2])
@@ -56,6 +65,34 @@ def test_fused(
     tri.backward(do)
     tri_dx, x.grad = x.grad.clone(), None
     tri_dw, x_weight.grad = x_weight.grad.clone(), None
+
+    assert_close("  o", ref, tri, 1e-2)
+    assert_close(" dx", ref_dx, tri_dx, 1e-2)
+    assert_close(" dw", ref_dw, tri_dw, 1e-2)
+
+
+@pytest.mark.parametrize("grad_scale", [1.0, 0.375, 0.0, -1.0])
+@pytest.mark.parametrize("accumulate_grad_in_fp32", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.skipif(device_platform == 'intel', reason="Intel Triton Failure")
+def test_fused_no_host_sync(grad_scale: float, accumulate_grad_in_fp32: bool, dtype: torch.dtype):
+    torch.manual_seed(42)
+    x = torch.randn(17, 32, device=device, dtype=dtype).requires_grad_()
+    weight = torch.randn(67, 32, device=device, dtype=dtype).requires_grad_()
+    target_x = torch.randn_like(x)
+    target_weight = torch.randn_like(weight)
+    do = torch.tensor(grad_scale, device=device, dtype=torch.float32)
+
+    ref = F.kl_div(
+        F.linear(x, weight).log_softmax(-1),
+        F.linear(target_x, target_weight).softmax(-1),
+        reduction='batchmean',
+    )
+    ref_dx, ref_dw = torch.autograd.grad(ref, (x, weight), grad_outputs=do)
+
+    with RejectScalarExtraction():
+        tri = FusedKLDivLoss(accumulate_grad_in_fp32=accumulate_grad_in_fp32)(x, target_x, weight, target_weight)
+        tri_dx, tri_dw = torch.autograd.grad(tri, (x, weight), grad_outputs=do)
 
     assert_close("  o", ref, tri, 1e-2)
     assert_close(" dx", ref_dx, tri_dx, 1e-2)


### PR DESCRIPTION
## Summary

Remove host scalar synchronizations from fused linear cross entropy and fused KL divergence on the default Triton and Ascend paths.

CE keeps the valid-token count on device. Both losses move the backward unit-gradient check into the existing scaling kernels: a gradient of 1 returns before reading or writing the saved gradients, while other gradients use the existing in-place multiplication. Public signatures, loss formulas, accumulation precision, chunking, and launch settings are unchanged.

## Test plan

- Dependent tests identified with `python scripts/find_dependent_tests.py` for the four changed production files.
- KL: the 29 existing cases selected by `python -m pytest tests/modules/test_kl_div.py -q --tb=short -k 'not (dtype0 and 100000 and 2048)'` passed. The four large FP32 cases at `V=100000, H=2048` exceed local 4 GB VRAM; the largest case reproduced the same OOM before and after the change. Existing tests are unchanged, and this PR adds no tests.
- Local validation rejects host scalar extraction during KL forward/backward and covers FP32/FP16/BF16, both accumulation modes, and upstream gradients 1, 0.375, 0, and -1.
- KL before/after: 48 configurations have bitwise-identical loss and input/weight gradients against `58374e5a`; another 12 `dw=None` backward cases are bitwise identical. CUDA Graph capture/replay matches eager execution when the upstream gradient changes between 1, 0.375, 0, and -1.
- CE validation: 40 fused linear CE cases passed, plus 12 local ignore-index edge cases. Loss/input/weight/bias gradients match the pre-review implementation bitwise, and CUDA Graph capture passed. Related L2Warp/model tests: 19 passed; DeltaFormer and PaTHAttention fail in unchanged `use_cache` handling before fused CE is called.
- Pre-commit checks passed. Ascend received static/lint validation only; NPU runtime validation remains pending. Existing Ascend block sizes and `num_warps=STATIC_WARPS` launch arguments are preserved.

## Benchmark / NCU (kernel changes only)

Hardware: NVIDIA RTX A1000 Laptop GPU (4 GB), PyTorch 2.13.0+cu130, Triton 3.7.1. BF16 forward + backward with FP32 weight-gradient accumulation. CUDA-event latency, median of alternating before/after trials with 50 iterations per trial. KL uses seven trials against `58374e5a`; CE uses the previously recorded five trials against `34682796` and includes bias with every fifth target ignored.

| Loss | N   | H   | V     | upstream grad | before   | after    | latency reduction |
| ---- | --- | --- | ----- | ------------- | -------- | -------- | ----------------- |
| KL   | 32  | 256 | 4096  | 1.0           | 1.132 ms | 0.964 ms | 14.8%             |
| KL   | 32  | 256 | 4096  | 0.375         | 1.191 ms | 0.978 ms | 17.9%             |
| KL   | 128 | 512 | 16384 | 1.0           | 5.874 ms | 5.824 ms | 0.9%              |
| KL   | 128 | 512 | 16384 | 0.375         | 6.324 ms | 6.256 ms | 1.1%              |
| CE   | 32  | 256 | 4096  | 1.0           | 2.092 ms | 2.070 ms | 1.1%              |
| CE   | 32  | 256 | 4096  | 0.375         | 2.139 ms | 1.963 ms | 8.2%              |
| CE   | 128 | 512 | 16384 | 1.0           | 5.461 ms | 5.213 ms | 4.5%              |
| CE   | 128 | 512 | 16384 | 0.375         | 5.770 ms | 5.647 ms | 2.1%              |


PyTorch profiler confirms that each KL call removes one `aten::_local_scalar_dense`, one HtoD scalar copy, one DtoH scalar copy, and two associated `cudaStreamSynchronize` calls for both unit and non-unit upstream gradients. Nsight Compute full/source collections were attempted but both returned `ERR_NVGPUCTRPERM`; no hardware-counter results are claimed.

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
