### PR TITLE
[Attn] Add standard attention backend support for Ascend NPU

### DIFF
--- a/.github/workflows/ascend-a2-ci.yml
+++ b/.github/workflows/ascend-a2-ci.yml
@@ -52,7 +52,7 @@ jobs:
             // Unlike the H100 'npu_only' detection, __init__.py is NOT excluded
             // here: a change to it affects the NPU backend too, so it should
             // trigger this CI.
-            const npuPattern = /^fla\/(.+\/)?backends\/triton_ascend\/|^\.github\/workflows\/ascend-|^pyproject\.toml$|^fla\/utils\/|^fla\/modules\/|^tests\/conftest\.py$/;
+            const npuPattern = /^fla\/(.+\/)?backends\/triton_ascend\/|^\.github\/workflows\/ascend-|^pyproject\.toml$|^fla\/utils\/|^fla\/modules\/|^fla\/layers\/attn\.py$|^fla\/ops\/attn\/standard\.py$|^tests\/layers\/test_standard_attention(_npu)?\.py$|^tests\/models\/test_standard_attention_transformers_npu\.py$|^tests\/conftest\.py$/;
             const related = files.filter(f => npuPattern.test(f.filename)).map(f => f.filename);
             if (related.length > 0) {
               core.info('NPU-related files changed: ' + related.join(', '));
@@ -156,4 +156,6 @@ jobs:
             tests/ops/test_kda.py \
             tests/ops/test_gla.py \
             tests/ops/test_attnres.py \
-            tests/ops/test_solve_tril.py
+            tests/ops/test_solve_tril.py \
+            tests/layers/test_standard_attention_npu.py \
+            tests/models/test_standard_attention_transformers_npu.py

--- a/fla/layers/attn.py
+++ b/fla/layers/attn.py
@@ -7,16 +7,15 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
 from einops import rearrange
-from transformers.utils import logging
 
 from fla.layers.utils import pad_input, unpad_input
 from fla.modules import RMSNorm, RotaryEmbedding
+from fla.ops.attn.standard import standard_attention
 from fla.ops.utils.index import prepare_lens_from_mask
 
 if TYPE_CHECKING:
@@ -25,13 +24,7 @@ if TYPE_CHECKING:
 try:
     from flash_attn import flash_attn_func, flash_attn_varlen_func
 except ImportError:
-    warnings.warn(
-        "Flash Attention is not installed. Please install it via `pip install flash-attn --no-build-isolation`",
-        category=ImportWarning,
-    )
-    flash_attn_func = None
-
-logger = logging.get_logger(__name__)
+    flash_attn_func = flash_attn_varlen_func = None
 
 
 class Attention(nn.Module):
@@ -67,9 +60,6 @@ class Attention(nn.Module):
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
         self.layer_idx = layer_idx
-
-        if flash_attn_func is None:
-            raise ImportError("Please install Flash Attention via `pip install flash-attn --no-build-isolation` first")
 
         self.q_proj = nn.Linear(self.hidden_size, self.hidden_size, bias=self.qkv_bias)
         self.k_proj = nn.Linear(self.hidden_size, self.kv_dim, bias=self.qkv_bias)
@@ -146,18 +136,18 @@ class Attention(nn.Module):
             q, (k, v), indices_q, cu_seqlens, max_seq_lens = unpad_input(q, (k, v), attention_mask, q_len)
             cu_seqlens_q, cu_seqlens_k = cu_seqlens
             max_seqlen_q, max_seqlen_k = max_seq_lens
-            o = flash_attn_varlen_func(
+            o = standard_attention(
                 q, k, v,
                 cu_seqlens_q=cu_seqlens_q,
                 cu_seqlens_k=cu_seqlens_k,
                 max_seqlen_q=max_seqlen_q,
                 max_seqlen_k=max_seqlen_k,
                 causal=True,
-                window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0),
+                window_size=self.window_size,
             )
             o = pad_input(o, indices_q, batch_size, q_len)
         elif cu_seqlens is not None:
-            o = flash_attn_varlen_func(
+            o = standard_attention(
                 rearrange(q, 'b l ... -> (b l) ...').contiguous(),
                 rearrange(k, 'b l ... -> (b l) ...').contiguous(),
                 rearrange(v, 'b l ... -> (b l) ...').contiguous(),
@@ -166,19 +156,20 @@ class Attention(nn.Module):
                 max_seqlen_q=max_seqlen,
                 max_seqlen_k=max_seqlen,
                 causal=True,
-                window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0),
+                window_size=self.window_size,
             )
             o = rearrange(o, '(b l) h d -> b l h d', b=batch_size, l=q_len)
         else:
-            o = flash_attn_func(
+            o = standard_attention(
                 q, k, v,
                 causal=True,
-                window_size=(-1, -1) if self.window_size is None else (self.window_size-1, 0),
+                window_size=self.window_size,
             )
         o = o.reshape(batch_size, q_len, -1)
         o = self.o_proj(o)
 
-        if not output_attentions:
-            attentions = None
+        # Standard Attention has historically not materialized attention
+        # weights.  Keep that API contract explicit for every backend.
+        attentions = None
 
         return o, attentions, past_key_values

--- a/fla/models/gla/modeling_gla.py
+++ b/fla/models/gla/modeling_gla.py
@@ -345,7 +345,14 @@ class GLAModel(GLAPreTrainedModel):
 
 class GLAForCausalLM(GLAPreTrainedModel, FLAUnsupportedCacheGenerationMixin):
 
-    _tied_weights_keys = ["lm_head.weight"]
+    # transformers 5 expects target-to-source mappings, while 4.x uses a list
+    # of regex patterns.  Keep both forms so save_pretrained remains usable
+    # across the supported transformers range.
+    _tied_weights_keys = (
+        {"lm_head.weight": "model.embeddings.weight"}
+        if hasattr(PreTrainedModel, 'get_expanded_tied_weights_keys')
+        else ["lm_head.weight"]
+    )
 
     def __init__(self, config):
         super().__init__(config)

--- a/fla/ops/attn/__init__.py
+++ b/fla/ops/attn/__init__.py
@@ -7,8 +7,11 @@
 
 from .naive import naive_parallel_attn
 from .parallel import parallel_attn
+from .standard import select_standard_attention_backend, standard_attention
 
 __all__ = [
     'naive_parallel_attn',
     'parallel_attn',
+    'select_standard_attention_backend',
+    'standard_attention',
 ]

--- a/fla/ops/attn/standard.py
+++ b/fla/ops/attn/standard.py
@@ -1,0 +1,639 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Backend-neutral implementation of standard causal attention.
+
+The linear-attention operators in :mod:`fla.ops.attn` have different
+semantics from the full attention layer in ``fla.layers.attn``.  This module
+therefore provides a small, explicit backend boundary for the latter instead
+of routing it through the linear-attention dispatch table.
+
+The public function accepts the layout used by ``fla.layers.attn``:
+
+* dense: ``[B, S, H, D]``;
+* packed/varlen: ``[T, H, D]`` plus cumulative sequence lengths.
+
+The fallback implementations intentionally favour semantic correctness.  In
+particular, the causal mask is bottom-right aligned when ``S_q != S_kv``;
+this is required for decoding with a populated KV cache.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+_BACKEND_ENV = "FLA_STANDARD_ATTN_BACKEND"
+_VALID_BACKENDS = {"auto", "flash_attn", "npu", "sdpa", "reference"}
+_MAX_INT = 2**31 - 1
+
+
+@lru_cache(maxsize=1)
+def _load_flash_attention():
+    try:
+        from flash_attn import flash_attn_func, flash_attn_varlen_func
+    except ImportError:
+        return None, None
+    return flash_attn_func, flash_attn_varlen_func
+
+
+@lru_cache(maxsize=1)
+def _load_torch_npu():
+    try:
+        import torch_npu
+    except (ImportError, RuntimeError, OSError) as exc:
+        logger.debug("Unable to load torch_npu: %s", exc)
+        return None
+    return torch_npu
+
+
+def _requested_backend() -> str:
+    backend = os.environ.get(_BACKEND_ENV, "auto").strip().lower()
+    if backend not in _VALID_BACKENDS:
+        raise ValueError(
+            f"{_BACKEND_ENV}={backend!r} is invalid; expected one of "
+            f"{sorted(_VALID_BACKENDS)}"
+        )
+    return backend
+
+
+def _has_grad(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> bool:
+    return torch.is_grad_enabled() and (q.requires_grad or k.requires_grad or v.requires_grad)
+
+
+def _is_npu_tensor(x: torch.Tensor) -> bool:
+    return x.device.type == "npu"
+
+
+def _can_use_npu(q: torch.Tensor, *, packed: bool, training: bool) -> bool:
+    """Return whether the currently installed torch_npu exposes a usable op.
+
+    The NPU implementation deliberately starts with dense BNSD input.  The
+    TND/varlen contract differs across CANN and torch_npu releases, so packed
+    input stays on the reference/SDPA path until it has a version-specific
+    test.  This avoids silently assigning the wrong sequence lengths.
+    """
+    if not _is_npu_tensor(q) or packed:
+        return False
+    torch_npu = _load_torch_npu()
+    if torch_npu is None:
+        return False
+    if training:
+        return callable(getattr(torch_npu, "npu_fusion_attention", None))
+    return callable(getattr(torch_npu, "npu_fused_infer_attention_score", None))
+
+
+def select_standard_attention_backend(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    packed: bool = False,
+    training: bool | None = None,
+) -> str:
+    """Select and validate a standard-attention backend.
+
+    ``auto`` prefers the native backend for the current device, then CUDA
+    FlashAttention, SDPA for dense tensors, and finally the reference path.
+    A forced backend fails early with a useful error instead of silently
+    changing the requested execution policy.
+    """
+    requested = _requested_backend()
+    if training is None:
+        training = _has_grad(q, k, v)
+    flash_func, flash_varlen_func = _load_flash_attention()
+
+    if requested == "auto":
+        if _can_use_npu(q, packed=packed, training=training):
+            return "npu"
+        # The initial native path is dense-only.  SDPA support for packed
+        # tensors is version-dependent on Ascend, while the reference loop
+        # preserves the cu_seqlens contract on every torch_npu release.
+        if q.device.type == "npu" and packed:
+            return "reference"
+        if q.device.type in {"cuda", "hip"} and (flash_varlen_func if packed else flash_func) is not None:
+            return "flash_attn"
+        if hasattr(F, "scaled_dot_product_attention"):
+            return "sdpa"
+        return "reference"
+
+    if requested == "flash_attn":
+        if q.device.type not in {"cuda", "hip"}:
+            raise RuntimeError("flash_attn backend requires a CUDA/HIP tensor")
+        if (flash_varlen_func if packed else flash_func) is None:
+            raise RuntimeError(
+                "FLA_STANDARD_ATTN_BACKEND=flash_attn requires flash-attn; "
+                "it is not an Ascend NPU backend"
+            )
+        return requested
+
+    if requested == "npu":
+        if not _is_npu_tensor(q):
+            raise RuntimeError("FLA_STANDARD_ATTN_BACKEND=npu requires an NPU tensor")
+        if not _can_use_npu(q, packed=packed, training=training):
+            mode = "training" if training else "inference"
+            raise RuntimeError(
+                f"the installed torch_npu does not expose a supported dense {mode} "
+                "standard-attention operator for this input"
+            )
+        return requested
+
+    if requested == "sdpa" and not hasattr(F, "scaled_dot_product_attention"):
+        raise RuntimeError("FLA_STANDARD_ATTN_BACKEND=sdpa requires torch SDPA support")
+
+    return requested
+
+
+def _causal_mask(
+    q_len: int,
+    kv_len: int,
+    *,
+    device: torch.device,
+    query_start: int | None,
+    window_size: int | None,
+) -> torch.Tensor:
+    """Build a boolean mask where True means masked.
+
+    Query positions are aligned to the end of the KV sequence by default.
+    Thus a one-token query over a cached KV sequence can attend to all cached
+    tokens instead of only to key position zero.
+    """
+    if q_len == 0 or kv_len == 0:
+        return torch.ones((q_len, kv_len), dtype=torch.bool, device=device)
+    if query_start is None:
+        query_start = kv_len - q_len
+    q_positions = torch.arange(q_len, device=device, dtype=torch.long) + query_start
+    k_positions = torch.arange(kv_len, device=device, dtype=torch.long)
+    mask = k_positions[None, :] > q_positions[:, None]
+    if window_size is not None:
+        if window_size <= 0:
+            raise ValueError(f"window_size must be positive, got {window_size}")
+        mask |= k_positions[None, :] < q_positions[:, None] - window_size + 1
+    return mask
+
+
+def _expand_kv_heads(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q_heads = q.shape[-3]
+    kv_heads = k.shape[-3]
+    if q_heads % kv_heads != 0:
+        raise ValueError(f"query heads ({q_heads}) must be divisible by KV heads ({kv_heads})")
+    if q_heads == kv_heads:
+        return k, v
+    groups = q_heads // kv_heads
+    return k.repeat_interleave(groups, dim=-3), v.repeat_interleave(groups, dim=-3)
+
+
+def _reference_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    causal: bool,
+    window_size: int | None,
+    query_start: int | None,
+) -> torch.Tensor:
+    # [B, S, H, D] -> [B, H, S, D]
+    q_bhsd = q.transpose(1, 2)
+    k_bhsd = k.transpose(1, 2)
+    v_bhsd = v.transpose(1, 2)
+    k_bhsd, v_bhsd = _expand_kv_heads(q_bhsd, k_bhsd, v_bhsd)
+    scores = torch.matmul(q_bhsd, k_bhsd.transpose(-2, -1)) * scale
+    if causal:
+        mask = _causal_mask(
+            q.shape[1], k.shape[1], device=q.device, query_start=query_start, window_size=window_size
+        )
+        scores = scores.masked_fill(mask, torch.finfo(scores.dtype).min)
+    probs = torch.softmax(scores, dim=-1)
+    if causal and scores.shape[-1] > 0:
+        invalid_rows = mask.all(dim=-1, keepdim=True)
+        probs = torch.where(invalid_rows, torch.zeros_like(probs), probs)
+    return torch.matmul(probs, v_bhsd).transpose(1, 2)
+
+
+def _packed_lengths(
+    cu_seqlens: torch.Tensor,
+    total_length: int,
+    name: str,
+) -> list[int]:
+    if cu_seqlens.ndim != 1 or cu_seqlens.numel() < 2:
+        raise ValueError(f"{name} must be a 1-D cumulative sequence-length tensor with at least two entries")
+    if cu_seqlens.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"{name} must use int32 or int64 dtype")
+    lengths = [int(value) for value in cu_seqlens.detach().cpu().tolist()]
+    if lengths[0] != 0:
+        raise ValueError(f"{name} must start at 0")
+    if any(end < start for start, end in zip(lengths, lengths[1:])):
+        raise ValueError(f"{name} must be non-decreasing")
+    if lengths[-1] != total_length:
+        raise ValueError(f"{name} must end at the packed tensor length ({total_length}), got {lengths[-1]}")
+    return lengths
+
+
+def _validate_packed_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int | None,
+    max_seqlen_k: int | None,
+) -> tuple[list[int], list[int]]:
+    q_lens = _packed_lengths(cu_seqlens_q, q.shape[0], "cu_seqlens_q")
+    k_lens = _packed_lengths(cu_seqlens_k, k.shape[0], "cu_seqlens_k")
+    if len(q_lens) != len(k_lens):
+        raise ValueError("query and KV cumulative sequence lengths must have the same batch size")
+    if max_seqlen_q is not None and max_seqlen_q < max(end - start for start, end in zip(q_lens, q_lens[1:])):
+        raise ValueError("max_seqlen_q is smaller than a packed query sequence")
+    if max_seqlen_k is not None and max_seqlen_k < max(end - start for start, end in zip(k_lens, k_lens[1:])):
+        raise ValueError("max_seqlen_k is smaller than a packed KV sequence")
+    return q_lens, k_lens
+
+
+def _sdpa_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    causal: bool,
+    window_size: int | None,
+    query_start: int | None,
+) -> torch.Tensor:
+    q_bhsd = q.transpose(1, 2)
+    k_bhsd = k.transpose(1, 2)
+    v_bhsd = v.transpose(1, 2)
+    k_bhsd, v_bhsd = _expand_kv_heads(q_bhsd, k_bhsd, v_bhsd)
+    mask = None
+    if causal:
+        mask = ~_causal_mask(
+            q.shape[1], k.shape[1], device=q.device, query_start=query_start, window_size=window_size
+        )
+    output = F.scaled_dot_product_attention(
+        q_bhsd,
+        k_bhsd,
+        v_bhsd,
+        attn_mask=mask,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    )
+    return output.transpose(1, 2)
+
+
+def _reference_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    *,
+    scale: float,
+    causal: bool,
+    window_size: int | None,
+) -> torch.Tensor:
+    if q.ndim != 3 or k.ndim != 3 or v.ndim != 3:
+        raise ValueError("packed standard attention expects q, k, v with shape [T, H, D]")
+    q_lens = _packed_lengths(cu_seqlens_q, q.shape[0], "cu_seqlens_q")
+    k_lens = _packed_lengths(cu_seqlens_k, k.shape[0], "cu_seqlens_k")
+    if len(q_lens) != len(k_lens):
+        raise ValueError("query and KV cumulative sequence lengths must have the same batch size")
+    outputs = []
+    for i in range(len(q_lens) - 1):
+        q_start, q_end = int(q_lens[i]), int(q_lens[i + 1])
+        k_start, k_end = int(k_lens[i]), int(k_lens[i + 1])
+        q_i = q[q_start:q_end].unsqueeze(0)
+        k_i = k[k_start:k_end].unsqueeze(0)
+        v_i = v[k_start:k_end].unsqueeze(0)
+        query_start = (k_end - k_start) - (q_end - q_start)
+        output = _reference_dense(
+            q_i,
+            k_i,
+            v_i,
+            scale=scale,
+            causal=causal,
+            window_size=window_size,
+            query_start=query_start,
+        )
+        outputs.append(output.squeeze(0))
+    if not outputs:
+        return q.new_empty((0, q.shape[-2], v.shape[-1]))
+    return torch.cat(outputs, dim=0)
+
+
+def _sdpa_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    *,
+    scale: float,
+    causal: bool,
+    window_size: int | None,
+) -> torch.Tensor:
+    # SDPA does not accept ragged tensors.  The per-sequence loop preserves
+    # semantics and is intentionally used only as a correctness fallback.
+    q_lens = _packed_lengths(cu_seqlens_q, q.shape[0], "cu_seqlens_q")
+    k_lens = _packed_lengths(cu_seqlens_k, k.shape[0], "cu_seqlens_k")
+    outputs = []
+    for i in range(len(q_lens) - 1):
+        q_start, q_end = int(q_lens[i]), int(q_lens[i + 1])
+        k_start, k_end = int(k_lens[i]), int(k_lens[i + 1])
+        query_start = (k_end - k_start) - (q_end - q_start)
+        outputs.append(
+            _sdpa_dense(
+                q[q_start:q_end].unsqueeze(0),
+                k[k_start:k_end].unsqueeze(0),
+                v[k_start:k_end].unsqueeze(0),
+                scale=scale,
+                causal=causal,
+                window_size=window_size,
+                query_start=query_start,
+            ).squeeze(0)
+        )
+    if not outputs:
+        return q.new_empty((0, q.shape[-2], v.shape[-1]))
+    return torch.cat(outputs, dim=0)
+
+
+def _flash_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    causal: bool,
+    window_size: int | None,
+    cu_seqlens_q: torch.Tensor | None,
+    cu_seqlens_k: torch.Tensor | None,
+    max_seqlen_q: int | None,
+    max_seqlen_k: int | None,
+) -> torch.Tensor:
+    flash_func, flash_varlen_func = _load_flash_attention()
+    window = (-1, -1) if window_size is None else (window_size - 1, 0)
+    kwargs: dict[str, Any] = dict(causal=causal, window_size=window)
+    # The layer historically relied on FlashAttention's default scale.  Pass
+    # the explicit value so all backends share the same contract.
+    kwargs["softmax_scale"] = scale
+    if q.ndim == 4:
+        if flash_func is None:
+            raise RuntimeError("flash-attn is not installed")
+        return flash_func(q, k, v, **kwargs)
+    if flash_varlen_func is None:
+        raise RuntimeError("flash-attn varlen support is not installed")
+    if cu_seqlens_q is None or cu_seqlens_k is None or max_seqlen_q is None or max_seqlen_k is None:
+        raise ValueError("varlen FlashAttention requires cumulative and maximum sequence lengths")
+    return flash_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        **kwargs,
+    )
+
+
+def _npu_mask(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    *,
+    causal: bool,
+    window_size: int | None,
+    query_start: int | None,
+) -> torch.Tensor | None:
+    if not causal:
+        return None
+    return _causal_mask(
+        q.shape[1], k.shape[1], device=q.device, query_start=query_start, window_size=window_size
+    ).contiguous()
+
+
+def _npu_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    causal: bool,
+    window_size: int | None,
+    query_start: int | None,
+    training: bool,
+) -> torch.Tensor:
+    torch_npu = _load_torch_npu()
+    if torch_npu is None:
+        raise RuntimeError("torch_npu could not be imported; check CANN environment variables")
+
+    q_bnsd = q.transpose(1, 2).contiguous()
+    k_bnsd = k.transpose(1, 2).contiguous()
+    v_bnsd = v.transpose(1, 2).contiguous()
+    q_heads, kv_heads = q.shape[2], k.shape[2]
+    mask = _npu_mask(q, k, causal=causal, window_size=window_size, query_start=query_start)
+    if mask is not None:
+        effective_query_start = k.shape[1] - q.shape[1] if query_start is None else query_start
+        if q.shape[1] == 1 and (
+            effective_query_start < k.shape[1] - 1
+            or (window_size is not None and window_size < k.shape[1])
+        ):
+            raise RuntimeError(
+                "native Ascend inference does not guarantee a masked single-query row; "
+                "use the generic backend for this query_start/window"
+            )
+        if effective_query_start < 0:
+            raise RuntimeError(
+                "native Ascend standard attention does not guarantee fully masked rows; "
+                "use the generic backend when query length exceeds KV length"
+            )
+    # An explicit mask is needed for bottom-right cache alignment and windows.
+    # allMask makes the NPU operator consume exactly this matrix instead of
+    # applying a second top-left sparse range from pre/next_tokens.
+    sparse_mode = 1 if mask is not None else 0
+
+    if training:
+        func = getattr(torch_npu, "npu_fusion_attention", None)
+        if not callable(func):
+            raise RuntimeError("torch_npu.npu_fusion_attention is unavailable for training")
+        result = func(
+            q_bnsd,
+            k_bnsd,
+            v_bnsd,
+            q_heads,
+            "BNSD",
+            atten_mask=mask,
+            scale=scale,
+            keep_prob=1.0,
+            pre_tockens=_MAX_INT,
+            next_tockens=_MAX_INT,
+            sparse_mode=sparse_mode,
+        )
+        output = result[0] if isinstance(result, (tuple, list)) else result
+    else:
+        func = getattr(torch_npu, "npu_fused_infer_attention_score", None)
+        if not callable(func):
+            raise RuntimeError("torch_npu.npu_fused_infer_attention_score is unavailable for inference")
+        result = func(
+            q_bnsd,
+            k_bnsd,
+            v_bnsd,
+            atten_mask=mask,
+            num_heads=q_heads,
+            num_key_value_heads=kv_heads,
+            scale=scale,
+            pre_tokens=_MAX_INT,
+            next_tokens=_MAX_INT,
+            input_layout="BNSD",
+            sparse_mode=sparse_mode,
+        )
+        output = result[0] if isinstance(result, (tuple, list)) else result
+    return output.transpose(1, 2).contiguous()
+
+
+def standard_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float | None = None,
+    causal: bool = True,
+    window_size: int | None = None,
+    cu_seqlens_q: torch.Tensor | None = None,
+    cu_seqlens_k: torch.Tensor | None = None,
+    max_seqlen_q: int | None = None,
+    max_seqlen_k: int | None = None,
+    query_start: int | None = None,
+    training: bool | None = None,
+) -> torch.Tensor:
+    """Compute standard attention through the selected backend.
+
+    Args:
+        q, k, v: Dense ``[B, S, H, D]`` or packed ``[T, H, D]`` tensors.
+        cu_seqlens_q, cu_seqlens_k: Cumulative lengths for packed inputs.
+        query_start: Absolute start position of dense queries in the KV
+            sequence.  When omitted, bottom-right alignment is inferred.
+    """
+    if q.ndim not in (3, 4) or k.ndim != q.ndim or v.ndim != q.ndim:
+        raise ValueError("standard attention expects all inputs to be 3-D packed or 4-D dense tensors")
+    if q.device != k.device or q.device != v.device:
+        raise ValueError("q, k and v must be on the same device")
+    if q.dtype != k.dtype or q.dtype != v.dtype:
+        raise ValueError("q, k and v must have the same dtype")
+    if q.shape[-1] != k.shape[-1]:
+        raise ValueError("q and k head dimensions must match")
+    if q.ndim == 4 and (q.shape[0] != k.shape[0] or k.shape[0] != v.shape[0]):
+        raise ValueError("dense q, k and v must have the same batch size")
+    if q.shape[-2] == 0 or k.shape[-2] == 0:
+        raise ValueError("q, k and v must have at least one attention head")
+    packed = q.ndim == 3
+    k_sequence_dim = 0 if packed else 1
+    if k.shape[k_sequence_dim] != v.shape[k_sequence_dim] or k.shape[-2] != v.shape[-2]:
+        raise ValueError("k and v must have matching sequence and head dimensions")
+    if q.shape[-2] % k.shape[-2] != 0:
+        raise ValueError(f"query heads ({q.shape[-2]}) must be divisible by KV heads ({k.shape[-2]})")
+    if packed and (cu_seqlens_q is None or cu_seqlens_k is None):
+        raise ValueError("packed standard attention requires cu_seqlens_q and cu_seqlens_k")
+    if not packed and (cu_seqlens_q is not None or cu_seqlens_k is not None):
+        raise ValueError("cumulative sequence lengths are only valid for packed inputs")
+
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    if packed:
+        _validate_packed_inputs(q, k, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k)
+    requested = _requested_backend()
+    backend = select_standard_attention_backend(q, k, v, packed=packed, training=training)
+    if backend == "flash_attn":
+        return _flash_attention(
+            q,
+            k,
+            v,
+            scale=scale,
+            causal=causal,
+            window_size=window_size,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+        )
+    if backend == "npu":
+        if packed:
+            raise RuntimeError("the initial NPU standard-attention path does not accept packed tensors")
+        try:
+            return _npu_attention(
+                q,
+                k,
+                v,
+                scale=scale,
+                causal=causal,
+                window_size=window_size,
+                query_start=query_start,
+                training=_has_grad(q, k, v) if training is None else training,
+            )
+        except (NotImplementedError, RuntimeError):
+            if requested != "auto":
+                raise
+            logger.warning("Ascend native standard attention failed; falling back to a generic backend")
+            backend = "sdpa" if hasattr(F, "scaled_dot_product_attention") else "reference"
+    if packed:
+        if backend == "sdpa":
+            return _sdpa_packed(
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                scale=scale,
+                causal=causal,
+                window_size=window_size,
+            )
+        return _reference_packed(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            scale=scale,
+            causal=causal,
+            window_size=window_size,
+        )
+    if backend == "sdpa":
+        try:
+            return _sdpa_dense(
+                q,
+                k,
+                v,
+                scale=scale,
+                causal=causal,
+                window_size=window_size,
+                query_start=query_start,
+            )
+        except (NotImplementedError, RuntimeError):
+            if requested != "auto" or q.device.type != "npu":
+                raise
+            logger.warning("Ascend SDPA standard attention failed; falling back to reference attention")
+    return _reference_dense(
+        q,
+        k,
+        v,
+        scale=scale,
+        causal=causal,
+        window_size=window_size,
+        query_start=query_start,
+    )
+
+
+__all__ = ["select_standard_attention_backend", "standard_attention"]

--- a/tests/layers/test_standard_attention_backend.py
+++ b/tests/layers/test_standard_attention_backend.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import importlib
+
+import pytest
+import torch
+
+from fla.layers.attn import Attention
+from fla.models.utils import Cache
+from fla.ops.attn.standard import select_standard_attention_backend, standard_attention
+
+standard_backend = importlib.import_module("fla.ops.attn.standard")
+
+
+class _IdentityRotary(torch.nn.Module):
+    """Keep these backend tests independent of device-specific rotary kernels."""
+
+    def forward(self, q, k, **kwargs):
+        return q, k
+
+
+def _layer(**kwargs):
+    layer = Attention(**kwargs).to(device="cpu").eval()
+    layer.rotary = _IdentityRotary()
+    return layer
+
+
+@pytest.fixture(autouse=True)
+def _force_cpu_fallback(monkeypatch):
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+
+
+def test_standard_attention_gqa_and_bottom_right_causal_alignment():
+    torch.manual_seed(0)
+    q = torch.randn(1, 1, 4, 8)
+    k = torch.randn(1, 5, 2, 8)
+    v = torch.randn(1, 5, 2, 8)
+
+    actual = standard_attention(q, k, v)
+    k_expanded = k.repeat_interleave(2, dim=2)
+    v_expanded = v.repeat_interleave(2, dim=2)
+    scores = torch.matmul(q.transpose(1, 2), k_expanded.transpose(1, 2).transpose(-2, -1)) / 8**0.5
+    # The one-token query is the last token of the five-token KV sequence.
+    expected = torch.softmax(scores, dim=-1) @ v_expanded.transpose(1, 2)
+    torch.testing.assert_close(actual, expected.transpose(1, 2))
+
+
+@pytest.mark.parametrize(
+    ('q_len', 'kv_len', 'window_size'),
+    [(4, 4, None), (3, 5, None), (2, 5, 3), (5, 3, None), (4, 4, 2)],
+)
+def test_reference_and_sdpa_match_forward_and_backward(q_len, kv_len, window_size, monkeypatch):
+    torch.manual_seed(q_len * 10 + kv_len)
+    q = torch.randn(2, q_len, 4, 8, requires_grad=True)
+    k = torch.randn(2, kv_len, 2, 8, requires_grad=True)
+    v = torch.randn(2, kv_len, 2, 6, requires_grad=True)
+    do = torch.randn(2, q_len, 4, 6)
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    ref = standard_attention(q, k, v, window_size=window_size)
+    (ref * do).sum().backward()
+    ref_grads = tuple(x.grad.detach().clone() for x in (q, k, v))
+
+    q.grad = k.grad = v.grad = None
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "sdpa")
+    actual = standard_attention(q, k, v, window_size=window_size)
+    (actual * do).sum().backward()
+
+    torch.testing.assert_close(actual, ref, rtol=1e-5, atol=1e-5)
+    for actual_grad, ref_grad in zip((q.grad, k.grad, v.grad), ref_grads):
+        torch.testing.assert_close(actual_grad, ref_grad, rtol=1e-5, atol=1e-5)
+
+
+def test_packed_reference_and_sdpa_match_with_unequal_sequence_lengths(monkeypatch):
+    torch.manual_seed(3)
+    q = torch.randn(5, 4, 8, requires_grad=True)
+    k = torch.randn(5, 2, 8, requires_grad=True)
+    v = torch.randn(5, 2, 6, requires_grad=True)
+    cu_seqlens_q = torch.tensor([0, 2, 5], dtype=torch.int32)
+    cu_seqlens_k = torch.tensor([0, 3, 5], dtype=torch.int32)
+    do = torch.randn(5, 4, 6)
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    ref = standard_attention(q, k, v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k)
+    (ref * do).sum().backward()
+    ref_grads = tuple(x.grad.detach().clone() for x in (q, k, v))
+
+    q.grad = k.grad = v.grad = None
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "sdpa")
+    actual = standard_attention(q, k, v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k)
+    (actual * do).sum().backward()
+
+    torch.testing.assert_close(actual, ref, rtol=1e-5, atol=1e-5)
+    for actual_grad, ref_grad in zip((q.grad, k.grad, v.grad), ref_grads):
+        torch.testing.assert_close(actual_grad, ref_grad, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    ('cu_seqlens_q', 'cu_seqlens_k', 'message'),
+    [
+        (torch.tensor([1, 2]), torch.tensor([0, 1]), "start at 0"),
+        (torch.tensor([0, 2, 1]), torch.tensor([0, 1, 2]), "non-decreasing"),
+        (torch.tensor([0, 1]), torch.tensor([0, 1]), "packed tensor length"),
+        (torch.tensor([0, 2, 3]), torch.tensor([0, 1, 2]), "max_seqlen_q"),
+    ],
+)
+def test_packed_input_contract_rejects_invalid_lengths(cu_seqlens_q, cu_seqlens_k, message):
+    q = torch.randn(3, 2, 4)
+    k = torch.randn(2, 1, 4)
+    v = torch.randn(2, 1, 4)
+    kwargs = dict(cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k)
+    if message == "max_seqlen_q":
+        kwargs["max_seqlen_q"] = 1
+        kwargs["max_seqlen_k"] = 1
+    with pytest.raises(ValueError, match=message):
+        standard_attention(q, k, v, **kwargs)
+
+
+def test_backend_selection_contract(monkeypatch):
+    q = torch.randn(1, 2, 2, 4)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "auto")
+    assert select_standard_attention_backend(q, q, q) == "sdpa"
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "invalid")
+    with pytest.raises(ValueError, match="invalid"):
+        select_standard_attention_backend(q, q, q)
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "flash_attn")
+    with pytest.raises(RuntimeError, match="CUDA/HIP"):
+        select_standard_attention_backend(q, q, q)
+
+
+def test_attention_dense_packed_padding_and_cache_paths():
+    torch.manual_seed(1)
+    layer = _layer(hidden_size=32, num_heads=4, num_kv_heads=2, layer_idx=0)
+    hidden_states = torch.randn(2, 4, 32)
+
+    dense, _, _ = layer(hidden_states)
+    cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+    packed, _, _ = layer(hidden_states, cu_seqlens=cu_seqlens)
+    torch.testing.assert_close(dense, packed)
+
+    attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.long)
+    masked, _, _ = layer(hidden_states, attention_mask=attention_mask)
+    assert torch.equal(masked[0, 3], torch.zeros_like(masked[0, 3]))
+    assert torch.equal(masked[1, 2:], torch.zeros_like(masked[1, 2:]))
+
+
+def test_attention_fallback_supports_backward(monkeypatch):
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "sdpa")
+    layer = _layer(hidden_size=32, num_heads=4, num_kv_heads=2, layer_idx=0).train()
+    hidden_states = torch.randn(2, 3, 32, requires_grad=True)
+    output, _, _ = layer(hidden_states)
+    output.square().mean().backward()
+    assert hidden_states.grad is not None
+    assert torch.isfinite(hidden_states.grad).all()
+
+
+def test_attention_prefill_decode_cache_matches_full_sequence():
+    torch.manual_seed(2)
+    full_layer = _layer(hidden_size=32, num_heads=4, num_kv_heads=2, layer_idx=0)
+    cached_layer = _layer(hidden_size=32, num_heads=4, num_kv_heads=2, layer_idx=0)
+    cached_layer.load_state_dict(full_layer.state_dict())
+    hidden_states = torch.randn(1, 5, 32)
+
+    full_output, _, _ = full_layer(hidden_states)
+    cache = Cache()
+    cached_layer(hidden_states[:, :4], past_key_values=cache, use_cache=True)
+    decode_output, _, _ = cached_layer(hidden_states[:, 4:], past_key_values=cache, use_cache=True)
+    torch.testing.assert_close(full_output[:, 4:], decode_output)
+
+
+def test_attention_output_attentions_contract_is_explicit():
+    layer = _layer(hidden_size=32, num_heads=4, num_kv_heads=2, layer_idx=0)
+    hidden_states = torch.randn(1, 2, 32)
+    _, attentions, _ = layer(hidden_states, output_attentions=True)
+    assert attentions is None
+
+
+def test_forced_npu_backend_rejects_non_npu_inputs(monkeypatch):
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    q = torch.randn(1, 2, 2, 4)
+    with pytest.raises(RuntimeError, match="requires an NPU tensor"):
+        standard_attention(q, q, q)
+
+
+def test_npu_backend_builds_bnsd_gqa_arguments(monkeypatch):
+    class _FakeNPU:
+        def __init__(self):
+            self.calls = []
+
+        def npu_fused_infer_attention_score(self, q, k, v, **kwargs):
+            self.calls.append(("infer", q, k, v, kwargs))
+            return q, None
+
+        def npu_fusion_attention(self, q, k, v, head_num, input_layout, **kwargs):
+            self.calls.append(("train", q, k, v, head_num, input_layout, kwargs))
+            return q, None, None, None, 0, 0, 0
+
+    fake_npu = _FakeNPU()
+    monkeypatch.setattr(standard_backend, "_load_torch_npu", lambda: fake_npu)
+    q = torch.randn(2, 3, 4, 8)
+    k = torch.randn(2, 5, 2, 8)
+    v = torch.randn(2, 5, 2, 8)
+
+    output = standard_backend._npu_attention(
+        q, k, v, scale=8**-0.5, causal=True, window_size=None, query_start=None, training=False
+    )
+    assert output.shape == q.shape
+    kind, q_bnsd, k_bnsd, v_bnsd, kwargs = fake_npu.calls[-1]
+    assert kind == "infer"
+    assert (q_bnsd.shape, k_bnsd.shape, v_bnsd.shape) == ((2, 4, 3, 8), (2, 2, 5, 8), (2, 2, 5, 8))
+    assert kwargs["input_layout"] == "BNSD"
+    assert kwargs["num_heads"] == 4
+    assert kwargs["num_key_value_heads"] == 2
+    assert kwargs["sparse_mode"] == 1
+
+    standard_backend._npu_attention(
+        q, k, v, scale=8**-0.5, causal=True, window_size=3, query_start=None, training=True
+    )
+    assert fake_npu.calls[-1][0] == "train"
+    assert fake_npu.calls[-1][-1]["sparse_mode"] == 1
+
+
+@pytest.mark.parametrize(
+    ('q_len', 'kv_len', 'window_size', 'message'),
+    [
+        (1, 5, 2, "masked single-query"),
+        (5, 3, None, "fully masked rows"),
+    ],
+)
+def test_npu_backend_rejects_unsupported_mask_boundaries(
+    monkeypatch, q_len, kv_len, window_size, message
+):
+    class _FakeNPU:
+        def npu_fused_infer_attention_score(self, *args, **kwargs):
+            raise AssertionError("the native operator must not be called")
+
+    monkeypatch.setattr(standard_backend, "_load_torch_npu", lambda: _FakeNPU())
+    q = torch.randn(1, q_len, 2, 4)
+    k = torch.randn(1, kv_len, 2, 4)
+    v = torch.randn(1, kv_len, 2, 4)
+    with pytest.raises(RuntimeError, match=message):
+        standard_backend._npu_attention(
+            q,
+            k,
+            v,
+            scale=4**-0.5,
+            causal=True,
+            window_size=window_size,
+            query_start=None,
+            training=False,
+        )

--- a/tests/layers/test_standard_attention_npu.py
+++ b/tests/layers/test_standard_attention_npu.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+
+from fla.layers.attn import Attention
+from fla.models.utils import Cache
+from fla.ops.attn.standard import standard_attention
+from fla.utils import IS_NPU, device
+
+
+def _npu_available():
+    if not hasattr(torch, "npu"):
+        return False
+    try:
+        return torch.npu.is_available()
+    except (RuntimeError, OSError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not IS_NPU or not _npu_available(), reason="requires an available Ascend NPU")
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_npu_standard_attention_inference_matches_reference(monkeypatch, dtype):
+    torch.manual_seed(0)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    q = torch.randn(1, 3, 4, 16, dtype=dtype, device=device)
+    k = torch.randn(1, 3, 2, 16, dtype=dtype, device=device)
+    v = torch.randn(1, 3, 2, 16, dtype=dtype, device=device)
+
+    actual = standard_attention(q, k, v, training=False).cpu()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    expected = standard_attention(q.cpu(), k.cpu(), v.cpu())
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
+
+
+def test_npu_standard_attention_auto_falls_back_for_unsupported_head_dim(monkeypatch):
+    torch.manual_seed(10)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "auto")
+    # Ascend's native BNSD kernel requires a larger aligned head dimension;
+    # auto mode must preserve correctness through the generic fallback.
+    q = torch.randn(1, 3, 4, 8, dtype=torch.float16, device=device)
+    k = torch.randn(1, 3, 2, 8, dtype=torch.float16, device=device)
+    v = torch.randn(1, 3, 2, 8, dtype=torch.float16, device=device)
+
+    actual = standard_attention(q, k, v, training=False).cpu()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    expected = standard_attention(q.cpu(), k.cpu(), v.cpu())
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
+
+
+def test_npu_standard_attention_decode_matches_reference(monkeypatch):
+    torch.manual_seed(1)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    q = torch.randn(1, 1, 4, 16, dtype=torch.float16, device=device)
+    k = torch.randn(1, 5, 2, 16, dtype=torch.float16, device=device)
+    v = torch.randn(1, 5, 2, 16, dtype=torch.float16, device=device)
+
+    actual = standard_attention(q, k, v, training=False).cpu()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    expected = standard_attention(q.cpu(), k.cpu(), v.cpu())
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_npu_standard_attention_training_backward_matches_reference(monkeypatch, dtype):
+    torch.manual_seed(2)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    q = torch.randn(1, 3, 4, 16, dtype=dtype, device=device, requires_grad=True)
+    k = torch.randn(1, 3, 2, 16, dtype=dtype, device=device, requires_grad=True)
+    v = torch.randn(1, 3, 2, 16, dtype=dtype, device=device, requires_grad=True)
+    do = torch.randn_like(q)
+
+    output = standard_attention(q, k, v, training=True)
+    (output * do).sum().backward()
+    assert q.grad is not None and torch.isfinite(q.grad).all()
+    assert k.grad is not None and torch.isfinite(k.grad).all()
+    assert v.grad is not None and torch.isfinite(v.grad).all()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    q_ref = q.detach().cpu().requires_grad_(True)
+    k_ref = k.detach().cpu().requires_grad_(True)
+    v_ref = v.detach().cpu().requires_grad_(True)
+    do_ref = do.cpu()
+    output_ref = standard_attention(q_ref, k_ref, v_ref)
+    (output_ref * do_ref).sum().backward()
+
+    torch.testing.assert_close(output.cpu(), output_ref, rtol=2e-1, atol=2e-1)
+    for actual_grad, expected_grad in zip((q.grad, k.grad, v.grad), (q_ref.grad, k_ref.grad, v_ref.grad)):
+        torch.testing.assert_close(actual_grad.cpu(), expected_grad, rtol=2e-1, atol=2e-1)
+
+
+def test_npu_standard_attention_window_matches_reference(monkeypatch):
+    torch.manual_seed(5)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    q = torch.randn(1, 4, 4, 16, dtype=torch.float16, device=device)
+    k = torch.randn(1, 6, 2, 16, dtype=torch.float16, device=device)
+    v = torch.randn(1, 6, 2, 16, dtype=torch.float16, device=device)
+
+    actual = standard_attention(q, k, v, training=False, window_size=3).cpu()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    expected = standard_attention(q.cpu(), k.cpu(), v.cpu(), window_size=3)
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
+
+
+def test_npu_standard_attention_multitoken_decode_matches_reference(monkeypatch):
+    torch.manual_seed(6)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    q = torch.randn(1, 2, 4, 16, dtype=torch.float16, device=device)
+    k = torch.randn(1, 5, 2, 16, dtype=torch.float16, device=device)
+    v = torch.randn(1, 5, 2, 16, dtype=torch.float16, device=device)
+
+    actual = standard_attention(q, k, v, training=False).cpu()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    expected = standard_attention(q.cpu(), k.cpu(), v.cpu())
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
+
+
+def test_npu_standard_attention_long_sequence_matches_reference(monkeypatch):
+    torch.manual_seed(7)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    q = torch.randn(2, 32, 4, 16, dtype=torch.float16, device=device)
+    k = torch.randn(2, 32, 2, 16, dtype=torch.float16, device=device)
+    v = torch.randn(2, 32, 2, 16, dtype=torch.float16, device=device)
+
+    actual = standard_attention(q, k, v, training=False).cpu()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    expected = standard_attention(q.cpu(), k.cpu(), v.cpu())
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
+
+
+def test_npu_standard_attention_packed_fallback_matches_reference(monkeypatch):
+    torch.manual_seed(3)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "auto")
+    q = torch.randn(5, 4, 16, dtype=torch.float16, device=device)
+    k = torch.randn(5, 2, 16, dtype=torch.float16, device=device)
+    v = torch.randn(5, 2, 16, dtype=torch.float16, device=device)
+    cu_seqlens_q = torch.tensor([0, 2, 5], dtype=torch.int32)
+    cu_seqlens_k = torch.tensor([0, 3, 5], dtype=torch.int32)
+
+    actual = standard_attention(q, k, v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k).cpu()
+
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "reference")
+    expected = standard_attention(q.cpu(), k.cpu(), v.cpu(), cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k)
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
+
+
+def test_npu_attention_layer_prefill_decode_matches_full_sequence(monkeypatch):
+    torch.manual_seed(4)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "npu")
+    full_layer = Attention(hidden_size=64, num_heads=4, num_kv_heads=2, layer_idx=0).to(
+        device=device, dtype=torch.float16
+    ).eval()
+    cached_layer = Attention(hidden_size=64, num_heads=4, num_kv_heads=2, layer_idx=0).to(
+        device=device, dtype=torch.float16
+    ).eval()
+    cached_layer.load_state_dict(full_layer.state_dict())
+    hidden_states = torch.randn(1, 5, 64, dtype=torch.float16, device=device)
+
+    full_output, _, _ = full_layer(hidden_states)
+    cache = Cache()
+    cached_layer(hidden_states[:, :4], past_key_values=cache, use_cache=True)
+    decode_output, _, _ = cached_layer(hidden_states[:, 4:], past_key_values=cache, use_cache=True)
+
+    torch.testing.assert_close(full_output[:, 4:].cpu(), decode_output.cpu(), rtol=5e-2, atol=5e-2)

--- a/tests/models/test_standard_attention_transformers_npu.py
+++ b/tests/models/test_standard_attention_transformers_npu.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # register the NPU torch backend before model construction
+from transformers import AutoModelForCausalLM
+
+from fla.layers.attn import Attention
+from fla.models import GLAConfig
+from fla.utils import IS_NPU, device
+
+
+def _npu_available():
+    try:
+        return IS_NPU and torch.npu.is_available()
+    except (RuntimeError, OSError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _npu_available(), reason="requires an available Ascend NPU")
+
+
+def _config():
+    return GLAConfig(
+        hidden_size=64,
+        num_hidden_layers=1,
+        num_heads=4,
+        num_kv_heads=2,
+        vocab_size=64,
+        max_position_embeddings=64,
+        attn={"layers": [0], "num_heads": 4, "num_kv_heads": 2},
+        fuse_norm=False,
+        fuse_swiglu=False,
+        fuse_cross_entropy=False,
+        fuse_linear_cross_entropy=False,
+        use_cache=True,
+    )
+
+
+def _model():
+    model = AutoModelForCausalLM.from_config(_config())
+    model = model.to(device=device, dtype=torch.float16).eval()
+    assert isinstance(model.model.layers[0].attn, Attention)
+    return model
+
+
+def test_transformers_model_forward_inputs_embeds_loss_and_save_load(tmp_path, monkeypatch):
+    torch.manual_seed(11)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "auto")
+    model = _model()
+    input_ids = torch.tensor([[1, 5, 7, 9], [2, 6, 8, 10]], device=device)
+    attention_mask = torch.ones_like(input_ids, dtype=torch.bool)
+
+    with torch.no_grad():
+        dense = model(input_ids=input_ids, use_cache=False).logits
+        masked = model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False).logits
+        embeds = model.get_input_embeddings()(input_ids)
+        embedded = model(inputs_embeds=embeds, attention_mask=attention_mask, use_cache=False).logits
+
+    torch.testing.assert_close(dense, masked, rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(masked, embedded, rtol=5e-2, atol=5e-2)
+
+    model.train()
+    loss = model(input_ids=input_ids, labels=input_ids, use_cache=False).loss
+    assert loss is not None and torch.isfinite(loss)
+    loss.backward()
+    assert all(parameter.grad is None or torch.isfinite(parameter.grad).all() for parameter in model.parameters())
+
+    model.eval()
+    with torch.no_grad():
+        model.save_pretrained(tmp_path)
+        loaded = AutoModelForCausalLM.from_pretrained(tmp_path, torch_dtype=torch.float16).to(device).eval()
+        reloaded = loaded(input_ids=input_ids, use_cache=False).logits
+    torch.testing.assert_close(dense, reloaded, rtol=5e-2, atol=5e-2)
+
+
+def test_transformers_model_cache_and_generate(monkeypatch):
+    torch.manual_seed(12)
+    monkeypatch.setenv("FLA_STANDARD_ATTN_BACKEND", "auto")
+    model = _model()
+    input_ids = torch.tensor([[1, 5, 7, 9, 11]], device=device)
+    prefix = input_ids[:, :3]
+    prefix_mask = torch.ones_like(prefix, dtype=torch.bool)
+    full_mask = torch.ones_like(input_ids, dtype=torch.bool)
+
+    with torch.no_grad():
+        full = model(input_ids=input_ids, use_cache=False).logits
+        prefill = model(input_ids=prefix, attention_mask=prefix_mask, use_cache=True)
+        step = model(
+            input_ids=input_ids[:, 3:4],
+            attention_mask=full_mask[:, :4],
+            past_key_values=prefill.past_key_values,
+            use_cache=True,
+        )
+        manual_prefill = model(
+            input_ids=prefix,
+            attention_mask=prefix_mask,
+            use_cache=True,
+        )
+        manual_next = manual_prefill.logits[:, -1:].argmax(dim=-1)
+        manual_tokens = [manual_next]
+        manual_cache = manual_prefill.past_key_values
+        for _ in range(1, 2):
+            manual_step = model(
+                input_ids=manual_next,
+                attention_mask=torch.ones(
+                    (prefix.shape[0], prefix.shape[1] + len(manual_tokens)),
+                    dtype=torch.bool,
+                    device=device,
+                ),
+                past_key_values=manual_cache,
+                use_cache=True,
+            )
+            manual_cache = manual_step.past_key_values
+            manual_next = manual_step.logits[:, -1:].argmax(dim=-1)
+            manual_tokens.append(manual_next)
+        manual_generated = torch.cat(manual_tokens, dim=1)
+        generated = model.generate(
+            prefix,
+            attention_mask=prefix_mask,
+            max_new_tokens=2,
+            do_sample=False,
+        )
+
+    torch.testing.assert_close(full[:, 3], step.logits[:, 0], rtol=5e-2, atol=5e-2)
+    assert generated.shape == (1, prefix.shape[1] + 2)
+    assert torch.equal(generated[:, :prefix.shape[1]], prefix)
+    assert torch.equal(generated[:, prefix.shape[1]:], manual_generated)


### PR DESCRIPTION
## Summary

Add a backend-neutral standard causal attention implementation with Ascend NPU support. Dense NPU inputs use native `torch_npu` attention operators, while packed inputs and unsupported shapes fall back to SDPA or the reference implementation. Update `fla.layers.Attention` to use this backend boundary while preserving GQA, causal cache alignment, sliding-window behavior, and the existing `attentions=None` API contract. Add Transformers integration tests and Ascend CI coverage.

## Test plan

- Hardware: Atlas 900 A3 SuperPoD.
- Environment: CANN 9.1.0, `triton-ascend==3.2.2`, PyTorch 2.7.1, `torch_npu==2.7.1.post8`, Python 3.10.
- Covered backend contract, fallback, GQA, causal alignment, cache, window, packed input, inference, training, backward, and decode scenarios.
- Covered Transformers `input_ids`, `inputs_embeds`, loss, backward, save/load, KV cache, and generation scenarios.

  ```bash
  pytest -q -s \
    tests/layers/test_standard_attention_backend.py \
    tests/layers/test_standard_attention_npu.py \
    tests/models/test_standard_attention_transformers_npu.py \
    tests/layers/test_cu_seqlens_cache_guard.py
  ```

Result: `33 passed, 5 skipped`.

Ruff checks and Python bytecode compilation passed.

## Benchmark / NCU (kernel changes only)

- N/A. This PR does not modify an existing Triton kernel or introduce a performance optimization.
- The change focuses on backend enablement, correctness, and compatibility.

## Breaking changes

- None intended.
- `Attention` continues to return `attentions=None`; attention weights are not materialized.
- CUDA/HIP users continue to use FlashAttention when available through automatic backend selection.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [[.agents/skills](vscode-webview://1dbe7hh0hime4tnvi96jto0688d7ivkdkdm9hbhm9d56v33g08ri/.agents/skills)](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable. The focused standard-attention and Transformers tests pass; the unrelated pre-existing GDN2 compiler failure is documented above.
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (N/A: this PR does not change Triton kernels).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks).