### PR TITLE
[Refactor] Align Based attention with FLA layer conventions

### DIFF
--- a/fla/layers/based.py
+++ b/fla/layers/based.py
@@ -5,11 +5,6 @@
 # For a list of all contributors, visit:
 #   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-"""
-Linear attention in Based.
-https://github.com/HazyResearch/zoology/blob/main/zoology/mixers/based.py
-"""
-
 import torch
 import torch.nn as nn
 from einops import rearrange
@@ -20,6 +15,31 @@ from fla.ops.linear_attn import chunk_linear_attn, fused_chunk_linear_attn
 
 
 class BasedLinearAttention(nn.Module):
+    r"""
+    Based linear attention with a second-order Taylor feature map.
+
+    Adapted from https://github.com/HazyResearch/zoology/blob/main/zoology/mixers/based.py.
+
+    Args:
+        hidden_size (int):
+            The hidden size of the input.
+        feature_dim (int, Optional):
+            The query/key dimension per head before feature mapping. Default: 16.
+        num_key_value_heads (int, Optional):
+            The number of key/value heads. Must equal `num_heads`. Default: 12.
+        num_heads (int, Optional):
+            The number of attention heads. Default: 12.
+        feature_name (str, Optional):
+            The feature map to use. Only `taylor_exp` is supported. Default: `taylor_exp`.
+        eps (float, Optional):
+            The denominator epsilon for `forward_reference`, also used for noncausal attention. Default: 1e-12.
+            Causal kernels use their own normalization epsilon.
+        causal (bool, Optional):
+            Whether to apply causal attention. Noncausal attention uses the PyTorch reference. Default: `True`.
+        mode (str, Optional):
+            Which causal kernel to use: `parallel`, `chunk`, or `fused_chunk`. Default: `parallel`.
+            The parallel kernel supports `feature_dim` up to 128.
+    """
 
     def __init__(
         self,
@@ -27,72 +47,90 @@ class BasedLinearAttention(nn.Module):
         feature_dim: int = 16,
         num_key_value_heads: int = 12,
         num_heads: int = 12,
-        feature_name: str = "taylor_exp",
+        feature_name: str = 'taylor_exp',
         eps: float = 1e-12,
         causal: bool = True,
-        mode: str = "parallel",
-    ):
+        mode: str = 'parallel',
+    ) -> None:
         super().__init__()
 
-        self.hidden_size = hidden_size
+        assert mode in ['parallel', 'chunk', 'fused_chunk'], f"Not supported mode `{mode}`."
+        assert feature_name == 'taylor_exp', f"Not supported feature map `{feature_name}`."
+        assert hidden_size > 0 and feature_dim > 0, "hidden_size and feature_dim must be positive."
+        assert num_heads > 0 and num_key_value_heads > 0, "Head counts must be positive."
+        assert num_heads == num_key_value_heads, "num_heads must equal num_key_value_heads."
+        assert hidden_size >= num_heads, "hidden_size must be at least num_heads."
+        if causal and mode == 'parallel':
+            assert feature_dim <= 128, "The parallel kernel only supports feature_dim up to 128."
+
         self.mode = mode
+        self.hidden_size = hidden_size
         self.feature_name = feature_name
         self.feature_dim = feature_dim
-        self.num_key_value_heads = num_key_value_heads
         self.num_heads = num_heads
-        self.head_dim = self.hidden_size // self.num_key_value_heads
-        assert self.hidden_size % self.head_dim == 0
+        self.num_key_value_heads = num_key_value_heads
+        self.head_k_dim = feature_dim
+        self.head_v_dim = hidden_size // num_heads
+        self.head_dim = self.head_v_dim
         self.causal = causal
-
-        self.q_proj = nn.Linear(self.hidden_size, self.feature_dim * self.num_heads, bias=False)
-        self.k_proj = nn.Linear(self.hidden_size, self.feature_dim * self.num_heads, bias=False)
-        self.v_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=False)
-        self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
-        self.dropout = nn.Identity()
-        self.feature_map = TaylorFeatureMap(feature_dim)
         self.eps = eps
 
-    def forward(self, hidden_states: torch.Tensor, **kwargs):
+        self.feature_map = TaylorFeatureMap(head_dim=self.head_k_dim)
+        self.q_proj = nn.Linear(hidden_size, num_heads * self.head_k_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, num_key_value_heads * self.head_k_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, num_key_value_heads * self.head_v_dim, bias=False)
+        self.o_proj = nn.Linear(num_heads * self.head_v_dim, hidden_size, bias=False)
+        self.dropout = nn.Identity()
+
+    def forward(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor:
+        """Return attention outputs with shape `[batch_size, seq_len, hidden_size]`."""
+        if not self.causal:
+            return self.forward_reference(hidden_states=hidden_states)
+
         mode = self.mode
-        q, k, v = self.q_proj(hidden_states), self.k_proj(hidden_states), self.v_proj(hidden_states)
-        q, k, v = map(lambda x: rearrange(x, "... (h d) -> ... h d", d=self.head_dim), [q, k, v])
-        if mode == "fused_chunk":
-            q, k = self.feature_map(q), self.feature_map(k)
-            o, _ = fused_chunk_linear_attn(q, k, v, normalize=True, scale=1)
-        elif mode == 'chunk':
-            q, k = self.feature_map(q), self.feature_map(k)
-            o, _ = chunk_linear_attn(q, k, v, normalize=True, scale=1)
-        elif mode == 'parallel':
-            assert q.shape[-1] <= 128
-            o = parallel_based(q, k, v, scale=1, use_norm=True)
-        o = rearrange(o, 'b t h d -> b t (h d)')
+        q = self.q_proj(hidden_states)
+        k = self.k_proj(hidden_states)
+        v = self.v_proj(hidden_states)
+
+        q = rearrange(q, '... (h d) -> ... h d', d=self.head_k_dim)
+        k = rearrange(k, '... (h d) -> ... h d', d=self.head_k_dim)
+        v = rearrange(v, '... (h d) -> ... h d', d=self.head_v_dim)
+
+        if mode == 'parallel':
+            o = parallel_based(q=q, k=k, v=v, scale=self.head_k_dim ** -0.5, use_norm=True)
+        elif mode in ['chunk', 'fused_chunk']:
+            q = self.feature_map(q)
+            k = self.feature_map(k)
+            if mode == 'chunk':
+                o, _ = chunk_linear_attn(q=q, k=k, v=v, scale=1, normalize=True)
+            else:
+                o, _ = fused_chunk_linear_attn(q=q, k=k, v=v, scale=1, normalize=True)
+        else:
+            raise NotImplementedError(f"Not supported mode `{mode}`.")
+
+        o = rearrange(o, '... h d -> ... (h d)')
         o = self.o_proj(o)
         o = self.dropout(o)
         return o
 
-    def forward_reference(self, hidden_states: torch.Tensor, **kwargs):
-        """
-        x (torch.Tensor): tensor of shape (b, d, t)
-        y (torch.Tensor): tensor of shape (b, d, t)
-        """
-        # hidden_states = hidden_states.transpose(1, 2)
-        b, t, _ = hidden_states.size()
-        q, k, v = self.q_proj(hidden_states), self.k_proj(hidden_states), self.v_proj(hidden_states)
+    def forward_reference(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor:
+        """Compute normalized Taylor attention in PyTorch, honoring `causal` and `eps`."""
+        q = self.q_proj(hidden_states)
+        k = self.k_proj(hidden_states)
+        v = self.v_proj(hidden_states)
 
-        q = q.view(b, t, self.num_heads, self.feature_dim).transpose(1, 2)
-        k = k.view(b, t, self.num_key_value_heads, self.feature_dim).transpose(1, 2)
-        v = v.view(b, t, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        q = rearrange(q, 'b t (h d) -> b t h d', d=self.head_k_dim)
+        k = rearrange(k, 'b t (h d) -> b t h d', d=self.head_k_dim)
+        v = rearrange(v, 'b t (h d) -> b t h d', d=self.head_v_dim)
+        q = self.feature_map(q).unsqueeze(-2)
+        k = self.feature_map(k).unsqueeze(-2)
+        v = v.unsqueeze(-1)
 
-        # Linear attention
-        q, k = self.feature_map(q), self.feature_map(k)
-        q, k, v = q.unsqueeze(-2), k.unsqueeze(-2), v.unsqueeze(-1)
-
-        # Compute attention
         if self.causal:
-            y = ((q * (k * v).cumsum(2)).sum(-1) / ((q * k.cumsum(2)).sum(-1) + self.eps))
+            o = (q * (k * v).cumsum(1)).sum(-1) / ((q * k.cumsum(1)).sum(-1) + self.eps)
         else:
-            y = ((q * (k * v).sum(2, True)).sum(-1) / ((q * k.sum(2, True)).sum(-1) + self.eps))
-        y = rearrange(y, 'b h t d -> b t (h d)')
-        y = self.o_proj(y.to(hidden_states.dtype))
-        y = self.dropout(y)
-        return y.to(hidden_states.dtype)
+            o = (q * (k * v).sum(1, True)).sum(-1) / ((q * k.sum(1, True)).sum(-1) + self.eps)
+        o = rearrange(o, 'b t h d -> b t (h d)')
+        o = self.o_proj(o.to(hidden_states.dtype))
+        o = self.dropout(o)
+        return o.to(hidden_states.dtype)

--- a/tests/layers/test_based.py
+++ b/tests/layers/test_based.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import copy
+
+import pytest
+import torch
+import triton
+from einops import rearrange
+
+from fla.layers.based import BasedLinearAttention
+from fla.utils import assert_close, device
+
+
+def _quadratic_attention(layer: BasedLinearAttention, hidden_states: torch.Tensor) -> torch.Tensor:
+    q = rearrange(layer.q_proj(hidden_states), 'b t (h d) -> b h t d', h=layer.num_heads)
+    k = rearrange(layer.k_proj(hidden_states), 'b t (h d) -> b h t d', h=layer.num_heads)
+    v = rearrange(layer.v_proj(hidden_states), 'b t (h d) -> b h t d', h=layer.num_heads)
+    scores = (q @ k.transpose(-1, -2)) * layer.feature_dim ** -0.5
+    scores = 1 + scores + 0.5 * scores.square()
+    if layer.causal:
+        scores = scores.tril()
+    o = (scores @ v) / (scores.sum(-1, keepdim=True) + layer.eps)
+    return layer.o_proj(rearrange(o, 'b h t d -> b t (h d)'))
+
+
+@pytest.mark.parametrize('mode', ['parallel', 'chunk', 'fused_chunk'])
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    ('B', 'T', 'H', 'K', 'V'),
+    [
+        pytest.param(*test, id='B{}-T{}-H{}-K{}-V{}'.format(*test))
+        for test in [(1, 1, 2, 16, 16), (2, 63, 3, 16, 32), (1, 129, 2, 8, 24), (1, 17, 1, 1, 16)]
+    ],
+)
+def test_forward(B: int, T: int, H: int, K: int, V: int, dtype: torch.dtype, mode: str, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('TRITON_F32_DEFAULT', 'ieee')
+    if hasattr(triton, 'knobs'):
+        monkeypatch.setattr(triton.knobs.language, 'fp32_default', 'ieee')
+    torch.manual_seed(42)
+    layer = BasedLinearAttention(
+        hidden_size=H * V,
+        feature_dim=K,
+        num_key_value_heads=H,
+        num_heads=H,
+        mode=mode,
+    ).to(device=device, dtype=dtype)
+    reference = copy.deepcopy(layer).float()
+    reference.eps = 1e-6 if mode == 'parallel' else 1e-10
+    x = torch.randn(B, T, H * V, device=device, dtype=dtype, requires_grad=True)
+    x_ref = x.detach().float().requires_grad_(True)
+    do = torch.randn_like(x)
+
+    ref = _quadratic_attention(reference, x_ref)
+    ref.backward(do.float())
+    actual = layer(hidden_states=x)
+    actual.backward(do)
+
+    assert actual.shape == x.shape
+    assert actual.dtype == dtype
+    tol = {torch.float32: 1e-3, torch.float16: 5e-3, torch.bfloat16: 2e-2}[dtype]
+    for name, expected, result in [
+        ('o', ref, actual),
+        ('dx', x_ref.grad, x.grad),
+        *[(name, parameter.grad, layer.get_parameter(name).grad) for name, parameter in reference.named_parameters()],
+    ]:
+        assert torch.isfinite(expected).all(), name
+        assert torch.isfinite(result).all(), name
+        # single-token attention has near-zero query/key gradients after normalization
+        atol = tol if T == 1 and dtype != torch.float32 and name in ['q_proj.weight', 'k_proj.weight'] else 1e-6
+        assert_close(name, expected, result, tol, err_atol=atol)
+
+
+@pytest.mark.parametrize('causal', [True, False])
+@pytest.mark.parametrize('eps', [1e-12, 0.1])
+@pytest.mark.parametrize(('hidden_size', 'H', 'K'), [(48, 2, 8), (10, 4, 2)])
+def test_forward_reference(causal: bool, eps: float, hidden_size: int, H: int, K: int):
+    torch.manual_seed(42)
+    layer = BasedLinearAttention(
+        hidden_size=hidden_size,
+        feature_dim=K,
+        num_key_value_heads=H,
+        num_heads=H,
+        eps=eps,
+        causal=causal,
+    )
+    x = torch.randn(2, 17, hidden_size, requires_grad=True)
+    do = torch.randn_like(x)
+    ref = _quadratic_attention(layer, x)
+    ref.backward(do)
+    ref_grads = [tensor.grad.clone() for tensor in (x, *layer.parameters())]
+    x.grad = None
+    layer.zero_grad(set_to_none=True)
+    actual = layer.forward_reference(hidden_states=x)
+    actual.backward(do)
+    actual_grads = [tensor.grad for tensor in (x, *layer.parameters())]
+
+    assert_close('o', ref, actual, 1e-5)
+    for i, (expected, result) in enumerate(zip(ref_grads, actual_grads)):
+        assert torch.isfinite(expected).all()
+        assert torch.isfinite(result).all()
+        assert_close(f'grad_{i}', expected, result, 1e-5)
+    if not causal:
+        assert_close('noncausal', actual, layer(hidden_states=x), 1e-5)
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'message'),
+    [
+        pytest.param({'mode': 'unknown'}, 'mode', id='mode'),
+        pytest.param({'feature_name': 'relu'}, 'feature', id='feature-map'),
+        pytest.param({'num_heads': 6}, 'equal', id='unequal-heads'),
+        pytest.param({'hidden_size': 2, 'num_heads': 4, 'num_key_value_heads': 4}, 'at least', id='hidden-size'),
+        pytest.param({'feature_dim': 0}, 'positive', id='feature-dim'),
+        pytest.param({'num_key_value_heads': 0}, 'positive', id='zero-heads'),
+        pytest.param({'feature_dim': 129}, '128', id='parallel-feature-dim'),
+    ],
+)
+def test_invalid_config(kwargs: dict, message: str):
+    config = {'hidden_size': 192, **kwargs}
+    with pytest.raises(AssertionError, match=message):
+        BasedLinearAttention(**config)


### PR DESCRIPTION
## Summary

Refactor `BasedLinearAttention` to follow the projection, head-dimension naming, tensor layout, and kernel dispatch conventions used by other FLA layers. The layer now reshapes queries/keys using `feature_dim` and values using `hidden_size // num_heads`; previously, the default configuration mixed those dimensions and produced mismatched head counts.

Fix the parallel path's scale to match the existing Taylor feature map and PyTorch reference, and honor `causal=False` through the reference implementation. Validate unsupported modes, feature maps, and unequal query/key-value head counts at construction. Preserve public argument names/order, Tensor returns, projection parameter names/shapes, `head_dim`, and `forward_reference`, including previously valid nondivisible hidden sizes.

## Test plan

- `python scripts/find_dependent_tests.py fla/layers/based.py` identifies `tests/layers/test_based.py`; no in-repo model instantiates this layer.
- `pre-commit run --files fla/layers/based.py tests/layers/test_based.py` and `git diff --check`: passed.
- `python -m pytest tests/layers/test_based.py -q -k 'reference or invalid'`: 15 passed on CPU.
- GPU validation: 51 passed (36 GPU cases and 15 reference/configuration cases), running `tests/layers/test_based.py -q` in four shards selected by shape. The full suite covers all three modes in fp32/fp16/bf16, single-token inputs, chunk boundaries, unequal key/value dimensions, and feature dimension 1. Outputs, input gradients, and all projection gradients are compared against an independent quadratic Taylor-attention reference. FP32 dot products use IEEE precision for this comparison; each reference uses its kernel's existing normalization epsilon.
- A separate legacy comparison on the PR base confirms bitwise-identical chunk outputs and all gradients with default precision in fp32/fp16 at sequence lengths 1 and 63. Constructor parameters, initialized weights, and strict state-dict loading also match the original layer, including `hidden_size=10, num_heads=4`.
- GPU environment: NVIDIA GB200, PyTorch 2.11.0.post1+cu132.msh, Triton 3.6.0.
- Varlen / CP / model tests: N/A; the layer exposes none of these paths and shared operators are unchanged.

## Benchmark / NCU (kernel changes only)

N/A: no kernel code changed; this is a layer refactor with correctness fixes, not a performance optimization.

## Breaking changes

Public signatures and checkpoint layouts are preserved for previously supported configurations. Intentional bug fixes change parallel outputs to use the same scaled Taylor attention as the chunk/reference paths, repair head reshaping when key/value dimensions differ, and make `causal=False` effective. Previously ignored invalid feature names and unsupported configurations now fail early. `eps` continues to control reference/noncausal attention; causal kernels retain their existing normalization constants.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
