### PR TITLE
[Fix] Eliminate per-call reference cycle in launch_grid_chunked

### DIFF
--- a/fla/utils/ascend_ub_manager.py
+++ b/fla/utils/ascend_ub_manager.py
@@ -584,6 +584,45 @@ def get_npu_properties() -> dict:
     return driver.active.utils.get_device_properties(torch.npu.current_device())
 
 
+def _launch_grid_chunked_recursive(
+    kernel,
+    grid: tuple[int, ...],
+    offset_keys: tuple[str, ...],
+    kernel_kwargs: dict,
+    quanta: tuple[int, ...],
+    budget: int,
+    extra: dict,
+    lens: list[int],
+    ax: int,
+    prod_so_far: int,
+) -> None:
+    quantum = quanta[ax]
+    rest = prod_so_far * quantum
+    for size in grid[ax + 1:]:
+        rest *= size
+    for off_q, len_q in iter_axis_launch_chunks(
+        triton.cdiv(grid[ax], quantum), rest, max_grid=budget,
+    ):
+        offset = off_q * quantum
+        lens[ax] = min(len_q * quantum, grid[ax] - offset)
+        kernel_kwargs[offset_keys[ax]] = offset
+        if ax == len(grid) - 1:
+            kernel[tuple(lens)](**kernel_kwargs, **extra)
+        else:
+            _launch_grid_chunked_recursive(
+                kernel,
+                grid,
+                offset_keys,
+                kernel_kwargs,
+                quanta,
+                budget,
+                extra,
+                lens,
+                ax + 1,
+                prod_so_far * len_q * quantum,
+            )
+
+
 def launch_grid_chunked(
     kernel,
     grid: tuple[int, ...],
@@ -611,20 +650,15 @@ def launch_grid_chunked(
     extra = compile_kwargs or {}
     lens = [0] * dims
 
-    def _recurse(ax: int, prod_so_far: int) -> None:
-        quantum = quanta[ax]
-        rest = prod_so_far * quantum
-        for size in grid[ax + 1:]:
-            rest *= size
-        for off_q, len_q in iter_axis_launch_chunks(
-            triton.cdiv(grid[ax], quantum), rest, max_grid=budget,
-        ):
-            offset = off_q * quantum
-            lens[ax] = min(len_q * quantum, grid[ax] - offset)
-            kernel_kwargs[offset_keys[ax]] = offset
-            if ax == dims - 1:
-                kernel[tuple(lens)](**kernel_kwargs, **extra)
-            else:
-                _recurse(ax + 1, prod_so_far * len_q * quantum)
-
-    _recurse(0, 1)
+    _launch_grid_chunked_recursive(
+        kernel,
+        grid,
+        offset_keys,
+        kernel_kwargs,
+        quanta,
+        budget,
+        extra,
+        lens,
+        0,
+        1,
+    )

--- a/tests/utils/test_ascend_launch_grid_chunked.py
+++ b/tests/utils/test_ascend_launch_grid_chunked.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import gc
+import weakref
+
+from fla.utils.ascend_ub_manager import launch_grid_chunked
+
+
+class _RecordingKernel:
+    def __init__(self):
+        self.calls = []
+
+    def __getitem__(self, grid):
+        def _launch(**kwargs):
+            self.calls.append((grid, dict(kwargs)))
+
+        return _launch
+
+
+class _NoopKernel:
+    def __getitem__(self, grid):
+        def _launch(**kwargs):
+            pass
+
+        return _launch
+
+
+class _Sentinel:
+    pass
+
+
+def test_launch_grid_chunked_2d_grid_offsets_and_compile_kwargs():
+    kernel = _RecordingKernel()
+    launch_grid_chunked(
+        kernel,
+        (5, 7),
+        offset_keys=('offset_0', 'offset_1'),
+        kernel_kwargs={'payload': 7},
+        budget=4,
+        compile_kwargs={'num_warps': 4},
+    )
+
+    expected = []
+    for offset_0 in range(5):
+        for offset_1, size_1 in ((0, 4), (4, 3)):
+            expected.append((
+                (1, size_1),
+                {
+                    'payload': 7,
+                    'offset_0': offset_0,
+                    'offset_1': offset_1,
+                    'num_warps': 4,
+                },
+            ))
+    assert kernel.calls == expected
+
+
+def test_launch_grid_chunked_3d_grid_offsets_and_order():
+    kernel = _RecordingKernel()
+    launch_grid_chunked(
+        kernel,
+        (3, 4, 5),
+        offset_keys=('offset_0', 'offset_1', 'offset_2'),
+        kernel_kwargs={'payload': 'keep'},
+        budget=4,
+    )
+
+    expected = []
+    for offset_0 in range(3):
+        for offset_1 in range(4):
+            for offset_2, size_2 in ((0, 4), (4, 1)):
+                expected.append((
+                    (1, 1, size_2),
+                    {
+                        'payload': 'keep',
+                        'offset_0': offset_0,
+                        'offset_1': offset_1,
+                        'offset_2': offset_2,
+                    },
+                ))
+    assert kernel.calls == expected
+
+
+def test_launch_grid_chunked_quanta_preserves_boundaries_and_tail_chunks():
+    kernel = _RecordingKernel()
+    launch_grid_chunked(
+        kernel,
+        (5, 10),
+        offset_keys=('offset_0', 'offset_1'),
+        kernel_kwargs={},
+        quanta=(2, 4),
+        budget=16,
+    )
+
+    assert kernel.calls == [
+        ((2, 8), {'offset_0': 0, 'offset_1': 0}),
+        ((2, 2), {'offset_0': 0, 'offset_1': 8}),
+        ((2, 8), {'offset_0': 2, 'offset_1': 0}),
+        ((2, 2), {'offset_0': 2, 'offset_1': 8}),
+        ((1, 8), {'offset_0': 4, 'offset_1': 0}),
+        ((1, 2), {'offset_0': 4, 'offset_1': 8}),
+    ]
+
+
+def _launch_with_weakref_sentinel():
+    sentinel = _Sentinel()
+    sentinel_ref = weakref.ref(sentinel)
+    launch_grid_chunked(
+        _NoopKernel(),
+        (2, 2),
+        offset_keys=('offset_0', 'offset_1'),
+        kernel_kwargs={'sentinel': sentinel},
+        budget=4,
+    )
+    return sentinel_ref
+
+
+def test_launch_grid_chunked_does_not_retain_kernel_kwargs_reference_cycle():
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        sentinel_ref = _launch_with_weakref_sentinel()
+        assert sentinel_ref() is None
+    finally:
+        if gc_was_enabled:
+            gc.enable()


### PR DESCRIPTION
## Summary

`launch_grid_chunked` built a nested `_recurse` closure that referenced itself by name, creating a self-referential reference cycle on every call. The cycle holds `kernel_kwargs` and the kernel object alive until the generational GC runs. Under benchmark loops (`do_bench` fires hundreds of op calls inside one rep window), this garbage accumulates device tensors at ~0.65 GiB per call on large shapes — NPU benchmark runs of `chunk_gla` at `B4_T4096_H64_D128` OOMed with `53 GiB already allocated`.

Hoist the nested closure to a module-level `_launch_grid_chunked_recursive` with all state passed as explicit parameters. No closure, no per-call cycle; chunk traversal order, offsets, and per-launch kwargs are unchanged.

## Test plan

- `pytest tests/utils/test_ascend_ub_manager.py`: 34 passed (launch semantics unchanged)
- `pytest tests/ops/test_gla.py`: 30 passed on Ascend910_9382 (CANN 9.0.0, PyTorch 2.7.1)
- **Memory loop (50 `chunk_gla` fwd calls, B4_T4096_H64_D128, no `gc.collect()`): constant 1.50 GiB, previously a 6.75→19.00 GiB sawtooth**

## Benchmark / NCU (kernel changes only)

Neutral for kernel performance — host-side launch helper, no kernel code touched. `chunk_gla` benchmark medians are within ±1% of the pre-fix numbers, and the previously OOMing shapes (B4_T4096_H64_D128 fwdbwd 267.146 ms, B8_T2048_H32_D256 fwd 147.048 ms / fwdbwd 459.219 ms) now complete.

## Breaking changes

None. Launch order, chunk boundaries, and per-launch `kernel_kwargs` are unchanged; all NPU backends using `launch_grid_chunked` behave identically except for the removed memory accumulation.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
