### PR TITLE
[CI] One-shot H100 runner disk cleanup

### DIFF
--- a/.github/workflows/runner-cleanup-oneshot.yml
+++ b/.github/workflows/runner-cleanup-oneshot.yml
@@ -1,0 +1,45 @@
+name: runner-cleanup-oneshot
+
+# One-shot runner maintenance PR: runs directly on the self-hosted H100 runner
+# to reclaim disk (triton/pip/pytest caches) and print diagnostics.
+# This PR is opened only to execute the job and is closed unmerged afterwards.
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: One-shot disk cleanup
+    runs-on: nvidia-h100-1
+    timeout-minutes: 20
+    steps:
+      - name: Diagnose before cleanup
+        shell: bash
+        run: |
+          echo "== context =="
+          whoami; echo "HOME=$HOME"; echo "container=${container:-not-in-container}"
+          echo "== df =="
+          df -h /
+          echo "== home top =="
+          du -x -d1 -h "$HOME" 2>/dev/null | sort -rh | head -10 || true
+          echo "== runner work =="
+          du -sh /home/ubuntu/actions-runner/_work 2>/dev/null || true
+          du -x -d1 -h /home/ubuntu/actions-runner/_work 2>/dev/null | sort -rh | head -8 || true
+          echo "== docker =="
+          (docker system df 2>/dev/null || sudo -n docker system df 2>/dev/null) || echo "no docker access"
+          echo "== root top (sudo if allowed) =="
+          sudo -n du -x -d1 -h / 2>/dev/null | sort -rh | head -8 || echo "no passwordless sudo"
+
+      - name: Clean triton, pip and pytest caches
+        shell: bash
+        run: |
+          rm -rf ~/.triton ~/.cache
+          find /home/ubuntu /github /tmp -maxdepth 4 -name '.pytest_cache' -prune -exec rm -rf {} + 2>/dev/null || true
+
+      - name: Disk usage after
+        shell: bash
+        run: df -h /


### PR DESCRIPTION
## Summary

One-shot runner maintenance PR — **will be closed unmerged after the job runs**.

The self-hosted H100 runner is out of disk (13 MB free at job start; the last several jobs died in `Setup CI Environment`). This PR exists only to execute a cleanup job directly on the runner (`pull_request`-triggered workflows run from the PR branch, so no change to `main` is needed):

- prints disk diagnostics (df / du / docker df) for follow-up decisions,
- deletes `~/.triton`, `~/.cache`, and stray `.pytest_cache` directories,
- prints disk usage after cleanup.

The commit message carries `[skip test]` so the regular pipelines no-op on this PR; the heavy runs are cancelled manually right after opening.

## Test plan

This PR *is* the test: the cleanup job runs on `nvidia-h100-1` and its log shows disk usage before/after.

## Benchmark / NCU (kernel changes only)

Neutral — no kernel code changed (CI runner maintenance only).

## Breaking changes

None.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
