### PR TITLE
[Ops] Enable TMA on AMD gfx1250

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,12 +225,9 @@ Don't hard-wrap prose at an arbitrary short column — this covers Markdown file
   any divisibility you rely on. Do not use `tl.make_block_ptr` / `tl.advance`:
   deprecated upstream and removed in triton main. (`backends/triton_ascend/` is
   exempt — triton-ascend still requires block pointers.)
-- `tl.make_tensor_descriptor` (TMA) is an opt-in optimization for hot-path
-  tiles on Hopper and newer, not a default substitute for block access. It
-  requires 16-byte-aligned bases and stride multiples, a stride-1 innermost
-  dim, no transposed blocks, and a registered allocator for device-side
-  descriptors. Use it when a per-kernel benchmark in the PR shows it pays off,
-  e.g. behind a flag as in `fla/ops/utils/solve_tril.py`.
+- `tl.make_tensor_descriptor` (TMA) is an opt-in optimization for hot-path tiles, not a default substitute for block access. Availability is `IS_TMA_SUPPORTED` in `fla/utils/_device.py`, which covers Nvidia Hopper and newer plus AMD gfx1250, and is gated behind `FLA_USE_TMA=1` on every backend. The AMD side is an arch allowlist rather than a version floor — gfx942 and gfx950 have no such lowering — so extend `IS_AMD_TMA_ARCH` explicitly when another arch gains it, and don't assume a higher `gfx` number implies support. Note that no CI runner currently has a TMA-capable AMD arch, so that path is only exercised by local runs.
+- Descriptors require 16-byte-aligned bases and stride multiples, a stride-1 innermost dim, no transposed blocks, and a registered allocator for device-side descriptors. Nothing verifies the alignment for you and a violation faults at launch rather than failing to compile, so derive a guard on the host from the dtype and the shapes the op is actually tested at, and fall back to the plain-pointer path when it fails — a head dim of `K=60` in fp16, as KDA is tested at, is 120 bytes per row and cannot back a descriptor. Descriptor stores are also asynchronous, so a kernel must never read back a location it just stored through a descriptor.
+- Use TMA when a per-kernel benchmark in the PR shows it pays off, behind a `USE_TMA: tl.constexpr` flag that keeps the plain-pointer path intact, as in `fla/ops/utils/solve_tril.py`. A benchmark on one vendor does not carry over to the other: the descriptor path in `solve_tril` was tuned on Hopper and has not been measured on gfx1250.
 - Treat program IDs and grid-derived indices as potentially narrow integers.
   Cast them to `tl.int64` before multiplying by sizes, strides, or sequence
   offsets. This is especially important for non-first grid dimensions on NVIDIA

--- a/ENVs.md
+++ b/ENVs.md
@@ -38,7 +38,7 @@ runtime. Variables are grouped by what they control:
 
 | Variable             | Default | Options    | Description                                                                                                  |
 | -------------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `FLA_USE_TMA`        | `0`     | `0` / `1`  | Enable the Tensor Memory Accelerator (TMA) on Hopper / Blackwell GPUs. Requires Triton with TMA support.     |
+| `FLA_USE_TMA`        | `0`     | `0` / `1`  | Enable the Tensor Memory Accelerator (TMA) on Nvidia Hopper / Blackwell and AMD gfx1250 GPUs. Requires Triton with TMA support. |
 | `FLA_USE_COMPILE`    | `1`     | `1` / `0`, `true` / `false`, `yes` / `no` | Use `torch.compile` for the RWKV7 fused addcmul path. Auto-disabled on Python < 3.11. |
 
 ---

--- a/fla/ops/utils/solve_tril.py
+++ b/fla/ops/utils/solve_tril.py
@@ -14,12 +14,18 @@ import triton.language as tl
 from fla.ops.backends import dispatch
 from fla.ops.utils.index import prepare_chunk_indices
 from fla.ops.utils.op import make_tensor_descriptor
-from fla.utils import IS_TMA_SUPPORTED, autotune_cache_kwargs, input_guard
+from fla.utils import IS_TF32_SUPPORTED, IS_TMA_SUPPORTED, autotune_cache_kwargs, input_guard
 
 FLA_TRIL_PRECISION = os.environ.get('FLA_TRIL_PRECISION', 'ieee')
 assert FLA_TRIL_PRECISION in ['ieee', 'tf32', 'tf32x3'], \
     f"FLA_TRIL_PRECISION must be one of 'ieee', 'tf32', or 'tf32x3', but got {FLA_TRIL_PRECISION}"
-DOT_PRECISION_AUTOTUNE_LIST = ["ieee"] if not IS_TMA_SUPPORTED else list({"ieee", FLA_TRIL_PRECISION})
+# NOTE: `IS_TF32_SUPPORTED` keeps the tf32 configs off non-Nvidia backends now that
+# `IS_TMA_SUPPORTED` can also be true on AMD. The order is fixed instead of derived from a set so
+# the autotune config order does not vary with the interpreter hash seed.
+if IS_TMA_SUPPORTED and IS_TF32_SUPPORTED and FLA_TRIL_PRECISION != "ieee":
+    DOT_PRECISION_AUTOTUNE_LIST = ["ieee", FLA_TRIL_PRECISION]
+else:
+    DOT_PRECISION_AUTOTUNE_LIST = ["ieee"]
 
 
 @triton.heuristics({

--- a/fla/utils/__init__.py
+++ b/fla/utils/__init__.py
@@ -34,6 +34,7 @@ from ._decorators import (  # noqa: F401
 )
 from ._device import (  # noqa: F401
     IS_AMD,
+    IS_AMD_TMA_ARCH,
     IS_ARM,
     IS_GATHER_SUPPORTED,
     IS_INTEL,
@@ -59,6 +60,7 @@ from ._device import (  # noqa: F401
     device_torch_lib,
     get_all_max_shared_mem,
     get_available_device,
+    get_device_arch,
     get_device_capability,
     get_device_smem_optin,
     get_multiprocessor_count,
@@ -71,6 +73,7 @@ def _register_aliases():
     current_module = sys.modules[__name__]
     for key in (
         'IS_AMD',
+        'IS_AMD_TMA_ARCH',
         'IS_ARM',
         'IS_INTEL',
         'IS_INTEL_ALCHEMIST',

--- a/fla/utils/_device.py
+++ b/fla/utils/_device.py
@@ -163,8 +163,6 @@ IS_TF32_SUPPORTED = (IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 8)
 IS_GATHER_SUPPORTED = hasattr(triton.language, 'gather')
 # AMD architectures whose Triton backend lowers `tl.make_tensor_descriptor` onto real
 # hardware tensor-descriptor loads/stores. gfx1250 is the first one; gfx942/gfx950 are not.
-# NOTE: this is an allowlist, not a floor — a newer gfx number does not imply support.
-# No CI runner has such an arch (amd-mi300 is gfx942), so this path is locally tested only.
 IS_AMD_TMA_ARCH = (IS_AMD and get_device_arch() in ('gfx1250',))
 
 IS_TMA_SUPPORTED = (

--- a/fla/utils/_device.py
+++ b/fla/utils/_device.py
@@ -114,6 +114,16 @@ def get_available_device() -> str:
         return 'cpu'
 
 
+@cache
+def get_device_arch() -> str:
+    """Triton target arch, e.g. 'gfx1250' on AMD or '90' on Nvidia. Empty when unavailable."""
+    try:
+        # AMD may append feature flags, e.g. 'gfx1250:xnack-'.
+        return str(triton.runtime.driver.active.get_current_target().arch).split(':')[0]
+    except Exception:
+        return ''
+
+
 def map_triton_backend_to_torch_device() -> str:
     backend = get_available_device()        # 'cuda' | 'hip' | 'xpu' | 'cpu' | ...
     return {'cuda': 'cuda', 'hip': 'cuda', 'xpu': 'xpu'}.get(backend, backend)
@@ -151,9 +161,17 @@ IS_NVIDIA_BLACKWELL = (IS_NVIDIA and torch.cuda.get_device_capability()[0] in (1
 # Nvidia Ampere or newer, haven't check AMD and intel yet.
 IS_TF32_SUPPORTED = (IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 8)
 IS_GATHER_SUPPORTED = hasattr(triton.language, 'gather')
+# AMD architectures whose Triton backend lowers `tl.make_tensor_descriptor` onto real
+# hardware tensor-descriptor loads/stores. gfx1250 is the first one; gfx942/gfx950 are not.
+# NOTE: this is an allowlist, not a floor — a newer gfx number does not imply support.
+# No CI runner has such an arch (amd-mi300 is gfx942), so this path is locally tested only.
+IS_AMD_TMA_ARCH = (IS_AMD and get_device_arch() in ('gfx1250',))
+
 IS_TMA_SUPPORTED = (
-    IS_NVIDIA
-    and torch.cuda.get_device_capability(0)[0] >= 9
+    (
+        (IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 9)
+        or IS_AMD_TMA_ARCH
+    )
     and os.environ.get('FLA_USE_TMA', '0') == '1'
     and (
         hasattr(triton.language, '_experimental_make_tensor_descriptor')

--- a/tests/ops/utils/test_tma.py
+++ b/tests/ops/utils/test_tma.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.op import make_tensor_descriptor
+from fla.utils import IS_TMA_SUPPORTED, assert_close, device
+
+pytestmark = pytest.mark.skipif(
+    not IS_TMA_SUPPORTED,
+    reason='TMA is unsupported on this arch, or FLA_USE_TMA is not set to 1',
+)
+
+
+@triton.jit(do_not_specialize=['T'])
+def tma_transposed_tile_kernel(
+    V,
+    O,
+    T,
+    Vd: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+):
+    i_t, i_v, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
+    # V is [T, H, Vd]. A descriptor cannot describe the [Vd, T] view directly, because that would
+    # need an innermost stride of H*Vd; describe the natural layout, where Vd is the stride-1 axis.
+    d_v = make_tensor_descriptor(V + i_h * Vd, [T, Vd], [H * Vd, 1], [BT, BV])
+    # O is [H, Vd, T], already row-major, so the transpose lands in registers rather than in the
+    # addressing. Both axes are ragged here: the descriptor zero-fills OOB loads and drops OOB
+    # stores, which is what replaces the explicit masks of the pointer path.
+    d_o = make_tensor_descriptor(O + i_h * Vd * T, [Vd, T], [T, 1], [BV, BT])
+    # [BT, BV] -> [BV, BT]
+    b_v = tl.trans(d_v.load([i_t * BT, i_v * BV]))
+    d_o.store([i_v * BV, i_t * BT], (b_v * 2.0).to(d_o.dtype))
+
+
+def tma_transposed_tile(v: torch.Tensor) -> torch.Tensor:
+    T, H, Vd = v.shape
+    o = torch.zeros((H, Vd, T), device=v.device, dtype=v.dtype)
+    BT, BV = 64, min(64, Vd)
+    grid = (triton.cdiv(T, BT), triton.cdiv(Vd, BV), H)
+    tma_transposed_tile_kernel[grid](v, o, T, Vd=Vd, H=H, BT=BT, BV=BV)
+    return o
+
+
+def naive_transposed_tile(v: torch.Tensor) -> torch.Tensor:
+    return v.permute(1, 2, 0).contiguous() * 2.0
+
+
+@pytest.mark.parametrize(
+    ('T', 'H', 'Vd', 'dtype'),
+    [
+        pytest.param(*test, id="T{}-H{}-Vd{}-{}".format(*test))
+        for test in [
+            # T is not a multiple of BT=64 in the first three, so the ragged tail is exercised.
+            (520, 3, 64, torch.float16),
+            # Vd=96 against BV=64 makes the value axis ragged as well.
+            (520, 3, 96, torch.float16),
+            (520, 2, 64, torch.float32),
+            (1024, 4, 128, torch.bfloat16),
+        ]
+    ],
+)
+def test_tma_transposed_tile(T: int, H: int, Vd: int, dtype: torch.dtype):
+    """A 2-D tile consumed transposed, as V is when it is the RHS of a matmul.
+
+    Every shape here satisfies the descriptor alignment rules, which are not checked by the
+    compiler and fault at launch when violated: both descriptor bases (`i_h * Vd` into V and
+    `i_h * Vd * T` into O) and both leading strides (`H * Vd` and `T`) must be multiples of
+    16 bytes, and the innermost axis must be stride-1.
+    """
+    torch.manual_seed(42)
+    itemsize = torch.empty(0, dtype=dtype).element_size()
+    assert (Vd * itemsize) % 16 == 0 and (H * Vd * itemsize) % 16 == 0 and (T * itemsize) % 16 == 0
+
+    v = torch.randn(T, H, Vd, dtype=dtype, device=device)
+
+    ref = naive_transposed_tile(v)
+    tri = tma_transposed_tile(v)
+
+    assert_close('o', ref, tri, 0)


### PR DESCRIPTION
## Summary
IS_TMA_SUPPORTED was Nvidia-only. gfx1250 is the first AMD arch whose Triton backend lowers tl.make_tensor_descriptor onto hardware supported tensor-descriptor loads and stores (TDM in AMD terminology). Add it behind a new IS_AMD_TMA_ARCH flag and a get_device_arch() helper. gfx942 and gfx950 have no TDM HW support. The path is gated behind FLA_USE_TMA=1.

 - Add IS_TF32_SUPPORTED to the solve_tril DOT_PRECISION gate. That list keyed off IS_TMA_SUPPORTED alone, which now admits AMD, where the tf32 dot precisions do not exist. 
- Fix the config order while there: it was derived from a set, so it varied with the interpreter hash seed.

## Test plan
Added tests/ops/utils/test_tma.py covering a 2-D tile transposed, skipped unless IS_TMA_SUPPORTED. All four shapes satisfy the descriptor alignment rules, which the compiler does not check and which fault at launch when violated; three leave a ragged tail so descriptor zero-fill on load and drop on store are exercised in place of explicit masks.

Updated the CONTRIBUTING TMA guidance and the FLA_USE_TMA row in ENVs.md to match, tested on a local gfx1250 there isn't currently a fla CI runner has a TMA-capable AMD arch.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.