### PR TITLE
[Fix] Make GDN-2 safe_gate diagonal path independent of future gates

### DIFF
--- a/fla/ops/gdn2/chunk_bwd.py
+++ b/fla/ops/gdn2/chunk_bwd.py
@@ -486,6 +486,7 @@ def chunk_gdn2_bwd(
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         safe_gate=safe_gate,
+        lower_bound=lower_bound,
     )
 
     dA_log, dt_bias_grad = None, None

--- a/fla/ops/gdn2/chunk_fwd.py
+++ b/fla/ops/gdn2/chunk_fwd.py
@@ -95,6 +95,7 @@ def chunk_gdn2_fwd(
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
         safe_gate=safe_gate,
+        lower_bound=lower_bound,
         disable_recompute=disable_recompute,
     )
 

--- a/fla/ops/gdn2/chunk_intra.py
+++ b/fla/ops/gdn2/chunk_intra.py
@@ -28,6 +28,7 @@ from fla.ops.gdn2.chunk_intra_token_parallel import chunk_gdn2_fwd_intra_token_p
 from fla.ops.gdn2.wy_fast import recompute_w_u_fwd_gdn2
 from fla.ops.utils import prepare_chunk_indices
 from fla.ops.utils.cache import fla_cache_autotune
+from fla.ops.utils.constant import RCP_LN2
 from fla.ops.utils.op import exp2, gather
 from fla.utils import IS_GATHER_SUPPORTED, IS_TF32_SUPPORTED, autotune_cache_kwargs
 
@@ -68,6 +69,7 @@ def chunk_gdn2_fwd_kernel_intra_sub_chunk(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_GATHER: tl.constexpr,
+    LOWER_BOUND_LOG2: tl.constexpr,
 ):
     i_t, i_i, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1), tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
@@ -105,12 +107,15 @@ def chunk_gdn2_fwd_kernel_intra_sub_chunk(
     b_g = tl.load(p_g, mask=m_kc, other=0.0)
     b_b = tl.load(p_b, mask=m_kc, other=0.0)
 
+    # Row 0 of the sub-chunk is in the past of every row here, and the centre is a fixed function
+    # of BC and the gate's lower bound, so the anchor cannot depend on a future gate or on T.
     if USE_GATHER:
-        b_gn = gather(b_g, tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16), axis=0)
+        b_gn = gather(b_g, tl.zeros([1, BK], dtype=tl.int16), axis=0)
     else:
-        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H * K + tl.arange(0, BK)
+        p_gn = g + i_ti * H * K + tl.arange(0, BK)
         b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
         b_gn = b_gn[None, :]
+    b_gn = b_gn + 0.5 * (BC - 1) * LOWER_BOUND_LOG2
 
     b_gm = (b_g - b_gn).to(tl.float32)
     b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.)
@@ -456,6 +461,7 @@ def chunk_gdn2_bwd_kernel_intra(
     NC: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     SAFE_GATE: tl.constexpr,
+    LOWER_BOUND_LOG2: tl.constexpr,
     USE_GATHER: tl.constexpr,
 ):
     i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
@@ -540,10 +546,11 @@ def chunk_gdn2_bwd_kernel_intra(
 
     if SAFE_GATE:
         if USE_GATHER:
-            b_gn = gather(b_g, tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16), axis=0)
+            b_gn = gather(b_g, tl.zeros([1, BK], dtype=tl.int16), axis=0)
         else:
-            p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H * K + o_k
+            p_gn = g + i_ti * H * K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0)[None, :]
+        b_gn = b_gn + 0.5 * (BC - 1) * LOWER_BOUND_LOG2
 
         m_dd = m_c[:, None] & ((i_i * BC + o_i)[None, :] < BT)
         p_dAqk = dAqk + o_c[:, None] * (H * BT) + (i_i * BC + o_i)[None, :]
@@ -632,10 +639,11 @@ def chunk_gdn2_bwd_kernel_intra(
 
     if SAFE_GATE:
         if USE_GATHER:
-            b_gn = gather(b_g, tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16), axis=0)
+            b_gn = gather(b_g, tl.zeros([1, BK], dtype=tl.int16), axis=0)
         else:
-            p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H * K + o_k
+            p_gn = g + i_ti * H * K + o_k
             b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+        b_gn = b_gn + 0.5 * (BC - 1) * LOWER_BOUND_LOG2
         p_q = q + o_c[:, None] * (H * K) + o_k[None, :]
         b_q = tl.load(p_q, mask=m_kc, other=0.0)
         m_dk = ((i_i * BC + o_i)[:, None] < BT) & m_c[None, :]
@@ -702,12 +710,15 @@ def chunk_gdn2_fwd_intra(
     chunk_size: int = 64,
     chunk_indices: torch.LongTensor | None = None,
     safe_gate: bool = False,
+    lower_bound: float | None = None,
     disable_recompute: bool = False,
 ):
     """Intra-chunk forward: build Aqk, Akk_inv, and the WY auxiliaries (w, u)."""
     B, T, H, K = k.shape
     BT = chunk_size
     BC = 16
+    # Centres the exponent range of the diagonal fast path; see the anchor comment in the kernel.
+    lower_bound_log2 = 0.0 if lower_bound is None else lower_bound * RCP_LN2
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
@@ -737,6 +748,7 @@ def chunk_gdn2_fwd_intra(
             BC=BC,
             BK=BK,
             USE_GATHER=IS_GATHER_SUPPORTED,
+            LOWER_BOUND_LOG2=lower_bound_log2,
         )
     else:
         chunk_gdn2_fwd_intra_token_parallel(
@@ -802,6 +814,7 @@ def chunk_gdn2_bwd_intra(
     chunk_indices: torch.LongTensor | None = None,
     chunk_size: int = 64,
     safe_gate: bool = False,
+    lower_bound: float | None = None,
 ):
     """Intra-chunk backward: q, k, g, b contributions from dAqk, dAkk.
 
@@ -812,6 +825,8 @@ def chunk_gdn2_bwd_intra(
     BT = chunk_size
     BC = min(16, BT)
     BK = min(32, triton.next_power_of_2(K))
+    # Centres the exponent range of the diagonal fast path; see the anchor comment in the kernel.
+    lower_bound_log2 = 0.0 if lower_bound is None else lower_bound * RCP_LN2
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -851,6 +866,7 @@ def chunk_gdn2_bwd_intra(
         NC=NC,
         SAFE_GATE=safe_gate,
         USE_GATHER=IS_GATHER_SUPPORTED,
+        LOWER_BOUND_LOG2=lower_bound_log2,
     )
     dq = dq2
     dk = dk2

--- a/tests/ops/test_gdn2.py
+++ b/tests/ops/test_gdn2.py
@@ -16,6 +16,8 @@
 # GDN-2 reuses KDA's gate activation verbatim, so the gate-in-kernel reference
 # uses ``naive_kda_gate`` / ``naive_kda_lowerbound_gate``.
 
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -596,4 +598,69 @@ def test_chunk_bwd_autotune_key_covers_head_dims():
     assert list(tuner.keys) == ['BT', 'K', 'V', 'STATE_V_FIRST'], (
         f"unexpected autotune key {list(tuner.keys)}; it must carry K and V, "
         "the head dimensions that bound the swept BK/BV tiles"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    ("T", "P", "H", "K", "V"),
+    [
+        (22, 21, 2, 64, 64),
+        (70, 69, 2, 64, 64),
+    ],
+)
+def test_chunk_gdn2_prefix_causality(T: int, P: int, H: int, K: int, V: int):
+    """Gates at positions >= P must not change the output at positions < P.
+
+    ``chunk_gdn2_fwd_kernel_intra_sub_chunk`` anchors the exponentials of a diagonal
+    sub-chunk on one of its own rows. Anchoring on the middle row made that anchor a
+    *future* row for the first half of the sub-chunk, so editing a gate after the prefix
+    moved an anchor shared by every row of the sub-chunk and changed the prefix output and
+    its gradients. Each case below ends the sequence inside a sub-chunk whose middle row
+    is its last valid token, which is the shape that triggered the leak.
+    """
+    torch.manual_seed(42)
+    generator = torch.Generator().manual_seed(42)
+    shape = (1, T, H, K)
+    q = F.normalize(torch.randn(shape, generator=generator), dim=-1).bfloat16().to(device)
+    k = F.normalize(torch.randn(shape, generator=generator), dim=-1).bfloat16().to(device)
+    v = (0.5 * torch.randn((1, T, H, V), generator=generator)).bfloat16().to(device)
+    b = torch.rand(shape, generator=generator).bfloat16().to(device)
+    w = torch.rand((1, T, H, V), generator=generator).bfloat16().to(device)
+    g = torch.randn(shape, generator=generator).bfloat16().to(device)
+    a_log = torch.log(torch.empty(H).uniform_(1.0, 16.0, generator=generator)).float().to(device)
+    dt_bias = (0.1 * torch.rand(H * K, generator=generator) - 0.05).float().to(device)
+
+    def run(gates: torch.Tensor) -> torch.Tensor:
+        return chunk_gdn2(
+            q=q,
+            k=k,
+            v=v,
+            g=gates,
+            b=b,
+            w=w,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            scale=1.0,
+            output_final_state=False,
+            use_gate_in_kernel=True,
+            safe_gate=True,
+            lower_bound=-5.0,
+            use_qk_l2norm_in_kernel=False,
+        )[0]
+
+    base = run(g)
+
+    # Move every gate at position >= P to the opposite end of the [lower_bound, 0) range,
+    # leaving the prefix bit-identical. Only the anchor for the trailing sub-chunk changes.
+    edited = g.clone()
+    edited[:, P:] = (
+        math.log(0.99 / 0.01) / a_log.exp().view(1, 1, H, 1) - dt_bias.view(1, 1, H, K)
+    ).to(edited.dtype)
+    assert not torch.equal(g[:, P:], edited[:, P:])
+
+    perturbed = run(edited)
+    assert torch.equal(base[:, :P], perturbed[:, :P]), (
+        f"changing gates at positions >= {P} changed the output at positions < {P}: "
+        f"max abs diff {(base[:, :P].float() - perturbed[:, :P].float()).abs().max().item()}"
     )


### PR DESCRIPTION
## Summary

The GDN-2 diagonal fast path has the same defect that #1242 fixes for KDA, and I verified it independently before touching anything.

`chunk_gdn2_fwd_kernel_intra_sub_chunk` and both `SAFE_GATE` blocks of `chunk_gdn2_bwd_kernel_intra` anchored their exponentials on the middle row of the sub-chunk, `min(BC // 2, T - i_ti - 1)`. For a partially filled trailing sub-chunk that row is the last valid token, so the anchor was a *future* row for the first half of the sub-chunk. `exp2(b_g - b_gn)` and `exp2(b_gn - b_g)` are rounded before `tl.dot` and the causal mask is applied after it, so the anchor's algebraic cancellation did not survive the rounding: editing a gate at position `t >= P` changed the outputs, the prefix-only loss and the gradients at positions `< P`.

The anchor is now row 0 of the sub-chunk — in the past of every row it serves — offset by half the worst-case gate span, `0.5 * (BC - 1) * lower_bound / ln2`. That offset is a fixed function of `BC` and `lower_bound`, so appending tokens no longer moves the anchor either. `chunk_gdn2_fwd_intra` / `chunk_gdn2_bwd_intra` gained a `lower_bound` argument, which `chunk_gdn2_fwd` and `chunk_gdn2_bwd` now pass through.

GDN-2 reuses KDA's gate activation verbatim (`fla/ops/gdn2/chunk.py` validates `safe_gate` + `use_gate_in_kernel` exactly as `fla/ops/kda/chunk.py` does), so this is the same bug in a second op, not a new design question. The KDA half is in #1242 and it is the discussion in #1240 that governs both.

## Test plan

Hardware: NVIDIA A100-PCIE-40GB (sm80), torch 2.8.0+cu128, triton 3.4.0.

Independent reproducer (bf16, `B=1, H=K=V=64`, `chunk_size=64`, `lower_bound=-5.0`), which edits only the gates at positions `>= P` and compares the prefix at positions `< P`. Five `(T, P)` shapes, all ending inside a trailing sub-chunk whose middle row is its last valid token:

| `(T, P)` | prefix output | prefix loss | prefix `dg` | `dA_log` |
|---|---|---|---|---|
| (22, 21) | changed | changed | changed | changed |
| (38, 37) | changed | changed | changed | changed |
| (70, 69) | changed | changed | changed | changed |
| (40, 33) | unchanged | unchanged | **changed** | changed |
| (100, 99) | changed | changed | changed | changed |

With this PR every cell is `False, 0, 0.0`. Note `(40, 33)`: the leak reached the gradients even where it did not reach the forward output, so a forward-only comparison would have missed it.

- Unit tests added: `tests/ops/test_gdn2.py::test_chunk_gdn2_prefix_causality`, two parametrizations at `T=22` and `T=70`.
- I checked the new test catches the bug rather than merely passing: on a clean `git worktree` of the parent commit it is `2 failed`, failing with `changing gates at positions >= 69 changed the output at positions < 69: max abs diff 0.000244140625`; on this branch it is `2 passed`.
- Dependent tests: `python scripts/find_dependent_tests.py fla/ops/gdn2/chunk_intra.py` lists `tests/ops/test_gdn2.py`, `tests/context_parallel/test_cp_gdn2.py` and `tests/layers/test_attn_varlen_pack_layout.py`. I ran `tests/ops/test_gdn2.py`: 31 passed with 0 failed and 0 errors before the run was cut short at 91%, and the remaining `test_layer` / autotune tests pass separately (`4 passed, 32 deselected`). I did not run the context-parallel or layer tests, and I could not run AMD, Intel or Ascend backends.
- Blast radius: `chunk_gdn2_fwd_intra` / `chunk_gdn2_bwd_intra` have exactly two callers in the tree (`fla/ops/gdn2/chunk_fwd.py:86`, `fla/ops/gdn2/chunk_bwd.py:474`), both updated; no context-parallel code calls them directly.

## Benchmark / NCU (kernel changes only)

Neutral. This PR replaces one numerical anchor and adds one `tl.constexpr`; it makes no performance claim and I did not benchmark it.

## Breaking changes

None to any public API or state dict. `chunk_gdn2_fwd_intra` / `chunk_gdn2_bwd_intra` gained an optional `lower_bound` keyword that defaults to `None`, and both callers pass it.

Numerics do change, by design, for `safe_gate=True` + `use_gate_in_kernel=True` — that path is exactly the one that was wrong. Affected users: anyone training GDN-2 with `safe_gate=True`, `use_gate_in_kernel=True`, `lower_bound` in `[-5, 0)`. `fla/ops/gdn2/chunk.py` already rejects `safe_gate=True` with `use_gate_in_kernel=True` unless `lower_bound` is set and inside that range, so the `lower_bound is None` fallback in the launcher is not reachable from `chunk_gdn2` and only affects direct callers of the intra helpers.

## Follow-up (not in this PR)

Same anchor idiom, same defect, not touched and not verified here:

- `fla/ops/precond_kda/chunk_intra.py:447,766,867`
- `fla/ops/kda/backends/triton_ascend/chunk_intra.py:260,801,868` (NPU — also needs `lower_bound` plumbed through the delegation at line 942, which currently drops it)

The KDA mainline is fixed in #1242.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
