### PR TITLE
[Fix] Reject odd K/V for 16-bit dtypes in chunk_bwd_dv

### DIFF
--- a/fla/ops/common/chunk_o.py
+++ b/fla/ops/common/chunk_o.py
@@ -608,6 +608,10 @@ def chunk_bwd_dv(
     chunk_indices: torch.LongTensor | None = None,
 ) -> torch.Tensor:
     B, T, H, K, V, HV = *k.shape, do.shape[-1], do.shape[2]
+    if q.dtype in (torch.float16, torch.bfloat16):
+        # Triton miscompiles masked K-tail iterations into OOB shared-memory access for 16-bit odd K/V (IMA)
+        assert K % 2 == 0 and V % 2 == 0, \
+            f"chunk_bwd_dv requires even K and V for {q.dtype}, got K={K}, V={V}"
     BT = chunk_size
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)

--- a/tests/layers/test_based.py
+++ b/tests/layers/test_based.py
@@ -38,6 +38,11 @@ def _quadratic_attention(layer: BasedLinearAttention, hidden_states: torch.Tenso
     ],
 )
 def test_forward(B: int, T: int, H: int, K: int, V: int, dtype: torch.dtype, mode: str, monkeypatch: pytest.MonkeyPatch):
+    if mode == 'chunk' and dtype != torch.float32:
+        # 16-bit chunk kernels reject odd K/V (see the assert in chunk_bwd_dv);
+        # the Taylor feature map expands K to 1 + K + K*(K+1)/2.
+        if (1 + K + K * (K + 1) // 2) % 2 == 1 or V % 2 == 1:
+            pytest.skip('odd expanded K/V is not supported for 16-bit chunk kernels')
     monkeypatch.setenv('TRITON_F32_DEFAULT', 'ieee')
     if hasattr(triton, 'knobs'):
         monkeypatch.setattr(triton.knobs.language, 'fp32_default', 'ieee')


### PR DESCRIPTION
## Summary

`chunk_bwd_kernel_dv` crashes with an illegal memory access on sm_90 (H100/H20) with Triton 3.7 when running fp16/bf16 inputs whose K is odd and crosses a BK-boundary tail iteration (BK=128), e.g. K=153 produced by Based's Taylor feature map with `feature_dim=16`. compute-sanitizer reports an out-of-range shared/local address at a single PC inside the kernel, i.e. a Triton miscompile of the masked tail iteration, not a fla indexing bug. fp32 inputs and even K/V are unaffected, and reverting #1224's accumulator rewrite does not change the crash, so this is a pre-existing issue exposed by #1238's new `test_based` chunk cases (currently failing nightly).

This PR rejects odd K/V for 16-bit dtypes with a clear assertion in `chunk_bwd_dv` instead of an IMA, and skips the corresponding `test_based` combinations.

Reproducer evidence (H20, torch 2.9.1+cu128, triton 3.7.0): K sweep over `chunk_bwd_dv` with T=1, BK=128 — crash at K ∈ {129, 131, 133, 153, 155, 161, 163, 255} (odd), pass at K ∈ {126, 127, 128, 130, 144, 152, 154, 160, 192, 256} (even, or odd within a single BK iteration), fp32 K=153 passes.

## Test plan

- Unit tests added/modified: `tests/layers/test_based.py` (skip 16-bit chunk cases whose Taylor-expanded K is odd)
- Dependent tests run: odd-K sweep of `chunk_bwd_dv` on H20 (above); replay of the exact tensors dumped from the failing `test_based` case crashes before the fix and raises the new `AssertionError` after it. Full `tests/layers/test_based.py` suite runs in this PR's CI.
- Varlen / CP / model tests: no (wrapper-level assert only; even-K/V paths unchanged)

## Benchmark / NCU (kernel changes only)

Neutral — no kernel code changed; only a wrapper-level assertion for inputs that previously crashed.

## Breaking changes

fp16/bf16 calls to `chunk_bwd_dv` (via `chunk_simple_gla` / `chunk_linear_attn`) with odd K or V now raise `AssertionError` instead of crashing with an IMA. fp32 and even-K/V behavior is unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
