### PR TITLE
[GDN] Restrict Blackwell chunk_fwd_o to <= 4 warps

### DIFF
--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -15,6 +15,7 @@ from fla.ops.utils.cache import fla_cache_autotune
 from fla.ops.utils.op import exp2
 from fla.utils import (
     IS_INTEL,
+    IS_NVIDIA_BLACKWELL,
     IS_NVIDIA_HOPPER,
     TRITON_ABOVE_3_4_0,
     TRITON_ABOVE_3_7_1,
@@ -29,8 +30,15 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
 # On Intel that pairing is off by a factor of two: BK=BV=64 is fastest at 8 warps but is
 # only offered at 4, so the autotuner falls back to the 32x32 config and leaves ~2.2x on
 # the table. Widen the space there instead of changing the defaults for other vendors.
-_O_CONFIGS = [
+# TODO: Triton mainline fixes a Blackwell tl.dot recurrence race.
+# Keep this kernel off its 8-warp (BK=BV=128) config for Blackwell until Triton 3.8
+# is released and we re-validate the wider config space.
+CHUNK_FWD_O_BLACKWELL_DROPPED_CONFIGS = [] if IS_NVIDIA_BLACKWELL else [
     triton.Config({'BK': 128, 'BV': 128}, num_warps=8, num_stages=3),
+]
+
+_O_CONFIGS = [
+    *CHUNK_FWD_O_BLACKWELL_DROPPED_CONFIGS,
     triton.Config({'BK': 64, 'BV': 64}, num_warps=4, num_stages=3),
     triton.Config({'BK': 32, 'BV': 32}, num_warps=2, num_stages=3),
 ]

--- a/tests/ops/test_gdn.py
+++ b/tests/ops/test_gdn.py
@@ -45,6 +45,19 @@ def test_chunk_gated_delta_rule_fwd_h_blackwell_triton_guard():
     assert {config.num_warps for config in tuner.configs} == {2}
 
 
+def test_chunk_fwd_o_blackwell_triton_guard():
+    if not IS_NVIDIA_BLACKWELL:
+        pytest.skip(reason='Blackwell guard is only active on Blackwell GPUs')
+
+    from fla.ops.common.chunk_o import chunk_fwd_kernel_o
+
+    tuner = _unwrap_autotuner(chunk_fwd_kernel_o)
+    # The 8-warp (BK=BV=128) config yields distinct outputs for identical
+    # inputs on Blackwell / Triton<3.8 (tl.dot recurrence race). The guard
+    # drops it, so no offered config may run more than 4 warps.
+    assert all(config.num_warps <= 4 for config in tuner.configs)
+
+
 @pytest.mark.parametrize(
     ('B', 'T', 'H', 'HV', 'D', 'scale', 'gate_logit_normalizer', 'dtype'),
     [


### PR DESCRIPTION
## Summary

Fixes #1228

`chunk_fwd_o` is nondeterministic on Blackwell (GB300, sm_103) under Triton 3.6 whenever its 8-warp (`BK=BV=128`) config is selected: it yields bitwise-different outputs for identical inputs, which flips MoE expert routes in production GRPO training (13-23% of tokens per step; zero with the config gated out — full data in the issue).

This is the same Triton `tl.dot` recurrence race class as the fwd_h kernel (PR #953), reached through a config the PR #1062 rewrite added; the #953 gate does not cover it.

Drop the 8-warp config for `chunk_fwd_o` on Blackwell until Triton 3.8 is released and the wider space is re-validated, mirroring the PR #953 approach for fwd_h: a named arch-gated constant (`CHUNK_FWD_O_BLACKWELL_DROPPED_CONFIGS`) holding the dropped entry, with the same TODO-comment form as #953/#1000. On every other architecture the config list is unchanged. Adds the matching config-space test, mirroring #953's test for the fwd_h guard.

## Test plan

- `pytest tests/ops/test_gdn.py::test_chunk_fwd_o_blackwell_triton_guard -v` — new test; passes on Blackwell (config space for `chunk_fwd_kernel_o` offers no config above 4 warps) and skips elsewhere, same guard structure as #953's test.
- Verified the constructed config list is identical to the original on all architectures: Blackwell (2 configs, 8-warp entry dropped), non-Blackwell NVIDIA (3 configs, unchanged), Intel (13 configs, widening block unchanged).
- Production validation on GB300 (Triton 3.6, Qwen3.5-397B GDN head shapes, 10 training steps per arm): with the gate, zero MoE route changes between identical forwards over 1.97M token comparisons; without the gate, 338,499 comparisons nonzero (13-23% of tokens per step). On a Triton 3.8 build the whole standalone matrix is deterministic with or without the gate, consistent with the upstream compiler fix.

## Benchmark / NCU (kernel changes only)

Neutral perf: the gate only removes the 8-warp config on Blackwell; the autotuner's next pick (BK=BV=64, 4 warps) was already selected in our gated production runs, with no measurable step-time difference. On all other architectures the config space is byte-identical.

## Breaking changes

None. The autotune space for `chunk_fwd_kernel_o` changes only on Blackwell, where the dropped config is nondeterministic under Triton 3.6/3.7.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.

### If you ticked the "minor" box above

N/A — this is a determinism fix with a matching test.
