### PR TITLE
[Test] Add regression coverage for token_shift cache on first single-token calls

### DIFF
--- a/tests/modules/test_token_shift.py
+++ b/tests/modules/test_token_shift.py
@@ -151,6 +151,31 @@ def test_token_shift_varlen_cache_mixed_lengths():
     assert_close("cache", cache_out, torch.tensor([[2.], [3.]], device=device), 1e-3)
 
 
+def test_token_shift_cache_written_on_first_single_token_call():
+    # The first call for a cache slot may process exactly one token with no
+    # prior cache (e.g. BOS-seeded decoding); cache_out must still be written.
+    torch.manual_seed(42)
+    x1 = torch.randn(2, 1, 64, device=device)
+    y1, cache_out1 = token_shift(x1, output_cache=True, cache=None)
+
+    assert_close(" y1", y1, -x1, 1e-3)
+    assert_close("cache", cache_out1, x1[:, 0], 1e-3)
+
+    x2 = torch.randn(2, 1, 64, device=device)
+    y2, _ = token_shift(x2, cache=cache_out1, output_cache=True)
+    assert_close(" y2", y2, x1 - x2, 1e-3)
+
+
+def test_token_shift_varlen_cache_first_call_all_singletons():
+    x = torch.tensor([[[1.], [2.], [3.]]], device=device)
+    cu_seqlens = torch.tensor([0, 1, 2, 3], dtype=torch.int32, device=device)
+
+    output, cache_out = token_shift(x, cu_seqlens, output_cache=True)
+
+    assert_close("output", output, torch.tensor([[[-1.], [-2.], [-3.]]], device=device), 1e-3)
+    assert_close("cache", cache_out, torch.tensor([[1.], [2.], [3.]], device=device), 1e-3)
+
+
 def _packed_cu_seqlens(total_tokens: int, doc_len: int) -> torch.Tensor:
     n_docs = (total_tokens + doc_len - 1) // doc_len
     lens = torch.full((n_docs,), doc_len, device=device, dtype=torch.long)


### PR DESCRIPTION
## Summary

Adds two regression tests to `tests/modules/test_token_shift.py` covering a `token_shift` cache path that released 0.5.x handles incorrectly and that current main has no test for.

While testing cached decoding against the 0.5.2 release, I hit a case where `token_shift` returns an output cache that was never written: when the **first** call for a cache slot processes **exactly one token** per sequence with no prior cache, `cache_out` comes back as an unwritten `torch.empty`. The next call then reads it, violating the documented contract (`cache_out` = "the last token that should be fed as `cache` in the next call").

Concretely, on v0.5.2:

```python
x1 = torch.randn(2, 1, 64, device='cuda')
y1, c1 = token_shift(x1, output_cache=True, cache=None)
torch.equal(c1, x1[:, 0])   # False — c1 is unwritten memory

x2 = torch.randn(2, 1, 64, device='cuda')
y2, _ = token_shift(x2, cache=c1, output_cache=True)
torch.equal(y2, x1 - x2)    # False — y2 == -x2 when the buffer reads as zeros
```

The common failure mode is silent rather than a crash: on a fresh allocator the buffer typically reads back as zeros, so the next token's shift computes `0 - x` instead of `prev - x` with no NaNs anywhere. With a dirtied caching allocator it's leftover garbage (all-NaN observed); the conftest NaN poisoning makes that variant deterministic in CI.

Root cause on the released tags is the one @taking-lying-flat's #1194 already fixed on main (thank you!): the first-position branch returned before the `STORE_FINAL_STATE` store, and the decode branch that writes the cache requires a prior cache. Since #1194's regression test covers the packed/varlen path with a prior cache, the dense first-call trigger had no coverage — that's the small gap this PR closes, so the fix can't quietly regress.

New tests, styled after the existing `test_token_shift_varlen_cache_mixed_lengths`:

- **`test_token_shift_cache_written_on_first_single_token_call`** — dense `[B, 1, H]` first call with `cache=None`: output is `-x`, `cache_out` equals the token, and a follow-up decode call produces `prev - x`.
- **`test_token_shift_varlen_cache_first_call_all_singletons`** — packed/varlen first call where every sequence has length 1.

One thing I'd flag for the maintainers' judgement, no pressure intended: every released 0.5.x (through 0.5.2) still ships the unwritten store, and the trigger is easy to hit in the wild — any decode loop whose first cached step is a single token (e.g. BOS-seeded generation). If a patch release is ever feasible, these tests would guard it.

## Test plan

- Identified dependent tests first: `python scripts/find_dependent_tests.py tests/modules/test_token_shift.py` → the file itself.
- `pytest tests/modules/test_token_shift.py` → **37 passed** (35 pre-existing + 2 new), fla imported from this branch, RTX 5070 Ti Laptop GPU, PyTorch 2.11.0+cu128, Python 3.12.
- Both new tests **fail** on the released 0.5.2 (cache assertion; values differ, not just tolerance) when run against a stock 0.5.2 install, and pass on this branch.
- The value-style `assert_close` checks matter here: NaN-based checks would miss the zero-filled variant of this failure.

## Benchmark / NCU (kernel changes only)

Not applicable — no kernel or runtime code changed (tests only).

## Breaking changes

None — test-only change.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and follow its conventions (code style, docstrings, commit prefixes).
- [x] I have read [AGENTS.md](../AGENTS.md) and, where my change matches its scope, the relevant skill under [.agents/skills](../.agents/skills).
- [x] Dependent tests pass locally or in CI, and new behavior is covered by tests where applicable (tick as N/A for changes with no testable code, e.g. docs-only).
- [x] Kernel changes include same-hardware before/after benchmark numbers, dense + varlen where applicable (tick as N/A when no kernel code changed).
- [ ] This PR is minor/cosmetic-only (typo, formatting, style-only tweaks) — tick only if it is, and justify below.
