### PR TITLE
[Perf] Reuse chunk metadata for graph-capturable state allocation

### DIFF
--- a/fla/ops/common/backends/triton_ascend/chunk_h.py
+++ b/fla/ops/common/backends/triton_ascend/chunk_h.py
@@ -264,6 +264,7 @@ def chunk_fwd_h_npu(
     chunk_size: int = 64,
     split_size: int | None = None,
     states_in_fp32: bool = False,
+    chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = chunk_size
@@ -275,7 +276,7 @@ def chunk_fwd_h_npu(
         assert B == 1, "NPU varlen chunk_h expects packed batch B=1"
         split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
         N = len(cu_seqlens) - 1
-        NS = int(split_offsets[-1].item())
+        NS = len(chunk_indices) if BS == BT and chunk_indices is not None else int(split_offsets[-1].item())
         state_shape = (V, K) if state_v_first else (K, V)
         # zero-init: kernels may only partially store each tile
         h = k.new_zeros(B, NS, H, *state_shape, dtype=torch.float if states_in_fp32 else k.dtype)
@@ -351,6 +352,7 @@ def chunk_bwd_dh_npu(
     chunk_size: int = 64,
     split_size: int | None = None,
     states_in_fp32: bool = False,
+    chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     HQ = q.shape[2]
@@ -363,7 +365,7 @@ def chunk_bwd_dh_npu(
         assert B == 1, "NPU varlen chunk_bwd_dh expects packed batch B=1"
         split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
         N = len(cu_seqlens) - 1
-        NS = int(split_offsets[-1].item())
+        NS = len(chunk_indices) if BS == BT and chunk_indices is not None else int(split_offsets[-1].item())
         state_shape = (V, K) if state_v_first else (K, V)
         dh = k.new_zeros(B, NS, HQ, *state_shape, dtype=torch.float if states_in_fp32 else k.dtype)
         dh0 = torch.zeros_like(h0, dtype=torch.float) if h0 is not None else None

--- a/fla/ops/common/chunk_h.py
+++ b/fla/ops/common/chunk_h.py
@@ -321,6 +321,7 @@ def chunk_fwd_h(
     chunk_size: int = 64,
     split_size: int | None = None,
     states_in_fp32: bool = False,
+    chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = chunk_size
@@ -331,7 +332,8 @@ def chunk_fwd_h(
         N, NS, split_offsets = B, triton.cdiv(T, BS), None
     else:
         split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
-        N, NS = len(cu_seqlens) - 1, split_offsets[-1].item()
+        N = len(cu_seqlens) - 1
+        NS = len(chunk_indices) if BS == BT and chunk_indices is not None else split_offsets[-1].item()
 
     # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`
     state_shape = (V, K) if state_v_first else (K, V)
@@ -383,6 +385,7 @@ def chunk_bwd_dh(
     chunk_size: int = 64,
     split_size: int | None = None,
     states_in_fp32: bool = False,
+    chunk_indices: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     HQ = q.shape[2]
@@ -395,7 +398,8 @@ def chunk_bwd_dh(
         N, NS, split_offsets = B, triton.cdiv(T, BS), None
     else:
         split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
-        N, NS = len(cu_seqlens) - 1, split_offsets[-1].item()
+        N = len(cu_seqlens) - 1
+        NS = len(chunk_indices) if BS == BT and chunk_indices is not None else split_offsets[-1].item()
     NG = HQ // H
 
     # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`

--- a/fla/ops/gla/chunk.py
+++ b/fla/ops/gla/chunk.py
@@ -1218,6 +1218,7 @@ def chunk_gla_fwd(
         chunk_size=chunk_size,
         states_in_fp32=False,
         state_v_first=state_v_first,
+        chunk_indices=chunk_indices,
     )
 
     # the intra A is kept in fp32
@@ -1284,6 +1285,7 @@ def chunk_gla_bwd(
             chunk_size=chunk_size,
             states_in_fp32=True,
             state_v_first=state_v_first,
+            chunk_indices=chunk_indices,
         )
     dh, dh0 = chunk_bwd_dh(
         q=q,
@@ -1300,6 +1302,7 @@ def chunk_gla_bwd(
         chunk_size=chunk_size,
         states_in_fp32=True,
         state_v_first=state_v_first,
+        chunk_indices=chunk_indices,
     )
 
     dv = chunk_gla_bwd_dv(

--- a/fla/ops/gsa/chunk.py
+++ b/fla/ops/gsa/chunk.py
@@ -625,6 +625,7 @@ def chunk_gsa_fwd_k(
         cu_seqlens=cu_seqlens,
         chunk_size=BT,
         states_in_fp32=False,
+        chunk_indices=chunk_indices,
     )
     o = v.new_empty(B, T, HQ, V)
     A = q.new_empty(B, T, HQ, BT)
@@ -752,6 +753,7 @@ def chunk_gsa_bwd_k(
             cu_seqlens=cu_seqlens,
             chunk_size=BT,
             states_in_fp32=False,
+            chunk_indices=chunk_indices,
         )
     dh, dh0 = chunk_bwd_dh(
         q=q,
@@ -767,6 +769,7 @@ def chunk_gsa_bwd_k(
         cu_seqlens=cu_seqlens,
         chunk_size=BT,
         states_in_fp32=True,
+        chunk_indices=chunk_indices,
     )
     dA = q.new_empty(NV, B, T, HQ, BT)
     grid = (NV * NT * NC * NC, B * HQ)

--- a/fla/ops/mesa_net/chunk.py
+++ b/fla/ops/mesa_net/chunk.py
@@ -116,6 +116,7 @@ def chunk_fwd_mesa_net_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         scale=1,
+        chunk_indices=chunk_indices,
     )
     dq, dk_beta, dv, dg = chunk_mesa_net_h_kv_bwd_intra_fn(
         q_star=q_star,
@@ -157,6 +158,7 @@ def chunk_fwd_mesa_net_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         scale=1,
+        chunk_indices=chunk_indices,
     )
     dk, dg2, dlamb, dbeta = chunk_mesa_net_h_kk_bwd_intra_fn(
         k=k,

--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -1071,6 +1071,7 @@ def chunk_rwkv6_fwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         states_in_fp32=True,
+        chunk_indices=chunk_indices,
     )
     A = chunk_rwkv6_fwd_intra(
         q=q,
@@ -1131,6 +1132,7 @@ def chunk_rwkv6_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         states_in_fp32=True,
+        chunk_indices=chunk_indices,
     )
     dh, dh0 = chunk_rwkv6_bwd_dh(
         q=q,

--- a/fla/ops/simple_gla/chunk.py
+++ b/fla/ops/simple_gla/chunk.py
@@ -41,6 +41,7 @@ def chunk_simple_gla_fwd(
         chunk_size=chunk_size,
         states_in_fp32=False,
         state_v_first=state_v_first,
+        chunk_indices=chunk_indices,
     )
     o = chunk_fwd_o(
         q=q,
@@ -87,6 +88,7 @@ def chunk_simple_gla_bwd(
         chunk_size=chunk_size,
         states_in_fp32=True,
         state_v_first=state_v_first,
+        chunk_indices=chunk_indices,
     )
     dh, dh0 = chunk_bwd_dh(
         q=q,
@@ -104,6 +106,7 @@ def chunk_simple_gla_bwd(
         chunk_size=chunk_size,
         states_in_fp32=True,
         state_v_first=state_v_first,
+        chunk_indices=chunk_indices,
     )
     dq, dk, _, dg = chunk_bwd_dqkwg(
         q=q,

--- a/tests/ops/test_chunk_state_metadata.py
+++ b/tests/ops/test_chunk_state_metadata.py
@@ -13,6 +13,7 @@ from fla.ops.simple_gla import chunk_simple_gla
 from fla.utils import assert_close, device
 
 
+@pytest.mark.smoke
 @pytest.mark.skipif(device != 'cuda', reason='CUDA graph capture requires CUDA')
 @pytest.mark.parametrize('state_v_first', [False, True])
 def test_chunk_varlen_cudagraph(state_v_first: bool):

--- a/tests/ops/test_chunk_state_metadata.py
+++ b/tests/ops/test_chunk_state_metadata.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from fla.ops.simple_gla import chunk_simple_gla
+from fla.utils import assert_close, device
+
+
+@pytest.mark.skipif(device != 'cuda', reason='CUDA graph capture requires CUDA')
+@pytest.mark.parametrize('state_v_first', [False, True])
+def test_chunk_varlen_cudagraph(state_v_first: bool):
+    torch.manual_seed(42)
+    cu_seqlens_cpu = torch.tensor([0, 63, 129, 256], dtype=torch.int32)
+    cu_seqlens = cu_seqlens_cpu.to(device)
+    q, k, v = [torch.randn(1, 256, 4, 64, device=device, dtype=torch.bfloat16).requires_grad_() for _ in range(3)]
+    g = F.logsigmoid(torch.randn(1, 256, 4, device=device, dtype=torch.bfloat16)).requires_grad_()
+    h0 = torch.randn(3, 4, 64, 64, device=device, requires_grad=True)
+    do, dht = torch.randn_like(v), torch.randn_like(h0)
+
+    def step():
+        o, ht = chunk_simple_gla(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            initial_state=h0,
+            output_final_state=True,
+            state_v_first=state_v_first,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_cpu=cu_seqlens_cpu,
+        )
+        grads = torch.autograd.grad((o, ht), (q, k, v, g, h0), (do, dht))
+        return o, ht, *grads
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            step()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        actual = step()
+    for _ in range(2):
+        with torch.no_grad():
+            q.add_(0.125)
+        expected = step()
+        graph.replay()
+        for name, ref, result in zip(('o', 'ht', 'dq', 'dk', 'dv', 'dg', 'dh0'), expected, actual, strict=True):
+            assert_close(name, ref, result, 0.005)


### PR DESCRIPTION
## Summary

I reuse the existing `chunk_indices` shape to allocate packed chunk states when `split_size == chunk_size`. Passing this metadata through Simple GLA, GLA, GSA, RWKV6, and MesaNet removes repeated device scalar reads in the shared state wrappers. Warmed, fixed-layout CUDA Graph capture passes for Simple GLA and `GLAForCausalLM`. MesaNet uses the metadata in its backward state wrappers. Kernel arithmetic, buffer shapes, public operator signatures, and metadata cache lifetime stay unchanged. The Ascend wrappers accept the same optional argument.

## Test plan

The full Simple GLA, GLA, GSA, RWKV6, and MesaNet operator files pass on H100. The new regression covers forward output, final state, and all five input gradients across two changed-input graph replays in both state layouts. It reproduces the original failure at `split_offsets[-1].item()`.

Same-seed operator and four-layer `GLAForCausalLM` comparisons match exactly for outputs, states, loss, and gradients. Changed-token model graph replays also match. Project pre-commit checks and the official Ascend A2 tests pass. The H100 smoke job reached its two-hour timeout.

```bash
for op in simple_gla gla gsa rwkv6 mesa; do
    python -m pytest "tests/ops/test_${op}.py" -q -x
done
python -m pytest tests/ops/test_chunk_state_metadata.py -q
```

## Benchmark

NVIDIA H100 80GB HBM3, CUDA 13.0, PyTorch 2.13.0, Triton 3.7.1, Python 3.10, driver 580.95.05. Baseline `516143e31fce09925e6c39ac37148444bad176c4`; candidate `550b9b47e0cfde0487969196d769ecfa2cfd3cc7`. The current head adds the smoke marker to the regression.

Each paired comparison uses the same GPU and CPU core, seed 42, nine ABBA rounds and 18 samples per variant. Tables report sample medians. Timings include host submission and final synchronization. Application clocks remain unset. Backward captures emit the existing `AccumulateGrad` stream-mismatch diagnostic and complete replay comparisons successfully. The operator environment uses Transformers 5.15.0 and tokenizers 0.22.2; the model uses Transformers 5.17.0 and tokenizers 0.23.2.

Simple GLA uses batch size 1, BF16 inputs, FP32 states and packed boundaries `[0, 63, T // 3, T - 17, T]`. Eager samples measure 100 calls after 20 warmups; graph samples measure 1,000 replays. `fwdbwd` includes gradients for `q`, `k`, `v`, `g` and the initial state.

| Tokens | Heads | Head dimension | Mode | Baseline eager, µs | Candidate eager, µs | Candidate graph, µs |
|---:|---:|---:|---|---:|---:|---:|
| 256 | 4 | 64 | fwd | 298.41 | 266.66 | 9.05 |
| 256 | 4 | 64 | fwdbwd | 1101.47 | 949.79 | 29.53 |
| 2048 | 4 | 64 | fwd | 295.90 | 271.18 | 16.12 |
| 2048 | 4 | 64 | fwdbwd | 1054.55 | 961.39 | 56.95 |
| 8192 | 16 | 128 | fwd | 312.38 | 273.36 | 152.35 |
| 8192 | 16 | 128 | fwdbwd | 1207.30 | 960.60 | 797.34 |

Packed forward removes one scalar read; forward-backward removes three. The four-layer model removes four and twelve respectively. The profiler measured scalar extraction and synchronization; NCU metrics remain uncollected.

The model uses four layers, vocabulary size 4,096, BF16 parameters and the same packed boundaries. Eager samples measure 20 calls after 20 warmups; graph samples measure 100 replays. Backward computes every parameter gradient through `torch.autograd.grad`.

| Tokens | Hidden size | Mode | Baseline eager, ms | Candidate eager, ms | Candidate graph, ms |
|---:|---:|---|---:|---:|---:|
| 256 | 512 | fwd | 7.755 | 7.056 | 0.345 |
| 256 | 512 | fwdbwd | 18.063 | 17.039 | 1.086 |
| 2048 | 512 | fwd | 7.193 | 7.010 | 0.565 |
| 2048 | 512 | fwdbwd | 17.550 | 17.255 | 2.070 |
| 8192 | 1024 | fwd | 7.564 | 7.004 | 2.874 |
| 8192 | 1024 | fwdbwd | 18.325 | 17.772 | 10.119 |

Dense controls cover the same shapes. The largest measured eager median increases are 0.86% for Simple GLA and 1.57% for the model; graph increases are 0.68% and 0.15%. The detailed samples, allocator probe and complete reproduction commands follow.

<details>
<summary>Sample statistics for all dense and packed controls</summary>

Every row summarizes 18 samples. Units are microseconds. Standard deviations use the sample estimator; P10 and P90 use linear interpolation between ordered samples. `fwdbwd` includes the complete forward and backward operation described above.

| Workload | Execution | Variant | Median | Mean | Sample std | Min | P10 | P90 |
|---|---|---|---:|---:|---:|---:|---:|---:|
| simple_gla-256-4-64-False-fwd | eager | baseline | 263.205 | 263.184 | 2.839 | 260.172 | 260.293 | 267.810 |
| simple_gla-256-4-64-False-fwd | eager | candidate | 254.970 | 255.788 | 3.115 | 252.840 | 253.116 | 260.769 |
| simple_gla-256-4-64-False-fwd | graph | baseline | 8.197 | 8.312 | 0.154 | 8.185 | 8.188 | 8.500 |
| simple_gla-256-4-64-False-fwd | graph | candidate | 8.177 | 8.267 | 0.132 | 8.170 | 8.171 | 8.448 |
| simple_gla-256-4-64-False-fwdbwd | eager | baseline | 943.081 | 943.865 | 9.771 | 931.719 | 935.448 | 949.594 |
| simple_gla-256-4-64-False-fwdbwd | eager | candidate | 920.388 | 922.876 | 9.668 | 910.368 | 914.131 | 932.617 |
| simple_gla-256-4-64-False-fwdbwd | graph | baseline | 27.219 | 27.291 | 0.230 | 27.217 | 27.218 | 27.391 |
| simple_gla-256-4-64-False-fwdbwd | graph | candidate | 27.203 | 27.337 | 0.294 | 27.199 | 27.201 | 27.728 |
| simple_gla-256-4-64-True-fwd | eager | baseline | 298.414 | 299.202 | 3.505 | 294.858 | 295.733 | 304.236 |
| simple_gla-256-4-64-True-fwd | eager | candidate | 266.656 | 266.901 | 2.553 | 263.005 | 263.881 | 270.816 |
| simple_gla-256-4-64-True-fwd | graph | candidate | 9.052 | 9.007 | 0.088 | 8.867 | 8.867 | 9.074 |
| simple_gla-256-4-64-True-fwdbwd | eager | baseline | 1101.465 | 1103.350 | 20.497 | 1078.489 | 1079.457 | 1130.702 |
| simple_gla-256-4-64-True-fwdbwd | eager | candidate | 949.790 | 952.574 | 14.996 | 939.023 | 941.286 | 959.981 |
| simple_gla-256-4-64-True-fwdbwd | graph | candidate | 29.527 | 29.719 | 0.334 | 29.522 | 29.524 | 30.162 |
| simple_gla-2048-4-64-False-fwd | eager | baseline | 262.477 | 264.882 | 8.214 | 258.701 | 260.668 | 270.141 |
| simple_gla-2048-4-64-False-fwd | eager | candidate | 255.822 | 256.643 | 3.061 | 252.987 | 254.175 | 262.355 |
| simple_gla-2048-4-64-False-fwd | graph | baseline | 17.898 | 17.999 | 0.207 | 17.895 | 17.896 | 18.339 |
| simple_gla-2048-4-64-False-fwd | graph | candidate | 17.876 | 17.963 | 0.202 | 17.872 | 17.875 | 18.140 |
| simple_gla-2048-4-64-False-fwdbwd | eager | baseline | 922.120 | 928.247 | 21.437 | 907.213 | 910.418 | 963.261 |
| simple_gla-2048-4-64-False-fwdbwd | eager | candidate | 930.045 | 930.293 | 13.455 | 910.793 | 915.325 | 945.356 |
| simple_gla-2048-4-64-False-fwdbwd | graph | baseline | 60.732 | 60.866 | 0.531 | 60.730 | 60.731 | 60.782 |
| simple_gla-2048-4-64-False-fwdbwd | graph | candidate | 61.017 | 61.146 | 0.455 | 61.013 | 61.015 | 61.162 |
| simple_gla-2048-4-64-True-fwd | eager | baseline | 295.898 | 297.499 | 4.489 | 291.282 | 294.000 | 305.178 |
| simple_gla-2048-4-64-True-fwd | eager | candidate | 271.180 | 271.661 | 2.929 | 267.682 | 269.333 | 274.342 |
| simple_gla-2048-4-64-True-fwd | graph | candidate | 16.121 | 16.214 | 0.184 | 15.990 | 15.994 | 16.411 |
| simple_gla-2048-4-64-True-fwdbwd | eager | baseline | 1054.548 | 1134.772 | 161.342 | 1043.047 | 1044.630 | 1442.426 |
| simple_gla-2048-4-64-True-fwdbwd | eager | candidate | 961.386 | 1040.037 | 159.758 | 947.159 | 949.775 | 1328.229 |
| simple_gla-2048-4-64-True-fwdbwd | graph | candidate | 56.953 | 57.179 | 0.572 | 56.944 | 56.945 | 57.703 |
| simple_gla-8192-16-128-False-fwd | eager | baseline | 258.052 | 260.901 | 8.588 | 256.633 | 256.949 | 263.155 |
| simple_gla-8192-16-128-False-fwd | eager | candidate | 252.563 | 254.827 | 7.938 | 249.625 | 250.256 | 258.040 |
| simple_gla-8192-16-128-False-fwd | graph | baseline | 147.941 | 148.023 | 0.356 | 147.853 | 147.869 | 148.038 |
| simple_gla-8192-16-128-False-fwd | graph | candidate | 148.175 | 148.170 | 0.036 | 148.109 | 148.120 | 148.216 |
| simple_gla-8192-16-128-False-fwdbwd | eager | baseline | 944.115 | 949.727 | 15.592 | 931.099 | 934.571 | 971.763 |
| simple_gla-8192-16-128-False-fwdbwd | eager | candidate | 912.014 | 910.864 | 13.555 | 890.189 | 895.337 | 925.278 |
| simple_gla-8192-16-128-False-fwdbwd | graph | baseline | 791.797 | 791.840 | 0.166 | 791.658 | 791.667 | 791.988 |
| simple_gla-8192-16-128-False-fwdbwd | graph | candidate | 797.166 | 797.140 | 0.158 | 796.859 | 796.944 | 797.317 |
| simple_gla-8192-16-128-True-fwd | eager | baseline | 312.379 | 314.175 | 7.751 | 306.239 | 308.690 | 319.936 |
| simple_gla-8192-16-128-True-fwd | eager | candidate | 273.358 | 273.519 | 2.722 | 268.050 | 270.321 | 276.778 |
| simple_gla-8192-16-128-True-fwd | graph | candidate | 152.350 | 152.430 | 0.419 | 152.145 | 152.189 | 152.541 |
| simple_gla-8192-16-128-True-fwdbwd | eager | baseline | 1207.301 | 1212.133 | 12.152 | 1202.400 | 1203.971 | 1228.570 |
| simple_gla-8192-16-128-True-fwdbwd | eager | candidate | 960.604 | 960.875 | 9.087 | 948.686 | 950.938 | 971.472 |
| simple_gla-8192-16-128-True-fwdbwd | graph | candidate | 797.344 | 797.354 | 0.242 | 797.080 | 797.131 | 797.507 |
| GLAForCausalLM-256-512-4-False-fwd | eager | baseline | 7166.402 | 7184.972 | 55.629 | 7125.621 | 7138.256 | 7274.224 |
| GLAForCausalLM-256-512-4-False-fwd | eager | candidate | 6977.220 | 7013.327 | 129.886 | 6913.053 | 6920.808 | 7145.669 |
| GLAForCausalLM-256-512-4-False-fwd | graph | baseline | 303.916 | 304.660 | 2.034 | 303.698 | 303.797 | 306.260 |
| GLAForCausalLM-256-512-4-False-fwd | graph | candidate | 303.966 | 304.842 | 2.152 | 303.847 | 303.911 | 306.541 |
| GLAForCausalLM-256-512-4-False-fwdbwd | eager | baseline | 17308.819 | 17449.631 | 400.443 | 17043.981 | 17068.614 | 18037.623 |
| GLAForCausalLM-256-512-4-False-fwdbwd | eager | candidate | 16940.671 | 17115.977 | 339.357 | 16777.487 | 16809.346 | 17631.351 |
| GLAForCausalLM-256-512-4-False-fwdbwd | graph | baseline | 967.298 | 968.526 | 4.777 | 967.172 | 967.189 | 968.017 |
| GLAForCausalLM-256-512-4-False-fwdbwd | graph | candidate | 967.110 | 967.735 | 1.961 | 966.871 | 966.985 | 968.374 |
| GLAForCausalLM-256-512-4-True-fwd | eager | baseline | 7755.024 | 7874.817 | 249.853 | 7690.006 | 7702.782 | 8098.241 |
| GLAForCausalLM-256-512-4-True-fwd | eager | candidate | 7056.238 | 7110.372 | 189.687 | 6927.122 | 6964.484 | 7365.533 |
| GLAForCausalLM-256-512-4-True-fwd | graph | candidate | 345.431 | 346.682 | 2.144 | 345.203 | 345.250 | 350.510 |
| GLAForCausalLM-256-512-4-True-fwdbwd | eager | baseline | 18063.208 | 18121.122 | 218.351 | 17933.155 | 17949.124 | 18344.429 |
| GLAForCausalLM-256-512-4-True-fwdbwd | eager | candidate | 17039.269 | 17067.672 | 111.109 | 16906.366 | 16955.242 | 17177.667 |
| GLAForCausalLM-256-512-4-True-fwdbwd | graph | candidate | 1086.481 | 1088.181 | 5.120 | 1086.045 | 1086.182 | 1089.640 |
| GLAForCausalLM-2048-512-4-False-fwd | eager | baseline | 6902.813 | 6979.424 | 249.459 | 6753.294 | 6817.465 | 7230.447 |
| GLAForCausalLM-2048-512-4-False-fwd | eager | candidate | 6981.775 | 7099.745 | 293.783 | 6911.451 | 6913.560 | 7453.959 |
| GLAForCausalLM-2048-512-4-False-fwd | graph | baseline | 547.961 | 546.714 | 4.773 | 540.428 | 540.591 | 551.858 |
| GLAForCausalLM-2048-512-4-False-fwd | graph | candidate | 548.242 | 546.855 | 4.399 | 540.557 | 540.934 | 551.692 |
| GLAForCausalLM-2048-512-4-False-fwdbwd | eager | baseline | 16950.994 | 17209.000 | 630.408 | 16815.289 | 16858.519 | 17753.873 |
| GLAForCausalLM-2048-512-4-False-fwdbwd | eager | candidate | 16827.570 | 16827.036 | 86.843 | 16730.874 | 16736.640 | 16938.946 |
| GLAForCausalLM-2048-512-4-False-fwdbwd | graph | baseline | 1955.567 | 1955.606 | 5.190 | 1936.335 | 1954.757 | 1959.434 |
| GLAForCausalLM-2048-512-4-False-fwdbwd | graph | candidate | 1958.427 | 1959.205 | 1.838 | 1957.102 | 1957.363 | 1961.565 |
| GLAForCausalLM-2048-512-4-True-fwd | eager | baseline | 7192.529 | 7282.148 | 204.919 | 7113.737 | 7122.647 | 7549.049 |
| GLAForCausalLM-2048-512-4-True-fwd | eager | candidate | 7009.728 | 7023.369 | 82.835 | 6956.941 | 6974.662 | 7047.926 |
| GLAForCausalLM-2048-512-4-True-fwd | graph | candidate | 564.725 | 565.742 | 2.642 | 563.993 | 564.000 | 569.375 |
| GLAForCausalLM-2048-512-4-True-fwdbwd | eager | baseline | 17549.996 | 17588.682 | 159.948 | 17403.547 | 17429.042 | 17871.904 |
| GLAForCausalLM-2048-512-4-True-fwdbwd | eager | candidate | 17255.427 | 17274.701 | 111.747 | 17070.505 | 17170.344 | 17404.331 |
| GLAForCausalLM-2048-512-4-True-fwdbwd | graph | candidate | 2070.396 | 2069.355 | 4.090 | 2054.351 | 2067.006 | 2071.831 |
| GLAForCausalLM-8192-1024-4-False-fwd | eager | baseline | 7135.607 | 7149.790 | 55.584 | 7090.711 | 7092.853 | 7231.802 |
| GLAForCausalLM-8192-1024-4-False-fwd | eager | candidate | 6825.036 | 6861.589 | 93.220 | 6795.902 | 6807.742 | 6936.191 |
| GLAForCausalLM-8192-1024-4-False-fwd | graph | baseline | 2941.144 | 2942.040 | 9.307 | 2923.987 | 2934.362 | 2952.186 |
| GLAForCausalLM-8192-1024-4-False-fwd | graph | candidate | 2943.941 | 2945.285 | 10.119 | 2921.375 | 2936.687 | 2957.655 |
| GLAForCausalLM-8192-1024-4-False-fwdbwd | eager | baseline | 17370.170 | 17404.327 | 171.722 | 17218.759 | 17224.667 | 17671.781 |
| GLAForCausalLM-8192-1024-4-False-fwdbwd | eager | candidate | 17643.065 | 17742.166 | 239.575 | 17547.569 | 17588.728 | 18196.379 |
| GLAForCausalLM-8192-1024-4-False-fwdbwd | graph | baseline | 10168.819 | 10172.895 | 8.075 | 10166.600 | 10166.939 | 10186.479 |
| GLAForCausalLM-8192-1024-4-False-fwdbwd | graph | candidate | 10163.688 | 10166.406 | 5.764 | 10161.910 | 10162.566 | 10175.842 |
| GLAForCausalLM-8192-1024-4-True-fwd | eager | baseline | 7564.481 | 7587.058 | 64.908 | 7509.620 | 7521.300 | 7674.071 |
| GLAForCausalLM-8192-1024-4-True-fwd | eager | candidate | 7003.741 | 7035.005 | 107.230 | 6939.245 | 6946.759 | 7112.620 |
| GLAForCausalLM-8192-1024-4-True-fwd | graph | candidate | 2873.759 | 2873.264 | 17.255 | 2834.660 | 2856.171 | 2891.296 |
| GLAForCausalLM-8192-1024-4-True-fwdbwd | eager | baseline | 18325.466 | 18363.504 | 151.507 | 18230.652 | 18244.960 | 18486.394 |
| GLAForCausalLM-8192-1024-4-True-fwdbwd | eager | candidate | 17771.601 | 17839.489 | 190.020 | 17625.003 | 17668.539 | 18058.942 |
| GLAForCausalLM-8192-1024-4-True-fwdbwd | graph | candidate | 10118.629 | 10117.789 | 2.285 | 10111.624 | 10115.580 | 10119.922 |

</details>

<details>
<summary>Benchmark scripts and execution commands</summary>

The following five files contain the executed workers and measurement loops. Save them together in the fresh scratch directory `/tmp/fla-bench`. Place the baseline tree at `/tmp/fla-baseline` and this PR's candidate tree at `/tmp/fla-candidate`. The baseline revision is `516143e31fce09925e6c39ac37148444bad176c4`. Use a Linux host with Python 3.10 and CUDA 13.0-compatible drivers. The benchmark uses the operator and model implementations directly from these trees.

Create an isolated Python environment and dependency target:

```bash
cd /tmp/fla-bench
python3.10 -m venv /tmp/fla-venv
/tmp/fla-venv/bin/python -m pip --isolated install --target /tmp/fla-site \
  --extra-index-url https://download.pytorch.org/whl/cu130 \
  torch==2.13.0+cu130 triton==3.7.1 einops==0.8.2 numpy==2.2.6 pytest==9.1.1 \
  transformers==5.15.0 tokenizers==0.22.2
export PYTHONNOUSERSITE=1 FLA_CACHE_RESULTS=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1
export TRITON_CACHE_DIR=/tmp/fla-triton-cache
export LD_LIBRARY_PATH="$(/tmp/fla-venv/bin/python - <<'PYLIB'
from pathlib import Path
site = Path('/tmp/fla-site')
print(':'.join([str(site / 'torch/lib'), *map(str, (site / 'nvidia').rglob('lib'))]))
PYLIB
)"
```

Reproduce the capture regression using a scratch copy of the new test in the baseline tree:

```bash
/tmp/fla-venv/bin/python - <<'PYCAPTURE'
import os
import shutil
import subprocess
import sys
from pathlib import Path
baseline, candidate = Path('/tmp/fla-baseline'), Path('/tmp/fla-candidate')
test = 'tests/ops/test_chunk_state_metadata.py'
shutil.copyfile(candidate / test, baseline / test)
env = dict(os.environ, PYTHONPATH='/tmp/fla-site:/tmp/fla-baseline')
result = subprocess.run([sys.executable, '-m', 'pytest', test, '-q', '-x'],
                        cwd=baseline, env=env, capture_output=True, text=True)
print(result.stdout, result.stderr)
assert result.returncode == 1
assert 'split_offsets[-1].item()' in result.stdout
assert 'operation not permitted when stream is capturing' in result.stdout
env['PYTHONPATH'] = '/tmp/fla-site:/tmp/fla-candidate'
subprocess.run([sys.executable, '-m', 'pytest', test, '-q'], cwd=candidate, env=env, check=True)
PYCAPTURE
```

Execute the operator comparison and both isolated memory probes:

```bash
/tmp/fla-venv/bin/python -u paired_driver.py simple_gla
PYTHONPATH=/tmp/fla-site:/tmp/fla-baseline /tmp/fla-venv/bin/python -u memory_probe.py baseline
PYTHONPATH=/tmp/fla-site:/tmp/fla-candidate /tmp/fla-venv/bin/python -u memory_probe.py candidate
```

Use the model experiment's dependency versions and cuBLAS setting for the model comparison:

```bash
/tmp/fla-venv/bin/python - <<'PYENV'
import shutil
from pathlib import Path
site = Path('/tmp/fla-site')
for package, version in [('transformers', '5.15.0'), ('tokenizers', '0.22.2')]:
    shutil.rmtree(site / package)
    shutil.rmtree(site / f'{package}-{version}.dist-info')
PYENV
/tmp/fla-venv/bin/python -m pip --isolated install --no-deps --target /tmp/fla-site \
  transformers==5.17.0 tokenizers==0.23.2
export CUBLAS_WORKSPACE_CONFIG=:4096:8 HF_HUB_OFFLINE=1
/tmp/fla-venv/bin/python -u model_driver.py
```

### `paired_worker.py`

```python
import gc
import json
import os
import sys
import time
from pathlib import Path

import torch
import torch.nn.functional as F
from fla.ops.gla import chunk_gla
from fla.ops.simple_gla import chunk_simple_gla

variant, op_name, T, H, D, varlen, mode, reference = sys.argv[1:]
T, H, D, varlen = int(T), int(H), int(D), bool(int(varlen))
if hasattr(os, 'sched_getaffinity'):
    os.sched_setaffinity(0, {min(os.sched_getaffinity(0))})
torch.set_num_threads(1)
torch.manual_seed(42)
lengths = [0, 63, T // 3, T - 17, T] if varlen else [0, T]
cu_cpu = torch.tensor(lengths, dtype=torch.int32) if varlen else None
cu = cu_cpu.cuda() if varlen else None
q, k, v = [torch.randn(1, T, H, D, device='cuda', dtype=torch.bfloat16).requires_grad_() for _ in range(3)]
g_shape = (1, T, H) if op_name == 'simple_gla' else (1, T, H, D)
g = F.logsigmoid(torch.randn(g_shape, device='cuda', dtype=torch.bfloat16)).requires_grad_()
h0 = torch.randn(len(lengths) - 1, H, D, D, device='cuda').requires_grad_()
do, dht = torch.randn_like(v), torch.randn_like(h0)
op = chunk_simple_gla if op_name == 'simple_gla' else chunk_gla


def step():
    o, ht = op(q=q, k=k, v=v, g=g, initial_state=h0, output_final_state=True,
               cu_seqlens=cu, cu_seqlens_cpu=cu_cpu)
    grads = torch.autograd.grad((o, ht), (q, k, v, g, h0), (do, dht)) if mode == 'fwdbwd' else ()
    return o, ht, *grads


def emit(value):
    print('RESULT ' + json.dumps(value), flush=True)


for _ in range(5):
    step()
torch.cuda.synchronize()
actual = tuple(t.detach().cpu() for t in step())
if variant == 'baseline':
    torch.save(actual, reference)
else:
    for a, b in zip(actual, torch.load(reference, weights_only=True), strict=True):
        torch.testing.assert_close(a, b, rtol=0, atol=0)
del actual
gc.collect()
torch.cuda.synchronize()
torch.cuda.reset_peak_memory_stats()
step()
torch.cuda.synchronize()
eager_peak = torch.cuda.max_memory_allocated()
with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA]) as prof:
    step()
    torch.cuda.synchronize()
scalar_events = {e.key: e.count for e in prof.key_averages() if '_local_scalar_dense' in e.key}
emit({'ready': variant, 'exact': True, 'scalar_events': scalar_events, 'eager_peak_allocated': eager_peak})
graph = None
captured = None
for line in sys.stdin:
    command = json.loads(line)
    if command == 'quit':
        break
    if command == 'capture':
        assert variant == 'candidate' or not varlen
        stream = torch.cuda.Stream()
        stream.wait_stream(torch.cuda.current_stream())
        with torch.cuda.stream(stream):
            for _ in range(3):
                step()
        torch.cuda.current_stream().wait_stream(stream)
        graph = torch.cuda.CUDAGraph()
        with torch.cuda.graph(graph, stream=stream):
            captured = step()
        for _ in range(2):
            with torch.no_grad():
                q.add_(0.125)
            expected = step()
            graph.replay()
            for a, b in zip(expected, captured, strict=True):
                torch.testing.assert_close(a, b, rtol=0, atol=0)
        del expected
        emit({'capture': True, 'replay_exact': True})
        continue
    action, repeats = command
    call = step if action == 'eager' else graph.replay
    for _ in range(20):
        call()
    torch.cuda.synchronize()
    start = time.perf_counter_ns()
    for _ in range(repeats):
        call()
    torch.cuda.synchronize()
    emit({'us': (time.perf_counter_ns() - start) / repeats / 1000})
```

### `paired_driver.py`

```python
import json
import os
import statistics
import subprocess
import sys
from pathlib import Path

source = Path(__file__).resolve().parent
op_name = sys.argv[1]
site = '/tmp/fla-site'


def receive(proc):
    for line in proc.stdout:
        if line.startswith('RESULT '):
            return json.loads(line.removeprefix('RESULT '))
        print(line, end='', flush=True)
    raise RuntimeError(f'Worker exited with {proc.wait()}')


def request(proc, command):
    proc.stdin.write(json.dumps(command) + '\n')
    proc.stdin.flush()
    return receive(proc)


for T, H, D in [(256, 4, 64), (2048, 4, 64), (8192, 16, 128)]:
    for varlen in (False, True):
        for mode in ('fwd', 'fwdbwd'):
            key = f'{op_name}-{T}-{H}-{D}-{varlen}-{mode}'
            workers = {}
            try:
                for name in ('baseline', 'candidate'):
                    root = f'/tmp/fla-{name}'
                    env = dict(os.environ, PYTHONPATH=f'{site}:{root}')
                    workers[name] = subprocess.Popen(
                        [sys.executable, '-u', source / 'paired_worker.py', name, op_name, str(T), str(H), str(D),
                         str(int(varlen)), mode, '/tmp/fla-paired-reference.pt'],
                        cwd=root, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True,
                    )
                    print(json.dumps({'case': key, **receive(workers[name])}), flush=True)
                samples = {'baseline': [], 'candidate': []}
                for _ in range(9):
                    for name in ('baseline', 'candidate', 'candidate', 'baseline'):
                        samples[name].append(request(workers[name], ['eager', 100])['us'])
                print(json.dumps({'case': key, 'execution': 'eager', 'order': 'ABBA', 'samples_us': samples,
                                  'medians_us': {name: statistics.median(values) for name, values in samples.items()}}), flush=True)
                graph_names = ['candidate'] if varlen else ['baseline', 'candidate']
                for name in graph_names:
                    print(json.dumps({'case': key, 'variant': name, **request(workers[name], 'capture')}), flush=True)
                graph_samples = {name: [] for name in graph_names}
                for _ in range(9):
                    for name in (['candidate', 'candidate'] if varlen else ['baseline', 'candidate', 'candidate', 'baseline']):
                        graph_samples[name].append(request(workers[name], ['graph', 1000])['us'])
                print(json.dumps({'case': key, 'execution': 'graph', 'samples_us': graph_samples,
                                  'medians_us': {name: statistics.median(values) for name, values in graph_samples.items()}}), flush=True)
            finally:
                for proc in workers.values():
                    if proc.poll() is None:
                        proc.stdin.write(json.dumps('quit') + '\n')
                        proc.stdin.flush()
                        proc.wait(timeout=30)
```

### `model_worker.py`

```python
import gc
import json
import os
import sys
import time
from pathlib import Path

import torch
from fla.models.gla import GLAConfig, GLAForCausalLM

variant, T, hidden_size, depth, varlen, mode, reference = sys.argv[1:]
T, hidden_size, depth, varlen = int(T), int(hidden_size), int(depth), bool(int(varlen))
if hasattr(os, 'sched_getaffinity'):
    os.sched_setaffinity(0, {min(os.sched_getaffinity(0))})
torch.set_num_threads(1)
torch.manual_seed(42)
config = GLAConfig(hidden_size=hidden_size, num_hidden_layers=depth, num_heads=hidden_size // 128,
                   vocab_size=4096, max_position_embeddings=T, use_cache=False)
model = GLAForCausalLM(config).cuda().bfloat16().train()
parameters = tuple(model.parameters())
input_ids = torch.randint(0, config.vocab_size, (1, T), device='cuda')
labels = input_ids.clone()
boundaries = [0, 63, T // 3, T - 17, T] if varlen else [0, T]
cu = torch.tensor(boundaries, device='cuda', dtype=torch.int32) if varlen else None
for end in boundaries[1:-1]:
    labels[:, end] = -100


def step():
    result = model(input_ids=input_ids, labels=labels, cu_seqlens=cu, use_cache=False)
    if mode == 'fwdbwd':
        return result.loss, *torch.autograd.grad(result.loss, parameters)
    return result.loss, result.logits


def emit(value):
    print('RESULT ' + json.dumps(value), flush=True)


for _ in range(5):
    step()
torch.cuda.synchronize()
actual = tuple(t.detach().cpu() for t in step())
if variant == 'baseline':
    torch.save(actual, reference)
else:
    for a, b in zip(actual, torch.load(reference, weights_only=True), strict=True):
        torch.testing.assert_close(a, b, rtol=0, atol=0)
del actual
gc.collect()
torch.cuda.synchronize()
torch.cuda.reset_peak_memory_stats()
step()
torch.cuda.synchronize()
eager_peak = torch.cuda.max_memory_allocated()
with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA]) as prof:
    step()
    torch.cuda.synchronize()
scalar_events = {e.key: e.count for e in prof.key_averages() if '_local_scalar_dense' in e.key}
emit({'ready': variant, 'exact': True, 'scalar_events': scalar_events, 'eager_peak_allocated': eager_peak})
graph = None
captured = None
for line in sys.stdin:
    command = json.loads(line)
    if command == 'quit':
        break
    if command == 'capture':
        assert variant == 'candidate' or not varlen
        stream = torch.cuda.Stream()
        stream.wait_stream(torch.cuda.current_stream())
        with torch.cuda.stream(stream):
            for _ in range(3):
                step()
        torch.cuda.current_stream().wait_stream(stream)
        graph = torch.cuda.CUDAGraph()
        with torch.cuda.graph(graph, stream=stream):
            captured = step()
        for _ in range(2):
            with torch.no_grad():
                input_ids.add_(1).remainder_(config.vocab_size)
                labels.copy_(input_ids)
                for end in boundaries[1:-1]:
                    labels[:, end] = -100
            expected = step()
            graph.replay()
            for a, b in zip(expected, captured, strict=True):
                torch.testing.assert_close(a, b, rtol=0, atol=0)
        del expected
        emit({'capture': True, 'replay_exact': True})
        continue
    action, repeats = command
    call = step if action == 'eager' else graph.replay
    for _ in range(20):
        call()
    torch.cuda.synchronize()
    start = time.perf_counter_ns()
    for _ in range(repeats):
        call()
    torch.cuda.synchronize()
    emit({'us': (time.perf_counter_ns() - start) / repeats / 1000})
```

### `model_driver.py`

```python
import json
import os
import statistics
import subprocess
import sys
from pathlib import Path

source = Path(__file__).resolve().parent
site = '/tmp/fla-site'


def receive(proc):
    for line in proc.stdout:
        if line.startswith('RESULT '):
            return json.loads(line.removeprefix('RESULT '))
        print(line, end='', flush=True)
    raise RuntimeError(f'Worker exited with {proc.wait()}')


def request(proc, command):
    proc.stdin.write(json.dumps(command) + '\n')
    proc.stdin.flush()
    return receive(proc)


for T, hidden_size, depth in [(256, 512, 4), (2048, 512, 4), (8192, 1024, 4)]:
    for varlen in (False, True):
        for mode in ('fwd', 'fwdbwd'):
            key = f'GLAForCausalLM-{T}-{hidden_size}-{depth}-{varlen}-{mode}'
            workers = {}
            try:
                for name in ('baseline', 'candidate'):
                    root = f'/tmp/fla-{name}'
                    env = dict(os.environ, PYTHONPATH=f'{site}:{root}')
                    workers[name] = subprocess.Popen(
                        [sys.executable, '-u', source / 'model_worker.py', name, str(T), str(hidden_size), str(depth),
                         str(int(varlen)), mode, '/tmp/fla-paired-reference.pt'],
                        cwd=root, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True,
                    )
                    print(json.dumps({'case': key, **receive(workers[name])}), flush=True)
                samples = {'baseline': [], 'candidate': []}
                for _ in range(9):
                    for name in ('baseline', 'candidate', 'candidate', 'baseline'):
                        samples[name].append(request(workers[name], ['eager', 20])['us'])
                print(json.dumps({'case': key, 'execution': 'eager', 'order': 'ABBA', 'samples_us': samples,
                                  'medians_us': {name: statistics.median(values) for name, values in samples.items()}}), flush=True)
                graph_names = ['candidate'] if varlen else ['baseline', 'candidate']
                for name in graph_names:
                    print(json.dumps({'case': key, 'variant': name, **request(workers[name], 'capture')}), flush=True)
                graph_samples = {name: [] for name in graph_names}
                for _ in range(9):
                    for name in (['candidate', 'candidate'] if varlen else ['baseline', 'candidate', 'candidate', 'baseline']):
                        graph_samples[name].append(request(workers[name], ['graph', 100])['us'])
                print(json.dumps({'case': key, 'execution': 'graph', 'samples_us': graph_samples,
                                  'medians_us': {name: statistics.median(values) for name, values in graph_samples.items()}}), flush=True)
            finally:
                for proc in workers.values():
                    if proc.poll() is None:
                        proc.stdin.write(json.dumps('quit') + '\n')
                        proc.stdin.flush()
                        proc.wait(timeout=30)
```

### `memory_probe.py`

```python
import gc
import json
import sys
from collections import Counter

import torch
import torch.nn.functional as F
from fla.ops.simple_gla import chunk_simple_gla
from fla.ops.utils.index import prepare_chunk_indices, prepare_chunk_offsets

variant = sys.argv[1]
torch.manual_seed(42)
T, H, D = 8192, 16, 128
cu_cpu = torch.tensor([0, 63, T // 3, T - 17, T], dtype=torch.int32)
cu = cu_cpu.cuda()
q, k, v = [torch.randn(1, T, H, D, device='cuda', dtype=torch.bfloat16).requires_grad_() for _ in range(3)]
g = F.logsigmoid(torch.randn(1, T, H, device='cuda', dtype=torch.bfloat16)).requires_grad_()
h0 = torch.randn(4, H, D, D, device='cuda').requires_grad_()
do, dht = torch.randn_like(v), torch.randn_like(h0)
indices = prepare_chunk_indices(cu, 64, cu_cpu)
offsets = prepare_chunk_offsets(cu, 64)
print(json.dumps({'variant': variant, 'indices_shape': list(indices.shape), 'offsets': offsets.cpu().tolist()}), flush=True)


def step():
    return chunk_simple_gla(q, k, v, g=g, initial_state=h0, output_final_state=True,
                            cu_seqlens=cu, cu_seqlens_cpu=cu_cpu)


for _ in range(5):
    step()
for pool in ('warm', 'fresh'):
    gc.collect()
    torch.cuda.synchronize()
    if pool == 'fresh':
        torch.cuda.empty_cache()
    torch.cuda.reset_peak_memory_stats()
    torch.cuda.memory._record_memory_history(enabled='all', max_entries=2000)
    step()
    torch.cuda.synchronize()
    stats = torch.cuda.memory_stats()
    snapshot = torch.cuda.memory._snapshot()
    torch.cuda.memory._record_memory_history(enabled=None)
    fields = {name: stats[name] for name in ('allocated_bytes.all.current', 'allocated_bytes.all.peak',
              'requested_bytes.all.current', 'requested_bytes.all.peak', 'reserved_bytes.all.current')}
    allocations = Counter(entry['size'] for entry in snapshot['device_traces'][0] if entry['action'] == 'alloc')
    blocks = [(block['size'], block['requested_size'], block['state']) for segment in snapshot['segments']
              for block in segment['blocks'] if block['state'] != 'inactive']
    print(json.dumps({'variant': variant, 'pool': pool, 'stats': fields, 'allocations': dict(allocations), 'active_blocks': blocks}), flush=True)
```

</details>

## Breaking changes

Public signatures, numerical tolerances and checkpoint formats stay unchanged. Graph capture uses warmed metadata with fixed sequence boundaries.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions.
- [x] I have read [AGENTS.md](../AGENTS.md) and the applicable repository guidance.
- [x] Dependent tests pass, and the new capture behavior is covered by a regression test.
- [x] Kernel changes include same-hardware benchmark evidence where applicable; this change preserves the Triton kernels and includes dense and packed measurements.
- [ ] This PR is minor or cosmetic.
